### PR TITLE
feat(logging): log command args

### DIFF
--- a/packages/core/src/shared/utilities/collectionUtils.ts
+++ b/packages/core/src/shared/utilities/collectionUtils.ts
@@ -290,6 +290,45 @@ export function assign<T extends Record<any, any>, U extends Partial<T>>(data: T
     }
 }
 
+/**
+ * Clones an object (copies "own properties") until `depth`, where:
+ * - depth=0 returns non-object value, or empty object (`{}` or `[]`).
+ * - depth=1 returns `obj` with its immediate children (but not their children).
+ * - depth=2 returns `obj` with its children and their children.
+ * - and so on...
+ *
+ * TODO: node's `util.inspect()` function is better, but doesn't work in web browser?
+ *
+ * @param obj Object to clone.
+ * @param depth
+ * @param omitKeys Omit properties matching these names (at any depth).
+ * @param replacement Replacement for object whose fields extend beyond `depth`, and properties matching `omitKeys`.
+ */
+export function partialClone(obj: any, depth: number = 3, omitKeys: string[] = [], replacement?: any): any {
+    // Base case: If input is not an object or has no children, return it.
+    if (typeof obj !== 'object' || obj === null || 0 === Object.getOwnPropertyNames(obj).length) {
+        return obj
+    }
+
+    // Create a new object of the same type as the input object.
+    const clonedObj = Array.isArray(obj) ? [] : {}
+
+    if (depth === 0) {
+        return replacement ? replacement : clonedObj
+    }
+
+    // Recursively clone properties of the input object
+    for (const key in obj) {
+        if (omitKeys.includes(key)) {
+            ;(clonedObj as any)[key] = replacement ? replacement : Array.isArray(obj) ? [] : {}
+        } else if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            ;(clonedObj as any)[key] = partialClone(obj[key], depth - 1, omitKeys, replacement)
+        }
+    }
+
+    return clonedObj
+}
+
 /** Recursively delete undefined key/value pairs */
 export function stripUndefined<T extends Record<string, any>>(
     obj: T

--- a/packages/core/src/ssmDocument/ssm/ssmClient.ts
+++ b/packages/core/src/ssmDocument/ssm/ssmClient.ts
@@ -102,7 +102,7 @@ export async function activate(extensionContext: ExtensionContext) {
     // Create the language client and start the client.
     const client = new LanguageClient(
         'ssm',
-        localize('ssm.server.name', 'SSM Document Language Server'),
+        localize('ssm.server.name', 'AWS: SSM Document Language Server'),
         serverOptions,
         clientOptions
     )

--- a/packages/core/src/stepFunctions/asl/client.ts
+++ b/packages/core/src/stepFunctions/asl/client.ts
@@ -105,7 +105,7 @@ export async function activate(extensionContext: ExtensionContext) {
     // Create the language client and start the client.
     const client = new LanguageClient(
         'asl',
-        localize('asl.server.name', 'Amazon States Language Server'),
+        localize('asl.server.name', 'AWS: Amazon States Language Server'),
         serverOptions,
         clientOptions
     )

--- a/packages/core/src/test/shared/utilities/collectionUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/collectionUtils.test.ts
@@ -30,6 +30,7 @@ import {
     toStream,
     joinAll,
     isPresent,
+    partialClone,
 } from '../../../shared/utilities/collectionUtils'
 
 import { asyncGenerator } from '../../../shared/utilities/collectionUtils'
@@ -672,6 +673,76 @@ describe('CollectionUtils', async function () {
         })
         it('returns false for undefined', function () {
             assert.strictEqual(isPresent<string>(undefined), false)
+        })
+    })
+
+    describe('partialClone', function () {
+        it('omits properties by depth', function () {
+            const testObj = {
+                a: 34234234234,
+                b: '123456789',
+                c: new Date(2023, 1, 1),
+                d: { d1: { d2: { d3: 'deep' } } },
+                e: {
+                    e1: [4, 3, 7],
+                    e2: 'loooooooooo \n nnnnnnnnnnn \n gggggggg \n string',
+                },
+                f: () => {
+                    throw Error()
+                },
+            }
+
+            assert.deepStrictEqual(partialClone(testObj, 1), {
+                ...testObj,
+                d: {},
+                e: {},
+            })
+            assert.deepStrictEqual(partialClone(testObj, 0, [], '[replaced]'), '[replaced]')
+            assert.deepStrictEqual(partialClone(testObj, 1, [], '[replaced]'), {
+                ...testObj,
+                d: '[replaced]',
+                e: '[replaced]',
+            })
+            assert.deepStrictEqual(partialClone(testObj, 3), {
+                ...testObj,
+                d: { d1: { d2: {} } },
+            })
+            assert.deepStrictEqual(partialClone(testObj, 4), testObj)
+        })
+
+        it('omits properties by name', function () {
+            const testObj = {
+                a: 34234234234,
+                b: '123456789',
+                c: new Date(2023, 1, 1),
+                d: { d1: { d2: { d3: 'deep' } } },
+                e: {
+                    e1: [4, 3, 7],
+                    e2: 'loooooooooo \n nnnnnnnnnnn \n gggggggg \n string',
+                },
+                f: () => {
+                    throw Error()
+                },
+            }
+
+            assert.deepStrictEqual(partialClone(testObj, 2, ['c', 'e2'], '[omitted]'), {
+                ...testObj,
+                c: '[omitted]',
+                d: { d1: '[omitted]' },
+                e: {
+                    e1: '[omitted]',
+                    e2: '[omitted]',
+                },
+            })
+            assert.deepStrictEqual(partialClone(testObj, 3, ['c', 'e2'], '[omitted]'), {
+                ...testObj,
+                c: '[omitted]',
+                d: { d1: { d2: '[omitted]' } },
+                e: {
+                    e1: [4, 3, 7],
+                    e2: '[omitted]',
+                },
+            })
         })
     })
 })


### PR DESCRIPTION
Problem:
Log message "command: running with arguments …" does not print useful argument info.

Solution:
Print objects at depth of 1.

before:

    2024-03-18 18:10:21 [DEBUG]: command: running "aws.cdk.renderStateMachineGraph" with arguments [[object Object], undefined]

after:

    2024-03-18 13:15:20 [DEBUG]: command: running "_aws.auth.reauthenticate" with arguments: {
      '0': Auth {
        ...
      },
      '1': {
        ...
      }
    }



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
