### PR TITLE
fix: npm install failure

### DIFF
--- a/plugins/eslint-plugin-aws-toolkits/test/rules/no-only-in-tests.test.ts
+++ b/plugins/eslint-plugin-aws-toolkits/test/rules/no-only-in-tests.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { rules } from '../..'
+import { rules } from '../../index'
 import { describeOnlyErrMsg, itOnlyErrMsg } from '../../lib/rules/no-only-in-tests'
 import { getRuleTester } from '../testUtil'
 


### PR DESCRIPTION
### Problem
Running `npm install` failed with an error:
`test/rules/no-only-in-tests.test.ts:6:23 - error TS7016: Could not find a declaration file for module '../..'.`

### Solution:
Update the path to point to the actual module and it now works

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
