### PR TITLE
auth: log errors when we go from valid to invalid state

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -754,6 +754,9 @@ export class Auth implements AuthService, ConnectionManager {
             })
         }
         if (previousState === 'valid') {
+            // Non-token expiration errors can happen. We must log it here, otherwise they are lost.
+            getLogger().warn(`auth: valid connection became invalid. Last error: %s`, this.#validationErrors.get(id))
+
             const timeout = new Timeout(60000)
             this.#invalidCredentialsTimeouts.set(id, timeout)
 


### PR DESCRIPTION
## Problem:
When errors occur somewhere in the getToken() process + the token was previously valid, if it fails we do not log the actual underlying error anywhere. We simply tell them to reauth.

This caused issues when debugging premature auth expiration problems since we couldn't see the actual error.

## Solution
If we switch from valid to invalid connection state, then log the error as a warning. This should give us the reason as to why it is failing, though we will also see the expected case where it actually expired.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
