### PR TITLE
changelog(codewhisperer): inline hint + active state UI improvements

### DIFF
--- a/.changes/next-release/Feature-04884433-f614-43a2-b7c6-58df79e31bbb.json
+++ b/.changes/next-release/Feature-04884433-f614-43a2-b7c6-58df79e31bbb.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeWhisperer: Improve UI to indicate CodeWhisperer is generating suggestions"
+}

--- a/.changes/next-release/Feature-36982776-d732-4c39-b76a-589745004928.json
+++ b/.changes/next-release/Feature-36982776-d732-4c39-b76a-589745004928.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeWhisperer: Improve UI to walk through new CodeWhisperer users how-to"
+}

--- a/packages/core/src/codewhisperer/views/lineAnnotationController.ts
+++ b/packages/core/src/codewhisperer/views/lineAnnotationController.ts
@@ -424,13 +424,7 @@ export class LineAnnotationController implements vscode.Disposable {
             return undefined
         }
 
-        let nextState: AnnotationState | undefined
-
-        if (force) {
-            nextState = this._currentState.nextState(source, true)
-        } else {
-            nextState = this._currentState.nextState(source, false)
-        }
+        const nextState: AnnotationState | undefined = this._currentState.nextState(source, force ?? false)
 
         if (nextState === undefined) {
             return undefined


### PR DESCRIPTION
## NOTE
* LineTracker implementation #4532
* Active state indicator UI implementation #4558
* Inlinehint UI Implementation #4539

## Problem
## Feature 1: Inline walk through tutorial

https://github.com/aws/aws-toolkit-vscode/assets/96078566/d3a5ab9c-c80c-493b-8eb4-5a05b8a90da6



## Feature 2: active indicator


https://github.com/aws/aws-toolkit-vscode/assets/96078566/0895c045-62f2-4928-a923-bfbde249ba84








## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
