### PR TITLE
fix: featureDev partial code acceptance

### DIFF
--- a/.changes/next-release/Bug Fix-c76a701b-a106-46ef-99d9-5bb0760c469a.json
+++ b/.changes/next-release/Bug Fix-c76a701b-a106-46ef-99d9-5bb0760c469a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "FeatureDev: Rejected files are excluded when generated code is accepted by the customer"
+}

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -166,7 +166,7 @@ export class Session {
     }
 
     public async insertChanges() {
-        for (const filePath of this.state.filePaths ?? []) {
+        for (const filePath of this.state.filePaths?.filter(i => !i.rejected) ?? []) {
             const absolutePath = path.join(filePath.workspaceFolder.uri.fsPath, filePath.relativePath)
 
             const uri = filePath.virtualMemoryUri


### PR DESCRIPTION
## Problem
Bug:
Rejected files were ignored when generated code was accepted.

Fix:
Rejected files are excluded when generated code was accepted.

Testing:
I added a test to ensure the `fileClick` action correctly updates the state of the file, including rejecting files and reverting rejections. 
Additionally, I manually tested the most common scenarios, such as accepting all files, rejecting all files, and accepting a subset of them. All cases functioned as expected.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
