### PR TITLE
fix(cwspr): Amend exposing listConnection api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,15 +20,15 @@ This command supports the following arguments:
 
 ### Extension API
 
-#### `listSsoConnections`
+#### `listConnections`
 
-**Signature**: _async () => Promise<AwsToolkitSsoConnection>_
+**Signature**: _async () => Promise<AwsConnection>_
 
-This is an API that exposes the metadata of SSO connections of AWS Toolkit. It returns a list of `AwsToolkitSsoConnection` which contains below fields:
+This is an API that exposes the metadata of SSO connections of AWS Toolkit. It returns a list of `AwsConnection` which contains below fields:
 
 -   id: string that presents the id of the connection
 -   label: label of the connection
--   type: type of the connection, can only be 'sso'
+-   type: type of the connection, currently only 'sso' is returned
 -   ssoRegion: region of the connection, e.g: us-west-2
 -   startUrl: start url of the connection
 -   scopes?: list of the scopes of the connection

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,3 +17,18 @@ This command supports the following arguments:
 -   startUrl and region. If both arguments are provided they will be used, otherwise the command prompts for them interactively.
 -   customizationArn: select customization by ARN. If provided, `customizationNamePrefix` is ignored.
 -   customizationNamePrefix: select customization by prefix, if `customizationArn` is `undefined`.
+
+### Extension API
+
+#### `listSsoConnections`
+
+**Signature**: _async () => Promise<AwsToolkitSsoConnection>_
+
+This is an API that exposes the metadata of SSO connections of AWS Toolkit. It returns a list of `AwsToolkitSsoConnection` which contains below fields:
+
+-   id: string that presents the id of the connection
+-   label: label of the connection
+-   type: type of the connection, can only be 'sso'
+-   ssoRegion: region of the connection, e.g: us-west-2
+-   startUrl: start url of the connection
+-   scopes?: list of the scopes of the connection

--- a/packages/toolkit/src/api.ts
+++ b/packages/toolkit/src/api.ts
@@ -5,7 +5,7 @@
 
 import { Auth, Connection } from 'aws-core-vscode/auth'
 
-export interface AwsToolkitSsoConnection {
+export interface AwsConnection {
     readonly id: string
     readonly label: string
     readonly type: string
@@ -19,9 +19,9 @@ export interface AwsToolkitSsoConnection {
  * the available connections in aws toolkit.
  */
 export const awsToolkitApi = {
-    async listSsoConnections(): Promise<AwsToolkitSsoConnection[]> {
+    async listConnections(): Promise<AwsConnection[]> {
         const connections = await Auth.instance.listConnections()
-        const exposedConnections: AwsToolkitSsoConnection[] = []
+        const exposedConnections: AwsConnection[] = []
         connections.forEach((x: Connection) => {
             if ('ssoRegion' in x) {
                 exposedConnections.push({

--- a/packages/toolkit/src/api.ts
+++ b/packages/toolkit/src/api.ts
@@ -4,12 +4,36 @@
  */
 
 import { Auth, Connection } from 'aws-core-vscode/auth'
+
+export interface AwsToolkitSsoConnection {
+    readonly id: string
+    readonly label: string
+    readonly type: string
+    readonly ssoRegion: string
+    readonly startUrl: string
+    readonly scopes?: string[]
+}
+
 /**
  * Exposing listConnections API for other extension to read or re-use
  * the available connections in aws toolkit.
  */
 export const awsToolkitApi = {
-    async listConnections(): Promise<Connection[]> {
-        return Auth.instance.listConnections()
+    async listSsoConnections(): Promise<AwsToolkitSsoConnection[]> {
+        const connections = await Auth.instance.listConnections()
+        const exposedConnections: AwsToolkitSsoConnection[] = []
+        connections.forEach((x: Connection) => {
+            if ('ssoRegion' in x) {
+                exposedConnections.push({
+                    id: x.id,
+                    label: x.label,
+                    type: x.type,
+                    ssoRegion: x.ssoRegion,
+                    startUrl: x.startUrl,
+                    scopes: x.scopes,
+                })
+            }
+        })
+        return exposedConnections
     },
 }


### PR DESCRIPTION
## Problem
This is a follow up PR of https://github.com/aws/aws-toolkit-vscode/pull/4544.

## Solution


It no longer exposes internal data structure `Connection` . Now it exposes a new type `AwsToolkitSsoConnection`  that does not have `getCredentials`. 

For AmazonQ extension, I have tested that it can cast the new type `AwsToolkitSsoConnection` into `Connection` and 
it can further getCredentials from this connection. This is possible only for AmazonQ because it is re-using the same auth library as toolkit. For other 3rd party extensions, they won't be able to perform `getCredentials` from `AwsToolkitSsoConnection`


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
