### PR TITLE
feat(codewhisperer): remove prompt "waiting for CodeWhisperer..."

### DIFF
--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -105,13 +105,12 @@ export class RecommendationHandler {
     async getServerResponse(
         triggerType: CodewhispererTriggerType,
         isManualTriggerOn: boolean,
-        isFirstPaginationCall: boolean,
         promise: Promise<any>
     ): Promise<any> {
         const timeoutMessage = hasVendedIamCredentials()
             ? 'Generate recommendation timeout.'
             : 'List recommendation timeout'
-        if (isManualTriggerOn && triggerType === 'OnDemand' && (hasVendedIamCredentials() || isFirstPaginationCall)) {
+        if (isManualTriggerOn && triggerType === 'OnDemand' && hasVendedIamCredentials()) {
             return vscode.window.withProgress(
                 {
                     location: vscode.ProgressLocation.Notification,
@@ -238,12 +237,7 @@ export class RecommendationHandler {
             const mappedReq = runtimeLanguageContext.mapToRuntimeLanguage(request)
             const codewhispererPromise =
                 pagination && !isSM ? client.listRecommendations(mappedReq) : client.generateRecommendations(mappedReq)
-            const resp = await this.getServerResponse(
-                triggerType,
-                config.isManualTriggerEnabled,
-                page === 0 && !retry,
-                codewhispererPromise
-            )
+            const resp = await this.getServerResponse(triggerType, config.isManualTriggerEnabled, codewhispererPromise)
             TelemetryHelper.instance.setSdkApiCallEndTime()
             latency = startTime !== 0 ? performance.now() - startTime : 0
             if ('recommendations' in resp) {


### PR DESCRIPTION
As discussed offline, after introducing #4558 feature, we would like to remove progress runner/prompt while running CodeWhisperer (`Waiting for CodeWhisperer...`) for manual trigger case.

## Problem

### Before

https://github.com/aws/aws-toolkit-vscode/assets/96078566/ca589453-e9f1-4a22-a246-73f85e66118a



### After

https://github.com/aws/aws-toolkit-vscode/assets/96078566/13d6a253-f83b-4cd9-9e62-aa63b35aebcf


## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
