### PR TITLE
Bugfix project details loggin

### DIFF
--- a/packages/core/src/codewhisperer/service/transformByQHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQHandler.ts
@@ -30,6 +30,7 @@ import {
 } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
 import { MetadataResult } from '../../shared/telemetry/telemetryClient'
 import request from '../../common/request'
+import { ToolkitError } from '../../shared/errors'
 
 // log project details silently
 export async function validateAndLogProjectDetails() {
@@ -54,6 +55,7 @@ export async function validateAndLogProjectDetails() {
     } finally {
         if (result || reason || codeTransformLocalJavaVersion || codeTransformPreValidationError) {
             telemetry.codeTransform_projectDetails.emit({
+                passive: true,
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                 codeTransformLocalJavaVersion,
                 codeTransformPreValidationError,
@@ -84,7 +86,7 @@ export async function getOpenProjects() {
                 CodeWhispererConstants.linkToPrerequisites
             )
         )
-        throw new Error('No open projects')
+        throw new ToolkitError('No Java projects found since no projects are open', { code: 'NoOpenProjects' })
     }
     const openProjects: vscode.QuickPickItem[] = []
     for (const folder of folders) {
@@ -212,7 +214,7 @@ export async function validateOpenProjects(projects: vscode.QuickPickItem[], onP
                 reason: 'CouldNotFindJavaProject',
             })
         }
-        throw new Error('Could not find Java project')
+        throw new ToolkitError('No Java projects found', { code: 'CouldNotFindJavaProject', name: 'NoJavaProject' })
     }
     const mavenJavaProjects = await getMavenJavaProjects(javaProjects)
     if (mavenJavaProjects.length === 0) {
@@ -230,7 +232,7 @@ export async function validateOpenProjects(projects: vscode.QuickPickItem[], onP
                 reason: 'NoPomFileFound',
             })
         }
-        throw new Error('No pom.xml file found')
+        throw new ToolkitError('No valid Maven build file found', { code: 'NoPomFileFound', name: 'NonMavenProject' })
     }
 
     /*

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -82,8 +82,8 @@ describe('transformByQ', function () {
                 await validateOpenProjects(dummyQuickPickItems)
             },
             {
-                name: 'Error',
-                message: 'Could not find Java project',
+                name: 'NoJavaProject',
+                message: 'No Java projects found',
             }
         )
     })
@@ -106,8 +106,8 @@ describe('transformByQ', function () {
                 await validateOpenProjects(dummyQuickPickItems)
             },
             {
-                name: 'Error',
-                message: 'No pom.xml file found',
+                name: 'NonMavenProject',
+                message: 'No valid Maven build file found',
             }
         )
     })
@@ -130,7 +130,7 @@ describe('transformByQ', function () {
             },
             {
                 name: 'Error',
-                message: 'No open projects',
+                message: 'No Java projects found since no projects are open',
             }
         )
     })


### PR DESCRIPTION
## Problem

Late discovery of an issue where upon opening VS Code with recently merged changes we get an error message about the "projectDetails" metric not being passive.

Also reverting the "Error" to "ToolkitError" (how it was originally) because I get a generic VS Code error about not being able to execute `aws.q.transform` when you open VS Code with no open projects.

## Solution

Implement the above.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
