### PR TITLE
fix(QCT): unnecessary notifications

### DIFF
--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -83,7 +83,7 @@ describe('transformByQ', function () {
             },
             {
                 name: 'NoJavaProject',
-                message: 'No Java projects found',
+                message: '',
             }
         )
     })
@@ -107,7 +107,7 @@ describe('transformByQ', function () {
             },
             {
                 name: 'NonMavenProject',
-                message: 'No valid Maven build file found',
+                message: '',
             }
         )
     })
@@ -129,8 +129,8 @@ describe('transformByQ', function () {
                 await getOpenProjects()
             },
             {
-                name: 'Error',
-                message: 'No Java projects found since no projects are open',
+                name: 'NoProjectsOpen',
+                message: '',
             }
         )
     })


### PR DESCRIPTION
## Problem

When opening VS Code, all CWSPR users were getting a notification that says if they have any valid projects open for transformation. Also, the `Error`s we were throwing was causing an error notification to popup saying "Cannot execute command aws.q.transform". Changing this back to ToolkitError (with an empty string, since we already show a notification and I don't want duplicate notifications), fixes this issue too.

## Solution

Implement the above.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
