### PR TITLE
feat(wizard): support async prompter functions

### DIFF
--- a/packages/core/src/lambda/wizards/samInitWizard.ts
+++ b/packages/core/src/lambda/wizards/samInitWizard.ts
@@ -36,7 +36,7 @@ import { createRegionPrompter } from '../../shared/ui/common/region'
 import { Region } from '../../shared/regions/endpoints'
 import { createCommonButtons } from '../../shared/ui/buttons'
 import { createExitPrompter } from '../../shared/ui/common/exitPrompter'
-import { getNonexistentFilenameSync } from '../../shared/filesystemUtilities'
+import { getNonexistentFilename } from '../../shared/filesystemUtilities'
 
 const localize = nls.loadMessageBundle()
 
@@ -272,10 +272,14 @@ export class CreateNewSamAppWizard extends Wizard<CreateNewSamAppWizardForm> {
             })
         )
 
-        this.form.name.bindPrompter(state =>
-            createNamePrompter(
-                getNonexistentFilenameSync(state.location!.fsPath, `lambda-${state.runtimeAndPackage!.runtime}`, '', 99)
+        this.form.name.bindPrompter(async state => {
+            const fname = await getNonexistentFilename(
+                state.location!.fsPath,
+                `lambda-${state.runtimeAndPackage!.runtime}`,
+                '',
+                99
             )
-        )
+            return createNamePrompter(fname)
+        })
     }
 }

--- a/packages/core/src/shared/filesystemUtilities.ts
+++ b/packages/core/src/shared/filesystemUtilities.ts
@@ -12,7 +12,6 @@ import * as pathutils from './utilities/pathUtils'
 import globals from '../shared/extensionGlobals'
 import { GlobalState } from './globalState'
 import { fsCommon } from '../srcShared/fs'
-import fs from 'fs'
 
 export const tempDirPath = path.join(
     // https://github.com/aws/aws-toolkit-vscode/issues/240
@@ -213,39 +212,7 @@ export async function getNonexistentFilename(
         const filename =
             i === 0 ? `${name}${suffix}` : `${name}-${i < max ? i : crypto.randomBytes(4).toString('hex')}${suffix}`
         const fullpath = path.join(dir, filename)
-        if (!(await fsCommon.existsFile(fullpath)) || i >= max + 99) {
-            return filename
-        }
-    }
-}
-
-/**
- * @deprecated this is a synchronous duplicate of {@link getNonexistentFilename}. We are only keeping it
- * since some code needs to do this process synchronously and the platform agnostic file system is async.
- *
- * Returns `name.suffix` if it does not already exist in directory `dir`, else appends
- * a number ("foo-1.txt", "foo-2.txt", etc.).
- *
- * To avoid excessive filesystem activity, if all filenames up to `max` exist,
- * the function instead appends a random string.
- *
- * @param dir  Path to a directory
- * @param name  Filename without extension
- * @param suffix  Filename suffix, typically an extension (".txt"), may be empty
- * @param max  Stop searching if all permutations up to this number exist
- */
-export function getNonexistentFilenameSync(dir: string, name: string, suffix: string, max: number = 99): string {
-    if (!name) {
-        throw new Error(`name is empty`)
-    }
-    if (!fs.existsSync(dir)) {
-        throw new Error(`directory does not exist: ${dir}`)
-    }
-    for (let i = 0; true; i++) {
-        const filename =
-            i === 0 ? `${name}${suffix}` : `${name}-${i < max ? i : crypto.randomBytes(4).toString('hex')}${suffix}`
-        const fullpath = path.join(dir, filename)
-        if (!fs.existsSync(fullpath) || i >= max + 99) {
+        if (!(await fsCommon.exists(fullpath)) || i >= max + 99) {
             return filename
         }
     }

--- a/packages/core/src/shared/wizards/wizard.ts
+++ b/packages/core/src/shared/wizards/wizard.ts
@@ -252,7 +252,7 @@ export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
         provider: PrompterProvider<TState, TProp>,
         impliedResponse?: TProp
     ): Promise<PromptResult<TProp>> {
-        const prompter = provider(state as StateWithCache<WizardState<TState>, TProp>)
+        const prompter = await provider(state as StateWithCache<WizardState<TState>, TProp>)
 
         this._stepOffset = state.stepCache.stepOffset ?? this._stepOffset
         state.stepCache.stepOffset = this._stepOffset

--- a/packages/core/src/shared/wizards/wizardForm.ts
+++ b/packages/core/src/shared/wizards/wizardForm.ts
@@ -8,7 +8,9 @@ import * as _ from 'lodash'
 import { StateWithCache, WizardState } from './wizard'
 import { ExpandWithObject } from '../utilities/tsUtils'
 
-export type PrompterProvider<TState, TProp> = (state: StateWithCache<WizardState<TState>, TProp>) => Prompter<TProp>
+export type PrompterProvider<TState, TProp> = (
+    state: StateWithCache<WizardState<TState>, TProp>
+) => Prompter<TProp> | Promise<Prompter<TProp>>
 
 type DefaultFunction<TState, TProp> = (state: WizardState<TState>) => TProp | undefined
 
@@ -41,8 +43,8 @@ interface ContextOptions<TState, TProp> {
 }
 export interface FormElement<TProp, TState> {
     /**
-     * Binds a Prompter-provider to the specified property. The provider is called with the current Wizard
-     * state whenever the property is ready for input, and should return a Prompter object.
+     * Binds a property to a function (may be async), which is invoked with the current Wizard state
+     * when the property is presented for input. Must return a {@link Prompter} object.
      */
     bindPrompter(provider: PrompterProvider<TState, TProp>, options?: ContextOptions<TState, TProp>): void
     // TODO: potentially add options to this, or rethink how defaults should work

--- a/packages/core/src/test/shared/filesystemUtilities.test.ts
+++ b/packages/core/src/test/shared/filesystemUtilities.test.ts
@@ -11,7 +11,6 @@ import {
     fileExists,
     getFileDistance,
     getNonexistentFilename,
-    getNonexistentFilenameSync,
     isInDirectory,
     makeTemporaryToolkitFolder,
     tempDirPath,
@@ -40,29 +39,25 @@ describe('filesystemUtilities', function () {
     })
 
     describe('getNonexistentFilename()', function () {
-        const methods = [getNonexistentFilename, getNonexistentFilenameSync]
-
-        methods.forEach(methodUnderTest => {
-            it(`${methodUnderTest.name}: failure modes`, async function () {
-                await assert.rejects(async () => methodUnderTest('/bogus/directory/', 'foo', '.txt', 99))
-                await assert.rejects(async () => methodUnderTest('zzz', 'foo', '.txt', 99))
-            })
-            it(`${methodUnderTest.name}: returns a filename that does not exist in the directory`, async function () {
-                const dir = tempFolder
-                await writeFile(path.join(dir, 'foo.txt'), '', 'utf8')
-                await writeFile(path.join(dir, 'foo-0.txt'), '', 'utf8')
-                await writeFile(path.join(dir, 'foo-1.txt'), '', 'utf8')
-                await writeFile(path.join(dir, 'foo-2.txt'), '', 'utf8')
-                assert.strictEqual(await methodUnderTest(dir, 'foo', '.txt', 99), 'foo-3.txt')
-                assert.strictEqual(await methodUnderTest(dir, 'foo', '', 99), 'foo')
-            })
-            it(`${methodUnderTest.name}: returns "foo-RANDOM.txt" if max is reached`, async function () {
-                const dir = tempFolder
-                await writeFile(path.join(dir, 'foo.txt'), '', 'utf8')
-                await writeFile(path.join(dir, 'foo-1.txt'), '', 'utf8')
-                // Looks like "foo-75446d5d.txt".
-                assert.ok(/^foo-[a-fA-F0-9]{8}.txt$/.test(await methodUnderTest(dir, 'foo', '.txt', 1)))
-            })
+        it(`failure modes`, async function () {
+            await assert.rejects(async () => getNonexistentFilename('/bogus/directory/', 'foo', '.txt', 99))
+            await assert.rejects(async () => getNonexistentFilename('zzz', 'foo', '.txt', 99))
+        })
+        it(`returns a filename that does not exist in the directory`, async function () {
+            const dir = tempFolder
+            await writeFile(path.join(dir, 'foo.txt'), '', 'utf8')
+            await writeFile(path.join(dir, 'foo-0.txt'), '', 'utf8')
+            await writeFile(path.join(dir, 'foo-1.txt'), '', 'utf8')
+            await writeFile(path.join(dir, 'foo-2.txt'), '', 'utf8')
+            assert.strictEqual(await getNonexistentFilename(dir, 'foo', '.txt', 99), 'foo-3.txt')
+            assert.strictEqual(await getNonexistentFilename(dir, 'foo', '', 99), 'foo')
+        })
+        it(`returns "foo-RANDOM.txt" if max is reached`, async function () {
+            const dir = tempFolder
+            await writeFile(path.join(dir, 'foo.txt'), '', 'utf8')
+            await writeFile(path.join(dir, 'foo-1.txt'), '', 'utf8')
+            // Looks like "foo-75446d5d.txt".
+            assert.ok(/^foo-[a-fA-F0-9]{8}.txt$/.test(await getNonexistentFilename(dir, 'foo', '.txt', 1)))
         })
     })
 

--- a/packages/core/src/test/shared/wizards/wizard.test.ts
+++ b/packages/core/src/test/shared/wizards/wizard.test.ts
@@ -14,6 +14,7 @@ import {
     WIZARD_BACK,
     WIZARD_EXIT,
 } from '../../../shared/wizards/wizard'
+import { SkipPrompter } from '../../../shared/ui/common/skipPrompter'
 
 interface TestWizardForm {
     prop1: string
@@ -208,10 +209,13 @@ describe('Wizard', function () {
         helloPrompter = new TestPrompter(...Array(100).fill('hello')).setName('Hello')
     })
 
-    it('binds prompter to property', async function () {
+    it('binds prompter to (sync AND async) property', async function () {
         wizard.form.prop1.bindPrompter(() => helloPrompter)
+        wizard.form.prop3.bindPrompter(async () => new SkipPrompter('helloooo (async)'))
 
-        assert.strictEqual((await wizard.run())?.prop1, 'hello')
+        const result = await wizard.run()
+        assert.strictEqual(result?.prop1, 'hello')
+        assert.strictEqual(result?.prop3, 'helloooo (async)')
     })
 
     it('initializes state to empty object if not provided', async function () {


### PR DESCRIPTION
Problem:
- `bindPrompter` does not support binding to async functions. This can be very awkward, and limits how prompts can be implemented.
- `getNonexistentFilename` has a bug: it checks `existsFile` which returns false for directories.

Solution:
- Change the definition of `PrompterProvider` to allow returning a Promise.
- Fix the check in `getNonexistentFilename`.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
