### PR TITLE
codewhisperer: zip util and triggers for file scans

### DIFF
--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -213,16 +213,15 @@ export async function startSecurityScan(
                 error.message.includes(CodeWhispererConstants.throttlingMessage)
             ) {
                 void vscode.window.showErrorMessage(CodeWhispererConstants.freeTierLimitReachedCodeScan)
-                await vscode.commands.executeCommand('aws.codeWhisperer.refresh', true)
+                // TODO: Should we set a graphical state?
+                // We shouldn't set vsCodeState.isFreeTierLimitReached here because it will hide CW and Q chat options.
             }
         }
         codeScanTelemetryEntry.reason = (error as Error).message
     } finally {
         codeScanState.setToNotStarted()
-        await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
         codeScanTelemetryEntry.duration = performance.now() - codeScanStartTime
         codeScanTelemetryEntry.codeScanServiceInvocationsDuration = performance.now() - serviceInvocationStartTime
-        getLogger().verbose(`Security scan telemetry: ${JSON.stringify(codeScanTelemetryEntry)}`)
         await emitCodeScanTelemetry(editor, codeScanTelemetryEntry)
     }
 }

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { ArtifactMap, DefaultCodeWhispererClient } from '../client/codewhisperer'
 import { isCloud9 } from '../../shared/extensionUtilities'
-import { initSecurityScanRender } from '../service/diagnosticsProvider'
+import { initSecurityScanRender, initSecurityScanRenderOld, securityScanRender } from '../service/diagnosticsProvider'
 import { SecurityPanelViewProvider } from '../views/securityPanelViewProvider'
 import { getLogger } from '../../shared/logger'
 import { makeLogger } from '../../shared/logger/activation'
@@ -20,9 +20,11 @@ import {
     pollScanJobStatus,
     listScanResults,
     throwIfCancelled,
+    throwIfCancelledOld,
+    pollScanJobStatusOld,
 } from '../service/securityScanHandler'
 import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
-import { codeScanState, CodeScanTelemetryEntry } from '../models/model'
+import { AggregatedCodeScanIssue, codeScanState, CodeScanTelemetryEntry } from '../models/model'
 import { openSettings } from '../../shared/settings'
 import { cancel, ok, viewSettings } from '../../shared/localizedText'
 import { statSync } from 'fs'
@@ -34,6 +36,8 @@ import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { AuthUtil } from '../util/authUtil'
 import { DependencyGraphConstants } from '../util/dependencyGraph/dependencyGraph'
 import path from 'path'
+import { ZipMetadata, ZipUtil } from '../util/zipUtil'
+import { debounce } from 'lodash'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 const securityScanOutputChannel = vscode.window.createOutputChannel('CodeWhisperer Security Scan Logs')
@@ -56,12 +60,200 @@ export function startSecurityScanWithProgress(
             cancellable: false,
         },
         async () => {
-            await startSecurityScan(securityPanelViewProvider, editor, client, context)
+            await startSecurityScan(
+                securityPanelViewProvider,
+                editor,
+                client,
+                context,
+                CodeWhispererConstants.SecurityScanType.Project
+            )
         }
     )
 }
 
+export const debounceStartSecurityScan = debounce(
+    startSecurityScan,
+    CodeWhispererConstants.autoScanDebounceDelaySeconds * 1000
+)
+
 export async function startSecurityScan(
+    securityPanelViewProvider: SecurityPanelViewProvider,
+    editor: vscode.TextEditor,
+    client: DefaultCodeWhispererClient,
+    context: vscode.ExtensionContext,
+    scanType: CodeWhispererConstants.SecurityScanType
+) {
+    /**
+     * Step 0: Initial Code Scan telemetry
+     */
+    const codeScanStartTime = performance.now()
+    let serviceInvocationStartTime = 0
+    const codeScanTelemetryEntry: CodeScanTelemetryEntry = {
+        codewhispererLanguage: runtimeLanguageContext.getLanguageContext(
+            editor.document.languageId,
+            path.extname(editor.document.fileName)
+        ).language,
+        codewhispererCodeScanSrcPayloadBytes: 0,
+        codewhispererCodeScanSrcZipFileBytes: 0,
+        codewhispererCodeScanLines: 0,
+        duration: 0,
+        contextTruncationDuration: 0,
+        artifactsUploadDuration: 0,
+        codeScanServiceInvocationsDuration: 0,
+        result: 'Succeeded',
+        codewhispererCodeScanTotalIssues: 0,
+        codewhispererCodeScanIssuesWithFixes: 0,
+        credentialStartUrl: AuthUtil.instance.startUrl,
+    }
+    try {
+        getLogger().verbose(`Starting security scan `)
+        /**
+         * Step 1: Generate zip
+         */
+        throwIfCancelled(scanType)
+        const zipUtil = new ZipUtil()
+        const zipMetadata = await zipUtil.generateZip(editor.document.uri)
+        const projectPath = zipUtil.getProjectPath(editor.document.uri)
+
+        const contextTruncationStartTime = performance.now()
+        codeScanTelemetryEntry.contextTruncationDuration = performance.now() - contextTruncationStartTime
+        getLogger().verbose(`Complete project context processing.`)
+        codeScanTelemetryEntry.codewhispererCodeScanSrcPayloadBytes = zipMetadata.srcPayloadSizeInBytes
+        codeScanTelemetryEntry.codewhispererCodeScanBuildPayloadBytes = zipMetadata.buildPayloadSizeInBytes
+        codeScanTelemetryEntry.codewhispererCodeScanSrcZipFileBytes = zipMetadata.zipFileSizeInBytes
+        codeScanTelemetryEntry.codewhispererCodeScanLines = zipMetadata.lines
+
+        /**
+         * Step 2: Get presigned Url, upload and clean up
+         */
+        throwIfCancelled(scanType)
+        let artifactMap: ArtifactMap = {}
+        const uploadStartTime = performance.now()
+        try {
+            artifactMap = await getPresignedUrlAndUpload(client, zipMetadata)
+        } catch (error) {
+            getLogger().error('Failed to upload code artifacts', error)
+            throw error
+        } finally {
+            await zipUtil.removeTmpFiles(zipMetadata)
+            codeScanTelemetryEntry.artifactsUploadDuration = performance.now() - uploadStartTime
+        }
+
+        /**
+         * Step 3:  Create scan job
+         */
+        throwIfCancelled(scanType)
+        serviceInvocationStartTime = performance.now()
+        const scanJob = await createScanJob(client, artifactMap, codeScanTelemetryEntry.codewhispererLanguage)
+        if (scanJob.status === 'Failed') {
+            throw new Error(scanJob.errorMessage)
+        }
+        getLogger().verbose(`Created security scan job.`)
+        codeScanTelemetryEntry.codewhispererCodeScanJobId = scanJob.jobId
+
+        /**
+         * Step 4:  Polling mechanism on scan job status
+         */
+        throwIfCancelled(scanType)
+        const jobStatus = await pollScanJobStatus(client, scanJob.jobId, scanType)
+        if (jobStatus === 'Failed') {
+            throw new Error('Security scan job failed.')
+        }
+
+        /**
+         * Step 5: Process and render scan results
+         */
+        throwIfCancelled(scanType)
+        getLogger().verbose(`Security scan job succeeded and start processing result.`)
+        const securityRecommendationCollection = await listScanResults(
+            client,
+            scanJob.jobId,
+            CodeWhispererConstants.codeScanFindingsSchema,
+            projectPath
+        )
+        const { total, withFixes } = securityRecommendationCollection.reduce(
+            (accumulator, current) => ({
+                total: accumulator.total + current.issues.length,
+                withFixes: accumulator.withFixes + current.issues.filter(i => i.suggestedFixes.length > 0).length,
+            }),
+            { total: 0, withFixes: 0 }
+        )
+        codeScanTelemetryEntry.codewhispererCodeScanTotalIssues = total
+        codeScanTelemetryEntry.codewhispererCodeScanIssuesWithFixes = withFixes
+        throwIfCancelled(scanType)
+        getLogger().verbose(`Security scan totally found ${total} issues. ${withFixes} of them have fixes.`)
+        if (codeScanStartTime > securityScanRender.lastUpdated) {
+            showSecurityScanResults(
+                securityPanelViewProvider,
+                securityRecommendationCollection,
+                editor,
+                context,
+                scanType,
+                zipMetadata,
+                total,
+                codeScanStartTime
+            )
+        } else {
+            getLogger().verbose('Received issues from older scan, discarding the results')
+        }
+
+        getLogger().verbose(`Security scan completed.`)
+    } catch (error) {
+        getLogger().error('Security scan failed.', error)
+        if (codeScanState.isCancelling()) {
+            codeScanTelemetryEntry.result = 'Cancelled'
+        } else {
+            errorPromptHelper(error as Error)
+            codeScanTelemetryEntry.result = 'Failed'
+        }
+
+        if (isAwsError(error)) {
+            if (
+                error.code === 'ThrottlingException' &&
+                error.message.includes(CodeWhispererConstants.throttlingMessage)
+            ) {
+                void vscode.window.showErrorMessage(CodeWhispererConstants.freeTierLimitReachedCodeScan)
+                await vscode.commands.executeCommand('aws.codeWhisperer.refresh', true)
+            }
+        }
+        codeScanTelemetryEntry.reason = (error as Error).message
+    } finally {
+        codeScanState.setToNotStarted()
+        await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+        codeScanTelemetryEntry.duration = performance.now() - codeScanStartTime
+        codeScanTelemetryEntry.codeScanServiceInvocationsDuration = performance.now() - serviceInvocationStartTime
+        getLogger().verbose(`Security scan telemetry: ${JSON.stringify(codeScanTelemetryEntry)}`)
+        await emitCodeScanTelemetry(editor, codeScanTelemetryEntry)
+    }
+}
+
+export function showSecurityScanResults(
+    securityPanelViewProvider: SecurityPanelViewProvider,
+    securityRecommendationCollection: AggregatedCodeScanIssue[],
+    editor: vscode.TextEditor,
+    context: vscode.ExtensionContext,
+    scanType: CodeWhispererConstants.SecurityScanType,
+    zipMetadata: ZipMetadata,
+    totalIssues: number,
+    codeScanStartTime: number
+) {
+    if (isCloud9()) {
+        securityPanelViewProvider.addLines(securityRecommendationCollection, editor)
+        void vscode.commands.executeCommand('workbench.view.extension.aws-codewhisperer-security-panel')
+    } else {
+        initSecurityScanRender(securityRecommendationCollection, context, editor, codeScanStartTime)
+        if (scanType === CodeWhispererConstants.SecurityScanType.Project) {
+            void vscode.commands.executeCommand('workbench.action.problems.focus')
+        }
+    }
+    populateCodeScanLogStream(zipMetadata.scannedFiles)
+    if (scanType === CodeWhispererConstants.SecurityScanType.Project) {
+        showScanCompletedNotification(totalIssues, zipMetadata.scannedFiles, false)
+    }
+}
+
+// TODO: Remove this
+export async function startSecurityScanOld(
     securityPanelViewProvider: SecurityPanelViewProvider,
     editor: vscode.TextEditor,
     client: DefaultCodeWhispererClient,
@@ -94,7 +286,7 @@ export async function startSecurityScan(
         /**
          * Step 1: Generate context truncations
          */
-        throwIfCancelled()
+        throwIfCancelledOld()
         const dependencyGraph = DependencyGraphFactory.getDependencyGraph(editor)
         if (dependencyGraph === undefined) {
             throw new Error(`"${editor.document.languageId}" is not supported for security scan.`)
@@ -132,7 +324,7 @@ export async function startSecurityScan(
         /**
          * Step 2: Get presigned Url, upload and clean up
          */
-        throwIfCancelled()
+        throwIfCancelledOld()
         let artifactMap: ArtifactMap = {}
         const uploadStartTime = performance.now()
         try {
@@ -148,7 +340,7 @@ export async function startSecurityScan(
         /**
          * Step 3:  Create scan job
          */
-        throwIfCancelled()
+        throwIfCancelledOld()
         serviceInvocationStartTime = performance.now()
         const scanJob = await createScanJob(client, artifactMap, codeScanTelemetryEntry.codewhispererLanguage)
         if (scanJob.status === 'Failed') {
@@ -160,8 +352,8 @@ export async function startSecurityScan(
         /**
          * Step 4:  Polling mechanism on scan job status
          */
-        throwIfCancelled()
-        const jobStatus = await pollScanJobStatus(client, scanJob.jobId)
+        throwIfCancelledOld()
+        const jobStatus = await pollScanJobStatusOld(client, scanJob.jobId)
         if (jobStatus === 'Failed') {
             throw new Error('Security scan job failed.')
         }
@@ -169,7 +361,7 @@ export async function startSecurityScan(
         /**
          * Step 5: Process and render scan results
          */
-        throwIfCancelled()
+        throwIfCancelledOld()
         getLogger().verbose(`Security scan job succeeded and start processing result.`)
         const securityRecommendationCollection = await listScanResults(
             client,
@@ -186,13 +378,13 @@ export async function startSecurityScan(
         )
         codeScanTelemetryEntry.codewhispererCodeScanTotalIssues = total
         codeScanTelemetryEntry.codewhispererCodeScanIssuesWithFixes = withFixes
-        throwIfCancelled()
+        throwIfCancelledOld()
         getLogger().verbose(`Security scan totally found ${total} issues. ${withFixes} of them have fixes.`)
         if (isCloud9()) {
             securityPanelViewProvider.addLines(securityRecommendationCollection, editor)
             void vscode.commands.executeCommand('workbench.view.extension.aws-codewhisperer-security-panel')
         } else {
-            initSecurityScanRender(securityRecommendationCollection, context)
+            initSecurityScanRenderOld(securityRecommendationCollection, context)
             void vscode.commands.executeCommand('workbench.action.problems.focus')
         }
         populateCodeScanLogStream(truncation.scannedFiles)

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -219,6 +219,8 @@ export const codeScanTerraformPayloadSizeLimitBytes = 200 * Math.pow(2, 10) // 2
 
 export const codeScanJavascriptPayloadSizeLimitBytes = 200 * Math.pow(2, 10) // 200 KB
 
+export const fileScanPayloadSizeLimitBytes = 200 * Math.pow(2, 10) // 200 KB
+
 export const codeScanTruncDirPrefix = 'codewhisperer_scan'
 
 export const codeScanZipExt = '.zip'
@@ -234,6 +236,33 @@ export const codeScanJobPollingIntervalSeconds = 1
 export const artifactTypeSource = 'SourceCode'
 
 export const codeScanFindingsSchema = 'codescan/findings/1.0'
+
+export const autoScanDebounceDelaySeconds = 2
+
+export const codewhispererDiagnosticSourceLabel = 'CodeWhisperer '
+
+// use vscode languageId here / Supported languages
+export const securityScanLanguageIds = [
+    'java',
+    'python',
+    'javascript',
+    'typescript',
+    'csharp',
+    'go',
+    'ruby',
+    'golang', // Cloud9 reports Go files with this language-id
+    'json',
+    'yaml',
+    'tf',
+    'hcl',
+    'terraform',
+    'terragrunt',
+    'packer',
+    'plaintext',
+    'jsonc',
+] as const
+
+export type SecurityScanLanguageId = (typeof securityScanLanguageIds)[number]
 
 // wait time for editor to update editor.selection.active (in milliseconds)
 export const vsCodeCursorUpdateDelay = 10

--- a/packages/core/src/codewhisperer/util/securityScanLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/securityScanLanguageContext.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { CodewhispererLanguage } from '../../shared/telemetry/telemetry.gen'
+import { ConstantMap, createConstantMap } from '../../shared/utilities/tsUtils'
+import * as CodeWhispererConstants from '../models/constants'
+
+export class SecurityScanLanguageContext {
+    private supportedLanguageMap: ConstantMap<CodeWhispererConstants.SecurityScanLanguageId, CodewhispererLanguage>
+
+    constructor() {
+        this.supportedLanguageMap = createConstantMap<
+            CodeWhispererConstants.SecurityScanLanguageId,
+            CodewhispererLanguage
+        >({
+            java: 'java',
+            python: 'python',
+            javascript: 'javascript',
+            typescript: 'typescript',
+            csharp: 'csharp',
+            go: 'go',
+            golang: 'go',
+            ruby: 'ruby',
+            json: 'json',
+            jsonc: 'json',
+            yaml: 'yaml',
+            tf: 'tf',
+            hcl: 'tf',
+            terraform: 'tf',
+            terragrunt: 'tf',
+            packer: 'tf',
+            plaintext: 'plaintext',
+        })
+    }
+
+    public normalizeLanguage(languageId?: string): CodewhispererLanguage | undefined {
+        return this.supportedLanguageMap.get(languageId)
+    }
+
+    public isLanguageSupported(languageId: string): boolean {
+        const lang = this.normalizeLanguage(languageId)
+        return lang !== undefined
+    }
+}
+
+export const securityScanLanguageContext = new SecurityScanLanguageContext()

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -1,0 +1,129 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import admZip from 'adm-zip'
+import * as vscode from 'vscode'
+import path from 'path'
+import { tempDirPath } from '../../shared/filesystemUtilities'
+import { getLogger } from '../../shared/logger'
+import * as CodeWhispererConstants from '../models/constants'
+import { fsCommon } from '../../srcShared/fs'
+import { statSync } from 'fs'
+
+export interface ZipMetadata {
+    rootDir: string
+    zipFilePath: string
+    scannedFiles: Set<string>
+    srcPayloadSizeInBytes: number
+    buildPayloadSizeInBytes: number
+    zipFileSizeInBytes: number
+    lines: number
+}
+
+export const ZipConstants = {
+    newlineRegex: /\r?\n/,
+}
+
+export class ZipUtil {
+    protected _pickedSourceFiles: Set<string> = new Set<string>()
+    protected _totalSize: number = 0
+    protected _tmpDir: string = tempDirPath
+    protected _zipDir: string = ''
+    protected _totalLines: number = 0
+
+    constructor() {}
+
+    getFileScanPayloadSizeLimitInBytes(): number {
+        return CodeWhispererConstants.fileScanPayloadSizeLimitBytes
+    }
+
+    public getProjectName(uri: vscode.Uri) {
+        const projectPath = this.getProjectPath(uri)
+        return path.basename(projectPath)
+    }
+
+    public getProjectPath(uri: vscode.Uri) {
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
+        if (workspaceFolder === undefined) {
+            return this.getBaseDirPath(uri)
+        }
+        return workspaceFolder.uri.fsPath
+    }
+
+    protected getBaseDirPath(uri: vscode.Uri) {
+        return path.dirname(uri.fsPath)
+    }
+
+    protected async getTextContent(uri: vscode.Uri) {
+        const document = await vscode.workspace.openTextDocument(uri)
+        const content = document.getText()
+        return content
+    }
+
+    public reachSizeLimit(size: number): boolean {
+        return size > this.getFileScanPayloadSizeLimitInBytes()
+    }
+
+    protected async zipFile(uri: vscode.Uri) {
+        const zip = new admZip()
+
+        const projectName = this.getProjectName(uri)
+        const relativePath = vscode.workspace.asRelativePath(uri)
+
+        const content = await this.getTextContent(uri)
+
+        zip.addFile(path.join(projectName, relativePath), Buffer.from(content, 'utf-8'))
+
+        this._pickedSourceFiles.add(relativePath)
+        this._totalSize += statSync(uri.fsPath).size
+        this._totalLines += content.split(ZipConstants.newlineRegex).length
+
+        if (this.reachSizeLimit(this._totalSize)) {
+            getLogger().error(`Payload size limit reached.`)
+            throw new Error('Payload size limit reached.')
+        }
+
+        const zipFilePath = this.getZipDirPath() + CodeWhispererConstants.codeScanZipExt
+        zip.writeZip(zipFilePath)
+        return zipFilePath
+    }
+
+    protected getZipDirPath(): string {
+        if (this._zipDir === '') {
+            this._zipDir = path.join(
+                this._tmpDir,
+                CodeWhispererConstants.codeScanTruncDirPrefix + '_' + Date.now().toString()
+            )
+        }
+        return this._zipDir
+    }
+
+    public async generateZip(uri: vscode.Uri): Promise<ZipMetadata> {
+        try {
+            const zipDirPath = this.getZipDirPath()
+            const zipFilePath = await this.zipFile(uri)
+            getLogger().debug(`Picked source files: [${[...this._pickedSourceFiles].join(', ')}]`)
+            const zipFileSize = statSync(zipFilePath).size
+            return {
+                rootDir: zipDirPath,
+                zipFilePath: zipFilePath,
+                srcPayloadSizeInBytes: this._totalSize,
+                scannedFiles: new Set(this._pickedSourceFiles),
+                zipFileSizeInBytes: zipFileSize,
+                buildPayloadSizeInBytes: 0,
+                lines: this._totalLines,
+            }
+        } catch (error) {
+            getLogger().error('Zip error caused by:', error)
+            throw error
+        }
+    }
+
+    public async removeTmpFiles(zipMetadata: ZipMetadata) {
+        getLogger().verbose(`Cleaning up temporary files...`)
+        await fsCommon.delete(zipMetadata.zipFilePath)
+        await fsCommon.delete(zipMetadata.rootDir)
+        getLogger().verbose(`Complete cleaning up temporary files.`)
+    }
+}

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -49,7 +49,7 @@ import {
 } from '../../../codewhisperer/ui/codeWhispererNodes'
 import { waitUntil } from '../../../shared/utilities/timeoutUtils'
 import { listCodeWhispererCommands } from '../../../codewhisperer/ui/statusBarMenu'
-import { CodeSuggestionsState } from '../../../codewhisperer/models/model'
+import { CodeScansState, CodeSuggestionsState } from '../../../codewhisperer/models/model'
 import { cwQuickPickSource } from '../../../codewhisperer/commands/types'
 import { switchToAmazonQNode } from '../../../amazonq/explorer/amazonQChildrenNodes'
 
@@ -327,6 +327,7 @@ describe('CodeWhisperer-basicCommands', function () {
         it('shows expected quick pick items when connected', async function () {
             sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
             sinon.stub(AuthUtil.instance, 'isConnected').returns(true)
+            sinon.stub(CodeScansState.instance, 'isScansEnabled').returns(false)
             getTestWindow().onDidShowQuickPick(e => {
                 e.assertContainsItems(
                     createAutoSuggestions(false),
@@ -349,6 +350,7 @@ describe('CodeWhisperer-basicCommands', function () {
             sinon.stub(AuthUtil.instance, 'isConnected').returns(true)
             sinon.stub(AuthUtil.instance, 'isValidEnterpriseSsoInUse').returns(true)
             sinon.stub(AuthUtil.instance, 'isCustomizationFeatureEnabled').value(true)
+            sinon.stub(CodeScansState.instance, 'isScansEnabled').returns(false)
 
             getTestWindow().onDidShowQuickPick(async e => {
                 e.assertContainsItems(

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScanOld.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScanOld.test.ts
@@ -194,7 +194,7 @@ describe('startSecurityScanOld', function () {
 
     it('Should stop security scan', async function () {
         getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
-        const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
+        const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRenderOld')
         const securityScanStoppedErrorSpy = sinon.spy(model, 'CodeScanStoppedError')
         const testWindow = getTestWindow()
         testWindow.onDidShowMessage(message => {

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScanOld.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScanOld.test.ts
@@ -135,13 +135,11 @@ describe('startSecurityScanOld', function () {
         extensionContext = await FakeExtensionContext.create()
         mockSecurityPanelViewProvider = new SecurityPanelViewProvider(extensionContext)
         appRoot = join(workspaceFolder, 'python3.7-plain-sam-app')
-        appCodePath = join(appRoot, 'hello_world', 'app.py')
+        appCodePath = join(appRoot, 'hello_world/app.py')
         editor = await openTestFile(appCodePath)
     })
-    afterEach(function () {
+    afterEach(async function () {
         sinon.restore()
-    })
-    after(async function () {
         await closeAllEditors()
     })
     const createClient = () => {

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScanOld.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScanOld.test.ts
@@ -24,7 +24,6 @@ import {
     codeScanLogsOutputChannelId,
     showScannedFilesMessage,
     stopScanMessage,
-    SecurityScanType,
 } from '../../../codewhisperer/models/constants'
 import * as model from '../../../codewhisperer/models/model'
 import { CodewhispererSecurityScan } from '../../../shared/telemetry/telemetry.gen'
@@ -129,7 +128,7 @@ let appRoot: string
 let appCodePath: string
 let editor: vscode.TextEditor
 
-describe('startSecurityScan', function () {
+describe('startSecurityScanOld', function () {
     const workspaceFolder = getTestWorkspaceFolder()
 
     beforeEach(async function () {
@@ -162,17 +161,30 @@ describe('startSecurityScan', function () {
         })
     }
 
+    it('Should prompt warning message if language is not supported', async function () {
+        appRoot = join(workspaceFolder, 'go1-plain-sam-app')
+        appCodePath = join(appRoot, 'hello-world', 'main.go')
+        editor = await openTestFile(appCodePath)
+        await startSecurityScan.startSecurityScanOld(
+            mockSecurityPanelViewProvider,
+            editor,
+            stub(DefaultCodeWhispererClient),
+            extensionContext
+        )
+        const warnings = getTestWindow().shownMessages.filter(m => m.severity === SeverityLevel.Warning)
+        assert.strictEqual(warnings.length, 1)
+    })
+
     it('Should render security scan result', async function () {
         getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
         const commandSpy = sinon.spy(vscode.commands, 'executeCommand')
-        const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
+        const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRenderOld')
 
-        await startSecurityScan.startSecurityScan(
+        await startSecurityScan.startSecurityScanOld(
             mockSecurityPanelViewProvider,
             editor,
             createClient(),
-            extensionContext,
-            SecurityScanType.Project
+            extensionContext
         )
         assert.ok(commandSpy.calledWith('workbench.action.problems.focus'))
         assert.ok(securityScanRenderSpy.calledOnce)
@@ -180,26 +192,7 @@ describe('startSecurityScan', function () {
         assert.strictEqual(warnings.length, 0)
     })
 
-    it('Should not focus problems panel for file scans', async function () {
-        getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
-        const commandSpy = sinon.spy(vscode.commands, 'executeCommand')
-        const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
-
-        await model.CodeScansState.instance.setScansEnabled(true)
-        await startSecurityScan.startSecurityScan(
-            mockSecurityPanelViewProvider,
-            editor,
-            createClient(),
-            extensionContext,
-            SecurityScanType.File
-        )
-        assert.ok(commandSpy.neverCalledWith('workbench.action.problems.focus'))
-        assert.ok(securityScanRenderSpy.calledOnce)
-        const warnings = getTestWindow().shownMessages.filter(m => m.severity === SeverityLevel.Warning)
-        assert.strictEqual(warnings.length, 0)
-    })
-
-    it('Should stop security scan for project scans when confirmed', async function () {
+    it('Should stop security scan', async function () {
         getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
         const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
         const securityScanStoppedErrorSpy = sinon.spy(model, 'CodeScanStoppedError')
@@ -210,12 +203,11 @@ describe('startSecurityScan', function () {
             }
         })
         model.codeScanState.setToRunning()
-        const scanPromise = startSecurityScan.startSecurityScan(
+        const scanPromise = startSecurityScan.startSecurityScanOld(
             mockSecurityPanelViewProvider,
             editor,
             createClient(),
-            extensionContext,
-            SecurityScanType.Project
+            extensionContext
         )
         await startSecurityScan.confirmStopSecurityScan()
         await scanPromise
@@ -225,9 +217,9 @@ describe('startSecurityScan', function () {
         assert.ok(warnings.map(m => m.message).includes(stopScanMessage))
     })
 
-    it('Should not stop security scan for project scans when not confirmed', async function () {
+    it('Should not stop security scan when not confirmed', async function () {
         getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
-        const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
+        const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRenderOld')
         const securityScanStoppedErrorSpy = sinon.spy(model, 'CodeScanStoppedError')
         const testWindow = getTestWindow()
         testWindow.onDidShowMessage(message => {
@@ -236,12 +228,11 @@ describe('startSecurityScan', function () {
             }
         })
         model.codeScanState.setToRunning()
-        const scanPromise = startSecurityScan.startSecurityScan(
+        const scanPromise = startSecurityScan.startSecurityScanOld(
             mockSecurityPanelViewProvider,
             editor,
             createClient(),
-            extensionContext,
-            SecurityScanType.Project
+            extensionContext
         )
         await startSecurityScan.confirmStopSecurityScan()
         await scanPromise
@@ -249,27 +240,6 @@ describe('startSecurityScan', function () {
         assert.ok(securityScanStoppedErrorSpy.notCalled)
         const warnings = testWindow.shownMessages.filter(m => m.severity === SeverityLevel.Warning)
         assert.ok(warnings.map(m => m.message).includes(stopScanMessage))
-    })
-
-    it('Should stop security scan for file scans if setting is disabled', async function () {
-        getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
-        const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
-        const securityScanStoppedErrorSpy = sinon.spy(model, 'CodeScanStoppedError')
-        const testWindow = getTestWindow()
-        await model.CodeScansState.instance.setScansEnabled(true)
-        const scanPromise = startSecurityScan.startSecurityScan(
-            mockSecurityPanelViewProvider,
-            editor,
-            createClient(),
-            extensionContext,
-            SecurityScanType.File
-        )
-        await model.CodeScansState.instance.setScansEnabled(false)
-        await scanPromise
-        assert.ok(securityScanRenderSpy.notCalled)
-        assert.ok(securityScanStoppedErrorSpy.calledOnce)
-        const warnings = testWindow.shownMessages.filter(m => m.severity === SeverityLevel.Warning)
-        assert.ok(warnings.map(m => m.message).includes('Security scan failed. Error: Security scan stopped by user.'))
     })
 
     it('Should highlight files after scan is completed', async function () {
@@ -284,39 +254,18 @@ describe('startSecurityScan', function () {
                 message.selectItem(showScannedFilesMessage)
             }
         })
-        await startSecurityScan.startSecurityScan(
+        await startSecurityScan.startSecurityScanOld(
             mockSecurityPanelViewProvider,
             editor,
             createClient(),
-            extensionContext,
-            SecurityScanType.Project
+            extensionContext
         )
         assert.ok(commandSpy.calledWith(codeScanLogsOutputChannelId))
         assertTelemetry('codewhisperer_securityScan', {
             codewhispererLanguage: 'python',
             codewhispererCodeScanTotalIssues: 1,
             codewhispererCodeScanIssuesWithFixes: 0,
-            codewhispererCodeScanLines: 66,
+            codewhispererCodeScanLines: 188,
         } as CodewhispererSecurityScan)
-    })
-
-    it('Should not show security scan results if a later scan already finished', async function () {
-        getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
-        const commandSpy = sinon.spy(vscode.commands, 'executeCommand')
-        const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
-        diagnosticsProvider.securityScanRender.lastUpdated = Date.now() + 60
-
-        await model.CodeScansState.instance.setScansEnabled(true)
-        await startSecurityScan.startSecurityScan(
-            mockSecurityPanelViewProvider,
-            editor,
-            createClient(),
-            extensionContext,
-            SecurityScanType.File
-        )
-        assert.ok(commandSpy.neverCalledWith('workbench.action.problems.focus'))
-        assert.ok(securityScanRenderSpy.notCalled)
-        const warnings = getTestWindow().shownMessages.filter(m => m.severity === SeverityLevel.Warning)
-        assert.strictEqual(warnings.length, 0)
     })
 })

--- a/packages/core/src/test/codewhisperer/util/securityScanLanguageContext.test.ts
+++ b/packages/core/src/test/codewhisperer/util/securityScanLanguageContext.test.ts
@@ -1,0 +1,127 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { SecurityScanLanguageContext } from '../../../codewhisperer/util/securityScanLanguageContext'
+import { resetCodeWhispererGlobalVariables } from '../testUtil'
+import { CodewhispererLanguage } from '../../../shared/telemetry/telemetry.gen'
+import { SecurityScanLanguageId } from '../../../codewhisperer/models/constants'
+
+describe('securityScanLanguageContext', function () {
+    const languageContext = new SecurityScanLanguageContext()
+
+    describe('test isLanguageSupported', function () {
+        const cases: [string, boolean][] = [
+            ['java', true],
+            ['javascript', true],
+            ['typescript', true],
+            ['jsx', false],
+            ['javascriptreact', false],
+            ['typescriptreact', false],
+            ['tsx', false],
+            ['csharp', true],
+            ['python', true],
+            ['c', false],
+            ['cpp', false],
+            ['go', true],
+            ['kotlin', false],
+            ['php', false],
+            ['ruby', true],
+            ['rust', false],
+            ['scala', false],
+            ['shellscript', false],
+            ['sql', false],
+            ['json', true],
+            ['yaml', true],
+            ['tf', true],
+            ['plaintext', true],
+            ['html', false],
+            ['r', false],
+            ['vb', false],
+        ]
+
+        beforeEach(async function () {
+            await resetCodeWhispererGlobalVariables()
+        })
+
+        cases.forEach(tuple => {
+            const languageId = tuple[0]
+            const expected = tuple[1]
+
+            it(`should ${expected ? '' : 'not'} support ${languageId}`, function () {
+                const actual = languageContext.isLanguageSupported(languageId)
+                assert.strictEqual(actual, expected)
+            })
+        })
+    })
+
+    describe('normalizeLanguage', function () {
+        beforeEach(async function () {
+            await resetCodeWhispererGlobalVariables()
+        })
+
+        const codewhispererLanguageIds: CodewhispererLanguage[] = [
+            'java',
+            'python',
+            'javascript',
+            'typescript',
+            'csharp',
+            'go',
+            'ruby',
+            'json',
+            'yaml',
+            'tf',
+            'plaintext',
+        ]
+
+        for (const inputCwsprLanguageId of codewhispererLanguageIds) {
+            it(`should return itself if input language is codewhispererLanguageId - ${inputCwsprLanguageId}`, function () {
+                const actual = languageContext.normalizeLanguage(inputCwsprLanguageId)
+                assert.strictEqual(actual, inputCwsprLanguageId)
+            })
+        }
+
+        const securityScanLanguageIds: [SecurityScanLanguageId, CodewhispererLanguage][] = [
+            ['java', 'java'],
+            ['python', 'python'],
+            ['javascript', 'javascript'],
+            ['typescript', 'typescript'],
+            ['csharp', 'csharp'],
+            ['go', 'go'],
+            ['ruby', 'ruby'],
+            ['golang', 'go'],
+            ['json', 'json'],
+            ['yaml', 'yaml'],
+            ['tf', 'tf'],
+            ['hcl', 'tf'],
+            ['terraform', 'tf'],
+            ['terragrunt', 'tf'],
+            ['packer', 'tf'],
+            ['plaintext', 'plaintext'],
+            ['jsonc', 'json'],
+        ]
+
+        for (const [securityScanLanguageId, expectedCwsprLanguageId] of securityScanLanguageIds) {
+            it(`should return mapped codewhispererLanguageId ${expectedCwsprLanguageId} if input language is securityScanLanguageId - ${securityScanLanguageId}`, function () {
+                const actual = languageContext.normalizeLanguage(securityScanLanguageId)
+                assert.strictEqual(actual, expectedCwsprLanguageId)
+            })
+        }
+
+        const arbitraryIds: [string | undefined, CodewhispererLanguage | undefined][] = [
+            [undefined, undefined],
+            ['r', undefined],
+            ['fooo', undefined],
+            ['bar', undefined],
+        ]
+
+        for (const [arbitraryId, _] of arbitraryIds) {
+            it(`should return undefined if languageId is undefined or not neither is type of codewhispererLanguageId or securityScanLanguageId - ${arbitraryId}`, function () {
+                const actual = languageContext.normalizeLanguage(undefined)
+                assert.strictEqual(actual, undefined)
+            })
+        }
+    })
+})

--- a/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
+++ b/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
@@ -18,7 +18,7 @@ import { statSync } from 'fs'
 import {
     getPresignedUrlAndUpload,
     createScanJob,
-    pollScanJobStatus,
+    pollScanJobStatusOld,
     listScanResults,
 } from '../../codewhisperer/service/securityScanHandler'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
@@ -134,7 +134,7 @@ describe('CodeWhisperer security scan', async function () {
 
         //get job status and result
         const scanJob = await createScanJob(client, artifactMap, editor.document.languageId)
-        const jobStatus = await pollScanJobStatus(client, scanJob.jobId)
+        const jobStatus = await pollScanJobStatusOld(client, scanJob.jobId)
         const securityRecommendationCollection = await listScanResults(
             client,
             scanJob.jobId,
@@ -160,7 +160,7 @@ describe('CodeWhisperer security scan', async function () {
         const scanJob = await createScanJob(client, artifactMap, editor.document.languageId)
 
         //get job status and result
-        const jobStatus = await pollScanJobStatus(client, scanJob.jobId)
+        const jobStatus = await pollScanJobStatusOld(client, scanJob.jobId)
         const securityRecommendationCollection = await listScanResults(
             client,
             scanJob.jobId,


### PR DESCRIPTION
## Problem

Add support for auto scanning of the current active file.

## Solution

- Add `ZipUtil` helper to prepare current file's contents as a zip file (tweaked from `DependencyGraph` implementation)
- Update `startSecurityScan` to run a scan on the current active file
- Add new activation subscriptions for auto scanning:
  - when the extension first loads
  - when contents of the text editor changes
  - when the active text editor changes
  - when the auto scan toggle has been enabled
- Add new `isLanguageSupported` check for security scans

Todo next: Update the existing security scan trigger to scan the whole project without dependency graph logic

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
