### PR TITLE
fix(auth): network error may invalidate SSO token

### DIFF
--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -108,9 +108,9 @@ export class SsoAccessTokenProvider {
         }
     }
 
-    public async createToken(identityProvider?: (token: SsoToken) => Promise<string>): Promise<SsoToken> {
+    public async createToken(): Promise<SsoToken> {
         const access = await this.runFlow()
-        const identity = (await identityProvider?.(access.token)) ?? this.tokenCacheKey
+        const identity = this.tokenCacheKey
         await this.cache.token.save(identity, access)
         await setSessionCreationDate(this.tokenCacheKey, new Date())
 

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -527,7 +527,7 @@ export class PermissionsError extends ToolkitError {
     }
 }
 
-export function isNetworkError(err?: unknown) {
+export function isNetworkError(err?: unknown): err is Error & { code: string } {
     if (!hasCode(err)) {
         return false
     }

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -240,6 +240,19 @@ describe('Auth', function () {
             assert.strictEqual(actual.cause, expected)
             assert.strictEqual(auth.getConnectionState(conn), 'valid')
         })
+
+        it('connection is not invalidated when networking issue during connection refresh', async function () {
+            const networkError = new ToolkitError('test', { code: 'ETIMEDOUT' })
+            const expectedError = new ToolkitError('Failed to update connection due to networking issues', {
+                cause: networkError,
+            })
+            const conn = await auth.createConnection(ssoProfile)
+            auth.getTestTokenProvider(conn)?.getToken.rejects(networkError)
+            const actual = await auth.refreshConnectionState(conn).catch(e => e)
+            assert.ok(actual instanceof ToolkitError)
+            assert.deepStrictEqual(actual, expectedError)
+            assert.strictEqual(auth.getConnectionState(conn), 'valid')
+        })
     })
 
     describe('Linked Connections', function () {


### PR DESCRIPTION
## Problem:

In Auth we were having premature SSO connection expiration issues due to network problems such as no internet connection. If the extension attempted a token refresh, or the extension was started without internet connected, the existing auth token would be invalidated.

## Solution:

We had some code that validated the token, but if it failed
due to network issues it would invalidate it.

Now, when we validate the token and there is a network error,
we will keep the state as-is instead of setting the connection
to invalid.

The user will instead see an error message indicating network issues or a log message depending on the action
performed.

## Additional
Some renaming in the auth code to improve readability. See each commit for specifics.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
