### PR TITLE
ci: publish "amazonq" prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
                   npm run createRelease  # Generate CHANGELOG.md
                   cp ./README.quickstart.vscode.md ./README.md
                   npm run -w packages/toolkit package -- --feature "$FEAT_NAME"
+                  npm run -w packages/amazonq package -- --feature "$FEAT_NAME"
             - uses: actions/upload-artifact@v4
               with:
                   name: artifacts


### PR DESCRIPTION
## Blocked

This is blocked until we have a `feature/standalone` branch.

## Problem

prereleases don't include `amazon-q-vscode-*.vsix` artifacts.

## Solution

build amazonq in the prerelease workflow.

<img width="408" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/55561878/dc1754e4-c85c-4641-9e60-0029ec040c20">


previous: 69f30585dc03fb3161eef42a008536e18e58bed5

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
