### PR TITLE
feat(codewhisperer): Add back arrow at login start screen;move code catalyst login option

### DIFF
--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -114,5 +114,6 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
         throw new Error('Method not implemented.')
     }
 
+    /** If users are unauthenticated in Q/CW, we should always display the auth screen. */
     async quitLoginScreen() {}
 }

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -113,4 +113,6 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
     ): Promise<AuthError | undefined> {
         throw new Error('Method not implemented.')
     }
+
+    async quitLoginScreen() {}
 }

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -111,6 +111,8 @@ export abstract class CommonAuthWebview extends VueWebview {
 
     abstract errorNotification(e: AuthError): void
 
+    abstract quitLoginScreen(): Promise<void>
+
     async listConnections(): Promise<Connection[]> {
         return Auth.instance.listConnections()
     }

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -72,6 +72,14 @@
             </svg>
         </div>
         <template v-if="stage === 'START'">
+            <button class="back-button" v-if="app === 'TOOLKIT'" @click="handleBackButtonClick">
+                <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
+                        fill="#21A2FF"
+                    />
+                </svg>
+            </button>
             <div class="auth-container-section">
                 <div class="existing-logins" v-if="existingLogins.length > 0 && app === 'AMAZONQ'">
                     <div class="title">Connect with an existing account:</div>
@@ -132,6 +140,13 @@
                     />
                 </svg>
             </button>
+            <div class="code-catalyst-login" v-if="app === 'TOOLKIT'">
+                <div class="h4">
+                    Using CodeCatalyst with AWS Builder ID?
+                    <a href="#" @click="handleCodeCatalystSignin()">Skip to sign-in</a>
+                </div>
+                <br /><br />
+            </div>
             <div class="auth-container-section">
                 <div class="title">Sign in with SSO:</div>
                 <div class="p">Start URL</div>
@@ -184,12 +199,6 @@
             </button>
             <div class="title">IAM Credentials:</div>
             <div class="hint">Credentials will be added to the appropriate ~/.aws/ files</div>
-            <div class="h4">
-                Using CodeCatalyst with AWS Builder ID?
-                <a href="#" @click="handleCodeCatalystSignin()">Skip to sign-in</a>
-            </div>
-
-            <br /><br />
             <br /><br />
             <div class="p">Profile Name</div>
             <div class="hint">The identifier for these credentials</div>
@@ -299,7 +308,11 @@ export default defineComponent({
             }
         },
         handleBackButtonClick() {
-            this.stage = 'START'
+            if (this.stage === 'START') {
+                void client.quitLoginScreen()
+            } else {
+                this.stage = 'START'
+            }
         },
         async handleContinueClick() {
             if (this.stage === 'START') {
@@ -444,7 +457,7 @@ export default defineComponent({
     color: white;
 }
 .h4 {
-    font-size: 8px;
+    font-size: 10px;
 }
 .continue-button:disabled {
     background-color: #252526;

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -140,15 +140,15 @@
                     />
                 </svg>
             </button>
-            <div class="code-catalyst-login" v-if="app === 'TOOLKIT'">
-                <div class="h4">
-                    Using CodeCatalyst with AWS Builder ID?
-                    <a href="#" @click="handleCodeCatalystSignin()">Skip to sign-in</a>
-                </div>
-                <br /><br />
-            </div>
             <div class="auth-container-section">
                 <div class="title">Sign in with SSO:</div>
+                <div class="code-catalyst-login" v-if="app === 'TOOLKIT'">
+                    <div class="h4">
+                        Using CodeCatalyst with AWS Builder ID?
+                        <a href="#" @click="handleCodeCatalystSignin()">Skip to sign-in</a>
+                    </div>
+                    <br /><br />
+                </div>
                 <div class="p">Start URL</div>
                 <div class="hint">URL for your organization, provided by an admin or help desk</div>
                 <input

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -72,4 +72,8 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
     async useConnection(connectionId: string): Promise<AuthError | undefined> {
         return undefined
     }
+
+    async quitLoginScreen() {
+        await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', false)
+    }
 }


### PR DESCRIPTION
## Problem
This is a PR moved from https://github.com/hayemaxi/aws-toolkit-vscode/pull/7.

    1. User cannot easily quit the login screen
    2. Code catalyst login should be under Workforce button

## Solution

1 Add back arrow at login start screen ONLY for aws toolkit
<img width="544" alt="Screenshot 2024-03-25 at 2 45 16 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/97199248/4964a099-d795-4b80-8dd3-57e74ad95b1b">


2. Move code catalyst under Workforce button login screen
![image (2)](https://github.com/aws/aws-toolkit-vscode/assets/97199248/f5793d8e-82b0-48e4-a3f7-461e8335ebf2)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
