### PR TITLE
fix(q): debugging and build scripts for amazonq

### DIFF
--- a/packages/amazonq/.vscode/tasks.json
+++ b/packages/amazonq/.vscode/tasks.json
@@ -13,7 +13,7 @@
                 "kind": "build",
                 "isDefault": true
             },
-            "dependsOn": ["serve"]
+            "dependsOn": ["watchCore", "serve"]
         },
         {
             "label": "serve",
@@ -34,12 +34,43 @@
                     "beginsPattern": "Project is running at",
                     "endsPattern": "compiled"
                 }
+            },
+            "options": {
+                "env": {
+                    "NODE_OPTIONS": "--max_old_space_size=5120"
+                }
+            }
+        },
+        {
+            "label": "watchCore",
+            "command": "npm run compileLite -- --watch",
+            "type": "shell",
+            "isBackground": true,
+            "problemMatcher": {
+                "owner": "custom",
+                "pattern": {
+                    "regexp": ".",
+                    "file": 1,
+                    "location": 2,
+                    "message": 3
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "Starting compilation",
+                    "endsPattern": "Watching for file changes."
+                }
+            },
+            "options": {
+                "cwd": "../core"
             }
         },
         {
             "label": "terminate",
             "command": "echo run terminate",
-            "type": "shell"
+            "type": "shell",
+            "presentation": {
+                "close": true
+            }
         },
         {
             "type": "npm",

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -40,7 +40,7 @@
     "scripts": {
         "vscode:prepublish": "npm run clean && npm run buildScripts && webpack --mode production",
         "buildScripts": "npm run generateNonCodeFiles && npm run copyFiles",
-        "generateNonCodeFiles": "ts-node ./scripts/build/generateNonCodeFiles.ts",
+        "generateNonCodeFiles": "ts-node ../../scripts/generateNonCodeFiles.ts",
         "copyFiles": "ts-node ./scripts/build/copyFiles.ts",
         "clean": "ts-node ../../scripts/clean.ts dist/ LICENSE NOTICE quickStart* README* CHANGELOG.md",
         "compile": "npm run clean && npm run buildScripts && webpack --mode development",


### PR DESCRIPTION
- Same debugging support as toolkit (hot reloads)
- build passes now, fixing a bug with location of generateNonCodeFiles script

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
