### PR TITLE
fix(codewhisperer): line tracker stuck in an infinite loop while user's editor focus is on OUTPUT/LOGS and documentChangedListener will not stop

### DIFF
--- a/.changes/next-release/Bug Fix-492bca4b-aec1-414d-a719-275c854aa1d2.json
+++ b/.changes/next-release/Bug Fix-492bca4b-aec1-414d-a719-275c854aa1d2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: Infinite loop of logging if users' editor focus is on OUTPUT tab"
+}

--- a/packages/core/src/codewhisperer/tracker/lineTracker.ts
+++ b/packages/core/src/codewhisperer/tracker/lineTracker.ts
@@ -115,8 +115,9 @@ export class LineTracker implements vscode.Disposable {
 
     // @VisibleForTesting
     onContentChanged(e: vscode.TextDocumentChangeEvent) {
-        if (e.document === vscode.window.activeTextEditor?.document && e.contentChanges.length > 0) {
-            this._editor = vscode.window.activeTextEditor
+        const editor = vscode.window.activeTextEditor
+        if (e.document === editor?.document && e.contentChanges.length > 0 && isTextEditor(editor)) {
+            this._editor = editor
             this._selections = toLineSelections(this._editor?.selections)
 
             this.notifyLinesChanged('content')

--- a/packages/core/src/codewhisperer/views/activeStateController.ts
+++ b/packages/core/src/codewhisperer/views/activeStateController.ts
@@ -114,11 +114,6 @@ export class ActiveStateController implements vscode.Disposable {
     }, 1000)
 
     private async _refresh(editor: vscode.TextEditor | undefined, shouldDisplay?: boolean) {
-        if (!this.container.auth.isConnectionValid()) {
-            this.clear(this._editor)
-            return
-        }
-
         if (!editor && !this._editor) {
             return
         }
@@ -137,6 +132,11 @@ export class ActiveStateController implements vscode.Disposable {
 
         // Make sure the editor hasn't died since the await above and that we are still on the same line(s)
         if (!editor.document || !this.container.lineTracker.includes(selections)) {
+            return
+        }
+
+        if (!this.container.auth.isConnectionValid()) {
+            this.clear(this._editor)
             return
         }
 

--- a/packages/core/src/codewhisperer/views/lineAnnotationController.ts
+++ b/packages/core/src/codewhisperer/views/lineAnnotationController.ts
@@ -327,11 +327,6 @@ export class LineAnnotationController implements vscode.Disposable {
             return
         }
 
-        if (!this.container.auth.isConnectionValid()) {
-            this.clear()
-            return
-        }
-
         if (this.isTutorialDone()) {
             this.clear()
             return
@@ -356,6 +351,11 @@ export class LineAnnotationController implements vscode.Disposable {
 
         // Make sure the editor hasn't died since the await above and that we are still on the same line(s)
         if (editor.document === undefined || !this.container.lineTracker.includes(selections)) {
+            this.clear()
+            return
+        }
+
+        if (!this.container.auth.isConnectionValid()) {
             this.clear()
             return
         }


### PR DESCRIPTION
## Problem
`LineTracker` is subscribing `vscode.TextDocumentChangeEvent` and VSCode will also fire the above event when the plugin is adding new entry of logs. 
Therefore when user's focus is at log file, the following events will happen in order
1. VSCode `onContentChanged`
2. `LineTracker` emits events to update CWSPR UI components
3. `ActiveStateController.refresh()` & `LineAnnotationController.refresh()` 
4. `refresh()` invoke `isConnectionValid()`, which will add logs
5. back to step (1)


## Before

https://github.com/aws/aws-toolkit-vscode/assets/96078566/aa499070-1953-4126-9ab2-505bda778bcd



## After

https://github.com/aws/aws-toolkit-vscode/assets/96078566/b34f75c9-aafb-4556-9bc4-c40c64dc476f



## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
