### PR TITLE
fix(codewhisperer): fix tutorial state not persisted when user press esc to skip tutorial

### DIFF
--- a/.changes/next-release/Bug Fix-b37b002f-d988-4b1c-ab9c-7ab16d2291f5.json
+++ b/.changes/next-release/Bug Fix-b37b002f-d988-4b1c-ab9c-7ab16d2291f5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: Inline tutorial state not persisted when user press ESC to skip the tutorial"
+}

--- a/packages/core/src/codewhisperer/views/lineAnnotationController.ts
+++ b/packages/core/src/codewhisperer/views/lineAnnotationController.ts
@@ -262,8 +262,7 @@ export class LineAnnotationController implements vscode.Disposable {
                     try {
                         telemetry.ui_click.emit({ elementId: `dismiss_${this._currentState.id}` })
                     } catch (_) {}
-                    this._currentState = new EndState()
-                    await vscode.commands.executeCommand('setContext', inlinehintWipKey, false)
+                    await this.markTutorialDone()
                     getLogger().debug(`codewhisperer: user dismiss tutorial.`)
                 }
             })


### PR DESCRIPTION
## Problem
Missing `set(inlinehintKey, this._currentState.id, globals.context.globalState)` call


## Solution
Add `set(inlinehintKey, this._currentState.id, globals.context.globalState)` call

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
