### PR TITLE
fix(q): login state context simplification

### DIFF
--- a/packages/core/src/amazonq/auth/controller.ts
+++ b/packages/core/src/amazonq/auth/controller.ts
@@ -28,7 +28,7 @@ export class AuthController {
 
     private handleFullAuth() {
         void vscode.commands.executeCommand('setContext', 'aws.amazonq.showLoginView', true)
-        void vscode.commands.executeCommand('aws.AmazonQChatView.focus')
+        void vscode.commands.executeCommand('aws.amazonq.AmazonCommonAuth.focus')
     }
 
     private handleReAuth() {

--- a/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
+++ b/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
@@ -46,9 +46,10 @@ export const switchToAmazonQCommand = Commands.declare(
             })
             if (signIn) {
                 await vscode.commands.executeCommand('setContext', 'aws.amazonq.showLoginView', true)
+                await vscode.commands.executeCommand('aws.amazonq.AmazonCommonAuth.focus')
+            } else {
+                await vscode.commands.executeCommand('aws.AmazonQChatView.focus')
             }
-            await vscode.commands.executeCommand('aws.AmazonQChatView.focus')
-            await vscode.commands.executeCommand('aws.amazonq.AmazonCommonAuth.focus')
         }
 )
 

--- a/packages/core/src/auth/ui/vue/show.ts
+++ b/packages/core/src/auth/ui/vue/show.ts
@@ -718,7 +718,7 @@ export function getShowManageConnections(): RegisteredCommand<any> {
 export function registerCommands(context: vscode.ExtensionContext, prefix: string) {
     showManageConnections = Commands.register(
         { id: `aws.${prefix}.auth.manageConnections`, compositeKey: { 1: 'source' } },
-        (_: VsCodeCommandArg, source: AuthSource, serviceToShow?: ServiceItemId) => {
+        async (_: VsCodeCommandArg, source: AuthSource, serviceToShow?: ServiceItemId) => {
             if (_ !== placeholder) {
                 source = 'vscodeComponent'
             }
@@ -739,8 +739,8 @@ export function registerCommands(context: vscode.ExtensionContext, prefix: strin
 
             // TODO: hack
             if (prefix === 'toolkit') {
-                void vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', true)
-                void vscode.commands.executeCommand('aws.toolkit.AmazonCommonAuth.focus')
+                await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', true)
+                await vscode.commands.executeCommand('aws.toolkit.AmazonCommonAuth.focus')
             }
         }
     )

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -69,6 +69,8 @@ export async function activate(context: ExtContext): Promise<void> {
     const codewhispererSettings = CodeWhispererSettings.instance
     // initialize AuthUtil earlier to make sure it can listen to connection change events.
     const auth = AuthUtil.instance
+    auth.initCodeWhispererHooks()
+
     /**
      * Enable essential intellisense default settings for AWS C9 IDE
      */

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -31,6 +31,7 @@ import { getCodeCatalystDevEnvId } from '../../shared/vscode/env'
 import { Commands, placeholder } from '../../shared/vscode/commands2'
 import { GlobalState } from '../../shared/globalState'
 import { vsCodeState } from '../models/model'
+import { once } from '../../shared/utilities/functionUtils'
 
 /** Backwards compatibility for connections w pre-chat scopes */
 export const codeWhispererCoreScopes = [...scopesSsoAccountAccess, ...scopesCodeWhispererCore]
@@ -110,7 +111,9 @@ export class AuthUtil {
     )
     public readonly restore = () => this.secondaryAuth.restoreConnection()
 
-    public constructor(public readonly auth = Auth.instance) {
+    public constructor(public readonly auth = Auth.instance) {}
+
+    public initCodeWhispererHooks = once(() => {
         this.auth.onDidChangeConnectionState(async e => {
             getLogger().info(`codewhisperer: connection changed to ${e.state}: ${e.id}`)
             if (e.state !== 'authenticating') {
@@ -157,7 +160,7 @@ export class AuthUtil {
             }
             await this.setVscodeContextProps()
         })
-    }
+    })
 
     public async setVscodeContextProps() {
         if (!isCloud9()) {

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -76,7 +76,6 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
             try {
                 await awsIdSignIn()
                 await vscode.window.showInformationMessage('AmazonQ: Successfully connected to AWS Builder ID')
-                await vscode.commands.executeCommand('setContext', 'aws.amazonq.showLoginView', false)
             } finally {
                 this.notifyToolkit()
             }
@@ -89,7 +88,6 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                 await connectToEnterpriseSso(startUrl, region)
                 this.notifyToolkit()
                 void vscode.window.showInformationMessage('AmazonQ: Successfully connected to AWS IAM Identity Center')
-                await vscode.commands.executeCommand('setContext', 'aws.amazonq.showLoginView', false)
             } finally {
                 this.notifyToolkit()
             }


### PR DESCRIPTION
- Move auth hook intializations to a dedicated function in AuthUtil, so that both extensions don't attach the hooks.
- Remove extra instances of context setting for the login page.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
