### PR TITLE
test: fix failing insiders tests

### DIFF
--- a/packages/core/src/test/shared/ui/pickerPrompter.test.ts
+++ b/packages/core/src/test/shared/ui/pickerPrompter.test.ts
@@ -315,13 +315,13 @@ describe('FilterBoxQuickPickPrompter', function () {
     it('adds a new item based off the filter box', async function () {
         const input = '123'
 
-        picker.onDidShow(() => {
+        picker.onDidShow(async () => {
             picker.onDidChangeActive(items => {
                 if (items[0]?.description !== undefined) {
                     picker.acceptItem(items[0])
                 }
             })
-            void picker.setFilter(input)
+            await picker.setFilter(input)
         })
 
         assert.strictEqual(await loadAndPrompt(), Number(input))
@@ -337,7 +337,7 @@ describe('FilterBoxQuickPickPrompter', function () {
                 }
             })
 
-            void picker.setFilter(input)
+            await picker.setFilter(input)
 
             const newItems = [{ label: 'item4', data: 3 }]
             const newItemsPromise = Promise.resolve(newItems)
@@ -360,7 +360,7 @@ describe('FilterBoxQuickPickPrompter', function () {
             })
 
             testPrompter.recentItem = { data: customUserInput, description: input } as any
-            void picker.setFilter(input)
+            await picker.setFilter(input)
         })
 
         assert.strictEqual(await loadAndPrompt(), Number(input))
@@ -369,8 +369,8 @@ describe('FilterBoxQuickPickPrompter', function () {
     it('validates the custom input', async function () {
         const input = 'not a number'
 
-        picker.onDidShow(() => {
-            const disposable = picker.onDidChangeActive(items => {
+        picker.onDidShow(async () => {
+            const disposable = picker.onDidChangeActive(async items => {
                 const item = items[0]
                 if (
                     isNonNullable(item) &&
@@ -386,11 +386,11 @@ describe('FilterBoxQuickPickPrompter', function () {
                     })
                     picker.acceptItem(picker.items[0])
                     disposable.dispose()
-                    void picker.setFilter()
+                    await picker.setFilter()
                 }
             })
 
-            void picker.setFilter(input)
+            await picker.setFilter(input)
         })
 
         assert.strictEqual(await loadAndPrompt(), testItems[0].data)

--- a/packages/core/src/test/shared/vscode/quickInput.ts
+++ b/packages/core/src/test/shared/vscode/quickInput.ts
@@ -308,11 +308,6 @@ export class PickerTester<T extends vscode.QuickPickItem> {
     public async setFilter(value?: string | undefined): Promise<void> {
         this.picker.value = value ?? ''
 
-        // XXX: this event does not fire from the native VSC API on minver
-        if (vscode.version.startsWith('1.50')) {
-            this.triggers.onDidChangeValue.fire(this.picker.value)
-        }
-
         await whenAppliedFilter(this.picker)
     }
 }


### PR DESCRIPTION
## Problem:

The tests below this change, starting at `'can accept custom input as ...'` were failing for some reason due to a change in VS Code Insiders.

## Solution:
After commenting out the test `'can handle additional items ...'` the other tests started passing.

By adding `await` to picker.setFilter() in all uses everything now passes.

This is the original ticket that connects to the Insiders change which uncovered this race condition we had in our code: https://github.com/microsoft/vscode/issues/208715
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
