### PR TITLE
fix(codewhisperer): Enable CodeWhisperer on activation of AmazonQ

### DIFF
--- a/packages/amazonq/src/extensionShared.ts
+++ b/packages/amazonq/src/extensionShared.ts
@@ -5,7 +5,11 @@
 
 import * as vscode from 'vscode'
 import { join } from 'path'
-import { activate as activateCodeWhisperer, shutdown as codewhispererShutdown } from 'aws-core-vscode/codewhisperer'
+import {
+    CodeSuggestionsState,
+    activate as activateCodeWhisperer,
+    shutdown as codewhispererShutdown,
+} from 'aws-core-vscode/codewhisperer'
 import {
     ExtContext,
     initialize,
@@ -70,6 +74,9 @@ export async function activateShared(context: vscode.ExtensionContext) {
 
     // reload webviews
     await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction')
+
+    // enable auto suggestions on activation
+    await CodeSuggestionsState.instance.setSuggestionsEnabled(true)
 }
 
 export async function deactivateShared() {

--- a/packages/core/src/codewhisperer/index.ts
+++ b/packages/core/src/codewhisperer/index.ts
@@ -5,3 +5,4 @@
 
 export { activate, shutdown } from './activation'
 export { AuthUtil, getChatAuthState, AuthState } from './util/authUtil'
+export { CodeSuggestionsState } from './models/model'


### PR DESCRIPTION
## Problem
The Code Whisperer auto suggestion should be enabled by default in Amazon Q.


## Solution

Enable CodeWhisperer on activation of AmazonQ

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
