### PR TITLE
telemetry: aws_loginWithBrowser includes user polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3556,9 +3556,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.196",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.196.tgz",
-            "integrity": "sha512-DU2Jeyaw+1aowIJKXntKJUIiknUFbFFzDOCksTY5LhtTNhbyanYVi91rggVYDDadQEWht0Lf9VaYffbxec6rHw==",
+            "version": "1.0.199",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.199.tgz",
+            "integrity": "sha512-jZmNZr/3vgzr0SNnyMzuuXhQOWoRHc5MWJKnhUaDFfGrOdjDiJuNG2hZGZqPMHUvqbM3vpb5H0wvcXadbwwo2Q==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",

--- a/packages/core/src/auth/sso/model.ts
+++ b/packages/core/src/auth/sso/model.ts
@@ -11,7 +11,6 @@ const localize = nls.loadMessageBundle()
 import * as vscode from 'vscode'
 import * as localizedText from '../../shared/localizedText'
 import { getLogger } from '../../shared/logger/logger'
-import { telemetry } from '../../shared/telemetry/telemetry'
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { ssoAuthHelpUrl } from '../../shared/constants'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
@@ -111,6 +110,7 @@ export async function openSsoPortalLink(startUrl: string, authorization: Authori
             throw new ToolkitError(`User clicked 'Copy' or 'Cancel' during the Trusted Domain popup`, {
                 code: trustedDomainCancellation,
                 name: trustedDomainCancellation,
+                cancelled: true,
             })
         }
         return didOpenUrl
@@ -144,7 +144,7 @@ export async function openSsoPortalLink(startUrl: string, authorization: Authori
         }
     }
 
-    return telemetry.aws_loginWithBrowser.run(() => showLoginNotification())
+    return showLoginNotification()
 }
 
 // Most SSO 'expirables' are fairly long lived, so a one minute buffer is plenty.

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -8,7 +8,7 @@ import * as sinon from 'sinon'
 import { ToolkitError, isUserCancelledError } from '../../shared/errors'
 import { assertTreeItem } from '../shared/treeview/testUtil'
 import { getTestWindow } from '../shared/vscode/window'
-import { captureEventOnce } from '../testUtil'
+import { assertTelemetry, captureEventOnce } from '../testUtil'
 import { createBuilderIdProfile, createSsoProfile, createTestAuth } from './testUtil'
 import { toCollection } from '../../shared/utilities/asyncCollection'
 import globals from '../../shared/extensionGlobals'
@@ -252,6 +252,12 @@ describe('Auth', function () {
             assert.ok(actual instanceof ToolkitError)
             assert.deepStrictEqual(actual, expectedError)
             assert.strictEqual(auth.getConnectionState(conn), 'valid')
+        })
+
+        it('reauthentication is indicated in metric', async function () {
+            const conn = await auth.createInvalidSsoConnection(ssoProfile)
+            await auth.reauthenticate(conn)
+            assertTelemetry('aws_loginWithBrowser', { isReAuth: true })
         })
     })
 

--- a/packages/core/src/test/credentials/sso/model.test.ts
+++ b/packages/core/src/test/credentials/sso/model.test.ts
@@ -5,7 +5,6 @@
 
 import assert from 'assert'
 import { openSsoPortalLink, proceedToBrowser } from '../../../auth/sso/model'
-import { assertTelemetry } from '../../testUtil'
 import { getOpenExternalStub } from '../../globalSetup.test'
 import { getTestWindow } from '../../shared/vscode/window'
 
@@ -42,7 +41,6 @@ describe('openSsoPortalLink', function () {
         await runFlow('open')
         assert.ok(getOpenExternalStub().calledOnce)
         assert.strictEqual(getOpenExternalStub().args[0].toString(), `${verificationUri}?user_code%3D${userCode}`)
-        assertTelemetry('aws_loginWithBrowser', { result: 'Succeeded' })
     })
 
     it('continues to show the notification if the user selects help', async function () {
@@ -50,6 +48,5 @@ describe('openSsoPortalLink', function () {
         await runFlow('help', 'open')
         assert.ok(getOpenExternalStub().calledTwice)
         assert.notStrictEqual(getOpenExternalStub().args[0].toString(), getOpenExternalStub().args[1].toString())
-        assertTelemetry('aws_loginWithBrowser', { result: 'Succeeded' })
     })
 })

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import * as FakeTimers from '@sinonjs/fake-timers'
 import * as sinon from 'sinon'
 import { SsoAccessTokenProvider } from '../../../auth/sso/ssoAccessTokenProvider'
-import { installFakeClock } from '../../testUtil'
+import { assertTelemetry, installFakeClock } from '../../testUtil'
 import { getCache } from '../../../auth/sso/cache'
 
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../../shared/filesystemUtilities'
@@ -221,6 +221,7 @@ describe('SsoAccessTokenProvider', function () {
             const cachedToken = await cache.token.load(startUrl).then(a => a?.token)
             assert.deepStrictEqual(cachedToken, token)
             assert.deepStrictEqual(await cache.registration.load({ region }), registration)
+            assertTelemetry('aws_loginWithBrowser', { result: 'Succeeded', isReAuth: undefined })
         })
 
         it('always creates a new token, even if already cached', async function () {
@@ -258,6 +259,7 @@ describe('SsoAccessTokenProvider', function () {
             await clock.tickAsync(750)
             assert.ok(!progress.visible)
             await assert.rejects(resp, ToolkitError)
+            assertTelemetry('aws_loginWithBrowser', { result: 'Failed', isReAuth: undefined })
         })
 
         /**
@@ -326,6 +328,7 @@ describe('SsoAccessTokenProvider', function () {
 
                 await assert.rejects(sut.createToken(), exception)
                 assert.strictEqual(await cache.registration.load({ region }), undefined)
+                assertTelemetry('aws_loginWithBrowser', { result: 'Failed', isReAuth: undefined })
             })
 
             it('preserves the client registration cache on server faults', async function () {
@@ -350,6 +353,7 @@ describe('SsoAccessTokenProvider', function () {
             it('stops the flow if user does not click the link', async function () {
                 stubOpen(false)
                 await assert.rejects(sut.createToken(), ToolkitError)
+                assertTelemetry('aws_loginWithBrowser', { result: 'Cancelled', isReAuth: undefined })
             })
 
             it('saves the client registration even when cancelled', async function () {


### PR DESCRIPTION
## Problem:

Before, `aws_loginWithBrowser` metric only represented the opening of the browser window and not the part where users would login and confirm scopes. So if they failed somewhere in the browser, `aws_loginWithBrowser` would still result in `Succeeded`.

We did not have good insight in to the success of the part where we poll until the user completes the browser login.

## Solution:

Now, `aws_loginWithBrowser` will include the part where the user must login and accept scopes. Only once that is done do we emit Succeeded.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
