### PR TITLE
feat(amazonq): enable builder id auth for amazon q

### DIFF
--- a/.changes/next-release/Feature-51070f02-21b0-447b-9743-e7ce616337fe.json
+++ b/.changes/next-release/Feature-51070f02-21b0-447b-9743-e7ce616337fe.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Enable Amazon Q feature development and Amazon Q transform capabilities (/dev and /transform) for AWS Builder ID users."
+}

--- a/packages/core/src/amazonq/explorer/amazonQTreeNode.ts
+++ b/packages/core/src/amazonq/explorer/amazonQTreeNode.ts
@@ -9,7 +9,7 @@ import { ResourceTreeDataProvider, TreeNode } from '../../shared/treeview/resour
 import { AuthUtil, amazonQScopes, codeWhispererChatScopes } from '../../codewhisperer/util/authUtil'
 import { createLearnMoreNode, enableAmazonQNode, switchToAmazonQNode } from './amazonQChildrenNodes'
 import { Command, Commands } from '../../shared/vscode/commands2'
-import { hasScopes, isSsoConnection } from '../../auth/connection'
+import { hasScopes, isBuilderIdConnection, isSsoConnection } from '../../auth/connection'
 import { listCodeWhispererCommands } from '../../codewhisperer/ui/statusBarMenu'
 import { getIcon } from '../../shared/icons'
 import { vsCodeState } from '../../codewhisperer/models/model'
@@ -70,6 +70,16 @@ export class AmazonQNode implements TreeNode {
         if (isSsoConnection(AuthUtil.instance.conn)) {
             const missingScopes =
                 (AuthUtil.instance.isEnterpriseSsoInUse() && !hasScopes(AuthUtil.instance.conn, amazonQScopes)) ||
+                !hasScopes(AuthUtil.instance.conn, codeWhispererChatScopes)
+
+            if (missingScopes) {
+                return [enableAmazonQNode(), createLearnMoreNode()]
+            }
+        }
+
+        if (isBuilderIdConnection(AuthUtil.instance.conn)) {
+            const missingScopes =
+                (AuthUtil.instance.isBuilderIdInUse() && !hasScopes(AuthUtil.instance.conn, amazonQScopes)) ||
                 !hasScopes(AuthUtil.instance.conn, codeWhispererChatScopes)
 
             if (missingScopes) {

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -325,9 +325,6 @@ export const transformByQPartiallyCompletedMessage =
 export const noPomXmlFoundMessage =
     'None of your open Java projects are supported by Amazon Q Code Transformation. Currently, Amazon Q can only upgrade Java projects built on Maven. A pom.xml must be present in the root of your project to upgrade it. For more information, see the [Amazon Q documentation](LINK_HERE).'
 
-export const noActiveIdCMessage =
-    'Amazon Q Code Transformation requires an active IAM Identity Center connection. For more information, see the [Code Transformation documentation](LINK_HERE).'
-
 export const noOngoingJobMessage = 'No job is in-progress at the moment'
 
 export const jobInProgressMessage = 'Job is already in-progress'

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -328,11 +328,10 @@ export class AuthUtil {
             // Edge Case: With the addition of Amazon Q/Chat scopes we may need to add
             // the new scopes to existing pre-chat connections.
             if (addMissingScopes) {
-                if (isBuilderIdConnection(this.conn) && !isValidAmazonQConnection(this.conn)) {
-                    const conn = await this.secondaryAuth.addScopes(this.conn, codeWhispererChatScopes)
-                    await this.secondaryAuth.useNewConnection(conn)
-                    return
-                } else if (isIdcSsoConnection(this.conn) && !isValidAmazonQConnection(this.conn)) {
+                if (
+                    (isBuilderIdConnection(this.conn) || isIdcSsoConnection(this.conn)) &&
+                    !isValidAmazonQConnection(this.conn)
+                ) {
                     const conn = await this.secondaryAuth.addScopes(this.conn, amazonQScopes)
                     await this.secondaryAuth.useNewConnection(conn)
                     return
@@ -416,17 +415,7 @@ export async function getChatAuthState(cwAuth = AuthUtil.instance): Promise<Feat
         return state
     }
 
-    if (isBuilderIdConnection(currentConnection)) {
-        if (isValidCodeWhispererCoreConnection(currentConnection)) {
-            state[Features.codewhispererCore] = AuthStates.connected
-        }
-        if (isValidCodeWhispererChatConnection(currentConnection)) {
-            state[Features.codewhispererChat] = AuthStates.connected
-        }
-        if (isValidAmazonQConnection(currentConnection)) {
-            Object.values(Features).forEach(v => (state[v as Feature] = AuthStates.connected))
-        }
-    } else if (isIdcSsoConnection(currentConnection)) {
+    if (isBuilderIdConnection(currentConnection) || isIdcSsoConnection(currentConnection)) {
         if (isValidCodeWhispererCoreConnection(currentConnection)) {
             state[Features.codewhispererCore] = AuthStates.connected
         }

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -57,18 +57,13 @@ export const isValidCodeWhispererCoreConnection = (conn?: Connection): conn is C
         (isSsoConnection(conn) && hasScopes(conn, codeWhispererCoreScopes))
     )
 }
-/** For Builder ID only, if using IdC then use {@link isValidAmazonQConnection} */
-export const isValidCodeWhispererChatConnection = (conn?: Connection): conn is Connection => {
-    return (
-        isBuilderIdConnection(conn) &&
-        isValidCodeWhispererCoreConnection(conn) &&
-        hasScopes(conn, codeWhispererChatScopes)
-    )
-}
-
 /** Superset that includes all of CodeWhisperer + Amazon Q */
 export const isValidAmazonQConnection = (conn?: Connection): conn is Connection => {
-    return isSsoConnection(conn) && isValidCodeWhispererCoreConnection(conn) && hasScopes(conn, amazonQScopes)
+    return (
+        (isSsoConnection(conn) || isBuilderIdConnection(conn)) &&
+        isValidCodeWhispererCoreConnection(conn) &&
+        hasScopes(conn, amazonQScopes)
+    )
 }
 
 interface HasAlreadySeenQWelcome {
@@ -217,9 +212,9 @@ export class AuthUtil {
         let conn = (await this.auth.listConnections()).find(isBuilderIdConnection)
 
         if (!conn) {
-            conn = await this.auth.createConnection(createBuilderIdProfile(codeWhispererChatScopes))
-        } else if (!isValidCodeWhispererChatConnection(conn)) {
-            conn = await this.secondaryAuth.addScopes(conn, codeWhispererChatScopes)
+            conn = await this.auth.createConnection(createBuilderIdProfile(amazonQScopes))
+        } else if (!isValidAmazonQConnection(conn)) {
+            conn = await this.secondaryAuth.addScopes(conn, amazonQScopes)
         }
 
         if (this.auth.getConnectionState(conn) === 'invalid') {
@@ -333,7 +328,7 @@ export class AuthUtil {
             // Edge Case: With the addition of Amazon Q/Chat scopes we may need to add
             // the new scopes to existing pre-chat connections.
             if (addMissingScopes) {
-                if (isBuilderIdConnection(this.conn) && !isValidCodeWhispererChatConnection(this.conn)) {
+                if (isBuilderIdConnection(this.conn) && !isValidAmazonQConnection(this.conn)) {
                     const conn = await this.secondaryAuth.addScopes(this.conn, codeWhispererChatScopes)
                     await this.secondaryAuth.useNewConnection(conn)
                     return
@@ -392,7 +387,7 @@ export class AuthUtil {
     }
 
     public isValidCodeTransformationAuthUser(): boolean {
-        return this.isEnterpriseSsoInUse() && this.isConnectionValid()
+        return (this.isEnterpriseSsoInUse() || this.isBuilderIdInUse()) && this.isConnectionValid()
     }
 }
 
@@ -417,11 +412,6 @@ export async function getChatAuthState(cwAuth = AuthUtil.instance): Promise<Feat
     // default to expired to indicate reauth is needed if unmodified
     const state: FeatureAuthState = buildFeatureAuthState(AuthStates.expired)
 
-    if (isBuilderIdConnection(currentConnection)) {
-        // Regardless, if using Builder ID, Amazon Q is unsupported
-        state[Features.amazonQ] = AuthStates.unsupported
-    }
-
     if (cwAuth.isConnectionExpired()) {
         return state
     }
@@ -430,8 +420,11 @@ export async function getChatAuthState(cwAuth = AuthUtil.instance): Promise<Feat
         if (isValidCodeWhispererCoreConnection(currentConnection)) {
             state[Features.codewhispererCore] = AuthStates.connected
         }
-        if (isValidCodeWhispererChatConnection(currentConnection)) {
+        if (isValidAmazonQConnection(currentConnection)) {
             state[Features.codewhispererChat] = AuthStates.connected
+        }
+        if (isValidAmazonQConnection(currentConnection)) {
+            Object.values(Features).forEach(v => (state[v as Feature] = AuthStates.connected))
         }
     } else if (isIdcSsoConnection(currentConnection)) {
         if (isValidCodeWhispererCoreConnection(currentConnection)) {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -420,7 +420,7 @@ export async function getChatAuthState(cwAuth = AuthUtil.instance): Promise<Feat
         if (isValidCodeWhispererCoreConnection(currentConnection)) {
             state[Features.codewhispererCore] = AuthStates.connected
         }
-        if (isValidAmazonQConnection(currentConnection)) {
+        if (isValidCodeWhispererChatConnection(currentConnection)) {
             state[Features.codewhispererChat] = AuthStates.connected
         }
         if (isValidAmazonQConnection(currentConnection)) {

--- a/packages/core/src/test/codewhisperer/util/authUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/authUtil.test.ts
@@ -44,7 +44,7 @@ describe('AuthUtil', async function () {
         const conn = authUtil.conn
         assert.strictEqual(conn?.type, 'sso')
         assert.strictEqual(conn.label, 'AWS Builder ID')
-        assert.deepStrictEqual(conn.scopes, codeWhispererChatScopes)
+        assert.deepStrictEqual(conn.scopes, amazonQScopes)
     })
 
     it('if there IS an existing AwsBuilderID conn, it will upgrade the scopes and use it', async function () {
@@ -61,7 +61,7 @@ describe('AuthUtil', async function () {
         const conn = authUtil.conn
         assert.strictEqual(conn?.type, 'sso')
         assert.strictEqual(conn.id, existingBuilderId.id)
-        assert.deepStrictEqual(conn.scopes, codeWhispererChatScopes)
+        assert.deepStrictEqual(conn.scopes, amazonQScopes)
     })
 
     it('if there is no valid enterprise SSO conn, will create and use one', async function () {
@@ -222,7 +222,7 @@ describe('AuthUtil', async function () {
         assert.strictEqual(authUtil.conn?.id, upgradeableConn.id)
         assert.strictEqual(authUtil.conn.startUrl, upgradeableConn.startUrl)
         assert.strictEqual(authUtil.conn.ssoRegion, upgradeableConn.ssoRegion)
-        assert.deepStrictEqual(authUtil.conn.scopes, codeWhispererChatScopes)
+        assert.deepStrictEqual(authUtil.conn.scopes, amazonQScopes)
         assert.strictEqual((await auth.listConnections()).filter(isAnySsoConnection).length, 1)
     })
 
@@ -277,12 +277,12 @@ describe('getChatAuthState()', function () {
             assert.deepStrictEqual(result, {
                 codewhispererCore: AuthStates.connected,
                 codewhispererChat: AuthStates.expired,
-                amazonQ: AuthStates.unsupported,
+                amazonQ: AuthStates.expired,
             })
         })
 
         it('indicates all SUPPORTED features connected when all scopes are set', async function () {
-            const conn = await auth.createConnection(createBuilderIdProfile({ scopes: codeWhispererChatScopes }))
+            const conn = await auth.createConnection(createBuilderIdProfile({ scopes: amazonQScopes }))
             createToken(conn)
             await auth.useConnection(conn)
 
@@ -290,7 +290,7 @@ describe('getChatAuthState()', function () {
             assert.deepStrictEqual(result, {
                 codewhispererCore: AuthStates.connected,
                 codewhispererChat: AuthStates.connected,
-                amazonQ: AuthStates.unsupported,
+                amazonQ: AuthStates.connected,
             })
         })
 
@@ -304,7 +304,7 @@ describe('getChatAuthState()', function () {
             assert.deepStrictEqual(result, {
                 codewhispererCore: AuthStates.expired,
                 codewhispererChat: AuthStates.expired,
-                amazonQ: AuthStates.unsupported,
+                amazonQ: AuthStates.expired,
             })
         })
     })

--- a/packages/core/src/test/codewhisperer/util/authUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/authUtil.test.ts
@@ -155,7 +155,7 @@ describe('AuthUtil', async function () {
         assert.deepStrictEqual(authUtil.conn?.scopes, codeWhispererCoreScopes)
     })
 
-    it('reauthenticate adds missing CodeWhisperer Chat Builder ID scopes when explicitly required', async function () {
+    it('reauthenticate adds missing Builder ID scopes when explicitly required', async function () {
         const conn = await auth.createConnection(createBuilderIdProfile({ scopes: codeWhispererCoreScopes }))
         await auth.useConnection(conn)
 
@@ -163,7 +163,7 @@ describe('AuthUtil', async function () {
         await authUtil.reauthenticate(true)
 
         assert.strictEqual(authUtil.conn?.type, 'sso')
-        assert.deepStrictEqual(authUtil.conn?.scopes, codeWhispererChatScopes)
+        assert.deepStrictEqual(authUtil.conn?.scopes, amazonQScopes)
     })
 
     it('reauthenticate adds missing Amazon Q IdC scopes when explicitly required', async function () {

--- a/packages/core/src/testE2E/util/codewhispererUtil.ts
+++ b/packages/core/src/testE2E/util/codewhispererUtil.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isValidCodeWhispererChatConnection } from '../../codewhisperer/util/authUtil'
+import { isValidAmazonQConnection } from '../../codewhisperer/util/authUtil'
 import { Auth } from '../../auth/auth'
 
 /*
@@ -17,7 +17,7 @@ If user has an expired connection they must reauthenticate prior to running test
 */
 
 async function getValidConnection() {
-    return (await Auth.instance.listConnections()).find(isValidCodeWhispererChatConnection)
+    return (await Auth.instance.listConnections()).find(isValidAmazonQConnection)
 }
 
 //Returns true if a valid connection is found and set, false if not


### PR DESCRIPTION
# Do not merge this PR until the backend changes are done.

# Update: scheduled for release on Thursday 4/18

## Problem

We want to enable builder id authentication for amazon q. This will allow all Q features to use builder id, including gumby (code transform).

This change does not completely work yet as it is still missing the backend changes. The goal here is to just show the /dev and /transform commands in vscode when signed in with builder id and request the correct scopes.

## Solution

Add the amazon q scopes to the builder id connection and show /dev and other q chat commands.

<img width="1222" alt="Screenshot 2024-03-15 at 11 27 13" src="https://github.com/aws/aws-toolkit-vscode-staging/assets/157400220/a1e3def6-1a01-4213-a5fb-6165b87a2bcb">
<img width="1222" alt="Screenshot 2024-03-15 at 11 27 13" src="https://github.com/aws/aws-toolkit-vscode/assets/157400220/dcb8f2e3-51d8-406e-9d25-bff8288599f2">



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
