### PR TITLE
fix(codecatalyst): use code catalyst sso login in new login view

### DIFF
--- a/packages/core/src/auth/ui/vue/show.ts
+++ b/packages/core/src/auth/ui/vue/show.ts
@@ -739,6 +739,7 @@ export function registerCommands(context: vscode.ExtensionContext, prefix: strin
 
             // TODO: hack
             if (prefix === 'toolkit') {
+                await vscode.commands.executeCommand('aws.explorer.setLoginService', serviceToShow)
                 await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', true)
                 await vscode.commands.executeCommand('aws.toolkit.AmazonCommonAuth.focus')
             }

--- a/packages/core/src/awsexplorer/activation.ts
+++ b/packages/core/src/awsexplorer/activation.ts
@@ -129,6 +129,7 @@ export async function activate(args: {
                 retainContextWhenHidden: true,
             },
         }),
+        // Hacky way for a webview to call setLoginService().
         vscode.commands.registerCommand('aws.explorer.setLoginService', (serviceToShow?: string) => {
             if (toolkitAuthProvider.webView && 'setLoginService' in toolkitAuthProvider.webView.server) {
                 toolkitAuthProvider.webView.server.setLoginService(serviceToShow)

--- a/packages/core/src/awsexplorer/activation.ts
+++ b/packages/core/src/awsexplorer/activation.ts
@@ -30,6 +30,7 @@ import { S3FolderNode } from '../s3/explorer/s3FolderNode'
 import { amazonQNode, refreshAmazonQ, refreshAmazonQRootNode } from '../amazonq/explorer/amazonQTreeNode'
 import { GlobalState } from '../shared/globalState'
 import { activateViewsShared, registerToolView } from './activationShared'
+import { CommonAuthViewProvider } from '../login/webview'
 
 /**
  * Activates the AWS Explorer UI and related functionality.
@@ -120,6 +121,20 @@ export async function activate(args: {
     for (const viewNode of viewNodes) {
         registerToolView(viewNode, args.context.extensionContext)
     }
+
+    const toolkitAuthProvider = new CommonAuthViewProvider(args.context.extensionContext, 'toolkit')
+    args.context.extensionContext.subscriptions.push(
+        vscode.window.registerWebviewViewProvider(toolkitAuthProvider.viewType, toolkitAuthProvider, {
+            webviewOptions: {
+                retainContextWhenHidden: true,
+            },
+        }),
+        vscode.commands.registerCommand('aws.explorer.setLoginService', (serviceToShow?: string) => {
+            if (toolkitAuthProvider.webView && 'setLoginService' in toolkitAuthProvider.webView.server) {
+                toolkitAuthProvider.webView.server.setLoginService(serviceToShow)
+            }
+        })
+    )
 }
 
 async function registerAwsExplorerCommands(

--- a/packages/core/src/dev/activation.ts
+++ b/packages/core/src/dev/activation.ts
@@ -21,7 +21,6 @@ import { isReleaseVersion } from '../shared/vscode/env'
 import { isAnySsoConnection } from '../auth/connection'
 import { Auth } from '../auth/auth'
 import { getLogger } from '../shared/logger'
-import { CommonAuthViewProvider } from '../login/webview/commonAuthViewProvider'
 
 interface MenuOption {
     readonly label: string
@@ -153,20 +152,6 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     if (!isCloud9() && !isReleaseVersion() && config.betaUrl) {
         ctx.subscriptions.push(watchBetaVSIX(config.betaUrl))
     }
-
-    const toolkitAuthProvider = new CommonAuthViewProvider(ctx, 'toolkit')
-    ctx.subscriptions.push(
-        vscode.window.registerWebviewViewProvider(toolkitAuthProvider.viewType, toolkitAuthProvider, {
-            webviewOptions: {
-                retainContextWhenHidden: true,
-            },
-        }),
-        vscode.commands.registerCommand('aws.explorer.setLoginService', (serviceToShow?: string) => {
-            if (toolkitAuthProvider.webView && 'setLoginService' in toolkitAuthProvider.webView.server) {
-                toolkitAuthProvider.webView.server.setLoginService(serviceToShow)
-            }
-        })
-    )
 }
 
 async function openMenu(ctx: vscode.ExtensionContext, options: typeof menuOptions): Promise<void> {

--- a/packages/core/src/dev/activation.ts
+++ b/packages/core/src/dev/activation.ts
@@ -160,6 +160,11 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
             webviewOptions: {
                 retainContextWhenHidden: true,
             },
+        }),
+        vscode.commands.registerCommand('aws.explorer.setLoginService', (serviceToShow?: string) => {
+            if (toolkitAuthProvider.webView && 'setLoginService' in toolkitAuthProvider.webView.server) {
+                toolkitAuthProvider.webView.server.setLoginService(serviceToShow)
+            }
         })
     )
 }

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -14,22 +14,18 @@ import { CodeCatalystAuthenticationProvider } from '../../../../codecatalyst/aut
 export class ToolkitLoginWebview extends CommonAuthWebview {
     public override id: string = 'aws.toolkit.AmazonCommonAuth'
     public static sourcePath: string = 'vue/src/login/webview/vue/toolkit/index.js'
-    private isCodeCatalystEnterpriseLogin = false
+    private isCodeCatalystLogin = false
 
     constructor(private readonly codeCatalystAuth: CodeCatalystAuthenticationProvider) {
         super(ToolkitLoginWebview.sourcePath)
     }
 
     setLoginService(serviceToShow?: string) {
-        if (serviceToShow === 'codecatalyst') {
-            this.isCodeCatalystEnterpriseLogin = true
-        } else {
-            this.isCodeCatalystEnterpriseLogin = false
-        }
+        this.isCodeCatalystLogin = serviceToShow === 'codecatalyst'
     }
 
     async startEnterpriseSetup(startUrl: string, region: string): Promise<AuthError | undefined> {
-        if (this.isCodeCatalystEnterpriseLogin) {
+        if (this.isCodeCatalystLogin) {
             return this.ssoSetup('startCodeCatalystSSOSetup', async () => {
                 await this.codeCatalystAuth.connectToEnterpriseSso(startUrl, region)
                 await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', false)

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -14,12 +14,28 @@ import { CodeCatalystAuthenticationProvider } from '../../../../codecatalyst/aut
 export class ToolkitLoginWebview extends CommonAuthWebview {
     public override id: string = 'aws.toolkit.AmazonCommonAuth'
     public static sourcePath: string = 'vue/src/login/webview/vue/toolkit/index.js'
+    private isCodeCatalystEnterpriseLogin = false
 
     constructor(private readonly codeCatalystAuth: CodeCatalystAuthenticationProvider) {
         super(ToolkitLoginWebview.sourcePath)
     }
 
+    setLoginService(serviceToShow?: string) {
+        if (serviceToShow === 'codecatalyst') {
+            this.isCodeCatalystEnterpriseLogin = true
+        } else {
+            this.isCodeCatalystEnterpriseLogin = false
+        }
+    }
+
     async startEnterpriseSetup(startUrl: string, region: string): Promise<AuthError | undefined> {
+        if (this.isCodeCatalystEnterpriseLogin) {
+            return this.ssoSetup('startCodeCatalystSSOSetup', async () => {
+                await this.codeCatalystAuth.connectToEnterpriseSso(startUrl, region)
+                await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', false)
+                await this.showResourceExplorer()
+            })
+        }
         return this.ssoSetup('createIdentityCenterConnection', async () => {
             const ssoProfile = createSsoProfile(startUrl, region)
             const conn = await Auth.instance.createConnection(ssoProfile)


### PR DESCRIPTION
## Problem

When signing in to Code Catalyst using IdC, Code Catalyst scope is missing.

## Solution

Add  Code Catalyst  scope by invoking
`await this.codeCatalystAuth.connectToEnterpriseSso(startUrl, region)`


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
