### PR TITLE
fix(cwspr): properly handle deletion from toolkit to q

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -946,18 +946,13 @@ export class Auth implements AuthService, ConnectionManager {
 
     // Used by Amazon Q to delete connection status & scope when this deletion is made by AWS Toolkit
     // NO event should be emitted from this deletion
-    public async deletionConnectionCallback(id: string) {
+    // Do not actually perform the delete because toolkit has done the deletion
+    // Delete the momento states only.
+    public async onDeleteConnection(id: string) {
         const profile = this.store.getProfile(id)
-        // it is possible the connection was already deleted
-        // but was still requested to be deleted. We pretend
-        // we deleted it and continue as normal
         if (profile) {
-            if (id === this.#activeConnection?.id) {
-                await this.store.setCurrentProfileId(undefined)
-            } else {
-                await this.invalidateConnection(id)
-            }
             await this.store.deleteProfile(id)
+            await this.store.setCurrentProfileId(undefined)
         }
     }
 }

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -929,7 +929,7 @@ export class Auth implements AuthService, ConnectionManager {
 
     // Used by Amazon Q to update connection status & scope when this connection is updated by AWS Toolkit
     // do not create connection in Q for each change event from Toolkit
-    public async updateConnectionCallback(connection: AwsConnection) {
+    public async onConnectionUpdate(connection: AwsConnection) {
         const conn = await this.getConnection({ id: connection.id })
         if (conn) {
             const profile = {

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -953,17 +953,11 @@ export class Auth implements AuthService, ConnectionManager {
         // we deleted it and continue as normal
         if (profile) {
             if (id === this.#activeConnection?.id) {
-                // Server-side invalidation.
-                await this.logout()
+                await this.store.setCurrentProfileId(undefined)
             } else {
                 await this.invalidateConnection(id)
             }
             await this.store.deleteProfile(id)
-            if (profile.type === 'sso') {
-                // There may have been linked IAM credentials attached to this
-                // so we will want to clear them.
-                await this.clearStaleLinkedIamConnections()
-            }
         }
     }
 }

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -276,11 +276,13 @@ export class SecondaryAuth<T extends Connection = Connection> {
     }
 
     // Used by Amazon Q to delete connection status & scope when this deletion is made by AWS Toolkit
-    // NO event should be emitted from this deletion
+    // NO event should be emitted from this deletion to avoid infinite loop
     public async deletionConnectionCallback(id: string) {
         await this.auth.deletionConnectionCallback(id)
-        await this.memento.update(this.key, undefined)
-        this.#savedConnection = undefined
-        this.#activeConnection = undefined
+        if (id === this.#activeConnection?.id) {
+            await this.memento.update(this.key, undefined)
+            this.#savedConnection = undefined
+            this.#activeConnection = undefined
+        }
     }
 }

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -274,4 +274,13 @@ export class SecondaryAuth<T extends Connection = Connection> {
             return conn
         }
     }
+
+    // Used by Amazon Q to delete connection status & scope when this deletion is made by AWS Toolkit
+    // NO event should be emitted from this deletion
+    public async deletionConnectionCallback(id: string) {
+        await this.auth.deletionConnectionCallback(id)
+        await this.memento.update(this.key, undefined)
+        this.#savedConnection = undefined
+        this.#activeConnection = undefined
+    }
 }

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -277,9 +277,9 @@ export class SecondaryAuth<T extends Connection = Connection> {
 
     // Used by Amazon Q to delete connection status & scope when this deletion is made by AWS Toolkit
     // NO event should be emitted from this deletion to avoid infinite loop
-    public async deletionConnectionCallback(id: string) {
-        await this.auth.deletionConnectionCallback(id)
-        if (id === this.#activeConnection?.id) {
+    public async onDeleteConnection(id: string) {
+        await this.auth.onDeleteConnection(id)
+        if (id === this.activeConnection?.id) {
             await this.memento.update(this.key, undefined)
             this.#savedConnection = undefined
             this.#activeConnection = undefined

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -370,7 +370,7 @@ const registerToolkitApiCallbackOnce = once(async () => {
         _toolkitApi.onDidChangeConnection(
             async (connection: AwsConnection) => {
                 getLogger().info(`toolkitApi: connection change callback ${connection.id}`)
-                await auth.updateConnectionCallback(connection)
+                await AuthUtil.instance.updateConnectionCallback(connection)
             },
 
             async (id: string) => {

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -370,12 +370,12 @@ const registerToolkitApiCallbackOnce = once(async () => {
         _toolkitApi.onDidChangeConnection(
             async (connection: AwsConnection) => {
                 getLogger().info(`toolkitApi: connection change callback ${connection.id}`)
-                await AuthUtil.instance.updateConnectionCallback(connection)
+                await AuthUtil.instance.onUpdateConnection(connection)
             },
 
             async (id: string) => {
                 getLogger().info(`toolkitApi: connection delete callback ${id}`)
-                await AuthUtil.instance.deletionConnectionCallback(id)
+                await AuthUtil.instance.onDeleteConnection(id)
             }
         )
     }

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -375,7 +375,7 @@ const registerToolkitApiCallbackOnce = once(async () => {
 
             async (id: string) => {
                 getLogger().info(`toolkitApi: connection delete callback ${id}`)
-                await auth.deletionConnectionCallback(id)
+                await AuthUtil.instance.deletionConnectionCallback(id)
             }
         )
     }

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -179,7 +179,7 @@ export class AuthUtil {
      ** 2. Should update the context key to update UX
      */
     public async deletionConnectionCallback(id: string) {
-        await this.secondaryAuth.deletionConnectionCallback(id)
+        await this.secondaryAuth.onDeleteConnection(id)
         await this.setVscodeContextProps()
         await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
     }

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -25,6 +25,7 @@ import {
     scopesFeatureDev,
     scopesGumby,
     isIdcSsoConnection,
+    AwsConnection,
 } from '../../auth/connection'
 import { getLogger } from '../../shared/logger'
 import { getCodeCatalystDevEnvId } from '../../shared/vscode/env'
@@ -180,6 +181,16 @@ export class AuthUtil {
      */
     public async deletionConnectionCallback(id: string) {
         await this.secondaryAuth.onDeleteConnection(id)
+        await this.setVscodeContextProps()
+        await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
+    }
+
+    /* Callback used by Amazon Q to delete connection status & scope when this deletion is made by AWS Toolkit
+     ** 1. NO event should be emitted from this deletion
+     ** 2. Should update the context key to update UX
+     */
+    public async updateConnectionCallback(connection: AwsConnection) {
+        await this.auth.onConnectionUpdate(connection)
         await this.setVscodeContextProps()
         await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
     }

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -181,6 +181,7 @@ export class AuthUtil {
     public async deletionConnectionCallback(id: string) {
         await this.secondaryAuth.deletionConnectionCallback(id)
         await this.setVscodeContextProps()
+        await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
     }
 
     public reformatStartUrl(startUrl: string | undefined) {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -174,6 +174,15 @@ export class AuthUtil {
         }
     }
 
+    /* Callback used by Amazon Q to delete connection status & scope when this deletion is made by AWS Toolkit
+     ** 1. NO event should be emitted from this deletion
+     ** 2. Should update the context key to update UX
+     */
+    public async deletionConnectionCallback(id: string) {
+        await this.secondaryAuth.deletionConnectionCallback(id)
+        await this.setVscodeContextProps()
+    }
+
     public reformatStartUrl(startUrl: string | undefined) {
         return !startUrl ? undefined : startUrl.replace(/[\/#]+$/g, '')
     }

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -179,7 +179,7 @@ export class AuthUtil {
      ** 1. NO event should be emitted from this deletion
      ** 2. Should update the context key to update UX
      */
-    public async deletionConnectionCallback(id: string) {
+    public async onDeleteConnection(id: string) {
         await this.secondaryAuth.onDeleteConnection(id)
         await this.setVscodeContextProps()
         await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
@@ -189,7 +189,7 @@ export class AuthUtil {
      ** 1. NO event should be emitted from this deletion
      ** 2. Should update the context key to update UX
      */
-    public async updateConnectionCallback(connection: AwsConnection) {
+    public async onUpdateConnection(connection: AwsConnection) {
         await this.auth.onConnectionUpdate(connection)
         await this.setVscodeContextProps()
         await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')


### PR DESCRIPTION
## Problem

Deletion events from Toolkit to Amazon Q does not refresh Amazon Q UX.

## Solution

Let deletion events from Toolkit to Amazon Q refresh Amazon Q UX.

When Toolkit delete a connection, if that connection also exists in Q, then Q only removes this connection from momento DB and active connection state.  Q do not perform logout API call. Q also updates login UX and status bar.

If that connection is not in Q, do nothing. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
