### PR TITLE
fix(standalone): Fix cancellation not working as expected when cancel from adding scope flow

### DIFF
--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -131,6 +131,4 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
 
     /** If users are unauthenticated in Q/CW, we should always display the auth screen. */
     async quitLoginScreen() {}
-
-    async refreshToolkit() {}
 }

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -37,7 +37,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
     }
 
     async useConnection(connectionId: string): Promise<AuthError | undefined> {
-        return this.ssoSetup('updateConnectionScope', async () => {
+        return this.ssoSetup('useConnection', async () => {
             if (!isExtensionInstalled(VSCODE_EXTENSION_ID.awstoolkit)) {
                 return
             }
@@ -117,4 +117,6 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
 
     /** If users are unauthenticated in Q/CW, we should always display the auth screen. */
     async quitLoginScreen() {}
+
+    async refreshToolkit() {}
 }

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -60,7 +60,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                                 // when re-using a connection from toolkit, if adding scope is necessary
                                 // temporarily create a new connection without triggerring any connection hooks
                                 // then try reauthenticate, if success, use this connection, toolkit connnection scope also gets updated.
-                                // if failed, remove this temporary connection. Toolkit connection stays the same without getting logged out.
+                                // if failed, connection is set to invalid
                                 const oldScopes = conn?.scopes ? conn.scopes : []
                                 const newScopes = Array.from(new Set([...oldScopes, ...amazonQScopes]))
                                 const newConn = await Auth.instance.createConnectionFromApi({

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -328,6 +328,7 @@ export default defineComponent({
                 } else if (this.selectedLoginOption === LoginOption.ENTERPRISE_SSO) {
                     this.stage = 'SSO_FORM'
                 } else if (this.selectedLoginOption >= LoginOption.EXISTING_LOGINS) {
+                    this.stage = 'AUTHENTICATING'
                     const selectedConnection =
                         this.existingLogins[this.selectedLoginOption - LoginOption.EXISTING_LOGINS]
                     const error = await client.useConnection(selectedConnection.connectionId)


### PR DESCRIPTION
## Problem

See #9 in the doc. 

> Be signed out of QSign into SSO in ToolkitUse existing connection to sign into Q, which should trigger a new auth to add the Q scopesCancel the login attemptQ is now unauthenticated, but we see the chat window AND the status bar menu says we are logged in if we open it


## Solution

Do not use the addScopes API which has many race conditions & edge cases because it update connection states, which triggers API to change toolkit states..

Instead use reauthenticate API. Also fix the await issue in forEach() loop. Previously, the forEach(async() => ) is not awaited.

https://github.com/aws/aws-toolkit-vscode/assets/97199248/5965acc6-6162-428a-a68d-7ce42f7f9b80





<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
