### PR TITLE
fix(CodeCatalyst): remove redundant bearer token header

### DIFF
--- a/packages/core/src/shared/clients/codecatalystClient.ts
+++ b/packages/core/src/shared/clients/codecatalystClient.ts
@@ -231,7 +231,6 @@ class CodeCatalystClientInternal {
     private async call<T>(req: AWS.Request<T, AWS.AWSError>, silent: boolean, defaultVal?: T): Promise<T> {
         const log = this.log
         const bearerToken = (await this.connection.getToken()).accessToken
-        req.httpRequest.headers['Authorization'] = `Bearer ${bearerToken}`
         const perflog = new PerfLog('API request')
 
         return new Promise<T>((resolve, reject) => {


### PR DESCRIPTION
## Problem
aws-sdk automatically adds the bearer token to requests during the signing process. The CodeCatalystClientInternal `call()` function manually adds the bearer token to the header which is unnecessary and may cause confusion.

## Solution
Remove the header assignment

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
