### PR TITLE
fix(codewhisperer): Add CodeRemediationEvent for SecurityScan

### DIFF
--- a/packages/core/src/codewhisperer/client/user-service-2.json
+++ b/packages/core/src/codewhisperer/client/user-service-2.json
@@ -456,6 +456,46 @@
             "max": 128,
             "min": 1
         },
+        "CodeScanRemediationsEvent": {
+            "type": "structure",
+            "members": {
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                },
+                "CodeScanRemediationsEventType": {
+                    "shape": "CodeScanRemediationsEventType"
+                },
+                "timestamp": {
+                    "shape": "Timestamp"
+                },
+                "detectorId": {
+                    "shape": "String"
+                },
+                "findingId": {
+                    "shape": "String"
+                },
+                "ruleId": {
+                    "shape": "String"
+                },
+                "component": {
+                    "shape": "String"
+                },
+                "reason": {
+                    "shape": "String"
+                },
+                "result": {
+                    "shape": "String"
+                },
+                "includesFix": {
+                    "shape": "Boolean"
+                }
+            }
+        },
+        "CodeScanRemediationsEventType": {
+            "type": "string",
+            "documentation": "<p>Code Scan Remediations Interaction Type</p>",
+            "enum": ["CODESCAN_ISSUE_HOVER", "CODESCAN_ISSUE_APPLY_FIX", "CODESCAN_ISSUE_VIEW_DETAILS"]
+        },
         "Completion": {
             "type": "structure",
             "required": ["content"],
@@ -1327,6 +1367,7 @@
                 "codeCoverageEvent": { "shape": "CodeCoverageEvent" },
                 "userModificationEvent": { "shape": "UserModificationEvent" },
                 "codeScanEvent": { "shape": "CodeScanEvent" },
+                "codeScanRemediationsEvent": { "shape": "CodeScanRemediationsEvent" },
                 "metricData": { "shape": "MetricData" },
                 "chatAddMessageEvent": { "shape": "ChatAddMessageEvent" },
                 "chatInteractWithMessageEvent": { "shape": "ChatInteractWithMessageEvent" },

--- a/packages/core/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/packages/core/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -9,6 +9,7 @@ import { SecurityIssueProvider } from './securityIssueProvider'
 import { Component, telemetry } from '../../shared/telemetry/telemetry'
 import path from 'path'
 import { AuthUtil } from '../util/authUtil'
+import { TelemetryHelper } from '../util/telemetryHelper'
 
 export class SecurityIssueHoverProvider extends SecurityIssueProvider implements vscode.HoverProvider {
     static #instance: SecurityIssueHoverProvider
@@ -40,6 +41,17 @@ export class SecurityIssueHoverProvider extends SecurityIssueProvider implements
                         includesFix: !!issue.suggestedFixes.length,
                         credentialStartUrl: AuthUtil.instance.startUrl,
                     })
+                    TelemetryHelper.instance.sendCodeScanRemediationsEvent(
+                        document.languageId,
+                        'CODESCAN_ISSUE_HOVER',
+                        issue.detectorId,
+                        issue.findingId,
+                        issue.ruleId,
+                        undefined,
+                        undefined,
+                        undefined,
+                        !!issue.suggestedFixes.length
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Problem

CodeRemediationEvent should also be sent to CWSPR service. Currently they are sent to toolkit telemetry. 


## Solution
Add CodeRemediationEvent for SecurityScan. 

No customer facing changes. 

Reference: https://github.com/aws/aws-toolkit-jetbrains/pull/4221

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
