### PR TITLE
fix(amazonq): allow 'start a new transformation' button to work and p…

### DIFF
--- a/.changes/next-release/Bug Fix-dbadf03d-9d56-484d-a40e-3e844b6574dc.json
+++ b/.changes/next-release/Bug Fix-dbadf03d-9d56-484d-a40e-3e844b6574dc.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Code Transformation: allow \"Start a new transformation\" button in chat to work after job fails"
+}

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -348,7 +348,7 @@ For more information, see the [Amazon Q documentation.](https://docs.aws.amazon.
 
         if (!cancelled) {
             message =
-                'The transformation job has been completed. If you want to start another transformation, choose **Start a new transformation.**'
+                'The transformation job is over. If you want to start another transformation, choose **Start a new transformation.**'
         }
 
         const buttons: ChatItemButton[] = []


### PR DESCRIPTION
…revent duplicate chat messages

## Problem

"Start a new transformation" button in our chat was not working. Also, duplicate chat messages were being sent when a job is stopped.

## Solution

Reset ConversationState to fix first issue. Get rid of duplicate messages to fix second issue.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
