### PR TITLE
auth: add more network related errors to check

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -550,7 +550,6 @@ export class Auth implements AuthService, ConnectionManager {
     }
 
     private async handleSsoTokenError(id: Connection['id'], err: unknown) {
-        // Bubble-up networking issues so we don't treat the session as invalid
         this.throwOnNetworkError(err)
 
         this.#validationErrors.set(id, UnknownError.cast(err))
@@ -725,7 +724,6 @@ export class Auth implements AuthService, ConnectionManager {
     private readonly getToken = keyedDebounce(this._getToken.bind(this))
     private async _getToken(id: Connection['id'], provider: SsoAccessTokenProvider): Promise<SsoToken> {
         const token = await provider.getToken().catch(err => {
-            // Bubble-up networking issues so we don't treat the session as invalid
             this.throwOnNetworkError(err)
 
             this.#validationErrors.set(id, err)
@@ -735,11 +733,11 @@ export class Auth implements AuthService, ConnectionManager {
     }
 
     /**
-     * Auth processes can fail if there are network issues, and we do not
-     * want to intepret these failures as invalid/expired auth tokens.
+     * Auth processes can fail due to reasons outside of authentication actually being expired.
+     * We do not want to intepret these failures as invalid/expired auth tokens.
      *
-     * We use this to check if the given error is network related and then
-     * throw, expecting the caller to not change the state of the connection.
+     * We use this to check if the given error is unanticipated. If it is we throw,
+     * expecting the caller to not change the state of the connection.
      */
     private throwOnNetworkError(e: unknown) {
         if (isNetworkError(e)) {

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -532,5 +532,18 @@ export function isNetworkError(err?: unknown): err is Error & { code: string } {
         return false
     }
 
-    return ['ENOTFOUND', 'EAI_AGAIN', 'ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT'].includes(err.code)
+    return [
+        'ENOTFOUND',
+        'EAI_AGAIN',
+        'ECONNRESET',
+        'ECONNREFUSED',
+        'ETIMEDOUT',
+        'ENETUNREACH',
+        'ERR_TLS_CERT_ALTNAME_INVALID', // dns issue?
+        'EPROTO', // due to legacy server "unsafe legacy renegotiation"?
+        'EHOSTUNREACH',
+        'EADDRINUSE',
+        'ENOBUFS', // client side memory issue during http request?
+        'EADDRNOTAVAIL', // port not available/allowed?
+    ].includes(err.code)
 }


### PR DESCRIPTION
## Problem:

We have a function `isNetworkError()` that determines if a an error is network related.

The issue is that we can see other network related errors in our telemetry metric `aws_refreshCredentials` that are not caught by `isNetworkError()`.

## Solution:

Add some of the network errors that we see in telemetry to the isNetworkError check.

This will improve false token invalidations during the sso token refresh process since we were previously invalidating incorrectly on certain network issues
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
