### PR TITLE
fix(commands): update command handling and ellipses menus for q, toolkit explorer

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -258,15 +258,20 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.amazonq.auth.switchConnections",
+                    "when": "false"
+                },
+                {
+                    "command": "aws.amazonq.auth.manageConnections",
+                    "when": "false"
+                },
+                {
                     "command": "aws.amazonq.auth.signout",
                     "when": "false"
                 },
                 {
                     "command": "aws.amazonq.auth.help",
                     "when": "false"
-                },
-                {
-                    "command": "aws.amazonq.auth.manageConnections"
                 },
                 {
                     "command": "aws.dev.openMenu",
@@ -329,11 +334,6 @@
                     "command": "aws.amazonq.learnMore",
                     "when": "view == aws.AmazonQChatView || view == aws.amazonq.AmazonCommonAuth",
                     "group": "1_amazonQ@1"
-                },
-                {
-                    "command": "aws.codewhisperer.manageConnections",
-                    "when": "(view == aws.AmazonQChatView) && !aws.codewhisperer.connected",
-                    "group": "2_amazonQ@2"
                 },
                 {
                     "command": "aws.codewhisperer.signout",
@@ -489,11 +489,6 @@
             },
             {
                 "command": "aws.amazonq.auth.manageConnections",
-                "title": "%AWS.command.auth.showConnectionsPage%",
-                "category": "%AWS.title%"
-            },
-            {
-                "command": "aws.codewhisperer.manageConnections",
                 "title": "%AWS.command.auth.showConnectionsPage%",
                 "category": "%AWS.title%"
             },

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -227,22 +227,6 @@
         ],
         "submenus": [
             {
-                "id": "aws.amazonq.auth",
-                "label": "%AWS.submenu.auth.title%",
-                "icon": "$(ellipsis)",
-                "when": "isCloud9 || !aws.isWebExtHost"
-            },
-            {
-                "id": "aws.codewhisperer.submenu",
-                "label": "%AWS.codewhisperer.submenu.title%",
-                "icon": "$(ellipsis)"
-            },
-            {
-                "id": "aws.amazonq.submenu",
-                "label": "%AWS.codewhisperer.submenu.title%",
-                "icon": "$(ellipsis)"
-            },
-            {
                 "label": "%AWS.submenu.amazonqEditorContextSubmenu.title%",
                 "id": "amazonqEditorContextSubmenu"
             },
@@ -258,10 +242,6 @@
         "menus": {
             "commandPalette": [
                 {
-                    "command": "aws.listCommands",
-                    "when": "false"
-                },
-                {
                     "command": "aws.codewhisperer.signout",
                     "when": "false"
                 },
@@ -275,10 +255,6 @@
                 },
                 {
                     "command": "aws.amazonq.auth.addConnection",
-                    "when": "false"
-                },
-                {
-                    "command": "aws.amazonq.auth.switchConnections",
                     "when": "false"
                 },
                 {
@@ -355,23 +331,18 @@
                     "group": "1_amazonQ@1"
                 },
                 {
-                    "command": "aws.codeWhisperer.introduction",
-                    "when": "view == aws.codewhisperer",
-                    "group": "1_amazonQ@1"
-                },
-                {
                     "command": "aws.codewhisperer.manageConnections",
-                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer) && !aws.codewhisperer.connected",
+                    "when": "(view == aws.AmazonQChatView) && !aws.codewhisperer.connected",
                     "group": "2_amazonQ@2"
                 },
                 {
                     "command": "aws.codewhisperer.signout",
-                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer) && aws.codewhisperer.connected",
+                    "when": "(view == aws.AmazonQChatView) && aws.codewhisperer.connected",
                     "group": "2_amazonQ@4"
                 },
                 {
                     "command": "aws.codewhisperer.reconnect",
-                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer) && aws.codewhisperer.connectionExpired",
+                    "when": "(view == aws.AmazonQChatView) && aws.codewhisperer.connectionExpired",
                     "group": "2_amazonQ@3"
                 },
                 {
@@ -412,33 +383,6 @@
                     "submenu": "amazonqEditorContextSubmenu",
                     "group": "cw_chat",
                     "when": "editorHasSelection"
-                }
-            ],
-            "view/item/context": [
-                {
-                    "command": "aws.codeWhisperer.introduction",
-                    "when": "viewItem =~ /^awsCodeWhispererNode/ && !isCloud9 && CODEWHISPERER_TERMS_ACCEPTED",
-                    "group": "inline@1"
-                },
-                {
-                    "submenu": "aws.amazonq.submenu",
-                    "when": "viewItem =~ /^awsAmazonQNode/",
-                    "group": "inline@1"
-                }
-            ],
-            "aws.amazonq.auth": [
-                {
-                    "command": "aws.amazonq.auth.manageConnections",
-                    "group": "0@1"
-                },
-                {
-                    "command": "aws.amazonq.auth.switchConnections",
-                    "group": "0@2"
-                },
-                {
-                    "command": "aws.amazonq.auth.signout",
-                    "enablement": "!isCloud9",
-                    "group": "0@3"
                 }
             ],
             "aws.amazonq.submenu.feedback": [

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -245,6 +245,14 @@
             {
                 "label": "%AWS.submenu.amazonqEditorContextSubmenu.title%",
                 "id": "amazonqEditorContextSubmenu"
+            },
+            {
+                "label": "%AWS.generic.feedback%",
+                "id": "aws.amazonq.submenu.feedback"
+            },
+            {
+                "label": "%AWS.generic.help%",
+                "id": "aws.amazonq.submenu.help"
             }
         ],
         "menus": {
@@ -343,7 +351,7 @@
                 },
                 {
                     "command": "aws.amazonq.learnMore",
-                    "when": "view == aws.AmazonQChatView || view == aws.amazonq",
+                    "when": "view == aws.AmazonQChatView || view == aws.amazonq.AmazonCommonAuth",
                     "group": "1_amazonQ@1"
                 },
                 {
@@ -353,18 +361,28 @@
                 },
                 {
                     "command": "aws.codewhisperer.manageConnections",
-                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer ||  view == aws.amazonq) && !aws.codewhisperer.connected",
+                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer) && !aws.codewhisperer.connected",
                     "group": "2_amazonQ@2"
                 },
                 {
                     "command": "aws.codewhisperer.signout",
-                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer ||  view == aws.amazonq) && aws.codewhisperer.connected",
+                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer) && aws.codewhisperer.connected",
                     "group": "2_amazonQ@4"
                 },
                 {
                     "command": "aws.codewhisperer.reconnect",
-                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer ||  view == aws.amazonq) && aws.codewhisperer.connectionExpired",
+                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer) && aws.codewhisperer.connectionExpired",
                     "group": "2_amazonQ@3"
+                },
+                {
+                    "submenu": "aws.amazonq.submenu.feedback",
+                    "when": "view == aws.AmazonQChatView || view == aws.amazonq.AmazonCommonAuth",
+                    "group": "y_toolkitMeta@1"
+                },
+                {
+                    "submenu": "aws.amazonq.submenu.help",
+                    "when": "view == aws.AmazonQChatView || view == aws.amazonq.AmazonCommonAuth",
+                    "group": "y_toolkitMeta@2"
                 }
             ],
             "amazonqEditorContextSubmenu": [
@@ -422,6 +440,31 @@
                     "enablement": "!isCloud9",
                     "group": "0@3"
                 }
+            ],
+            "aws.amazonq.submenu.feedback": [
+                {
+                    "command": "aws.amazonq.submitFeedback",
+                    "when": "!aws.isWebExtHost",
+                    "group": "1_feedback@1"
+                },
+                {
+                    "command": "aws.amazonq.createIssueOnGitHub",
+                    "group": "1_feedback@2"
+                }
+            ],
+            "aws.amazonq.submenu.help": [
+                {
+                    "command": "aws.amazonq.github",
+                    "group": "1_help@3"
+                },
+                {
+                    "command": "aws.amazonq.aboutExtension",
+                    "group": "1_help@4"
+                },
+                {
+                    "command": "aws.amazonq.viewLogs",
+                    "group": "1_help@5"
+                }
             ]
         },
         "commands": [
@@ -454,13 +497,13 @@
                 "command": "aws.amazonq.login",
                 "title": "%AWS.command.login%",
                 "category": "%AWS.title%",
-                "enablement": "isCloud9 || !aws.isWebExtHost",
                 "cloud9": {
                     "cn": {
                         "title": "%AWS.command.login.cn%",
                         "category": "%AWS.title.cn%"
                     }
-                }
+                },
+                "enablement": "false"
             },
             {
                 "command": "aws.amazonq.credentials.profile.create",
@@ -470,7 +513,8 @@
                     "cn": {
                         "category": "%AWS.title.cn%"
                     }
-                }
+                },
+                "enablement": "false"
             },
             {
                 "command": "aws.amazonq.credentials.edit",
@@ -480,7 +524,8 @@
                     "cn": {
                         "category": "%AWS.title.cn%"
                     }
-                }
+                },
+                "enablement": "false"
             },
             {
                 "command": "aws.amazonq.logout",
@@ -490,7 +535,8 @@
                     "cn": {
                         "category": "%AWS.title.cn%"
                     }
-                }
+                },
+                "enablement": "false"
             },
             {
                 "command": "aws.amazonq.auth.addConnection",
@@ -558,7 +604,7 @@
                 "icon": "$(question)"
             },
             {
-                "command": "aws.createIssueOnGitHub",
+                "command": "aws.amazonq.createIssueOnGitHub",
                 "title": "%AWS.command.createIssueOnGitHub%",
                 "category": "%AWS.title%",
                 "cloud9": {
@@ -568,7 +614,7 @@
                 }
             },
             {
-                "command": "aws.submitFeedback",
+                "command": "aws.amazonq.submitFeedback",
                 "title": "%AWS.command.submitFeedback%",
                 "enablement": "!aws.isWebExtHost",
                 "category": "%AWS.title%",
@@ -580,33 +626,12 @@
                 }
             },
             {
-                "command": "aws.listCommands",
-                "title": "%AWS.command.listCommands%",
-                "category": "%AWS.title%",
-                "cloud9": {
-                    "cn": {
-                        "title": "%AWS.command.listCommands.cn%",
-                        "category": "%AWS.title.cn%"
-                    }
-                }
-            },
-            {
                 "command": "aws.amazonq.viewLogs",
                 "title": "%AWS.command.viewLogs%",
                 "category": "%AWS.title%"
             },
             {
-                "command": "aws.help",
-                "title": "%AWS.command.help%",
-                "category": "%AWS.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.title.cn%"
-                    }
-                }
-            },
-            {
-                "command": "aws.github",
+                "command": "aws.amazonq.github",
                 "title": "%AWS.command.github%",
                 "category": "%AWS.title%",
                 "cloud9": {
@@ -616,18 +641,7 @@
                 }
             },
             {
-                "command": "aws.quickStart",
-                "title": "%AWS.command.quickStart%",
-                "category": "%AWS.title%",
-                "enablement": "isCloud9",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.title.cn%"
-                    }
-                }
-            },
-            {
-                "command": "aws.aboutToolkit",
+                "command": "aws.amazonq.aboutExtension",
                 "title": "%AWS.command.aboutToolkit%",
                 "category": "%AWS.title%"
             },

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -262,15 +262,15 @@
                     "when": "false"
                 },
                 {
-                    "command": "aws.amazonq.auth.manageConnections",
-                    "when": "false"
-                },
-                {
                     "command": "aws.amazonq.auth.signout",
                     "when": "false"
                 },
                 {
                     "command": "aws.amazonq.auth.help",
+                    "when": "false"
+                },
+                {
+                    "command": "aws.amazonq.auth.manageConnections",
                     "when": "false"
                 },
                 {

--- a/packages/amazonq/src/extensionShared.ts
+++ b/packages/amazonq/src/extensionShared.ts
@@ -24,11 +24,12 @@ import {
     RegionProvider,
 } from 'aws-core-vscode/shared'
 import { initializeAuth } from 'aws-core-vscode/auth'
-import { makeEndpointsProvider } from 'aws-core-vscode'
+import { makeEndpointsProvider, registerCommands } from 'aws-core-vscode'
 import { activate as activateCWChat } from 'aws-core-vscode/amazonq'
 import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
 import { CommonAuthViewProvider } from 'aws-core-vscode/login'
 import { isExtensionActive, VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
+import { registerSubmitFeedback } from 'aws-core-vscode/feedback'
 
 export async function activateShared(context: vscode.ExtensionContext) {
     const contextPrefix = 'amazonq'
@@ -58,13 +59,17 @@ export async function activateShared(context: vscode.ExtensionContext) {
     await activateCWChat(context)
     await activateQGumby(extContext as ExtContext)
 
+    // Generic extension commands
+    registerCommands(context, contextPrefix)
+
     const authProvider = new CommonAuthViewProvider(context, contextPrefix)
     context.subscriptions.push(
         vscode.window.registerWebviewViewProvider(authProvider.viewType, authProvider, {
             webviewOptions: {
                 retainContextWhenHidden: true,
             },
-        })
+        }),
+        registerSubmitFeedback(context, 'Amazon Q', contextPrefix)
     )
 
     // If the toolkit extension is active, we can let the toolkit extension know

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,8 @@
         "./auth": "./dist/src/auth/index.js",
         "./amazonqGumby": "./dist/src/amazonqGumby/index.js",
         "./login": "./dist/src/login/webview/index.js",
-        "./utils": "./dist/src/shared/utilities/index.js"
+        "./utils": "./dist/src/shared/utilities/index.js",
+        "./feedback": "./dist/src/feedback/index.js"
     },
     "contributes": {
         "configuration": {
@@ -697,11 +698,11 @@
             },
             {
                 "label": "%AWS.generic.feedback%",
-                "id": "aws.submenu.feedback"
+                "id": "aws.toolkit.submenu.feedback"
             },
             {
                 "label": "%AWS.generic.help%",
-                "id": "aws.submenu.help"
+                "id": "aws.toolkit.submenu.help"
             }
         ],
         "menus": {
@@ -1195,7 +1196,7 @@
             ],
             "view/title": [
                 {
-                    "command": "aws.submitFeedback",
+                    "command": "aws.toolkit.submitFeedback",
                     "when": "view == aws.explorer && !aws.isWebExtHost",
                     "group": "navigation@6"
                 },
@@ -1210,7 +1211,7 @@
                     "group": "navigation@1"
                 },
                 {
-                    "command": "aws.login",
+                    "command": "aws.toolkit.login",
                     "when": "view == aws.explorer",
                     "group": "1_account@1"
                 },
@@ -1245,13 +1246,13 @@
                     "group": "3_lambda@3"
                 },
                 {
-                    "submenu": "aws.submenu.feedback",
-                    "when": "view =~ /^aws\\./",
+                    "submenu": "aws.toolkit.submenu.feedback",
+                    "when": "view =~ /^aws\\./ && view != aws.AmazonQChatView && view != aws.amazonq.AmazonCommonAuth",
                     "group": "y_toolkitMeta@1"
                 },
                 {
-                    "submenu": "aws.submenu.help",
-                    "when": "view =~ /^aws\\./",
+                    "submenu": "aws.toolkit.submenu.help",
+                    "when": "view =~ /^aws\\./ && view != aws.AmazonQChatView && view != aws.amazonq.AmazonCommonAuth",
                     "group": "y_toolkitMeta@2"
                 },
                 {
@@ -1939,33 +1940,33 @@
                     "group": "0@3"
                 }
             ],
-            "aws.submenu.feedback": [
+            "aws.toolkit.submenu.feedback": [
                 {
-                    "command": "aws.submitFeedback",
+                    "command": "aws.toolkit.submitFeedback",
                     "when": "!aws.isWebExtHost",
                     "group": "1_feedback@1"
                 },
                 {
-                    "command": "aws.createIssueOnGitHub",
+                    "command": "aws.toolkit.createIssueOnGitHub",
                     "group": "1_feedback@2"
                 }
             ],
-            "aws.submenu.help": [
+            "aws.toolkit.submenu.help": [
                 {
                     "command": "aws.quickStart",
                     "when": "isCloud9",
                     "group": "1_help@1"
                 },
                 {
-                    "command": "aws.help",
+                    "command": "aws.toolkit.help",
                     "group": "1_help@2"
                 },
                 {
-                    "command": "aws.github",
+                    "command": "aws.toolkit.github",
                     "group": "1_help@3"
                 },
                 {
-                    "command": "aws.aboutToolkit",
+                    "command": "aws.toolkit.aboutExtension",
                     "group": "1_help@4"
                 },
                 {
@@ -2021,7 +2022,7 @@
                 }
             },
             {
-                "command": "aws.login",
+                "command": "aws.toolkit.login",
                 "title": "%AWS.command.login%",
                 "category": "%AWS.title%",
                 "enablement": "isCloud9 || !aws.isWebExtHost",
@@ -2033,7 +2034,7 @@
                 }
             },
             {
-                "command": "aws.credentials.profile.create",
+                "command": "aws.toolkit.credentials.profile.create",
                 "title": "%AWS.command.credentials.profile.create%",
                 "category": "%AWS.title%",
                 "cloud9": {
@@ -2043,7 +2044,7 @@
                 }
             },
             {
-                "command": "aws.credentials.edit",
+                "command": "aws.toolkit.credentials.edit",
                 "title": "%AWS.command.credentials.edit%",
                 "category": "%AWS.title%",
                 "cloud9": {
@@ -2102,7 +2103,7 @@
                 "enablement": "isCloud9 || !aws.isWebExtHost"
             },
             {
-                "command": "aws.logout",
+                "command": "aws.toolkit.logout",
                 "title": "%AWS.command.logout%",
                 "category": "%AWS.title%",
                 "cloud9": {
@@ -2144,7 +2145,7 @@
                 "icon": "$(question)"
             },
             {
-                "command": "aws.createIssueOnGitHub",
+                "command": "aws.toolkit.createIssueOnGitHub",
                 "title": "%AWS.command.createIssueOnGitHub%",
                 "category": "%AWS.title%",
                 "cloud9": {
@@ -2684,7 +2685,7 @@
                 }
             },
             {
-                "command": "aws.submitFeedback",
+                "command": "aws.toolkit.submitFeedback",
                 "title": "%AWS.command.submitFeedback%",
                 "enablement": "!aws.isWebExtHost",
                 "category": "%AWS.title%",
@@ -2843,7 +2844,7 @@
                 "category": "%AWS.title%"
             },
             {
-                "command": "aws.help",
+                "command": "aws.toolkit.help",
                 "title": "%AWS.command.help%",
                 "category": "%AWS.title%",
                 "cloud9": {
@@ -2853,7 +2854,7 @@
                 }
             },
             {
-                "command": "aws.github",
+                "command": "aws.toolkit.github",
                 "title": "%AWS.command.github%",
                 "category": "%AWS.title%",
                 "cloud9": {
@@ -2936,7 +2937,7 @@
                 "icon": "$(aws-stepfunctions-preview)"
             },
             {
-                "command": "aws.aboutToolkit",
+                "command": "aws.toolkit.aboutExtension",
                 "title": "%AWS.command.aboutToolkit%",
                 "category": "%AWS.title%"
             },

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -249,8 +249,6 @@
     "AWS.codewhisperer.customization.quickPick.placeholder": "You have access to the following customizations",
     "AWS.codewhisperer.customization.notification.new_customizations.select": "Select Customization",
     "AWS.codewhisperer.customization.notification.new_customizations.learn_more": "Learn More",
-    "AWS.codewhisperer.submenu.title": "Manage CodeWhisperer",
-    "AWS.amazonq.submenu.title": "Manage Amazon Q (Preview)",
     "AWS.amazonq.title": "Amazon Q (Preview)",
     "AWS.amazonq.chat": "Chat",
     "AWS.amazonq.login": "Login",

--- a/packages/core/src/amazonq/activation.ts
+++ b/packages/core/src/amazonq/activation.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode'
 import { ExtensionContext, window } from 'vscode'
 import { AmazonQChatViewProvider } from './webview/webView'
 import { init as cwChatAppInit } from '../codewhispererChat/app'
@@ -15,6 +16,7 @@ import { welcome } from './onboardingPage'
 import { activateBadge } from './util/viewBadgeHandler'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { focusAmazonQPanel } from '../auth/ui/vue/show'
+import { amazonQHelpUrl } from '../shared/constants'
 
 export async function activate(context: ExtensionContext) {
     const appInitContext = DefaultAmazonQAppInitContext.instance
@@ -39,6 +41,9 @@ export async function activate(context: ExtensionContext) {
     )
 
     amazonQWelcomeCommand.register(context, cwcWebViewToAppsPublisher)
+    Commands.register('aws.amazonq.learnMore', () => {
+        void vscode.env.openExternal(vscode.Uri.parse(amazonQHelpUrl))
+    })
 
     await activateBadge()
 }

--- a/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
+++ b/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
@@ -17,7 +17,7 @@ import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
 
 const localize = nls.loadMessageBundle()
 
-export const learnMoreAmazonQCommand = Commands.declare('aws.amazonq.learnMore', () => () => {
+export const learnMoreAmazonQCommand = Commands.declare('aws.toolkit.amazonq.learnMore', () => () => {
     void vscode.env.openExternal(vscode.Uri.parse(amazonQHelpUrl))
 })
 

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -734,7 +734,7 @@ export class FeatureDevController {
     }
 
     private sendFeedback() {
-        void submitFeedback.execute(placeholder, 'Amazon Q')
+        void submitFeedback(placeholder, 'Amazon Q')
     }
 
     private processLink(message: any) {

--- a/packages/core/src/applicationcomposer/messageHandlers/openFeedbackMessageHandler.ts
+++ b/packages/core/src/applicationcomposer/messageHandlers/openFeedbackMessageHandler.ts
@@ -7,5 +7,5 @@ import { submitFeedback } from '../../feedback/vue/submitFeedback'
 import { placeholder } from '../../shared/vscode/commands2'
 
 export function openFeedbackMessageHandler() {
-    void submitFeedback.execute(placeholder, 'Application Composer')
+    void submitFeedback(placeholder, 'Application Composer')
 }

--- a/packages/core/src/auth/credentials/utils.ts
+++ b/packages/core/src/auth/credentials/utils.ts
@@ -49,7 +49,7 @@ export function showLoginFailedMessage(credentialsId: string, errMsg: string): v
             return openUrl(vscode.Uri.parse(authHelpUrl))
         } else if (selection === editCreds) {
             // TODO: clean this up, its confusing. Only Toolkit should enter this flow, which is why we are hardcoding it.
-            // (Also, if we got it dynamically, it would be a circular dependency)
+            // (Also, if we got it dynamically by calling authCommands(), it would be a circular dependency)
             return vscode.commands.executeCommand('aws.toolkit.credentials.edit')
         }
     })

--- a/packages/core/src/auth/credentials/utils.ts
+++ b/packages/core/src/auth/credentials/utils.ts
@@ -48,7 +48,9 @@ export function showLoginFailedMessage(credentialsId: string, errMsg: string): v
         if (selection === getHelp) {
             return openUrl(vscode.Uri.parse(authHelpUrl))
         } else if (selection === editCreds) {
-            return vscode.commands.executeCommand('aws.credentials.edit')
+            // TODO: clean this up, its confusing. Only Toolkit should enter this flow, which is why we are hardcoding it.
+            // (Also, if we got it dynamically, it would be a circular dependency)
+            return vscode.commands.executeCommand('aws.toolkit.credentials.edit')
         }
     })
 }

--- a/packages/core/src/auth/ui/vue/show.ts
+++ b/packages/core/src/auth/ui/vue/show.ts
@@ -412,7 +412,7 @@ export class AuthWebview extends VueWebview {
     }
 
     openFeedbackForm() {
-        return submitFeedback.execute(placeholder, 'AWS Toolkit')
+        return submitFeedback(placeholder, 'AWS Toolkit')
     }
 
     // -------------------- Telemetry Stuff --------------------

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -38,7 +38,6 @@ import {
     connectWithCustomization,
     applySecurityFix,
     signoutCodeWhisperer,
-    showManageCwConnections,
     fetchFeatureConfigsCmd,
     registerToolkitApiCallback,
 } from './commands/basicCommands'
@@ -106,7 +105,6 @@ export async function activate(context: ExtContext): Promise<void> {
         // register toolkit api callback
         registerToolkitApiCallback.register(),
         signoutCodeWhisperer.register(auth),
-        showManageCwConnections.register(),
         refreshToolkitQState.register(),
         /**
          * Configuration change

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -30,7 +30,6 @@ import { closeSecurityIssueWebview, showSecurityIssueWebview } from '../views/se
 import { fsCommon } from '../../srcShared/fs'
 import { Mutable } from '../../shared/utilities/tsUtils'
 import { CodeWhispererSource } from './types'
-import { getShowManageConnections } from '../../auth/ui/vue/show'
 import { FeatureConfigProvider } from '../service/featureConfigProvider'
 import { Auth, AwsConnection } from '../../auth'
 import { once } from '../../shared/utilities/functionUtils'
@@ -126,14 +125,6 @@ export const reconnect = Commands.declare(
             }
             await AuthUtil.instance.reauthenticate(addMissingScopes)
         }
-)
-
-/** Opens the Add Connections webview with CW highlighted */
-export const showManageCwConnections = Commands.declare(
-    { id: 'aws.codewhisperer.manageConnections', compositeKey: { 1: 'source' } },
-    () => (_: VsCodeCommandArg, source: CodeWhispererSource) => {
-        return getShowManageConnections().execute(_, source, 'codewhisperer')
-    }
 )
 
 /** @deprecated in favor of the `Add Connection` page */

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -374,7 +374,7 @@ export async function postTransformationJob() {
             )
             .then(choice => {
                 if (choice === CodeWhispererConstants.amazonQFeedbackText) {
-                    void submitFeedback.execute(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
+                    void submitFeedback(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
                 }
             })
     }
@@ -396,7 +396,7 @@ export async function transformationJobErrorHandler(error: any) {
                 )
                 .then(choice => {
                     if (choice === CodeWhispererConstants.amazonQFeedbackText) {
-                        void submitFeedback.execute(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
+                        void submitFeedback(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
                     }
                 })
         } catch {
@@ -407,7 +407,7 @@ export async function transformationJobErrorHandler(error: any) {
                 )
                 .then(choice => {
                     if (choice === CodeWhispererConstants.amazonQFeedbackText) {
-                        void submitFeedback.execute(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
+                        void submitFeedback(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
                     }
                 })
         }
@@ -424,7 +424,7 @@ export async function transformationJobErrorHandler(error: any) {
             .showErrorMessage(displayedErrorMessage, CodeWhispererConstants.amazonQFeedbackText)
             .then(choice => {
                 if (choice === CodeWhispererConstants.amazonQFeedbackText) {
-                    void submitFeedback.execute(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
+                    void submitFeedback(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
                 }
             })
     }

--- a/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
+++ b/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
@@ -183,7 +183,7 @@ export function createFeedbackNode(): DataQuickPickItem<'sendFeedback'> {
         data: 'sendFeedback',
         label: 'Send Feedback',
         iconPath: getIcon('vscode-thumbsup'),
-        onClick: () => submitFeedback.execute(placeholder, 'CodeWhisperer'),
+        onClick: () => submitFeedback(placeholder, 'CodeWhisperer'),
     } as DataQuickPickItem<'sendFeedback'>
 }
 
@@ -192,7 +192,7 @@ export function createGitHubNode(): DataQuickPickItem<'visitGithub'> {
         data: 'visitGithub',
         label: 'Connect with us on Github',
         iconPath: getIcon('vscode-github-alt'),
-        onClick: () => Commands.tryExecute('aws.github'),
+        onClick: () => Commands.tryExecute('aws.amazonq.github'),
     } as DataQuickPickItem<'visitGithub'>
 }
 

--- a/packages/core/src/codewhisperer/vue/backend.ts
+++ b/packages/core/src/codewhisperer/vue/backend.ts
@@ -93,7 +93,7 @@ export class CodeWhispererWebview extends VueWebview {
 
     //This function opens the Feedback CodeWhisperer page in the webview
     async openFeedBack(): Promise<void> {
-        return submitFeedback.execute(placeholder, 'CodeWhisperer')
+        return submitFeedback(placeholder, 'CodeWhisperer')
     }
 
     //------Telemetry------

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -17,7 +17,7 @@ import { activate as activateCloudFormationTemplateRegistry } from './shared/clo
 import { AwsContextCommands } from './shared/awsContextCommands'
 import {
     getIdeProperties,
-    getToolkitEnvironmentDetails,
+    getExtEnvironmentDetails,
     isCloud9,
     isSageMaker,
     showWelcomeMessage,
@@ -48,7 +48,7 @@ import { Experiments, Settings, showSettingsFailedMsg } from './shared/settings'
 import { isReleaseVersion } from './shared/vscode/env'
 import { telemetry } from './shared/telemetry/telemetry'
 import { Auth } from './auth/auth'
-import { submitFeedback } from './feedback/vue/submitFeedback'
+import { registerSubmitFeedback } from './feedback/vue/submitFeedback'
 import { activateShared, deactivateShared } from './extensionShared'
 import {
     learnMoreAmazonQCommand,
@@ -71,14 +71,15 @@ let localize: nls.LocalizeFunc
 export async function activate(context: vscode.ExtensionContext) {
     const activationStartedOn = Date.now()
     localize = nls.loadMessageBundle()
+    const contextPrefix = 'toolkit'
 
     try {
         // IMPORTANT: If you are doing setup that should also work in web mode (browser), it should be done in the function below
-        const extContext = await activateShared(context)
+        const extContext = await activateShared(context, contextPrefix)
 
         initializeCredentialsProviderManager()
 
-        const toolkitEnvDetails = getToolkitEnvironmentDetails()
+        const toolkitEnvDetails = getExtEnvironmentDetails()
         // Splits environment details by new line, filter removes the empty string
         toolkitEnvDetails
             .split(/\r?\n/)
@@ -109,7 +110,7 @@ export async function activate(context: vscode.ExtensionContext) {
             getLogger().debug(`Developer Tools (internal): failed to activate: ${(error as Error).message}`)
         }
 
-        context.subscriptions.push(submitFeedback.register(context))
+        context.subscriptions.push(registerSubmitFeedback(context, 'AWS Toolkit', contextPrefix))
 
         // do not enable codecatalyst for sagemaker
         // TODO: remove setContext if SageMaker adds the context to their IDE

--- a/packages/core/src/extensionShared.ts
+++ b/packages/core/src/extensionShared.ts
@@ -15,7 +15,7 @@ import globals, { initialize } from './shared/extensionGlobals'
 import { join } from 'path'
 import { Commands } from './shared/vscode/commands2'
 import { documentationUrl, endpointsFileUrl, githubCreateIssueUrl, githubUrl } from './shared/constants'
-import { getIdeProperties, aboutToolkit, isCloud9 } from './shared/extensionUtilities'
+import { getIdeProperties, aboutExtension, isCloud9 } from './shared/extensionUtilities'
 import { telemetry } from './shared/telemetry/telemetry'
 import { openUrl } from './shared/utilities/vsCodeUtils'
 import { activateViewsShared } from './awsexplorer/activationShared'
@@ -59,10 +59,9 @@ let localize: nls.LocalizeFunc
  * Activation/setup code that is shared by the regular (nodejs) extension AND web mode extension.
  * Most setup code should live here, unless there is a reason not to.
  */
-export async function activateShared(context: vscode.ExtensionContext): Promise<ExtContext> {
+export async function activateShared(context: vscode.ExtensionContext, contextPrefix: string): Promise<ExtContext> {
     localize = nls.loadMessageBundle()
-    const contextPrefix = 'toolkit'
-    globals.contextPrefix = '' //todo: disconnect from above line
+    globals.contextPrefix = '' //todo: disconnect supplied argument
 
     // some "initialize" functions
     await initializeComputeRegion()
@@ -125,7 +124,23 @@ export async function activateShared(context: vscode.ExtensionContext): Promise<
     // Toolkit services have a chance to register their path handlers. #4105
     globals.uriHandler = new UriHandler()
 
-    registerCommands(context)
+    // Generic extension commands
+    registerCommands(context, contextPrefix)
+
+    // Toolkit specific commands
+    context.subscriptions.push(
+        // No-op command used for decoration-only codelenses.
+        vscode.commands.registerCommand('aws.doNothingCommand', () => {}),
+        // "Show AWS Commands..."
+        Commands.register('aws.listCommands', () =>
+            vscode.commands.executeCommand('workbench.action.quickOpen', `> ${getIdeProperties().company}:`)
+        ),
+        // register URLs in extension menu
+        Commands.register(`aws.toolkit.help`, async () => {
+            void openUrl(vscode.Uri.parse(documentationUrl))
+            telemetry.aws_help.emit()
+        })
+    )
 
     const extContext: ExtContext = {
         extensionContext: context,
@@ -151,29 +166,19 @@ export async function deactivateShared() {
 /**
  * Registers generic commands used by both web and node versions of the toolkit.
  */
-export function registerCommands(extensionContext: vscode.ExtensionContext) {
+export function registerCommands(extensionContext: vscode.ExtensionContext, contextPrefix: string) {
     extensionContext.subscriptions.push(
-        // No-op command used for decoration-only codelenses.
-        vscode.commands.registerCommand('aws.doNothingCommand', () => {}),
-        // "Show AWS Commands..."
-        Commands.register('aws.listCommands', () =>
-            vscode.commands.executeCommand('workbench.action.quickOpen', `> ${getIdeProperties().company}:`)
-        ),
         // register URLs in extension menu
-        Commands.register('aws.help', async () => {
-            void openUrl(vscode.Uri.parse(documentationUrl))
-            telemetry.aws_help.emit()
-        }),
-        Commands.register('aws.github', async () => {
+        Commands.register(`aws.${contextPrefix}.github`, async () => {
             void openUrl(vscode.Uri.parse(githubUrl))
             telemetry.aws_showExtensionSource.emit()
         }),
-        Commands.register('aws.createIssueOnGitHub', async () => {
+        Commands.register(`aws.${contextPrefix}.createIssueOnGitHub`, async () => {
             void openUrl(vscode.Uri.parse(githubCreateIssueUrl))
             telemetry.aws_reportPluginIssue.emit()
         }),
-        Commands.register('aws.aboutToolkit', async () => {
-            await aboutToolkit()
+        Commands.register(`aws.${contextPrefix}.aboutExtension`, async () => {
+            await aboutExtension()
         })
     )
 }

--- a/packages/core/src/extensionWeb.ts
+++ b/packages/core/src/extensionWeb.ts
@@ -11,13 +11,14 @@ import os from 'os'
 
 export async function activate(context: vscode.ExtensionContext) {
     setWeb(true) // THIS MUST ALWAYS BE FIRST
+    const contextPrefix = 'toolkit'
 
     try {
         patchOsVersion()
 
         // IMPORTANT: Any new activation code should be done in the function below unless
         // it is web mode specific activation code.
-        await activateShared(context)
+        await activateShared(context, contextPrefix)
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')
         // truncate if the stacktrace is unusually long

--- a/packages/core/src/feedback/index.ts
+++ b/packages/core/src/feedback/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { registerSubmitFeedback } from './vue/submitFeedback'

--- a/packages/core/src/feedback/vue/submitFeedback.ts
+++ b/packages/core/src/feedback/vue/submitFeedback.ts
@@ -10,7 +10,7 @@ import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { VueWebview, VueWebviewPanel } from '../../webviews/main'
 import { telemetry } from '../../shared/telemetry/telemetry'
-import { Commands, VsCodeCommandArg, placeholder } from '../../shared/vscode/commands2'
+import { Commands, RegisteredCommand, VsCodeCommandArg, placeholder } from '../../shared/vscode/commands2'
 import { transformByQState } from '../../codewhisperer/models/model'
 
 export interface FeedbackMessage {
@@ -69,16 +69,33 @@ export class FeedbackWebview extends VueWebview {
 
 type FeedbackId = 'AWS Toolkit' | 'CodeWhisperer' | 'Amazon Q' | 'Application Composer'
 
-export const submitFeedback = Commands.declare(
-    { id: 'aws.submitFeedback', autoconnect: false },
-    (context: vscode.ExtensionContext) => async (_: VsCodeCommandArg, id: FeedbackId) => {
-        if (_ !== placeholder) {
-            // No args exist, we must supply them
-            id = 'AWS Toolkit'
-        }
-        await showFeedbackView(context, id)
+let _submitFeedback: RegisteredCommand<(_: VsCodeCommandArg, id: FeedbackId) => Promise<void>> | undefined
+export function submitFeedback(_: VsCodeCommandArg, id: FeedbackId) {
+    if (_submitFeedback === undefined) {
+        getLogger().error(
+            'Attempted to access "submitFeedback" command, but it was never initialized.' +
+                '\nThis should be initialized during extension activation.'
+        )
+        throw new Error("'submitFeedback' command was called programmitically, but its not registered.")
     }
-)
+    return _submitFeedback.execute(_, id)
+}
+
+export function registerSubmitFeedback(context: vscode.ExtensionContext, defaultId: FeedbackId, contextPrefix: string) {
+    _submitFeedback = Commands.register(
+        { id: `aws.${contextPrefix}.submitFeedback`, autoconnect: false },
+        async (_: VsCodeCommandArg, id: FeedbackId) => {
+            if (_ !== placeholder) {
+                // No args exist, we must supply them
+                id = defaultId
+            }
+            await showFeedbackView(context, id)
+        }
+    )
+    getLogger().info(`initialized \'submitFeedback\' command with default feedback id: ${defaultId}`)
+
+    return _submitFeedback
+}
 
 let activeWebview: VueWebviewPanel | undefined
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,4 +4,4 @@
  */
 
 export { awsToolkitActivate, awsToolkitDeactivate } from './extension'
-export { makeEndpointsProvider } from './extensionShared'
+export { makeEndpointsProvider, registerCommands } from './extensionShared'

--- a/packages/core/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
+++ b/packages/core/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
@@ -26,6 +26,7 @@ import { credentialHelpUrl } from '../constants'
 import { createHelpButton } from '../ui/buttons'
 import { recentlyUsed } from '../localizedText'
 import { messages } from '../utilities/messages'
+import { authCommands } from '../../auth/utils'
 
 interface ProfileEntry {
     profileName: string
@@ -253,7 +254,7 @@ export async function credentialProfileSelector(
         ]
         const item = await dataProvider.pickCredentialProfile(input, actions, state)
         if (item.label === actions[0].label) {
-            await vscode.commands.executeCommand('aws.credentials.edit')
+            await authCommands().profileEdit.execute()
         } else {
             state.credentialProfile = item
         }

--- a/packages/core/src/shared/extensionUtilities.ts
+++ b/packages/core/src/shared/extensionUtilities.ts
@@ -255,20 +255,19 @@ export function showWelcomeMessage(context: vscode.ExtensionContext): void {
 /**
  * Shows info about the extension and its environment.
  */
-export async function aboutToolkit(): Promise<void> {
-    const toolkitEnvDetails = getToolkitEnvironmentDetails()
+export async function aboutExtension(): Promise<void> {
+    const extEnvDetails = getExtEnvironmentDetails()
     const copyButtonLabel = localize('AWS.message.prompt.copyButtonLabel', 'Copy')
-    const result = await vscode.window.showInformationMessage(toolkitEnvDetails, { modal: true }, copyButtonLabel)
+    const result = await vscode.window.showInformationMessage(extEnvDetails, { modal: true }, copyButtonLabel)
     if (result === copyButtonLabel) {
-        void vscode.env.clipboard.writeText(toolkitEnvDetails)
+        void vscode.env.clipboard.writeText(extEnvDetails)
     }
 }
 
 /**
- * Returns a string that includes the OS, AWS Toolkit,
- * and VS Code versions.
+ * Returns a string that includes the OS, extension, and VS Code versions.
  */
-export function getToolkitEnvironmentDetails(): string {
+export function getExtEnvironmentDetails(): string {
     const osType = os.type()
     const osArch = os.arch()
     const osRelease = os.release()

--- a/packages/core/src/test/amazonq/auth/controller.test.ts
+++ b/packages/core/src/test/amazonq/auth/controller.test.ts
@@ -5,36 +5,22 @@
 
 import sinon from 'sinon'
 import { AuthController } from '../../../amazonq/auth/controller'
-import { reconnect, showManageCwConnections } from '../../../codewhisperer/commands/basicCommands'
+import { reconnect } from '../../../codewhisperer/commands/basicCommands'
 import assert from 'assert'
 import { placeholder } from '../../../shared/vscode/commands2'
 import { amazonQChatSource } from '../../../codewhisperer/commands/types'
 
 describe('AuthController', () => {
     let authController: AuthController
-    let showManageCwConnectionsStub: any
     let reconnectStub: any
 
     beforeEach(() => {
         authController = new AuthController()
-        showManageCwConnectionsStub = sinon.stub(showManageCwConnections, 'execute')
         reconnectStub = sinon.stub(reconnect, 'execute')
     })
 
     afterEach(() => {
         sinon.restore()
-    })
-
-    it('should call showManageCwConnections for "use-supported-auth"', () => {
-        authController.handleAuth('use-supported-auth')
-
-        assert.strictEqual(showManageCwConnectionsStub.calledWith(placeholder, amazonQChatSource), true)
-    })
-
-    it('should call showManageCwConnections for "full-auth"', () => {
-        authController.handleAuth('full-auth')
-
-        assert.strictEqual(showManageCwConnectionsStub.calledWith(placeholder, amazonQChatSource), true)
     })
 
     it('should call reconnect for "missing_scopes"', () => {


### PR DESCRIPTION
- Hide unnecessary auth commands in amazon q (we should evaluate and remove them in the future)
- Add Q versions of generic toolkit commands for: feedback, going to github, about extension, submit issue, etc.
  - This means the status bar menu github button works now.
- Ellipses for Q menu now independent of the toolkit ext.
- Toolkit explorer buttons no longer throw missing command errors.
- Cleanup package.json to remove unneeded or unused context values.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
