### PR TITLE
auth: add more info when connecting to auth

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,12 +8,13 @@ Details about any publicly accessible functionalities exposed through [extension
 
 #### `aws.codeWhisperer.connect`
 
-**Signature**: _async (startUrl?: string, region?: string, customizationArn?: string, customizationNamePrefix?: string) => Promise<void>_
+**Signature**: _async (source: string, startUrl?: string, region?: string, customizationArn?: string, customizationNamePrefix?: string) => Promise<void>_
 
 Shortcut command to directly connect to Identity Center or prompt start URL entry, as well as set a customization for CodeWhisperer requests.
 
 This command supports the following arguments:
 
+-   source: An identifier of the caller of this command. This can be used for something like telemetry.
 -   startUrl and region. If both arguments are provided they will be used, otherwise the command prompts for them interactively.
 -   customizationArn: select customization by ARN. If provided, `customizationNamePrefix` is ignored.
 -   customizationNamePrefix: select customization by prefix, if `customizationArn` is `undefined`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3556,9 +3556,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.199",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.199.tgz",
-            "integrity": "sha512-jZmNZr/3vgzr0SNnyMzuuXhQOWoRHc5MWJKnhUaDFfGrOdjDiJuNG2hZGZqPMHUvqbM3vpb5H0wvcXadbwwo2Q==",
+            "version": "1.0.200",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.200.tgz",
+            "integrity": "sha512-SlErwCLiZNr0kZUZi3InXii8SQhcUqEP0mw1205uSLJ5LiMoidZ8EdCIqZzUcDuLlbIiVokTwEO2+Wg8h3aMNg==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -172,10 +172,10 @@ export class Auth implements AuthService, ConnectionManager {
         if (profile.type === 'sso') {
             const provider = this.getSsoTokenProvider(id, profile)
 
-            // We create our own span with run() since we want to
-            // set the isReAuth attribute
+            // We cannot easily set isReAuth inside the createToken() call,
+            // so we need to set it here.
             await telemetry.aws_loginWithBrowser.run(async span => {
-                span.record({ isReAuth: true })
+                span.record({ isReAuth: true, credentialStartUrl: profile.startUrl })
                 await this.authenticate(id, () => provider.createToken())
             })
 

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -143,48 +143,60 @@ export const showSsoSignIn = Commands.declare('aws.codeWhisperer.sso', () => asy
 // Shortcut command to directly connect to Identity Center or prompt start URL entry
 // It can optionally set a customization too based on given values to match on
 export const connectWithCustomization = Commands.declare(
-    'aws.codeWhisperer.connect',
-    () => async (startUrl?: string, region?: string, customizationArn?: string, customizationNamePrefix?: string) => {
-        // This command supports the following arguments:
-        //  * startUrl and region. If both arguments are provided they will be used, otherwise
-        //    the command prompts for them interactively.
-        //  * customizationArn: select customization by ARN. If provided, `customizationNamePrefix` is ignored.
-        //  * customizationNamePrefix: select customization by prefix, if `customizationArn` is `undefined`.
-        if (startUrl && region) {
-            await connectToEnterpriseSso(startUrl, region)
-        } else {
-            await getStartUrl()
+    { id: 'aws.codeWhisperer.connect', compositeKey: { 0: 'source' } },
+    /**
+     * This command supports the following arguments:
+     * @param source - an identifier for who used this command. This value is not explicitly used in the function, but is used elsewhere.
+     * startUrl and region. If both arguments are provided they will be used, otherwise
+     *  the command prompts for them interactively.
+     * customizationArn: select customization by ARN. If provided, `customizationNamePrefix` is ignored.
+     * customizationNamePrefix: select customization by prefix, if `customizationArn` is `undefined`.
+     */
+    () =>
+        async (
+            source: string,
+            startUrl?: string,
+            region?: string,
+            customizationArn?: string,
+            customizationNamePrefix?: string
+        ) => {
+            if (startUrl && region) {
+                await connectToEnterpriseSso(startUrl, region)
+            } else {
+                await getStartUrl()
+            }
+
+            // No customization match information given, exit early.
+            if (!customizationArn && !customizationNamePrefix) {
+                return
+            }
+
+            let persistedCustomizations = getPersistedCustomizations()
+
+            // Check if any customizations have already been persisted.
+            // If not, call `notifyNewCustomizations` to handle it then recheck.
+            if (persistedCustomizations.length === 0) {
+                await notifyNewCustomizations()
+                persistedCustomizations = getPersistedCustomizations()
+            }
+
+            // If given an ARN, assume a specific customization is desired and find an entry that matches it. Ignores the prefix logic.
+            // Otherwise if only a prefix is given, find an entry that matches it.
+            // Backwards compatible with previous implementation.
+            const match = customizationArn
+                ? persistedCustomizations.find(c => c.arn === customizationArn)
+                : persistedCustomizations.find(c => c.name?.startsWith(customizationNamePrefix as string))
+
+            // If no match is found, nothing to do :)
+            if (!match) {
+                getLogger().error(
+                    `No customization match found: arn=${customizationArn} prefix=${customizationNamePrefix}`
+                )
+                return
+            }
+            // Since we selected based on a match, we'll reuse the persisted values.
+            await selectCustomization(match)
         }
-
-        // No customization match information given, exit early.
-        if (!customizationArn && !customizationNamePrefix) {
-            return
-        }
-
-        let persistedCustomizations = getPersistedCustomizations()
-
-        // Check if any customizations have already been persisted.
-        // If not, call `notifyNewCustomizations` to handle it then recheck.
-        if (persistedCustomizations.length === 0) {
-            await notifyNewCustomizations()
-            persistedCustomizations = getPersistedCustomizations()
-        }
-
-        // If given an ARN, assume a specific customization is desired and find an entry that matches it. Ignores the prefix logic.
-        // Otherwise if only a prefix is given, find an entry that matches it.
-        // Backwards compatible with previous implementation.
-        const match = customizationArn
-            ? persistedCustomizations.find(c => c.arn === customizationArn)
-            : persistedCustomizations.find(c => c.name?.startsWith(customizationNamePrefix as string))
-
-        // If no match is found, nothing to do :)
-        if (!match) {
-            getLogger().error(`No customization match found: arn=${customizationArn} prefix=${customizationNamePrefix}`)
-            return
-        }
-        // Since we selected based on a match, we'll reuse the persisted values.
-        await selectCustomization(match)
-    }
 )
 
 export const showLearnMore = Commands.declare(

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -8,7 +8,7 @@ import * as sinon from 'sinon'
 import { ToolkitError, isUserCancelledError } from '../../shared/errors'
 import { assertTreeItem } from '../shared/treeview/testUtil'
 import { getTestWindow } from '../shared/vscode/window'
-import { assertTelemetry, captureEventOnce } from '../testUtil'
+import { assertTelemetry, captureEventOnce, getMetrics } from '../testUtil'
 import { createBuilderIdProfile, createSsoProfile, createTestAuth } from './testUtil'
 import { toCollection } from '../../shared/utilities/asyncCollection'
 import globals from '../../shared/extensionGlobals'
@@ -257,7 +257,12 @@ describe('Auth', function () {
         it('reauthentication is indicated in metric', async function () {
             const conn = await auth.createInvalidSsoConnection(ssoProfile)
             await auth.reauthenticate(conn)
-            assertTelemetry('aws_loginWithBrowser', { isReAuth: true })
+            assertTelemetry('aws_loginWithBrowser', {
+                result: 'Succeeded',
+                isReAuth: true,
+                credentialStartUrl: ssoProfile.startUrl,
+            })
+            assert.strictEqual(getMetrics('aws_loginWithBrowser').length, 1)
         })
     })
 

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -221,7 +221,11 @@ describe('SsoAccessTokenProvider', function () {
             const cachedToken = await cache.token.load(startUrl).then(a => a?.token)
             assert.deepStrictEqual(cachedToken, token)
             assert.deepStrictEqual(await cache.registration.load({ region }), registration)
-            assertTelemetry('aws_loginWithBrowser', { result: 'Succeeded', isReAuth: undefined })
+            assertTelemetry('aws_loginWithBrowser', {
+                result: 'Succeeded',
+                isReAuth: undefined,
+                credentialStartUrl: startUrl,
+            })
         })
 
         it('always creates a new token, even if already cached', async function () {
@@ -259,7 +263,11 @@ describe('SsoAccessTokenProvider', function () {
             await clock.tickAsync(750)
             assert.ok(!progress.visible)
             await assert.rejects(resp, ToolkitError)
-            assertTelemetry('aws_loginWithBrowser', { result: 'Failed', isReAuth: undefined })
+            assertTelemetry('aws_loginWithBrowser', {
+                result: 'Failed',
+                isReAuth: undefined,
+                credentialStartUrl: startUrl,
+            })
         })
 
         /**
@@ -328,7 +336,11 @@ describe('SsoAccessTokenProvider', function () {
 
                 await assert.rejects(sut.createToken(), exception)
                 assert.strictEqual(await cache.registration.load({ region }), undefined)
-                assertTelemetry('aws_loginWithBrowser', { result: 'Failed', isReAuth: undefined })
+                assertTelemetry('aws_loginWithBrowser', {
+                    result: 'Failed',
+                    isReAuth: undefined,
+                    credentialStartUrl: startUrl,
+                })
             })
 
             it('preserves the client registration cache on server faults', async function () {
@@ -353,7 +365,11 @@ describe('SsoAccessTokenProvider', function () {
             it('stops the flow if user does not click the link', async function () {
                 stubOpen(false)
                 await assert.rejects(sut.createToken(), ToolkitError)
-                assertTelemetry('aws_loginWithBrowser', { result: 'Cancelled', isReAuth: undefined })
+                assertTelemetry('aws_loginWithBrowser', {
+                    result: 'Cancelled',
+                    isReAuth: undefined,
+                    credentialStartUrl: startUrl,
+                })
             })
 
             it('saves the client registration even when cancelled', async function () {


### PR DESCRIPTION
This PR does the following:
- Requires a `source` argument for partner teams using the VS Code command `aws.codeWhisperer.connect`
  - We will use this to help identify which external extension is using the toolkit to connect
- In the metric `aws_loginWithBrowser` we are adding in the attribute `credentialStartUrl`
  - This will help us determine which type of SSO the user is using when they go through the browser login flow for SSO

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
