### PR TITLE
fix(tests): undefined ToolkitGlobals.context

### DIFF
--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -298,13 +298,16 @@ describe('CodeWhisperer-basicCommands', function () {
     })
 
     describe('listCodeWhispererCommands()', function () {
-        const genericItems = [createFeedbackNode(), createGitHubNode(), createDocumentationNode()]
+        function genericItems() {
+            return [createFeedbackNode(), createGitHubNode(), createDocumentationNode()]
+        }
+
         it('shows expected items when not connected', async function () {
             sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
             sinon.stub(AuthUtil.instance, 'isConnected').returns(false)
 
             getTestWindow().onDidShowQuickPick(e => {
-                e.assertContainsItems(createSignIn('item'), createLearnMore(), ...genericItems)
+                e.assertContainsItems(createSignIn('item'), createLearnMore(), ...genericItems())
                 e.dispose() // skip needing to select an item to continue
             })
 
@@ -316,7 +319,7 @@ describe('CodeWhisperer-basicCommands', function () {
             sinon.stub(AuthUtil.instance, 'isConnected').returns(true)
 
             getTestWindow().onDidShowQuickPick(e => {
-                e.assertContainsItems(createReconnect('item'), createLearnMore(), ...genericItems, createSignout())
+                e.assertContainsItems(createReconnect('item'), createLearnMore(), ...genericItems(), createSignout())
                 e.dispose() // skip needing to select an item to continue
             })
 
@@ -333,7 +336,7 @@ describe('CodeWhisperer-basicCommands', function () {
                     createGettingStarted(),
                     switchToAmazonQNode('item'),
                     createSecurityScan(),
-                    ...genericItems,
+                    ...genericItems(),
                     createSettingsNode(),
                     createSignout()
                 )
@@ -356,7 +359,7 @@ describe('CodeWhisperer-basicCommands', function () {
                     createGettingStarted(),
                     switchToAmazonQNode('item'),
                     createSecurityScan(),
-                    ...genericItems,
+                    ...genericItems(),
                     createSettingsNode(),
                     createSignout()
                 )

--- a/packages/core/src/test/shared/sam/sync.test.ts
+++ b/packages/core/src/test/shared/sam/sync.test.ts
@@ -19,9 +19,8 @@ import { ToolkitError } from '../../../shared/errors'
 import globals from '../../../shared/extensionGlobals'
 
 describe('SyncWizard', async function () {
-    const registry = await globals.templateRegistry
     const createTester = async (params?: Partial<SyncParams>) =>
-        createWizardTester(new SyncWizard({ deployType: 'code', ...params }, registry))
+        createWizardTester(new SyncWizard({ deployType: 'code', ...params }, await globals.templateRegistry))
 
     it('shows steps in correct order', async function () {
         const tester = await createTester()

--- a/packages/core/src/test/shared/telemetry/telemetryService.test.ts
+++ b/packages/core/src/test/shared/telemetry/telemetryService.test.ts
@@ -35,7 +35,7 @@ export function fakeMetric(metric: Partial<Metric> = {}): ClientTelemetry.Metric
     }
 }
 
-describe('DefaultTelemetryService', function () {
+describe('TelemetryService', function () {
     const testFlushPeriod = 10
     let clock: FakeTimers.InstalledClock
     let sandbox: sinon.SinonSandbox


### PR DESCRIPTION
# Problem:
CI sometimes fails because the `ToolkitGlobals.context` global is undefined.



    TypeError: Cannot read properties of undefined (reading 'asAbsolutePath')
        at resolveIconId (…/aws-toolkit-vscode/packages/core/src/shared/icons.ts:90:33)
        at …/aws-toolkit-vscode/packages/core/src/shared/utilities/functionUtils.ts:77:64
        at createFeedbackNode (…/aws-toolkit-vscode/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts:223:26)
        at Suite.<anonymous> (…/aws-toolkit-vscode/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts:302:49)
        ...
        at runMocha (…/aws-toolkit-vscode/packages/core/src/test/testRunner.ts:93:16)
        at runTests (…/aws-toolkit-vscode/packages/core/src/test/testRunner.ts:118:11)

This suggests either:
- `globalSetup.test.ts` is not invoked before the test is executed
- mocha initalize `describe()` scope, before executing any tests (which _includes_ `globalSetup.test.ts`)?

# Solution:
- During startup, proxy globals to give a more useful error.
- Avoid calling non-trivial functions in `describe()` scope.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
