### PR TITLE
feat(codewhisperer): only register cw.connect command in Q

### DIFF
--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -233,6 +233,9 @@ export async function activate(context: ExtContext): Promise<void> {
          * On recommendation acceptance
          */
         acceptSuggestion.register(context),
+
+        connectWithCustomization()?.register() ?? { dispose() {} },
+
         // on text document close.
         vscode.workspace.onDidCloseTextDocument(e => {
             if (isInlineCompletionEnabled() && e.uri.fsPath !== InlineCompletionService.instance.filePath()) {
@@ -264,11 +267,6 @@ export async function activate(context: ExtContext): Promise<void> {
             SecurityIssueCodeActionProvider.instance
         )
     )
-
-    const connectWithCustomizationCommand = connectWithCustomization()
-    if (connectWithCustomizationCommand) {
-        context.extensionContext.subscriptions.push(connectWithCustomizationCommand.register())
-    }
 
     await auth.restore()
 

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -189,8 +189,6 @@ export async function activate(context: ExtContext): Promise<void> {
         }),
         // show introduction
         showIntroduction.register(),
-        // direct CodeWhisperer connection setup with customization
-        connectWithCustomization.register(),
         // toggle code suggestions
         toggleCodeSuggestions.register(CodeSuggestionsState.instance),
         // enable code suggestions
@@ -266,6 +264,11 @@ export async function activate(context: ExtContext): Promise<void> {
             SecurityIssueCodeActionProvider.instance
         )
     )
+
+    const connectWithCustomizationCommand = connectWithCustomization()
+    if (connectWithCustomizationCommand) {
+        context.extensionContext.subscriptions.push(connectWithCustomizationCommand.register())
+    }
 
     await auth.restore()
 

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import { CodewhispererCodeScanIssueApplyFix, Component, telemetry } from '../../shared/telemetry/telemetry'
 import { ExtContext, VSCODE_EXTENSION_ID } from '../../shared/extensions'
-import { Commands, VsCodeCommandArg } from '../../shared/vscode/commands2'
+import { Commands, DeclaredCommand, VsCodeCommandArg } from '../../shared/vscode/commands2'
 import * as CodeWhispererConstants from '../models/constants'
 import { DefaultCodeWhispererClient } from '../client/codewhisperer'
 import { startSecurityScanWithProgress, confirmStopSecurityScan } from './startSecurityScan'

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -227,10 +227,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
         // Register the aws.CodeWhisperer.connect command if Amazon Q is not active
         if (!isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq) || !isExtensionActive(VSCODE_EXTENSION_ID.amazonq)) {
-            const connectWithCustomizationCommand = connectWithCustomization()
-            if (connectWithCustomizationCommand) {
-                context.subscriptions.push(connectWithCustomizationCommand.register())
-            }
+            context.subscriptions.push(connectWithCustomization()?.register() ?? { dispose() {} })
         }
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -57,8 +57,8 @@ import {
     switchToAmazonQCommand,
 } from './amazonq/explorer/amazonQChildrenNodes'
 import { AuthUtil, isPreviousQUser } from './codewhisperer/util/authUtil'
-import { installAmazonQExtension } from './codewhisperer/commands/basicCommands'
-import { isExtensionInstalled, VSCODE_EXTENSION_ID } from './shared/utilities'
+import { connectWithCustomization, installAmazonQExtension } from './codewhisperer/commands/basicCommands'
+import { isExtensionActive, isExtensionInstalled, VSCODE_EXTENSION_ID } from './shared/utilities'
 
 let localize: nls.LocalizeFunc
 
@@ -224,6 +224,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
         if (!isReleaseVersion()) {
             globals.telemetry.assertPassiveTelemetry(globals.didReload)
+        }
+        // Register the aws.CodeWhisperer.connect command if Amazon Q is not active
+        if (!isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq) || !isExtensionActive(VSCODE_EXTENSION_ID.amazonq)) {
+            const connectWithCustomizationCommand = connectWithCustomization()
+            if (connectWithCustomizationCommand) {
+                context.subscriptions.push(connectWithCustomizationCommand.register())
+            }
         }
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')


### PR DESCRIPTION
## Problem

Command `aws.codeWhisperer.connect` should only be declared in Amazon Q. 

## Solution

1. Move the declaration & registration of command `aws.codeWhisperer.connect` inside Amazon Q activation.
2. Output log information when the declaration of command `aws.codeWhisperer.connect` fails. 


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
