### PR TITLE
fix(codewhisperer): inline tutorial telemetry

### DIFF
--- a/packages/core/src/codewhisperer/views/lineAnnotationController.ts
+++ b/packages/core/src/codewhisperer/views/lineAnnotationController.ts
@@ -47,7 +47,7 @@ interface AnnotationState {
 
     text: () => string
     updateState(changeSource: AnnotationChangeSource, force: boolean): AnnotationState | undefined
-    isNextState(state: AnnotationState): boolean
+    isNextState(state: AnnotationState | undefined): boolean
 }
 
 /**
@@ -79,7 +79,7 @@ class AutotriggerState implements AnnotationState {
         }
     }
 
-    isNextState(state: AnnotationState): boolean {
+    isNextState(state: AnnotationState | undefined): boolean {
         return state instanceof ManualtriggerState
     }
 }
@@ -105,7 +105,7 @@ class PressTabState implements AnnotationState {
         return new AutotriggerState().updateState(changeSource, force)
     }
 
-    isNextState(state: AnnotationState): boolean {
+    isNextState(state: AnnotationState | undefined): boolean {
         return state instanceof ManualtriggerState
     }
 }
@@ -147,7 +147,7 @@ class ManualtriggerState implements AnnotationState {
         }
     }
 
-    isNextState(state: AnnotationState): boolean {
+    isNextState(state: AnnotationState | undefined): boolean {
         return state instanceof TryMoreExState
     }
 }
@@ -175,7 +175,7 @@ class TryMoreExState implements AnnotationState {
         return this
     }
 
-    isNextState(state: AnnotationState): boolean {
+    isNextState(state: AnnotationState | undefined): boolean {
         return state instanceof EndState
     }
 
@@ -451,10 +451,8 @@ export class LineAnnotationController implements vscode.Disposable {
             return undefined
         }
 
-        if (!this._seen.has(updatedState.id)) {
-            try {
-                telemetry.ui_click.emit({ elementId: this._currentState.id, passive: true })
-            } catch (e) {}
+        if (this._currentState.isNextState(updatedState)) {
+            telemetry.ui_click.emit({ elementId: this._currentState.id, passive: true })
         }
 
         // update state

--- a/packages/core/src/codewhisperer/views/lineAnnotationController.ts
+++ b/packages/core/src/codewhisperer/views/lineAnnotationController.ts
@@ -214,8 +214,6 @@ export class LineAnnotationController implements vscode.Disposable {
 
     private _currentState: AnnotationState
 
-    private _seen: Set<string> = new Set()
-
     private readonly cwLineHintDecoration: vscode.TextEditorDecorationType =
         vscode.window.createTextEditorDecorationType({
             after: {
@@ -451,12 +449,16 @@ export class LineAnnotationController implements vscode.Disposable {
         }
 
         if (this._currentState.isNextState(updatedState)) {
+            // special case because PressTabState is part of case_1 (1a) which possibly jumps directly from case_1a to case_2 and miss case_1
+            if (this._currentState instanceof PressTabState) {
+                telemetry.ui_click.emit({ elementId: AutotriggerState.id, passive: true })
+            }
             telemetry.ui_click.emit({ elementId: this._currentState.id, passive: true })
         }
 
         // update state
         this._currentState = updatedState
-        this._seen.add(this._currentState.id)
+
         // take snapshot of accepted session so that we can compre if there is delta -> users accept 1 suggestion after seeing this state
         AutotriggerState.acceptedCount = RecommendationService.instance.acceptedSuggestionCount
         // take snapshot of total trigger count so that we can compare if there is delta -> users accept/reject suggestions after seeing this state

--- a/packages/core/src/codewhisperer/views/lineAnnotationController.ts
+++ b/packages/core/src/codewhisperer/views/lineAnnotationController.ts
@@ -284,7 +284,7 @@ export class LineAnnotationController implements vscode.Disposable {
                     try {
                         telemetry.ui_click.emit({ elementId: `dismiss_${this._currentState.id}` })
                     } catch (_) {}
-                    await this.markTutorialDone()
+                    await this.dismissTutorial()
                     getLogger().debug(`codewhisperer: user dismiss tutorial.`)
                 }
             })
@@ -306,7 +306,7 @@ export class LineAnnotationController implements vscode.Disposable {
         return this._currentState.id === new EndState().id
     }
 
-    async markTutorialDone() {
+    async dismissTutorial() {
         this._currentState = new EndState()
         await vscode.commands.executeCommand('setContext', inlinehintWipKey, false)
         await set(inlinehintKey, this._currentState.id, globals.context.globalState)
@@ -406,14 +406,13 @@ export class LineAnnotationController implements vscode.Disposable {
             // special case
             // Endstate is meaningless and doesnt need to be rendered
             this.clear()
-            await this.markTutorialDone()
+            await this.dismissTutorial()
             return
         } else if (decorationOptions.renderOptions?.after?.contentText === new TryMoreExState().text()) {
             // special case
             // case 3 exit criteria is to fade away in 30s
             setTimeout(async () => {
-                await this.markTutorialDone()
-                await this.refresh(editor, source)
+                await this.refresh(editor, source, true)
             }, case3TimeWindow)
         }
 


### PR DESCRIPTION
## Problem
telemetry ui_click `codewhisperer_learnmore_case*` should ONLY be sent if users complete the corresponding case/step. However


- `codewhisperer_learnmore_case_1` is sent as soon as user has seen it
  - root cause: `seen.has(this.currentState)` will allow case_1's telemetry sent and not blocking it because either case_1a or case_2 is not in the set of `seen` https://github.com/aws/aws-toolkit-vscode/pull/4632/files#diff-9c8a244cafa64940c3c9f141252d08c61e9e6e79cf5e84773548bd1961f3591eL432

- `codewhisperer_learnmore_case_3` is *not* sent if the step is fulfilled by 30s timeout (case_3 has two exit criteria: one is to click the statusBar and the other is it will disappear itself after 30 seconds)
  - root cause: invocation of `markTutorialDone` will immediately stop any logic being executed within `updateDecoration()` https://github.com/aws/aws-toolkit-vscode/pull/4632/files#diff-9c8a244cafa64940c3c9f141252d08c61e9e6e79cf5e84773548bd1961f3591eL393

## Solution

## Before
Case 1: telemetry will be sent out once case_1 is rendered (which is supposed to be sent out ONLY if case_1 is "completed" by accepting a recommendation)


https://github.com/aws/aws-toolkit-vscode/assets/96078566/6f82cc25-ddf9-40b2-abab-04f1eca45311



Case 3: timeout will not send telemetry


https://github.com/aws/aws-toolkit-vscode/assets/96078566/bd2bee23-6dff-4537-9a27-aecd429d5e9d




## After

Case 1: accept a recommendation

https://github.com/aws/aws-toolkit-vscode/assets/96078566/6953a687-1f85-4a09-981c-acc826b97680


Case 2: manual trigger

https://github.com/aws/aws-toolkit-vscode/assets/96078566/a15fe68d-6ffb-42a8-a037-c07f04e8f819



Case 3: 30s timeout

https://github.com/aws/aws-toolkit-vscode/assets/96078566/1bb49e6f-6f62-4c5f-ae94-9689aab001d1


Case 3: click status bar

https://github.com/aws/aws-toolkit-vscode/assets/96078566/4e76839d-d244-4d67-af2b-d8f1595c3d71






<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
