### PR TITLE
ci: add dynamic release/publish capability

### DIFF
--- a/buildspec/release/10changeversion.yml
+++ b/buildspec/release/10changeversion.yml
@@ -8,6 +8,7 @@ phases:
     pre_build:
         commands:
             - aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO"
+            - test -n "${TARGET_EXTENSION}"
 
     install:
         runtime-versions:
@@ -16,18 +17,19 @@ phases:
     build:
         commands:
             - |
+                echo "TARGET_EXTENSION=${TARGET_EXTENSION}"
                 echo "Removing SNAPSHOT from version string"
                 git config --global user.name "aws-toolkit-automation"
                 git config --global user.email "<>"
-                VERSION=$(node -e "console.log(require('./packages/toolkit/package.json').version);" | (IFS="-"; read -r version unused && echo "$version"))
+                VERSION=$(node -e "console.log(require('./packages/${TARGET_EXTENSION}/package.json').version);" | (IFS="-"; read -r version unused && echo "$version"))
                 DATE=$(date)
-                npm version --no-git-tag-version "$VERSION" -w packages/toolkit
+                npm version --no-git-tag-version "$VERSION" -w packages/${TARGET_EXTENSION}
                 # Call npm ci because 'createRelease' uses ts-node
                 npm ci
             - |
                 npm run createRelease
             - |
-                git add packages/toolkit/package.json
+                git add packages/${TARGET_EXTENSION}/package.json
                 git add package-lock.json
                 git commit -m "Release $VERSION"
                 echo "tagging commit"

--- a/buildspec/release/20buildrelease.yml
+++ b/buildspec/release/20buildrelease.yml
@@ -8,6 +8,7 @@ phases:
     pre_build:
         commands:
             - aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO"
+            - test -n "${TARGET_EXTENSION}"
     install:
         runtime-versions:
             nodejs: 16
@@ -19,13 +20,17 @@ phases:
             - apt-get install -y libasound2-plugins
     build:
         commands:
+            - echo "TARGET_EXTENSION=${TARGET_EXTENSION}"
             # --unsafe-perm is needed because we run as root
             - npm ci --unsafe-perm
-            - cp ./README.quickstart.vscode.md ./README.md
-            - npm run package
+            - |
+                if [ $TARGET_EXTENSION = 'toolkit' ]; then
+                  cp ./README.quickstart.vscode.md ./README.md
+                fi
+            - npm run package -w packages/${TARGET_EXTENSION}
+            - cp packages/${TARGET_EXTENSION}/package.json ./package.json
 
 artifacts:
     files:
-        - aws-toolkit-vscode*
-        - packages/toolkit/package.json
-    discard-paths: true
+        - '*.vsix'
+        - package.json

--- a/buildspec/release/20buildrelease.yml
+++ b/buildspec/release/20buildrelease.yml
@@ -29,6 +29,12 @@ phases:
                 fi
             - npm run package -w packages/${TARGET_EXTENSION}
             - cp packages/${TARGET_EXTENSION}/package.json ./package.json
+            - NUM_VSIX=$(ls -1q *.vsix | wc -l)
+            - |
+                if [ "$NUM_VSIX" != "1" ]; then
+                  echo "Number of .vsix to release is not exactly 1, it is: ${NUM_VSIX}"
+                  exit 1
+                fi
 
 artifacts:
     files:

--- a/buildspec/release/40pushtogithub.yml
+++ b/buildspec/release/40pushtogithub.yml
@@ -14,21 +14,23 @@ phases:
             # Check for implicit env vars passed from the release pipeline.
             - test -n "${TOOLKITS_GITHUB_REPO_OWNER}"
             - test -n "${GITHUB_TOKEN}"
+            - test -n "${TARGET_EXTENSION}"
             - REPO_URL="https://$GITHUB_TOKEN@github.com/${TOOLKITS_GITHUB_REPO_OWNER}/aws-toolkit-vscode.git"
 
     build:
         commands:
             - |
+                echo "TARGET_EXTENSION=${TARGET_EXTENSION}"
                 git config --global user.name "aws-toolkit-automation"
                 git config --global user.email "<>"
                 git remote add originWithCreds "$REPO_URL"
                 echo "Adding SNAPSHOT to next version string"
                 # Increase minor version
-                npm version --no-git-tag-version minor -w packages/toolkit
-                VERSION=$(node -e "console.log(require('./packages/toolkit/package.json').version);")
+                npm version --no-git-tag-version minor -w packages/${TARGET_EXTENSION}
+                VERSION=$(node -e "console.log(require('./packages/${TARGET_EXTENSION}/package.json').version);")
                 # Append -SNAPSHOT
-                npm version --no-git-tag-version "${VERSION}-SNAPSHOT" -w packages/toolkit
-                git add packages/toolkit/package.json
+                npm version --no-git-tag-version "${VERSION}-SNAPSHOT" -w packages/${TARGET_EXTENSION}
+                git add packages/${TARGET_EXTENSION}/package.json
                 git add package-lock.json
                 git commit -m "Update version to snapshot version: ${VERSION}-SNAPSHOT"
             - |

--- a/buildspec/release/50githubrelease.yml
+++ b/buildspec/release/50githubrelease.yml
@@ -19,14 +19,16 @@ phases:
         commands:
             # Check for implicit env vars passed from the release pipeline.
             - test -n "${TOOLKITS_GITHUB_REPO_OWNER}"
+            - test -n "${TARGET_EXTENSION}"
             - REPO="${TOOLKITS_GITHUB_REPO_OWNER}/aws-toolkit-vscode"
 
     build:
         commands:
+            - echo "TARGET_EXTENSION=${TARGET_EXTENSION}"
             # pull in the build artifacts
             - cp -r ${CODEBUILD_SRC_DIR_buildPipeline}/* .
-            - VERSION=$(node -e "console.log(require('./packages/toolkit/package.json').version);")
-            - UPLOAD_TARGET=$(ls aws-toolkit-vscode*.vsix)
+            - VERSION=$(node -e "console.log(require('./packages/${TARGET_EXTENSION}/package.json').version);")
+            - UPLOAD_TARGET=$(ls *.vsix)
             - HASH_UPLOAD_TARGET=${UPLOAD_TARGET}.sha384
             - 'HASH=$(sha384sum -b $UPLOAD_TARGET | cut -d" " -f1)'
             - echo "Writing hash to $HASH_UPLOAD_TARGET"
@@ -34,7 +36,7 @@ phases:
             - echo "posting $VERSION with sha384 hash $HASH to GitHub"
             - RELEASE_MESSAGE="AWS Toolkit for VS Code $VERSION"
             - |
-                if [ $STAGE = "prod" ]; then
+                if [ $STAGE = "prod" || $TARGET_EXTENSION != 'toolkit' ]; then
                   gh release create --repo $REPO --title "$VERSION" --notes "$RELEASE_MESSAGE" -- "v$VERSION" "$UPLOAD_TARGET" "$HASH_UPLOAD_TARGET"
                 else
                   echo "SKIPPED: 'gh release create --repo $REPO'"

--- a/buildspec/release/60publish.yml
+++ b/buildspec/release/60publish.yml
@@ -16,9 +16,11 @@ phases:
         commands:
             # Check for implicit env vars passed from the release pipeline.
             - test -n "${VS_MARKETPLACE_PAT}"
+            - test -n "${TARGET_EXTENSION}"
 
     build:
         commands:
+            - echo "TARGET_EXTENSION=${TARGET_EXTENSION}"
             # pull in the build artifacts
             - cp -r ${CODEBUILD_SRC_DIR_buildPipeline}/* .
             - |
@@ -26,5 +28,5 @@ phases:
                   echo "Stage is not production, skipping publish step"
                   exit 0
                 fi
-                UPLOAD_TARGET=$(ls aws-toolkit-vscode*.vsix)
+                UPLOAD_TARGET=$(ls *.vsix)
                 npx vsce publish --pat "$VS_MARKETPLACE_PAT" --packagePath "$UPLOAD_TARGET"


### PR DESCRIPTION
- To publish to marketplace.
- Env var `TARGET_EXTENSION` will be provided by the release pipeline.
- Only one .vsix is expected at a time.
- Only 'toolkit' will get the full release for now (e.g. a github release). We will revisit full releasing soon.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
