### PR TITLE
feat(amazonq): Auto install AmazonQ when logging into aws toolkit

### DIFF
--- a/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
+++ b/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
@@ -24,7 +24,7 @@ export const learnMoreAmazonQCommand = Commands.declare('aws.toolkit.amazonq.lea
 })
 
 export const qExtensionPageCommand = Commands.declare('aws.toolkit.amazonq.extensionpage', () => () => {
-    void vscode.env.openExternal(vscode.Uri.parse(`vscode:extension/${VSCODE_EXTENSION_ID.awstoolkit}`))
+    void vscode.env.openExternal(vscode.Uri.parse(`vscode:extension/${VSCODE_EXTENSION_ID.amazonq}`))
 })
 
 export const dismissQTree = Commands.declare('aws.toolkit.amazonq.dismiss', () => async () => {

--- a/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
+++ b/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { Command, Commands, placeholder } from '../../shared/vscode/commands2'
 import { codicon, getIcon } from '../../shared/icons'
-import { reconnect } from '../../codewhisperer/commands/basicCommands'
+import { installAmazonQExtension, reconnect } from '../../codewhisperer/commands/basicCommands'
 import { amazonQHelpUrl } from '../../shared/constants'
 import { cwTreeNodeSource } from '../../codewhisperer/commands/types'
 import { telemetry } from '../../shared/telemetry/telemetry'
@@ -31,9 +31,9 @@ export const dismissQTree = Commands.declare('aws.toolkit.amazonq.dismiss', () =
     await globals.context.globalState.update(amazonQDismissedKey, true)
     await vscode.commands.executeCommand('setContext', amazonQDismissedKey, true)
 })
-
+// Learn more button of Amazon Q now opens the Amazon Q marketplace page.
 export const createLearnMoreNode = () =>
-    learnMoreAmazonQCommand.build().asTreeNode({
+    qExtensionPageCommand.build().asTreeNode({
         label: localize('AWS.amazonq.learnMore', 'Learn More About Amazon Q (Preview)'),
         iconPath: getIcon('vscode-question'),
         contextValue: 'awsAmazonQLearnMoreNode',
@@ -103,7 +103,7 @@ export function createSignIn(type: 'item' | 'tree'): any {
 }
 
 export function createInstallQNode() {
-    return qExtensionPageCommand.build().asTreeNode({
+    return installAmazonQExtension.build().asTreeNode({
         label: 'Install the Amazon Q Extension', // TODO: localize
         iconPath: getIcon('vscode-extensions'),
     })

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -270,7 +270,7 @@ export const installAmazonQExtension = Commands.declare(
     () => async () => {
         await vscode.window.withProgress(
             {
-                title: 'Installing Amazon Q... (placeholder)',
+                title: 'Installing Amazon Q...',
                 cancellable: true,
                 location: vscode.ProgressLocation.Notification,
             },

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -268,7 +268,7 @@ export const fetchFeatureConfigsCmd = Commands.declare(
 export const installAmazonQExtension = Commands.declare(
     { id: 'aws.toolkit.installAmazonQExtension', logging: true },
     () => async () => {
-        void vscode.window.withProgress(
+        await vscode.window.withProgress(
             {
                 title: 'Installing Amazon Q... (placeholder)',
                 cancellable: true,

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -275,7 +275,10 @@ export const installAmazonQExtension = Commands.declare(
                 location: vscode.ProgressLocation.Notification,
             },
             async () => {
-                await new Promise(r => setTimeout(r, 5000))
+                await vscode.commands.executeCommand(
+                    'workbench.extensions.installExtension',
+                    VSCODE_EXTENSION_ID.amazonq
+                )
             }
         )
     }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -175,7 +175,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     if (isPreviousQUser()) {
                         await installAmazonQExtension.execute()
                         await vscode.window.showInformationMessage(
-                            'Amazon Q has moved to its own VSCode extension, which has been automatically installed',
+                            'Amazon Q has moved to its own VSCode extension, which has been automatically installed.',
                             'OK'
                         )
                     } else {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -175,9 +175,12 @@ export async function activate(context: vscode.ExtensionContext) {
                     if (isPreviousQUser()) {
                         await installAmazonQExtension.execute()
                         void vscode.window
-                            .showInformationMessage('We have installed Amazon Q extension for you', 'Restart')
+                            .showInformationMessage(
+                                'Amazon Q has moved to its own VSCode extension, which has been automatically installed',
+                                'Reload Now'
+                            )
                             .then(async resp => {
-                                if (resp === 'Restart') {
+                                if (resp === 'Reload Now') {
                                     await vscode.commands.executeCommand('workbench.action.reloadWindow')
                                 }
                             })

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -188,7 +188,8 @@ export async function activate(context: vscode.ExtensionContext) {
                             )
                             .then(async resp => {
                                 if (resp === 'Learn More') {
-                                    void learnMoreAmazonQCommand.execute()
+                                    // Clicking learn more will open the q extension page
+                                    void qExtensionPageCommand.execute()
                                 } else if (resp === 'Install') {
                                     void installAmazonQExtension.execute()
                                 }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -173,15 +173,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
                 if (!isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq)) {
                     if (isPreviousQUser()) {
-                        void installAmazonQExtension.execute().then(
-                            void vscode.window
-                                .showInformationMessage('We have installed Amazon Q extension for you', 'Restart')
-                                .then(async resp => {
-                                    if (resp === 'Restart') {
-                                        await vscode.commands.executeCommand('workbench.action.reloadWindow')
-                                    }
-                                })
-                        )
+                        await installAmazonQExtension.execute()
+                        void vscode.window
+                            .showInformationMessage('We have installed Amazon Q extension for you', 'Restart')
+                            .then(async resp => {
+                                if (resp === 'Restart') {
+                                    await vscode.commands.executeCommand('workbench.action.reloadWindow')
+                                }
+                            })
                     } else {
                         void vscode.window
                             .showInformationMessage(

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -187,8 +187,7 @@ export async function activate(context: vscode.ExtensionContext) {
                                 'Amazon Q has moved to its own VSCode extension.' +
                                     '\nInstall to work with Amazon Q, a generative AI assistant, with chat and code suggestions.',
                                 'Install',
-                                'Learn More',
-                                'Dismiss'
+                                'Learn More'
                             )
                             .then(async resp => {
                                 if (resp === 'Learn More') {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -171,22 +171,34 @@ export async function activate(context: vscode.ExtensionContext) {
                 switchToAmazonQCommand.register()
                 installAmazonQExtension.register()
 
-                if (!isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq) && isPreviousQUser()) {
-                    void vscode.window
-                        .showInformationMessage(
-                            'Amazon Q has moved to its own VSCode extension.' +
-                                '\nInstall to work with Amazon Q, a generative AI assistant, with chat and code suggestions.',
-                            'Install',
-                            'Learn More',
-                            'Dismiss'
+                if (!isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq)) {
+                    if (isPreviousQUser()) {
+                        void installAmazonQExtension.execute().then(
+                            void vscode.window
+                                .showInformationMessage('We have installed Amazon Q extension for you', 'Restart')
+                                .then(async resp => {
+                                    if (resp === 'Restart') {
+                                        await vscode.commands.executeCommand('workbench.action.reloadWindow')
+                                    }
+                                })
                         )
-                        .then(async resp => {
-                            if (resp === 'Learn More') {
-                                void learnMoreAmazonQCommand.execute()
-                            } else if (resp === 'Install') {
-                                void installAmazonQExtension.execute()
-                            }
-                        })
+                    } else {
+                        void vscode.window
+                            .showInformationMessage(
+                                'Amazon Q has moved to its own VSCode extension.' +
+                                    '\nInstall to work with Amazon Q, a generative AI assistant, with chat and code suggestions.',
+                                'Install',
+                                'Learn More',
+                                'Dismiss'
+                            )
+                            .then(async resp => {
+                                if (resp === 'Learn More') {
+                                    void learnMoreAmazonQCommand.execute()
+                                } else if (resp === 'Install') {
+                                    void installAmazonQExtension.execute()
+                                }
+                            })
+                    }
                 }
             }
             await activateApplicationComposer(context)

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -174,16 +174,10 @@ export async function activate(context: vscode.ExtensionContext) {
                 if (!isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq)) {
                     if (isPreviousQUser()) {
                         await installAmazonQExtension.execute()
-                        void vscode.window
-                            .showInformationMessage(
-                                'Amazon Q has moved to its own VSCode extension, which has been automatically installed',
-                                'Reload Now'
-                            )
-                            .then(async resp => {
-                                if (resp === 'Reload Now') {
-                                    await vscode.commands.executeCommand('workbench.action.reloadWindow')
-                                }
-                            })
+                        void vscode.window.showInformationMessage(
+                            'Amazon Q has moved to its own VSCode extension, which has been automatically installed',
+                            'OK'
+                        )
                     } else {
                         void vscode.window
                             .showInformationMessage(

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -174,12 +174,12 @@ export async function activate(context: vscode.ExtensionContext) {
                 if (!isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq)) {
                     if (isPreviousQUser()) {
                         await installAmazonQExtension.execute()
-                        void vscode.window.showInformationMessage(
+                        await vscode.window.showInformationMessage(
                             'Amazon Q has moved to its own VSCode extension, which has been automatically installed',
                             'OK'
                         )
                     } else {
-                        void vscode.window
+                        await vscode.window
                             .showInformationMessage(
                                 'Amazon Q has moved to its own VSCode extension.' +
                                     '\nInstall to work with Amazon Q, a generative AI assistant, with chat and code suggestions.',
@@ -189,9 +189,9 @@ export async function activate(context: vscode.ExtensionContext) {
                             .then(async resp => {
                                 if (resp === 'Learn More') {
                                     // Clicking learn more will open the q extension page
-                                    void qExtensionPageCommand.execute()
+                                    await qExtensionPageCommand.execute()
                                 } else if (resp === 'Install') {
-                                    void installAmazonQExtension.execute()
+                                    await installAmazonQExtension.execute()
                                 }
                             })
                     }


### PR DESCRIPTION
## Problem
Toolkit Q users should be migrated to Q standalone.


![Screenshot 2024-04-04 at 5 28 50 PM](https://github.com/aws/aws-toolkit-vscode/assets/97199248/0481bc02-7c07-47ff-8745-5eda1f721b2d)

![Screenshot 2024-04-04 at 5 29 31 PM](https://github.com/aws/aws-toolkit-vscode/assets/97199248/a64726af-f4b1-4400-87e7-85368913b240)



## Solution
Auto install AmazonQ when logging into aws toolkit for existing Q users. Prompt for Q install for new users. 



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
