### PR TITLE
fix(S3 View): Display bucket contents with specific IAM role policies

### DIFF
--- a/.changes/next-release/Bug Fix-77137e24-593d-4859-a15f-e029edf843a7.json
+++ b/.changes/next-release/Bug Fix-77137e24-593d-4859-a15f-e029edf843a7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Resource Explorer: S3 tree view now shows bucket contents correctly, even when restricted to root prefix."
+}

--- a/packages/core/src/shared/clients/s3Client.ts
+++ b/packages/core/src/shared/clients/s3Client.ts
@@ -18,7 +18,7 @@ import { toStream } from '../utilities/collectionUtils'
 
 export const DEFAULT_MAX_KEYS = 300 // eslint-disable-line @typescript-eslint/naming-convention
 export const DEFAULT_DELIMITER = '/' // eslint-disable-line @typescript-eslint/naming-convention
-export const DEFAULT_PREFIX = '' // eslint-disable-line @typescript-eslint/naming-convention
+export const defaultPrefix = ''
 
 export type Bucket = InterfaceNoSymbol<DefaultBucket>
 export type Folder = InterfaceNoSymbol<DefaultFolder>
@@ -451,7 +451,12 @@ export class DefaultS3Client {
                 Bucket: bucket.name,
                 Delimiter: DEFAULT_DELIMITER,
                 MaxKeys: request.maxResults ?? DEFAULT_MAX_KEYS,
-                Prefix: request.folderPath ?? DEFAULT_PREFIX,
+                /**
+                 * Set '' as the default prefix to ensure that the bucket's content will be displayed 
+                 * when the user has at least list access to the root of the bucket.
+                 * https://github.com/aws/aws-toolkit-vscode/issues/4643
+                 */ 
+                Prefix: request.folderPath ?? defaultPrefix,
                 ContinuationToken: request.continuationToken,
             })
             .promise()

--- a/packages/core/src/shared/clients/s3Client.ts
+++ b/packages/core/src/shared/clients/s3Client.ts
@@ -18,6 +18,7 @@ import { toStream } from '../utilities/collectionUtils'
 
 export const DEFAULT_MAX_KEYS = 300 // eslint-disable-line @typescript-eslint/naming-convention
 export const DEFAULT_DELIMITER = '/' // eslint-disable-line @typescript-eslint/naming-convention
+export const DEFAULT_PREFIX = '' // eslint-disable-line @typescript-eslint/naming-convention
 
 export type Bucket = InterfaceNoSymbol<DefaultBucket>
 export type Folder = InterfaceNoSymbol<DefaultFolder>
@@ -47,7 +48,7 @@ export interface ListBucketsResponse {
 
 export interface ListFilesRequest {
     readonly bucketName: string
-    readonly folderPath?: string
+    readonly folderPath: string
     readonly continuationToken?: string
     readonly maxResults?: number // Defaults to DEFAULT_MAX_KEYS
 }
@@ -450,7 +451,7 @@ export class DefaultS3Client {
                 Bucket: bucket.name,
                 Delimiter: DEFAULT_DELIMITER,
                 MaxKeys: request.maxResults ?? DEFAULT_MAX_KEYS,
-                Prefix: request.folderPath,
+                Prefix: request.folderPath ?? DEFAULT_PREFIX,
                 ContinuationToken: request.continuationToken,
             })
             .promise()

--- a/packages/core/src/shared/clients/s3Client.ts
+++ b/packages/core/src/shared/clients/s3Client.ts
@@ -48,7 +48,7 @@ export interface ListBucketsResponse {
 
 export interface ListFilesRequest {
     readonly bucketName: string
-    readonly folderPath: string
+    readonly folderPath?: string
     readonly continuationToken?: string
     readonly maxResults?: number // Defaults to DEFAULT_MAX_KEYS
 }

--- a/packages/core/src/shared/clients/s3Client.ts
+++ b/packages/core/src/shared/clients/s3Client.ts
@@ -452,10 +452,11 @@ export class DefaultS3Client {
                 Delimiter: DEFAULT_DELIMITER,
                 MaxKeys: request.maxResults ?? DEFAULT_MAX_KEYS,
                 /**
-                 * Set '' as the default prefix to ensure that the bucket's content will be displayed 
+                 * Set '' as the default prefix to ensure that the bucket's content will be displayed
                  * when the user has at least list access to the root of the bucket.
                  * https://github.com/aws/aws-toolkit-vscode/issues/4643
-                 */ 
+                 * @default '' 
+                 */
                 Prefix: request.folderPath ?? defaultPrefix,
                 ContinuationToken: request.continuationToken,
             })


### PR DESCRIPTION
## Problem: 
S3 tree view doesn't show contents with specific IAM role policies. Prefix parameter was null.

## Solution: 
Set Prefix parameter to an empty string as default. Allows bucket contents display if root prefix is allowed.

## Related issue:
#4643 S3 Tree View Not Displaying Bucket Contents with Specific IAM Role Policies

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
