### PR TITLE
fix(tests): amazon q featureDev e2e test prompts

### DIFF
--- a/packages/core/src/testE2E/amazonq/featureDev.test.ts
+++ b/packages/core/src/testE2E/amazonq/featureDev.test.ts
@@ -20,9 +20,9 @@ describe('Amazon Q Feature Dev', function () {
     let tab: Messenger
 
     const maxTestDuration = 600000
-    const prompt = 'Implement fibonacci in typescript'
-    const iterateApproachPrompt = prompt + ' and add tests'
-    const codegenApproachPrompt = prompt + ' and add even more tests'
+    const prompt = 'Implement fibonacci in python'
+    const iterateApproachPrompt = prompt + ' and add a unit test'
+    const codegenApproachPrompt = prompt + ' and add a readme that describes the changes'
     const tooManyRequestsWaitTime = 100000
 
     before(async function () {


### PR DESCRIPTION
## Problem
 The current e2e prompts cause false positive rejections and other internal quality issues which we are working on resolving.
## Solution
The new prompts are more stable. It used to always fail now it passed twice in a row.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
