### PR TITLE
fix(amazonq): packaging after merge from mainline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,6 @@ packages/toolkit/resources
 packages/amazonq/package.nls.json
 packages/amazonq/resources
 
-!packages/amazonq/README.md
-
 # Icons
 packages/*/resources/icons/cloud9/generated/**
 packages/*/resources/fonts/aws-toolkit-icons.woff

--- a/scripts/generateNonCodeFiles.ts
+++ b/scripts/generateNonCodeFiles.ts
@@ -19,7 +19,21 @@ const projectRoot = process.cwd()
  * @param outputFile Filepath to output HTML to
  * @param cn Converts "AWS" to "Amazon" for CN-based compute.
  */
-function translateReadmeToHtml(root: string, inputFile: string, outputFile: string, cn: boolean = false) {
+function translateReadmeToHtml(
+    root: string,
+    inputFile: string,
+    outputFile: string,
+    throwIfNotExists: boolean,
+    cn: boolean = false
+) {
+    const inputPath = path.join(root, inputFile)
+    if (!fs.existsSync(inputPath)) {
+        if (throwIfNotExists) {
+            throw Error(`File ${inputFile} was not found, but it is required.`)
+        }
+        console.log(`File ${inputFile} was not found, skipping transformation...`)
+        return
+    }
     const fileText = fs.readFileSync(path.join(root, inputFile)).toString()
     const relativePathRegex = /]\(\.\//g
     let transformedText = fileText.replace(relativePathRegex, '](!!EXTENSIONROOT!!/')
@@ -47,9 +61,9 @@ function generateFileHash(root: string) {
 }
 
 try {
-    translateReadmeToHtml(projectRoot, 'README.md', 'quickStartVscode.html')
-    translateReadmeToHtml(projectRoot, 'README.quickstart.cloud9.md', 'quickStartCloud9.html')
-    translateReadmeToHtml(projectRoot, 'README.quickstart.cloud9.md', 'quickStartCloud9-cn.html', true)
+    translateReadmeToHtml(projectRoot, 'README.md', 'quickStartVscode.html', true)
+    translateReadmeToHtml(projectRoot, 'README.quickstart.cloud9.md', 'quickStartCloud9.html', false)
+    translateReadmeToHtml(projectRoot, 'README.quickstart.cloud9.md', 'quickStartCloud9-cn.html', false, true)
     generateFileHash(projectRoot)
 } catch (error) {
     console.error(error)

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -155,9 +155,13 @@ function main() {
         fs.copyFileSync('../../CHANGELOG.md', 'CHANGELOG.md')
 
         fs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, undefined, '    '))
-        child_process.execFileSync('vsce', ['package', '--ignoreFile', '../.vscodeignore.packages'], {
-            stdio: 'inherit',
-        })
+        child_process.execFileSync(
+            'vsce',
+            ['package', '--ignoreFile', '../.vscodeignore.packages', '--allow-missing-repository'],
+            {
+                stdio: 'inherit',
+            }
+        )
 
         console.log(`VSIX Version: ${packageJson.version}`)
 


### PR DESCRIPTION
- generateNonCodeFiles wont fail if certain files don't exist
- fix packaging command to ignore the missing repo field in amazonq because its temporary

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
