### PR TITLE
codewhisperer: update menu item labels

### DIFF
--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -241,7 +241,7 @@ export const codeScanFindingsSchema = 'codescan/findings/1.0'
 
 export const autoScanDebounceDelaySeconds = 2
 
-export const codewhispererDiagnosticSourceLabel = 'CodeWhisperer '
+export const codewhispererDiagnosticSourceLabel = 'Amazon Q '
 
 // use vscode languageId here / Supported languages
 export const securityScanLanguageIds = [

--- a/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
+++ b/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
@@ -44,9 +44,9 @@ export function createAutoSuggestions(pause: boolean): DataQuickPickItem<'autoSu
 }
 
 export function createAutoScans(pause: boolean): DataQuickPickItem<'autoScans'> {
-    const labelResume = localize('AWS.codewhisperer.resumeCodeWhispererNode.label', 'Resume Auto-Scans')
+    const labelResume = localize('AWS.codewhisperer.resumeCodeWhispererNode.label', 'Resume Automatic File Scanning')
     const iconResume = getIcon('vscode-debug-alt')
-    const labelPause = localize('AWS.codewhisperer.pauseCodeWhispererNode.label', 'Pause Auto-Scans')
+    const labelPause = localize('AWS.codewhisperer.pauseCodeWhispererNode.label', 'Pause Automatic File Scanning')
     const iconPause = getIcon('vscode-debug-pause')
 
     return {
@@ -70,7 +70,7 @@ export function createOpenReferenceLog(): DataQuickPickItem<'openReferenceLog'> 
 
 export function createSecurityScan(): DataQuickPickItem<'securityScan'> {
     const prefix = codeScanState.getPrefixTextForButton()
-    const label = `${prefix} Security Scan`
+    const label = `${prefix} Full Project Scan`
     const icon = codeScanState.getIconForButton()
 
     return {

--- a/packages/core/src/codewhisperer/ui/statusBarMenu.ts
+++ b/packages/core/src/codewhisperer/ui/statusBarMenu.ts
@@ -76,11 +76,14 @@ function getAmazonQCodeWhispererNodes() {
         createOpenReferenceLog(),
         createGettingStarted(), // "Learn" node : opens Learn CodeWhisperer page
 
+        // Security scans
+        createSeparator('Security Scans'),
+        createAutoScans(autoScansEnabled),
+        createSecurityScan(),
+
         // Amazon Q + others
         createSeparator('Other Features'),
         ...(amazonq ? [amazonq.switchToAmazonQNode('item')] : []),
-        createAutoScans(autoScansEnabled),
-        createSecurityScan(),
     ]
 }
 

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -336,9 +336,9 @@ describe('CodeWhisperer-basicCommands', function () {
                     createAutoSuggestions(false),
                     createOpenReferenceLog(),
                     createGettingStarted(),
-                    switchToAmazonQNode('item'),
                     createAutoScans(false),
                     createSecurityScan(),
+                    switchToAmazonQNode('item'),
                     ...genericItems(),
                     createSettingsNode(),
                     createSignout()
@@ -361,9 +361,9 @@ describe('CodeWhisperer-basicCommands', function () {
                     createSelectCustomization(),
                     createOpenReferenceLog(),
                     createGettingStarted(),
-                    switchToAmazonQNode('item'),
                     createAutoScans(false),
                     createSecurityScan(),
+                    switchToAmazonQNode('item'),
                     ...genericItems(),
                     createSettingsNode(),
                     createSignout()


### PR DESCRIPTION
## Problem

There are two menu options for security scans, it may be unclear what the difference is.

## Solution

- Create a new sub menu section for security scans
- Update labels
- Also updated diagnostic source label

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
