### PR TITLE
fix(q): Upload workspaces' root directories instead of /src folder for feature dev capability

### DIFF
--- a/.changes/next-release/Feature-b9e8098d-e1a6-46e8-b13e-137b3ac6f95e.json
+++ b/.changes/next-release/Feature-b9e8098d-e1a6-46e8-b13e-137b3ac6f95e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q Feature Dev: Upload workspaces' root directories instead of /src folder"
+}

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -614,7 +614,7 @@ export class FeatureDevController {
         }
 
         if (uri && uri instanceof vscode.Uri) {
-            session.config.sourceRoots = [uri.fsPath]
+            session.config.workspaceRoots = [uri.fsPath]
             this.messenger.sendAnswer({
                 message: `Changed source root to: ${uri.fsPath}`,
                 type: 'answer',

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -90,7 +90,7 @@ export class Session {
 
     private getSessionStateConfig(): Omit<SessionStateConfig, 'uploadId'> {
         return {
-            sourceRoots: this.config.sourceRoots,
+            workspaceRoots: this.config.workspaceRoots,
             workspaceFolders: this.config.workspaceFolders,
             proxyClient: this.proxyClient,
             conversationId: this.conversationId,

--- a/packages/core/src/amazonqFeatureDev/session/sessionConfigFactory.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionConfigFactory.ts
@@ -9,11 +9,10 @@ import { VirtualFileSystem } from '../../shared/virtualFilesystem'
 import { VirtualMemoryFile } from '../../shared/virtualMemoryFile'
 import { WorkspaceFolderNotFoundError } from '../errors'
 import { CurrentWsFolders } from '../types'
-import { getSourceCodePath } from '../util/files'
 
 export interface SessionConfig {
     // The paths on disk to where the source code lives
-    sourceRoots: string[]
+    workspaceRoots: string[]
     readonly fs: VirtualFileSystem
     readonly workspaceFolders: CurrentWsFolders
 }
@@ -29,7 +28,7 @@ export async function createSessionConfig(): Promise<SessionConfig> {
         throw new WorkspaceFolderNotFoundError()
     }
 
-    const sourceRoots = await Promise.all(workspaceFolders.map(f => getSourceCodePath(f.uri.fsPath, 'src')))
+    const workspaceRoots = workspaceFolders.map(f => f.uri.fsPath)
 
     const fs = new VirtualFileSystem()
 
@@ -39,5 +38,5 @@ export async function createSessionConfig(): Promise<SessionConfig> {
         new VirtualMemoryFile(new Uint8Array())
     )
 
-    return Promise.resolve({ sourceRoots, fs, workspaceFolders: [firstFolder, ...workspaceFolders.slice(1)] })
+    return Promise.resolve({ workspaceRoots, fs, workspaceFolders: [firstFolder, ...workspaceFolders.slice(1)] })
 }

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -62,7 +62,7 @@ export class PrepareRefinementState implements Omit<SessionState, 'uploadId'> {
                 credentialStartUrl: AuthUtil.instance.startUrl,
             })
             const { zipFileBuffer, zipFileChecksum } = await prepareRepoData(
-                this.config.sourceRoots,
+                this.config.workspaceRoots,
                 this.config.workspaceFolders,
                 action.telemetry,
                 span
@@ -461,7 +461,7 @@ export class PrepareCodeGenState implements SessionState {
 
         const uploadId = await telemetry.amazonq_createUpload.run(async span => {
             const { zipFileBuffer, zipFileChecksum } = await prepareRepoData(
-                this.config.sourceRoots,
+                this.config.workspaceRoots,
                 this.config.workspaceFolders,
                 action.telemetry,
                 span

--- a/packages/core/src/amazonqFeatureDev/types.ts
+++ b/packages/core/src/amazonqFeatureDev/types.ts
@@ -53,7 +53,7 @@ export interface SessionState {
 }
 
 export interface SessionStateConfig {
-    sourceRoots: string[]
+    workspaceRoots: string[]
     workspaceFolders: CurrentWsFolders
     conversationId: string
     proxyClient: FeatureDevClient

--- a/packages/core/src/amazonqFeatureDev/util/files.ts
+++ b/packages/core/src/amazonqFeatureDev/util/files.ts
@@ -20,7 +20,6 @@ import { CurrentWsFolders } from '../types'
 import { ToolkitError } from '../../shared/errors'
 import { AmazonqCreateUpload, Metric } from '../../shared/telemetry/telemetry'
 import { TelemetryHelper } from './telemetryHelper'
-import { FileSystemCommon } from '../../srcShared/fs'
 import { sanitizeFilename } from '../../shared/utilities/textUtilities'
 
 export function getExcludePattern(additionalPatterns: string[] = []) {
@@ -319,18 +318,5 @@ export function getPathsFromZipFilePath(
         absolutePath: path.join(workspaceFolder.uri.fsPath, zipFilePath.substring(prefix.length + 1)),
         relativePath: zipFilePath.substring(prefix.length + 1),
         workspaceFolder,
-    }
-}
-
-export async function getSourceCodePath(workspaceRoot: string, projectRoot: string) {
-    const srcRoot = path.join(workspaceRoot, projectRoot)
-    try {
-        const srcFound = await FileSystemCommon.instance.stat(srcRoot)
-        return srcFound !== undefined ? srcRoot : workspaceRoot
-    } catch (error) {
-        if ((error as { code: string }).code === 'FileNotFound') {
-            return workspaceRoot
-        }
-        throw error
     }
 }

--- a/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -106,7 +106,7 @@ describe('Controller', () => {
             const newFileLocation = path.join(controllerSetup.workspaceFolder.uri.fsPath, 'foo', 'fi', 'mynewfile.js')
             await toFile('', newFileLocation)
             sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(controllerSetup.workspaceFolder)
-            session.config.sourceRoots = [path.join(controllerSetup.workspaceFolder.uri.fsPath, 'foo', 'fi')]
+            session.config.workspaceRoots = [path.join(controllerSetup.workspaceFolder.uri.fsPath, 'foo', 'fi')]
             const executedDiff = await openDiff(path.join('foo', 'fi', 'mynewfile.js'))
             assert.strictEqual(
                 executedDiff.calledWith(
@@ -167,8 +167,8 @@ describe('Controller', () => {
             sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(controllerSetup.workspaceFolder)
             const expectedSourceRoot = path.join(controllerSetup.workspaceFolder.uri.fsPath, 'src')
             const modifiedSession = await modifyDefaultSourceFolder(expectedSourceRoot)
-            assert.strictEqual(modifiedSession.config.sourceRoots.length, 1)
-            assert.strictEqual(modifiedSession.config.sourceRoots[0], expectedSourceRoot)
+            assert.strictEqual(modifiedSession.config.workspaceRoots.length, 1)
+            assert.strictEqual(modifiedSession.config.workspaceRoots[0], expectedSourceRoot)
         })
     })
 
@@ -178,7 +178,7 @@ describe('Controller', () => {
                 {
                     conversationId: conversationID,
                     proxyClient: new FeatureDevClient(),
-                    sourceRoots: [''],
+                    workspaceRoots: [''],
                     workspaceFolders: [controllerSetup.workspaceFolder],
                 },
                 '',
@@ -260,7 +260,7 @@ describe('Controller', () => {
                     getCodeGeneration: () => mockGetCodeGeneration(),
                     exportResultArchive: () => sinon.stub(),
                 } as unknown as FeatureDevClient,
-                sourceRoots: [''],
+                workspaceRoots: [''],
                 uploadId: uploadID,
                 workspaceFolders,
             }

--- a/packages/core/src/test/amazonqFeatureDev/session/sessionState.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/session/sessionState.test.ts
@@ -51,7 +51,7 @@ const mockSessionStateConfig = ({
     uploadId: string
     workspaceFolder: vscode.WorkspaceFolder
 }): SessionStateConfig => ({
-    sourceRoots: ['fake-source'],
+    workspaceRoots: ['fake-source'],
     workspaceFolders: [workspaceFolder],
     conversationId,
     proxyClient: {


### PR DESCRIPTION
## Problem

Currently, we're looking for the `/src` folder to upload, and if not found we're falling back to uploading the root directory. this was causing to missing multiple relevant files (e.g test directories) for the code generation. 
## Solution

We're changing the Amazon Q feature dev to upload workspaces' root directory instead of looking for `/src` folder so that we'll include all relevant files during plan and code generation. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
