### PR TITLE
fix: Toolkit/Q creates too many Output channels

### DIFF
--- a/packages/core/src/awsexplorer/activation.ts
+++ b/packages/core/src/awsexplorer/activation.ts
@@ -41,7 +41,6 @@ export async function activate(args: {
     context: ExtContext
     regionProvider: RegionProvider
     toolkitOutputChannel: vscode.OutputChannel
-    remoteInvokeOutputChannel: vscode.OutputChannel
 }): Promise<void> {
     const awsExplorer = new AwsExplorer(globals.context, args.regionProvider)
 

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -121,14 +121,13 @@ export async function activate(context: vscode.ExtensionContext) {
             context: extContext,
             regionProvider: globals.regionProvider,
             toolkitOutputChannel: globals.outputChannel,
-            remoteInvokeOutputChannel: globals.invokeOutputChannel,
         })
 
         await activateAppRunner(extContext)
 
         await activateApiGateway({
             extContext: extContext,
-            outputChannel: globals.invokeOutputChannel,
+            outputChannel: globals.outputChannel,
         })
 
         await activateLambda(extContext)

--- a/packages/core/src/extensionShared.ts
+++ b/packages/core/src/extensionShared.ts
@@ -94,10 +94,6 @@ export async function activateShared(context: vscode.ExtensionContext): Promise<
         )
     }
 
-    globals.invokeOutputChannel = vscode.window.createOutputChannel(
-        localize('AWS.channel.aws.remoteInvoke', '{0} Remote Invocations', getIdeProperties().company)
-    )
-
     //setup globals
     globals.machineId = await getMachineId()
     globals.awsContext = new DefaultAwsContext()
@@ -130,7 +126,6 @@ export async function activateShared(context: vscode.ExtensionContext): Promise<
         samCliContext: getSamCliContext,
         regionProvider: globals.regionProvider,
         outputChannel: globals.outputChannel,
-        invokeOutputChannel: globals.invokeOutputChannel,
         telemetryService: globals.telemetry,
         uriHandler: globals.uriHandler,
         credentialsStore: globals.loginManager.store,

--- a/packages/core/src/shared/extensionGlobals.ts
+++ b/packages/core/src/shared/extensionGlobals.ts
@@ -138,7 +138,6 @@ interface ToolkitGlobals {
     readonly context: ExtensionContext
     // TODO: make the rest of these readonly (or delete them)
     outputChannel: OutputChannel
-    invokeOutputChannel: OutputChannel
     loginManager: LoginManager
     awsContextCommands: AwsContextCommands
     awsContext: AwsContext

--- a/packages/core/src/shared/extensions.ts
+++ b/packages/core/src/shared/extensions.ts
@@ -44,7 +44,6 @@ export interface ExtContext {
     telemetryService: TelemetryService
     credentialsStore: CredentialsStore
     uriHandler: UriHandler
-    invokeOutputChannel: vscode.OutputChannel
 }
 
 /**

--- a/packages/core/src/test/fakeExtensionContext.ts
+++ b/packages/core/src/test/fakeExtensionContext.ts
@@ -128,7 +128,6 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
         }
         const regionProvider = createTestRegionProvider({ globalState: ctx.globalState, awsContext })
         const outputChannel = new MockOutputChannel()
-        const invokeOutputChannel = new MockOutputChannel()
         const fakeTelemetryPublisher = new FakeTelemetryPublisher()
         const telemetryService = await DefaultTelemetryService.create(
             ctx,
@@ -143,7 +142,6 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
             samCliContext,
             regionProvider,
             outputChannel,
-            invokeOutputChannel,
             telemetryService,
             credentialsStore: new CredentialsStore(),
             uriHandler: new UriHandler(),


### PR DESCRIPTION
Problem:
- Toolkit creates a "Remote Invocations" channel that is:
  - never actually used by the Lambda remote invoke feature.
  - created eagerly on startup, even if APIG or Lambda remote invoke are never used (clutters the user's OutputChannel list).

Solution:
Use the main Toolkit OutputChannel instead.

Followup to https://github.com/aws/aws-toolkit-vscode/pull/4527


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
