### PR TITLE
fix(release): don't use bash syntax in buildspec

### DIFF
--- a/buildspec/release/50githubrelease.yml
+++ b/buildspec/release/50githubrelease.yml
@@ -36,7 +36,7 @@ phases:
             - echo "posting $VERSION with sha384 hash $HASH to GitHub"
             - RELEASE_MESSAGE="AWS Toolkit for VS Code $VERSION"
             - |
-                if [[ $STAGE = "prod" && $TARGET_EXTENSION = "toolkit" ]]; then
+                if [ "$STAGE" = "prod" ] && [ "$TARGET_EXTENSION" = "toolkit" ]; then
                   gh release create --repo $REPO --title "$VERSION" --notes "$RELEASE_MESSAGE" -- "v$VERSION" "$UPLOAD_TARGET" "$HASH_UPLOAD_TARGET"
                 else
                   echo "SKIPPED: 'gh release create --repo $REPO'"


### PR DESCRIPTION
Problem: CodeBuild running sh, not bash.
Solution: Use sh compatibly syntax.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
