### PR TITLE
fix(ci): tests hang on showInformationMessage()

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -173,12 +173,12 @@ export async function activate(context: vscode.ExtensionContext) {
                 if (!isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq)) {
                     if (isPreviousQUser()) {
                         await installAmazonQExtension.execute()
-                        await vscode.window.showInformationMessage(
+                        void vscode.window.showInformationMessage(
                             'Amazon Q has moved to its own VSCode extension, which has been automatically installed.',
                             'OK'
                         )
                     } else {
-                        await vscode.window
+                        void vscode.window
                             .showInformationMessage(
                                 'Amazon Q has moved to its own VSCode extension.' +
                                     '\nInstall to work with Amazon Q, a generative AI assistant, with chat and code suggestions.',


### PR DESCRIPTION
related: https://github.com/aws/aws-toolkit-vscode/pull/4656

fix(ci): tests hang on showInformationMessage()

# Problem:
Tests hang since da98c70a1aad5946515b0b941c6e1fa1535d1588

# Solution:
Don't await messages that require user input.


---


# Notes

- da98c70 first commit where Toolkit fails to initialize (thus any commit hereafter _could_ cause a hang, but we don't know because CI fails to run the tests at all)
- [removing the "globals" proxy](https://github.com/aws/aws-toolkit-vscode/pull/4662/commits/f9be94cf8061a01a81991ba8642ab8c55b78db3f) allows the tests to run, and CI indeed hangs at commit https://github.com/aws/aws-toolkit-vscode/commit/da98c70a1aad5946515b0b941c6e1fa1535d1588 . This indicates:
    - the hang isn't caused by later commits
    - the hang isn't caused by https://github.com/aws/aws-toolkit-vscode/pull/4656/commits/30507f96f57de5fb579d05e2238dd08a5af58da0 nor https://github.com/aws/aws-toolkit-vscode/pull/4656/commits/46af0cd1b884177537de2bc9548a3d5cf85999b4
- reverting https://github.com/aws/aws-toolkit-vscode/commit/da98c70a1aad5946515b0b941c6e1fa1535d1588 allows CI tests to run (doesn't hang), on codebuild at least...

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
