### PR TITLE
feat(amazonq): Skip login screen for migration use case

### DIFF
--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -35,15 +35,22 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
         }
         return connections
     }
-
-    // Prioritize reusing a valid connection that has Amazon Q scopes
+    /**
+     * Select a connection for Amazon Q to use
+     * @param connections List of AWS Toolkit Connections
+     * @returns A connection that has Amazon Q scopes. It will return a valid connection if exists.
+     * Returns undefined if no connection has Q scopes.
+     */
     selectConnection(connections: AwsConnection[]): AwsConnection | undefined {
-        const score = (c: AwsConnection) =>
-            Number(c.scopes?.includes(scopesCodeWhispererChat[0])) * 10 + Number(c.state === 'valid')
+        const hasQScopes = (c: AwsConnection) => amazonQScopes.every(s => c.scopes?.includes(s))
+        const score = (c: AwsConnection) => Number(hasQScopes(c)) * 10 + Number(c.state === 'valid')
         connections.sort(function (a, b) {
             return score(b) - score(a)
         })
-        return connections[0]
+        if (hasQScopes(connections[0])) {
+            return connections[0]
+        }
+        return undefined
     }
 
     async useConnection(connectionId: string): Promise<AuthError | undefined> {

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -36,12 +36,12 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
         return connections
     }
     /**
-     * Select a connection for Amazon Q to use
+     * Gets a connection that is usable by Amazon Q.
+     *
      * @param connections List of AWS Toolkit Connections
-     * @returns A connection that has Amazon Q scopes. It will return a valid connection if exists.
-     * Returns undefined if no connection has Q scopes.
+     * @returns Amazon Q connection, or undefined if none of the given connections have scopes required for Amazon Q.
      */
-    selectConnection(connections: AwsConnection[]): AwsConnection | undefined {
+    findConnection(connections: AwsConnection[]): AwsConnection | undefined {
         const hasQScopes = (c: AwsConnection) => amazonQScopes.every(s => c.scopes?.includes(s))
         const score = (c: AwsConnection) => Number(hasQScopes(c)) * 10 + Number(c.state === 'valid')
         connections.sort(function (a, b) {

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -12,7 +12,7 @@ import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import { trustedDomainCancellation } from '../../../auth/sso/model'
 import { handleWebviewError } from '../../../webviews/server'
 import { InvalidGrantException } from '@aws-sdk/client-sso-oidc'
-import { Connection, SsoConnection } from '../../../auth/connection'
+import { AwsConnection, Connection } from '../../../auth/connection'
 import { Auth } from '../../../auth/auth'
 import { StaticProfile, StaticProfileKeyErrorMessage } from '../../../auth/credentials/types'
 
@@ -105,9 +105,11 @@ export abstract class CommonAuthWebview extends VueWebview {
         await vscode.commands.executeCommand('aws.explorer.focus')
     }
 
-    abstract fetchConnections(): Promise<SsoConnection[] | undefined>
+    abstract fetchConnections(): Promise<AwsConnection[] | undefined>
 
     abstract useConnection(connectionId: string): Promise<AuthError | undefined>
+
+    abstract selectConnection(connections: AwsConnection[]): AwsConnection | undefined
 
     abstract errorNotification(e: AuthError): void
 

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -109,7 +109,7 @@ export abstract class CommonAuthWebview extends VueWebview {
 
     abstract useConnection(connectionId: string): Promise<AuthError | undefined>
 
-    abstract selectConnection(connections: AwsConnection[]): AwsConnection | undefined
+    abstract findConnection(connections: AwsConnection[]): AwsConnection | undefined
 
     abstract errorNotification(e: AuthError): void
 

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -415,7 +415,7 @@ export default defineComponent({
             // If Amazon Q has no connections while Toolkit has connections
             // Auto connect Q using toolkit connection.
             if (connections.length === 0 && toolkitConnections && toolkitConnections.length > 0) {
-                const conn = await client.selectConnection(toolkitConnections)
+                const conn = await client.findConnection(toolkitConnections)
                 if (conn) {
                     await client.useConnection(conn.id)
                 }

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -415,7 +415,7 @@ export default defineComponent({
             // If Amazon Q has no connections while Toolkit has connections
             // Auto connect Q using toolkit connection.
             if (connections.length === 0 && toolkitConnections && toolkitConnections.length > 0) {
-                const conn = client.selectConnection(toolkitConnections)
+                const conn = await client.selectConnection(toolkitConnections)
                 if (conn) {
                     await client.useConnection(conn.id)
                 }

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -411,6 +411,16 @@ export default defineComponent({
                     this.existingConnectionStartUrls.push(connection.startUrl)
                 }
             })
+
+            // If Amazon Q has no connections while Toolkit has connections
+            // Auto connect Q using toolkit connection.
+            if (connections.length === 0 && toolkitConnections && toolkitConnections.length > 0) {
+                const conn = client.selectConnection(toolkitConnections)
+                if (conn) {
+                    await client.useConnection(conn.id)
+                }
+            }
+
             this.$forceUpdate()
         },
     },

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import { tryAddCredentials } from '../../../../auth/utils'
 import { getLogger } from '../../../../shared/logger'
 import { AuthError, CommonAuthWebview } from '../backend'
-import { SsoConnection, createSsoProfile } from '../../../../auth/connection'
+import { AwsConnection, createSsoProfile } from '../../../../auth/connection'
 import { Auth } from '../../../../auth/auth'
 import { CodeCatalystAuthenticationProvider } from '../../../../codecatalyst/auth'
 
@@ -76,12 +76,16 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
         await vscode.window.showInformationMessage(`${e.text}`)
     }
 
-    async fetchConnections(): Promise<SsoConnection[] | undefined> {
+    async fetchConnections(): Promise<AwsConnection[] | undefined> {
         //This does not need to be implement in aws toolkit vue backend
         return undefined
     }
 
     async useConnection(connectionId: string): Promise<AuthError | undefined> {
+        return undefined
+    }
+
+    selectConnection(connections: AwsConnection[]): AwsConnection | undefined {
         return undefined
     }
 

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -85,7 +85,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
         return undefined
     }
 
-    selectConnection(connections: AwsConnection[]): AwsConnection | undefined {
+    findConnection(connections: AwsConnection[]): AwsConnection | undefined {
         return undefined
     }
 


### PR DESCRIPTION
## Problem

For users who migrate from toolkit to Q, we need to let them use Q without doing any login. The migration should be seamless.

## Solution

For users who installed Q, if this user

1. Has aws toolkit installed
2. has a Amazon Q connection in toolkit 
3. Do not have any connection in Q.

Then we know this user is doing the migration from toolkit to Q, in this case, we skip the login screen for the user and immediately use the toolkit connection in Q. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
