### PR TITLE
codewhisperer: pass scope to createCodeAnalysis api

### DIFF
--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -298,7 +298,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 editor,
                 client,
                 context.extensionContext,
-                CodeWhispererConstants.SecurityScanType.File
+                CodeWhispererConstants.CodeAnalysisScope.FILE
             )
         }
 
@@ -325,7 +325,7 @@ export async function activate(context: ExtContext): Promise<void> {
                             editor,
                             client,
                             context.extensionContext,
-                            CodeWhispererConstants.SecurityScanType.File
+                            CodeWhispererConstants.CodeAnalysisScope.FILE
                         )
                     }
                 }
@@ -345,7 +345,7 @@ export async function activate(context: ExtContext): Promise<void> {
                         editor,
                         client,
                         context.extensionContext,
-                        CodeWhispererConstants.SecurityScanType.File
+                        CodeWhispererConstants.CodeAnalysisScope.FILE
                     )
                 }
             })
@@ -365,7 +365,7 @@ export async function activate(context: ExtContext): Promise<void> {
                     editor,
                     client,
                     context.extensionContext,
-                    CodeWhispererConstants.SecurityScanType.File
+                    CodeWhispererConstants.CodeAnalysisScope.FILE
                 )
             }
         })

--- a/packages/core/src/codewhisperer/client/user-service-2.json
+++ b/packages/core/src/codewhisperer/client/user-service-2.json
@@ -405,6 +405,10 @@
             "type": "string",
             "enum": ["codeanalysis/findings/1.0"]
         },
+        "CodeAnalysisScope": {
+            "type": "string",
+            "enum": ["FILE", "PROJECT"]
+        },
         "CodeAnalysisStatus": {
             "type": "string",
             "enum": ["Completed", "Pending", "Failed"]
@@ -1210,6 +1214,7 @@
             "members": {
                 "artifacts": { "shape": "ArtifactMap" },
                 "programmingLanguage": { "shape": "ProgrammingLanguage" },
+                "scope": { "shape": "CodeAnalysisScope" },
                 "clientToken": {
                     "shape": "StartCodeAnalysisRequestClientTokenString",
                     "idempotencyToken": true

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -501,7 +501,7 @@ export const utgConfig = {
 
 export const transformTreeNode = 'qTreeNode'
 
-export enum SecurityScanType {
-    File = 'File',
-    Project = 'Project',
+export enum CodeAnalysisScope {
+    FILE = 'FILE',
+    PROJECT = 'PROJECT',
 }

--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import { CodeScanIssue, AggregatedCodeScanIssue, CodeScansState } from '../models/model'
 import { SecurityIssueHoverProvider } from './securityIssueHoverProvider'
 import { SecurityIssueCodeActionProvider } from './securityIssueCodeActionProvider'
-import { SecurityScanType, codewhispererDiagnosticSourceLabel } from '../models/constants'
+import { CodeAnalysisScope, codewhispererDiagnosticSourceLabel } from '../models/constants'
 
 interface SecurityScanRender {
     securityDiagnosticCollection: vscode.DiagnosticCollection | undefined
@@ -25,13 +25,13 @@ export function initSecurityScanRender(
     securityRecommendationList: AggregatedCodeScanIssue[],
     context: vscode.ExtensionContext,
     editor: vscode.TextEditor,
-    scanType: SecurityScanType,
+    scope: CodeAnalysisScope,
     codeScanStartTime: number
 ) {
     securityScanRender.initialized = false
-    if (scanType === SecurityScanType.File) {
+    if (scope === CodeAnalysisScope.FILE) {
         securityScanRender.securityDiagnosticCollection?.delete(editor.document.uri)
-    } else if (scanType === SecurityScanType.Project) {
+    } else if (scope === CodeAnalysisScope.PROJECT) {
         securityScanRender.securityDiagnosticCollection?.clear()
     }
     securityRecommendationList.forEach(securityRecommendation => {

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -75,8 +75,8 @@ export class ZipUtil {
         return uri.fsPath.endsWith(ZipConstants.javaBuildExt)
     }
 
-    public reachSizeLimit(size: number, scanType: CodeWhispererConstants.SecurityScanType): boolean {
-        if (scanType === CodeWhispererConstants.SecurityScanType.File) {
+    public reachSizeLimit(size: number, scope: CodeWhispererConstants.CodeAnalysisScope): boolean {
+        if (scope === CodeWhispererConstants.CodeAnalysisScope.FILE) {
             return size > this.getFileScanPayloadSizeLimitInBytes()
         } else {
             return size > this.getProjectScanPayloadSizeLimitInBytes()
@@ -102,7 +102,7 @@ export class ZipUtil {
         this._totalSize += (await fsCommon.stat(uri.fsPath)).size
         this._totalLines += content.split(ZipConstants.newlineRegex).length
 
-        if (this.reachSizeLimit(this._totalSize, CodeWhispererConstants.SecurityScanType.File)) {
+        if (this.reachSizeLimit(this._totalSize, CodeWhispererConstants.CodeAnalysisScope.FILE)) {
             throw new ToolkitError('Payload size limit reached.')
         }
 
@@ -129,7 +129,7 @@ export class ZipUtil {
                 this._totalBuildSize += fileSize
             } else {
                 if (
-                    this.reachSizeLimit(this._totalSize, CodeWhispererConstants.SecurityScanType.Project) ||
+                    this.reachSizeLimit(this._totalSize, CodeWhispererConstants.CodeAnalysisScope.PROJECT) ||
                     this.willReachSizeLimit(this._totalSize, fileSize)
                 ) {
                     throw new ToolkitError('Payload size limit reached.')
@@ -156,16 +156,16 @@ export class ZipUtil {
         return this._zipDir
     }
 
-    public async generateZip(uri: vscode.Uri, scanType: CodeWhispererConstants.SecurityScanType): Promise<ZipMetadata> {
+    public async generateZip(uri: vscode.Uri, scope: CodeWhispererConstants.CodeAnalysisScope): Promise<ZipMetadata> {
         try {
             const zipDirPath = this.getZipDirPath()
             let zipFilePath: string
-            if (scanType === CodeWhispererConstants.SecurityScanType.File) {
+            if (scope === CodeWhispererConstants.CodeAnalysisScope.FILE) {
                 zipFilePath = await this.zipFile(uri)
-            } else if (scanType === CodeWhispererConstants.SecurityScanType.Project) {
+            } else if (scope === CodeWhispererConstants.CodeAnalysisScope.PROJECT) {
                 zipFilePath = await this.zipProject(uri)
             } else {
-                throw new ToolkitError(`Unknown scan type: ${scanType}`)
+                throw new ToolkitError(`Unknown code analysis scope: ${scope}`)
             }
 
             getLogger().debug(`Picked source files: [${[...this._pickedSourceFiles].join(', ')}]`)

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -20,7 +20,7 @@ import { HttpResponse } from 'aws-sdk'
 import { getTestWindow } from '../../shared/vscode/window'
 import { SeverityLevel } from '../../shared/vscode/message'
 import { cancel } from '../../../shared/localizedText'
-import { showScannedFilesMessage, stopScanMessage, SecurityScanType } from '../../../codewhisperer/models/constants'
+import { showScannedFilesMessage, stopScanMessage, CodeAnalysisScope } from '../../../codewhisperer/models/constants'
 import * as model from '../../../codewhisperer/models/model'
 import { CodewhispererSecurityScan } from '../../../shared/telemetry/telemetry.gen'
 import { getFetchStubWithResponse } from '../../common/request.test'
@@ -167,7 +167,7 @@ describe('startSecurityScan', function () {
             editor,
             createClient(),
             extensionContext,
-            SecurityScanType.Project
+            CodeAnalysisScope.PROJECT
         )
         assert.ok(commandSpy.calledWith('workbench.action.problems.focus'))
         assert.ok(securityScanRenderSpy.calledOnce)
@@ -186,7 +186,7 @@ describe('startSecurityScan', function () {
             editor,
             createClient(),
             extensionContext,
-            SecurityScanType.File
+            CodeAnalysisScope.FILE
         )
         assert.ok(commandSpy.neverCalledWith('workbench.action.problems.focus'))
         assert.ok(securityScanRenderSpy.calledOnce)
@@ -210,7 +210,7 @@ describe('startSecurityScan', function () {
             editor,
             createClient(),
             extensionContext,
-            SecurityScanType.Project
+            CodeAnalysisScope.PROJECT
         )
         await startSecurityScan.confirmStopSecurityScan()
         await scanPromise
@@ -236,7 +236,7 @@ describe('startSecurityScan', function () {
             editor,
             createClient(),
             extensionContext,
-            SecurityScanType.Project
+            CodeAnalysisScope.PROJECT
         )
         await startSecurityScan.confirmStopSecurityScan()
         await scanPromise
@@ -257,7 +257,7 @@ describe('startSecurityScan', function () {
             editor,
             createClient(),
             extensionContext,
-            SecurityScanType.File
+            CodeAnalysisScope.FILE
         )
         await model.CodeScansState.instance.setScansEnabled(false)
         await scanPromise
@@ -284,7 +284,7 @@ describe('startSecurityScan', function () {
             editor,
             createClient(),
             extensionContext,
-            SecurityScanType.Project
+            CodeAnalysisScope.PROJECT
         )
         assertTelemetry('codewhisperer_securityScan', {
             codewhispererLanguage: 'python',
@@ -305,7 +305,7 @@ describe('startSecurityScan', function () {
             editor,
             createClient(),
             extensionContext,
-            SecurityScanType.File
+            CodeAnalysisScope.FILE
         )
         assert.ok(commandSpy.neverCalledWith('workbench.action.problems.focus'))
         assert.ok(securityScanRenderSpy.notCalled)

--- a/packages/core/src/test/codewhisperer/util/zipUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/zipUtil.test.ts
@@ -9,7 +9,7 @@ import sinon from 'sinon'
 import { join } from 'path'
 import { getTestWorkspaceFolder } from '../../../testInteg/integrationTestsUtilities'
 import { ZipUtil } from '../../../codewhisperer/util/zipUtil'
-import { SecurityScanType } from '../../../codewhisperer/models/constants'
+import { CodeAnalysisScope } from '../../../codewhisperer/models/constants'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
 import { ToolkitError } from '../../../shared/errors'
 
@@ -42,7 +42,7 @@ describe('zipUtil', function () {
         })
 
         it('Should generate zip for file scan and return expected metadata', async function () {
-            const zipMetadata = await zipUtil.generateZip(vscode.Uri.file(appCodePath), SecurityScanType.File)
+            const zipMetadata = await zipUtil.generateZip(vscode.Uri.file(appCodePath), CodeAnalysisScope.FILE)
             assert.strictEqual(zipMetadata.lines, 49)
             assert.ok(zipMetadata.rootDir.includes(CodeWhispererConstants.codeScanTruncDirPrefix))
             assert.ok(zipMetadata.srcPayloadSizeInBytes > 0)
@@ -56,13 +56,13 @@ describe('zipUtil', function () {
             sinon.stub(zipUtil, 'reachSizeLimit').returns(true)
 
             await assert.rejects(
-                () => zipUtil.generateZip(vscode.Uri.file(appCodePath), SecurityScanType.File),
+                () => zipUtil.generateZip(vscode.Uri.file(appCodePath), CodeAnalysisScope.FILE),
                 new ToolkitError('Payload size limit reached.')
             )
         })
 
         it('Should generate zip for project scan and return expected metadata', async function () {
-            const zipMetadata = await zipUtil.generateZip(vscode.Uri.file(appCodePath), SecurityScanType.Project)
+            const zipMetadata = await zipUtil.generateZip(vscode.Uri.file(appCodePath), CodeAnalysisScope.PROJECT)
             assert.ok(zipMetadata.lines > 0)
             assert.ok(zipMetadata.rootDir.includes(CodeWhispererConstants.codeScanTruncDirPrefix))
             assert.ok(zipMetadata.srcPayloadSizeInBytes > 0)
@@ -76,7 +76,7 @@ describe('zipUtil', function () {
             sinon.stub(zipUtil, 'reachSizeLimit').returns(true)
 
             await assert.rejects(
-                () => zipUtil.generateZip(vscode.Uri.file(appCodePath), SecurityScanType.Project),
+                () => zipUtil.generateZip(vscode.Uri.file(appCodePath), CodeAnalysisScope.PROJECT),
                 new ToolkitError('Payload size limit reached.')
             )
         })
@@ -85,7 +85,7 @@ describe('zipUtil', function () {
             sinon.stub(zipUtil, 'willReachSizeLimit').returns(true)
 
             await assert.rejects(
-                () => zipUtil.generateZip(vscode.Uri.file(appCodePath), SecurityScanType.Project),
+                () => zipUtil.generateZip(vscode.Uri.file(appCodePath), CodeAnalysisScope.PROJECT),
                 new ToolkitError('Payload size limit reached.')
             )
         })
@@ -101,7 +101,7 @@ describe('zipUtil', function () {
                     return zipUtil.isJavaClassFile(...args)
                 })
 
-            const zipMetadata = await zipUtil.generateZip(vscode.Uri.file(appCodePath), SecurityScanType.Project)
+            const zipMetadata = await zipUtil.generateZip(vscode.Uri.file(appCodePath), CodeAnalysisScope.PROJECT)
             assert.ok(zipMetadata.lines > 0)
             assert.ok(zipMetadata.rootDir.includes(CodeWhispererConstants.codeScanTruncDirPrefix))
             assert.ok(zipMetadata.srcPayloadSizeInBytes > 0)
@@ -113,8 +113,8 @@ describe('zipUtil', function () {
 
         it('Should throw error if scan type is invalid', async function () {
             await assert.rejects(
-                () => zipUtil.generateZip(vscode.Uri.file(appCodePath), 'unknown' as SecurityScanType),
-                new ToolkitError('Unknown scan type: unknown')
+                () => zipUtil.generateZip(vscode.Uri.file(appCodePath), 'unknown' as CodeAnalysisScope),
+                new ToolkitError('Unknown code analysis scope: unknown')
             )
         })
     })

--- a/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
+++ b/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
@@ -30,7 +30,7 @@ def execute_input_noncompliant():
     module_version = request.args.get("module_version")
     # Noncompliant: executes unsanitized inputs.
     exec("import urllib%s as urllib" % module_version)
-        
+
 def execute_input_compliant():
     from flask import request
     module_version = request.args.get("module_version")
@@ -41,7 +41,7 @@ const largePrompt = 'a'.repeat(CodeWhispererConstants.codeScanPythonPayloadSizeL
 
 const javaPromptNoBuild = `class HelloWorld {
     public static void main(String[] args) {
-        System.out.println("Hello World!"); 
+        System.out.println("Hello World!");
     }
 }`
 
@@ -80,7 +80,7 @@ describe('CodeWhisperer security scan', async function () {
 
     /*
     securityJobSetup: combines steps 1 and 2 in startSecurityScan:
-    
+
         Step 1: Generate context truncations
         Step 2: Get presigned Url and upload
 
@@ -91,7 +91,7 @@ describe('CodeWhisperer security scan', async function () {
         const uri = editor.document.uri
 
         const projectPath = zipUtil.getProjectPath(editor.document.uri)
-        const zipMetadata = await zipUtil.generateZip(uri, CodeWhispererConstants.SecurityScanType.Project)
+        const zipMetadata = await zipUtil.generateZip(uri, CodeWhispererConstants.CodeAnalysisScope.PROJECT)
 
         let artifactMap
         try {
@@ -116,13 +116,11 @@ describe('CodeWhisperer security scan', async function () {
         const artifactMap = securityJobSetupResult.artifactMap
         const projectPath = securityJobSetupResult.projectPath
 
+        const scope = CodeWhispererConstants.CodeAnalysisScope.PROJECT
+
         //get job status and result
-        const scanJob = await createScanJob(client, artifactMap, editor.document.languageId)
-        const jobStatus = await pollScanJobStatus(
-            client,
-            scanJob.jobId,
-            CodeWhispererConstants.SecurityScanType.Project
-        )
+        const scanJob = await createScanJob(client, artifactMap, editor.document.languageId, scope)
+        const jobStatus = await pollScanJobStatus(client, scanJob.jobId, scope)
         const securityRecommendationCollection = await listScanResults(
             client,
             scanJob.jobId,
@@ -141,18 +139,16 @@ describe('CodeWhisperer security scan', async function () {
         await testutil.toFile(filePromptWithSecurityIssues, tempFile)
         const editor = await openTestFile(tempFile)
 
+        const scope = CodeWhispererConstants.CodeAnalysisScope.PROJECT
+
         //run security scan
         const securityJobSetupResult = await securityJobSetup(editor)
         const artifactMap = securityJobSetupResult.artifactMap
         const projectPath = securityJobSetupResult.projectPath
-        const scanJob = await createScanJob(client, artifactMap, editor.document.languageId)
+        const scanJob = await createScanJob(client, artifactMap, editor.document.languageId, scope)
 
         //get job status and result
-        const jobStatus = await pollScanJobStatus(
-            client,
-            scanJob.jobId,
-            CodeWhispererConstants.SecurityScanType.Project
-        )
+        const jobStatus = await pollScanJobStatus(client, scanJob.jobId, scope)
         const securityRecommendationCollection = await listScanResults(
             client,
             scanJob.jobId,


### PR DESCRIPTION
## Problem

Need to tell CreateCodeScan API the type of scan to perform

## Solution

- Pass `scope` to CreateCodeScan API which is either `FILE` or `PROJECT`
- Update `scanType` enum to `scope` for consistency

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
