### PR TITLE
fix(ci): restore settings type checking, fix unit tests

### DIFF
--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -27,9 +27,8 @@ phases:
             - export HOME=/home/codebuild-user
             # Generate CHANGELOG.md
             - npm run createRelease
-            - npm run package
+            - npm run package -w packages/toolkit -w packages/amazonq
 
 artifacts:
     files:
-        - aws-toolkit-vscode*vsix
-    discard-paths: true
+        - '*.vsix'

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -23,9 +23,10 @@
     "main": "./dist/src/extension",
     "scripts": {
         "vscode:prepublish": "npm run clean && npm run buildScripts && webpack --mode production",
-        "buildScripts": "npm run generateNonCodeFiles && npm run copyFiles",
+        "buildScripts": "npm run generateNonCodeFiles && npm run copyFiles && npm run syncPackageJson",
         "generateNonCodeFiles": "ts-node ../../scripts/generateNonCodeFiles.ts",
         "copyFiles": "ts-node ./scripts/build/copyFiles.ts",
+        "syncPackageJson": "ts-node ./scripts/build/syncPackageJson.ts",
         "clean": "ts-node ../../scripts/clean.ts dist/ LICENSE NOTICE CHANGELOG.md",
         "compile": "npm run clean && npm run buildScripts && webpack --mode development",
         "package": "ts-node ../../scripts/package.ts",
@@ -39,6 +40,11 @@
         "aws-core-vscode": "file:../core/"
     },
     "devDependencies": {},
+    "contributesComments": {
+        "configuration": {
+            "properties": "Any settings also defined in packages/core/package.json will override same-named settings in this file."
+        }
+    },
     "contributes": {
         "configuration": {
             "type": "object",

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -49,11 +49,6 @@
                 }
             },
             "properties": {
-                "aws.profile": {
-                    "type": "string",
-                    "deprecationMessage": "The current profile is now stored internally by the Toolkit.",
-                    "description": "%AWS.configuration.profileDescription%"
-                },
                 "aws.amazonq.logLevel": {
                     "type": "string",
                     "default": "debug",

--- a/packages/amazonq/scripts/build/syncPackageJson.ts
+++ b/packages/amazonq/scripts/build/syncPackageJson.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * We are currently in the process of splitting the toolkit into a core library and separate extensions.
+ * A lot of the core toolkit code depends on contents of its package.json. However, in order for
+ * individual extensions to function, they need to have the same entries in their local package.jsons as well.
+ *
+ * Unlike the Toolkit extension, the Amazon Q extension only needs to copy its settings from the core.
+ * Settings type checking is performed at compile time in core/src/shared/settings.ts, so it needs to
+ * exist in the core package.json as well.
+ *
+ * TODO: Drop settings initialization into respective extensions.
+ */
+
+import * as fs from 'fs-extra'
+
+function main() {
+    const packageJsonFile = './package.json'
+    const coreLibPackageJsonFile = '../core/package.json'
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonFile, { encoding: 'utf-8' }))
+    const coreLibPackageJson = JSON.parse(fs.readFileSync(coreLibPackageJsonFile, { encoding: 'utf-8' }))
+
+    const coreSettings = coreLibPackageJson.contributes.configuration.properties
+    Object.keys(coreSettings).forEach(key => {
+        if (key.startsWith('aws.amazonq') || key.startsWith('aws.codeWhisperer')) {
+            packageJson.contributes.configuration.properties[key] = coreSettings[key]
+        }
+    })
+
+    fs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, undefined, '    ') + '\n')
+}
+
+main()

--- a/packages/core/.vscode/launch.json
+++ b/packages/core/.vscode/launch.json
@@ -21,7 +21,7 @@
                 "AWS_TOOLKIT_AUTOMATION": "local"
             },
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-            "preLaunchTask": "${defaultBuildTask}"
+            "preLaunchTask": "watch"
         },
         {
             "name": "Extension Tests (current file)",
@@ -40,7 +40,7 @@
                 "AWS_TOOLKIT_AUTOMATION": "local"
             },
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-            "preLaunchTask": "${defaultBuildTask}"
+            "preLaunchTask": "watch"
         },
         {
             "name": "Extension Tests (web)",
@@ -74,7 +74,7 @@
                 "AWS_TOOLKIT_AUTOMATION": "local"
             },
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-            "preLaunchTask": "${defaultBuildTask}"
+            "preLaunchTask": "watch"
         },
         {
             "name": "Integration Tests (current file)",
@@ -93,7 +93,7 @@
                 "AWS_TOOLKIT_AUTOMATION": "local"
             },
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-            "preLaunchTask": "${defaultBuildTask}"
+            "preLaunchTask": "watch"
         },
         {
             "name": "E2E Test (current file)",
@@ -112,7 +112,7 @@
                 "AWS_TOOLKIT_AUTOMATION": "local"
             },
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-            "preLaunchTask": "${defaultBuildTask}"
+            "preLaunchTask": "watch"
         },
         {
             "name": "Test Lint",
@@ -120,7 +120,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/scripts/lint/testLint.ts",
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-            "preLaunchTask": "${defaultBuildTask}"
+            "preLaunchTask": "watch"
         },
         {
             "name": "Attach to ASL Server",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -156,7 +156,7 @@
                     "description": "%AWS.configuration.enableCodeLenses%",
                     "default": false
                 },
-                "aws.toolkit.suppressPrompts": {
+                "aws.suppressPrompts": {
                     "type": "object",
                     "description": "%AWS.configuration.description.suppressPrompts%",
                     "default": {},
@@ -233,6 +233,85 @@
                     "type": "object",
                     "description": "%AWS.configuration.description.lambda.recentlyUploaded%",
                     "default": []
+                },
+                "aws.amazonq.logLevel": {
+                    "type": "string",
+                    "default": "debug",
+                    "enum": [
+                        "error",
+                        "warn",
+                        "info",
+                        "verbose",
+                        "debug"
+                    ],
+                    "enumDescriptions": [
+                        "Errors Only",
+                        "Errors and Warnings",
+                        "Errors, Warnings, and Info",
+                        "Errors, Warnings, Info, and Verbose",
+                        "Errors, Warnings, Info, Verbose, and Debug"
+                    ],
+                    "markdownDescription": "%AWS.configuration.description.logLevel%",
+                    "cloud9": {
+                        "cn": {
+                            "markdownDescription": "%AWS.configuration.description.logLevel.cn%"
+                        }
+                    }
+                },
+                "aws.amazonq.telemetry": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "%AWS.configuration.description.telemetry%",
+                    "cloud9": {
+                        "cn": {
+                            "markdownDescription": "%AWS.configuration.description.telemetry.cn%"
+                        }
+                    }
+                },
+                "aws.amazonq.suppressPrompts": {
+                    "type": "object",
+                    "description": "%AWS.configuration.description.suppressPrompts%",
+                    "default": {},
+                    "properties": {
+                        "createCredentialsProfile": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "codeWhispererNewWelcomeMessage": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "codeWhispererConnectionExpired": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "amazonQWelcomePage": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "aws.codeWhisperer.includeSuggestionsWithCodeReferences": {
+                    "type": "boolean",
+                    "markdownDescription": "%AWS.configuration.description.codewhisperer%",
+                    "default": true
+                },
+                "aws.codeWhisperer.importRecommendation": {
+                    "type": "boolean",
+                    "description": "%AWS.configuration.description.codewhisperer.importRecommendation%",
+                    "default": true
+                },
+                "aws.codeWhisperer.shareCodeWhispererContentWithAWS": {
+                    "type": "boolean",
+                    "markdownDescription": "%AWS.configuration.description.codewhisperer.shareCodeWhispererContentWithAWS%",
+                    "default": true,
+                    "scope": "application"
+                },
+                "aws.codeWhisperer.javaCompilationOutput": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Provide the ABSOLUTE path which is used to store java project compilation results."
                 }
             }
         },

--- a/packages/core/src/apprunner/commands/pauseService.ts
+++ b/packages/core/src/apprunner/commands/pauseService.ts
@@ -9,7 +9,7 @@ const localize = nls.loadMessageBundle()
 import * as localizedText from '../../shared/localizedText'
 import { showConfirmationMessage } from '../../shared/utilities/messages'
 import { AppRunnerServiceNode } from '../explorer/apprunnerServiceNode'
-import { PromptSettings } from '../../shared/settings'
+import { ToolkitPromptSettings } from '../../shared/settings'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { Result } from '../../shared/telemetry/telemetry'
 
@@ -17,7 +17,7 @@ export async function pauseService(node: AppRunnerServiceNode): Promise<void> {
     let telemetryResult: Result = 'Failed'
 
     try {
-        const prompts = PromptSettings.instance
+        const prompts = ToolkitPromptSettings.instance
         const shouldNotify = await prompts.isPromptEnabled('apprunnerNotifyPause')
         const notifyPrompt = localize(
             'aws.apprunner.pauseService.notify',

--- a/packages/core/src/apprunner/wizards/deploymentButton.ts
+++ b/packages/core/src/apprunner/wizards/deploymentButton.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 
 import { QuickInputButton, QuickInputToggleButton } from '../../shared/ui/buttons'
 import { apprunnerPricingUrl } from '../../shared/constants'
-import { PromptSettings } from '../../shared/settings'
+import { ToolkitPromptSettings } from '../../shared/settings'
 import { getIcon } from '../../shared/icons'
 import { dontShow } from '../../shared/localizedText'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
@@ -30,7 +30,7 @@ function makeDeployButtons() {
 }
 
 async function showDeploymentCostNotification(): Promise<void> {
-    const settings = PromptSettings.instance
+    const settings = ToolkitPromptSettings.instance
 
     if (await settings.isPromptEnabled('apprunnerNotifyPricing')) {
         const notice = localize(

--- a/packages/core/src/codecatalyst/activation.ts
+++ b/packages/core/src/codecatalyst/activation.ts
@@ -14,7 +14,7 @@ import { CodeCatalystAuthenticationProvider } from './auth'
 import { registerDevfileWatcher, updateDevfileCommand } from './devfile'
 import { DevEnvClient, DevEnvActivity } from '../shared/clients/devenvClient'
 import { watchRestartingDevEnvs } from './reconnect'
-import { PromptSettings } from '../shared/settings'
+import { ToolkitPromptSettings } from '../shared/settings'
 import { dontShow } from '../shared/localizedText'
 import { getIdeProperties, isCloud9 } from '../shared/extensionUtilities'
 import { Commands, placeholder } from '../shared/vscode/commands2'
@@ -96,7 +96,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
         await showReadmeFileOnFirstLoad(ctx.extensionContext.workspaceState)
 
-        const settings = PromptSettings.instance
+        const settings = ToolkitPromptSettings.instance
         if (await settings.isPromptEnabled('remoteConnected')) {
             const message = localize(
                 'AWS.codecatalyst.connectedMessage',

--- a/packages/core/src/codewhisperer/commands/gettingStartedPageCommands.ts
+++ b/packages/core/src/codewhisperer/commands/gettingStartedPageCommands.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode'
 import { CommandDeclarations, Commands, VsCodeCommandArg } from '../../shared/vscode/commands2'
 import { showCodeWhispererWebview } from '../vue/backend'
 import { telemetry } from '../../shared/telemetry/telemetry'
-import { PromptSettings } from '../../shared/settings'
+import { AmazonQPromptSettings } from '../../shared/settings'
 import { CodeWhispererSource } from './types'
 /**
  * The methods with backend logic for the Codewhisperer Getting Started Page commands.
@@ -18,7 +18,7 @@ export class CodeWhispererCommandBackend {
             source = 'vscodeComponent'
         }
 
-        const prompts = PromptSettings.instance
+        const prompts = AmazonQPromptSettings.instance
         //To check the condition If the user has already seen the welcome message
         if (!(await prompts.isPromptEnabled('codeWhispererNewWelcomeMessage'))) {
             telemetry.ui_click.emit({ elementId: 'codewhisperer_Learn_ButtonClick', passive: true })

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -9,7 +9,7 @@ import { Auth } from '../../auth/auth'
 import { ToolkitError } from '../../shared/errors'
 import { getSecondaryAuth } from '../../auth/secondaryAuth'
 import { isCloud9, isSageMaker } from '../../shared/extensionUtilities'
-import { PromptSettings } from '../../shared/settings'
+import { AmazonQPromptSettings } from '../../shared/settings'
 import {
     scopesCodeWhispererCore,
     createBuilderIdProfile,
@@ -387,7 +387,7 @@ export class AuthUtil {
     }
 
     public async showReauthenticatePrompt(isAutoTrigger?: boolean) {
-        const settings = PromptSettings.instance
+        const settings = AmazonQPromptSettings.instance
         const shouldShow = await settings.isPromptEnabled('codeWhispererConnectionExpired')
         if (!shouldShow || (isAutoTrigger && this.reauthenticatePromptShown)) {
             return

--- a/packages/core/src/codewhisperer/vue/backend.ts
+++ b/packages/core/src/codewhisperer/vue/backend.ts
@@ -13,7 +13,7 @@ import globals from '../../shared/extensionGlobals'
 import { telemetry, CodewhispererLanguage, CodewhispererGettingStartedTask } from '../../shared/telemetry/telemetry'
 import { fsCommon } from '../../srcShared/fs'
 import { getLogger } from '../../shared/logger'
-import { PromptSettings } from '../../shared/settings'
+import { AmazonQPromptSettings } from '../../shared/settings'
 import { CodeWhispererSource } from '../commands/types'
 import { submitFeedback } from '../../feedback/vue/submitFeedback'
 import { placeholder } from '../../shared/vscode/commands2'
@@ -159,7 +159,7 @@ export async function showCodeWhispererWebview(
                 subscriptions = undefined
             }),
         ]
-        const prompts = PromptSettings.instance
+        const prompts = AmazonQPromptSettings.instance
         //To check the condition If the user has already seen the welcome message
         if (await prompts.isPromptEnabled('codeWhispererNewWelcomeMessage')) {
             telemetry.ui_click.emit({ elementId: 'codewhisperer_Learn_PageOpen', passive: true })

--- a/packages/core/src/ecs/commands.ts
+++ b/packages/core/src/ecs/commands.ts
@@ -8,7 +8,7 @@ const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
 import globals from '../shared/extensionGlobals'
-import { PromptSettings } from '../shared/settings'
+import { ToolkitPromptSettings } from '../shared/settings'
 import { ChildProcess } from '../shared/utilities/childProcess'
 import { showMessageWithCancel, showOutputMessage } from '../shared/utilities/messages'
 import { formatDateTimestamp, removeAnsi } from '../shared/utilities/textUtilities'
@@ -29,7 +29,11 @@ async function runCommandWizard(
 ): Promise<CommandWizardState & { container: Container }> {
     const container = getResourceFromTreeNode(param, Instance(Container))
 
-    const wizard = new CommandWizard(container, await PromptSettings.instance.isPromptEnabled('ecsRunCommand'), command)
+    const wizard = new CommandWizard(
+        container,
+        await ToolkitPromptSettings.instance.isPromptEnabled('ecsRunCommand'),
+        command
+    )
     const response = await wizard.run()
 
     if (!response) {
@@ -37,7 +41,7 @@ async function runCommandWizard(
     }
 
     if (response.confirmation === 'suppress') {
-        await PromptSettings.instance.disablePrompt('ecsRunCommand')
+        await ToolkitPromptSettings.instance.disablePrompt('ecsRunCommand')
     }
 
     return { container, ...response }
@@ -51,7 +55,7 @@ export enum EcsRunCommandPrompt {
 export async function toggleExecuteCommandFlag(
     service: Service,
     window = vscode.window,
-    settings = PromptSettings.instance
+    settings = ToolkitPromptSettings.instance
 ): Promise<void> {
     const yes = localize('AWS.generic.response.yes', 'Yes')
     const yesDontAskAgain = localize('AWS.message.prompt.yesDontAskAgain', "Yes, don't ask again")

--- a/packages/core/src/s3/fileViewerManager.ts
+++ b/packages/core/src/s3/fileViewerManager.ts
@@ -14,7 +14,7 @@ import { CancellationError } from '../shared/utilities/timeoutUtils'
 import { downloadFile } from './commands/downloadFileAs'
 import { s3FileViewerHelpUrl } from '../shared/constants'
 import { FileProvider, VirtualFileSystem } from '../shared/virtualFilesystem'
-import { PromptSettings } from '../shared/settings'
+import { ToolkitPromptSettings } from '../shared/settings'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { ToolkitError } from '../shared/errors'
 
@@ -124,7 +124,7 @@ export class S3FileViewerManager {
     public constructor(
         private readonly clientFactory: S3ClientFactory,
         private readonly fs: VirtualFileSystem,
-        private readonly settings = PromptSettings.instance,
+        private readonly settings = ToolkitPromptSettings.instance,
         private readonly schemes = { read: s3ReadScheme, edit: s3EditScheme }
     ) {
         this.disposables.push(this.registerTabCleanup())

--- a/packages/core/src/shared/awsContextCommands.ts
+++ b/packages/core/src/shared/awsContextCommands.ts
@@ -14,7 +14,7 @@ import * as localizedText from './localizedText'
 import { RegionProvider } from './regions/regionProvider'
 import { getIdeProperties } from './extensionUtilities'
 import { credentialHelpUrl } from './constants'
-import { PromptSettings } from './settings'
+import { ToolkitPromptSettings } from './settings'
 import { isNonNullable } from './utilities/tsUtils'
 import { CreateProfileWizard } from '../auth/wizards/createProfile'
 import { staticCredentialsTemplate } from '../auth/wizards/templates'
@@ -62,7 +62,7 @@ export class AwsContextCommands {
         await this.editCredentials()
         if (
             credentialsFiles.length === 0 &&
-            (await PromptSettings.instance.isPromptEnabled('createCredentialsProfile')) &&
+            (await ToolkitPromptSettings.instance.isPromptEnabled('createCredentialsProfile')) &&
             (await this.promptCredentialsSetup())
         ) {
             await this.onCommandCreateCredentialsProfile()
@@ -164,7 +164,7 @@ export class AwsContextCommands {
         if (userResponse === localizedText.yes) {
             return true
         } else if (userResponse === localizedText.no) {
-            await PromptSettings.instance.disablePrompt('createCredentialsProfile')
+            await ToolkitPromptSettings.instance.disablePrompt('createCredentialsProfile')
         } else if (userResponse === localizedText.help) {
             await openUrl(vscode.Uri.parse(credentialHelpUrl))
             return await this.promptCredentialsSetup()

--- a/packages/core/src/shared/sam/activation.ts
+++ b/packages/core/src/shared/sam/activation.ts
@@ -34,7 +34,7 @@ import { AWS_SAM_DEBUG_TYPE } from './debugger/awsSamDebugConfiguration'
 import { SamDebugConfigProvider } from './debugger/awsSamDebugger'
 import { addSamDebugConfiguration } from './debugger/commands/addSamDebugConfiguration'
 import { lazyLoadSamTemplateStrings } from '../../lambda/models/samTemplates'
-import { PromptSettings } from '../settings'
+import { ToolkitPromptSettings } from '../settings'
 import { shared } from '../utilities/functionUtils'
 import { SamCliSettings } from './cli/samCliSettings'
 import { Commands } from '../vscode/commands2'
@@ -297,7 +297,7 @@ async function activateCodefileOverlays(
  * Will not show if the YAML extension is installed or if a user has permanently dismissed the message.
  */
 async function createYamlExtensionPrompt(): Promise<void> {
-    const settings = PromptSettings.instance
+    const settings = ToolkitPromptSettings.instance
 
     /**
      * Prompt the user to install the YAML plugin when AWSTemplateFormatVersion becomes available as a top level key
@@ -415,7 +415,7 @@ async function promptInstallYamlPlugin(disposables: vscode.Disposable[]) {
     for (const prompt of disposables) {
         prompt.dispose()
     }
-    const settings = PromptSettings.instance
+    const settings = ToolkitPromptSettings.instance
 
     const installBtn = localize('AWS.missingExtension.install', 'Install...')
     const permanentlySuppress = localize('AWS.message.info.yaml.suppressPrompt', "Don't show again")

--- a/packages/core/src/shared/sam/sync.ts
+++ b/packages/core/src/shared/sam/sync.ts
@@ -24,7 +24,7 @@ import { AWSTreeNodeBase } from '../treeview/nodes/awsTreeNodeBase'
 import { ToolkitError, UnknownError } from '../errors'
 import { telemetry } from '../telemetry/telemetry'
 import { createCommonButtons } from '../ui/buttons'
-import { PromptSettings } from '../settings'
+import { ToolkitPromptSettings } from '../settings'
 import { getLogger } from '../logger'
 import { isCloud9 } from '../extensionUtilities'
 import { removeAnsi } from '../utilities/textUtilities'
@@ -647,7 +647,7 @@ async function updateRecentResponse(region: string, key: string, value: string |
 }
 
 async function confirmDevStack() {
-    const canPrompt = await PromptSettings.instance.isPromptEnabled('samcliConfirmDevStack')
+    const canPrompt = await ToolkitPromptSettings.instance.isPromptEnabled('samcliConfirmDevStack')
     if (!canPrompt) {
         return
     }
@@ -667,7 +667,7 @@ Confirm that you are synchronizing a development stack.
     }
 
     if (resp === okDontShow) {
-        await PromptSettings.instance.disablePrompt('samcliConfirmDevStack')
+        await ToolkitPromptSettings.instance.disablePrompt('samcliConfirmDevStack')
     }
 }
 

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -582,6 +582,8 @@ export function fromExtensionManifest<T extends TypeDescriptor & Partial<Section
 }
 
 /**
+ * PromptSettings
+ *
  * Controls flags for prompts that allow the user to hide them. Usually this is presented as
  * some variation of "Don't show again".
  *
@@ -597,8 +599,14 @@ export function fromExtensionManifest<T extends TypeDescriptor & Partial<Section
  *     }
  * }
  * ```
+ *
+ * There are individual implementations for the Toolkit extension and Amazon Q extension.
+ * This is a temporary workaround to get compile time checking and runtime fetching
+ * of settings working.
+ *
+ * TODO: Settings should be defined in individual extensions, and passed to the
+ * core lib as necessary.
  */
-
 export const toolkitPrompts = settingsProps['aws.suppressPrompts'].properties
 type toolkitPromptName = keyof typeof toolkitPrompts
 export class ToolkitPromptSettings extends Settings.define(

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode'
 import * as codecatalyst from './clients/codecatalystClient'
 import * as codewhisperer from '../codewhisperer/client/codewhisperer'
+import packageJson from '../../package.json'
 import { getLogger } from './logger'
 import { cast, FromDescriptor, Record, TypeConstructor, TypeDescriptor } from './utilities/typeConstructors'
 import { assertHasProps, ClassToInterfaceType, keys } from './utilities/tsUtils'
@@ -319,7 +320,7 @@ function createSettingsClass<T extends TypeDescriptor>(section: string, descript
          * @param key Setting name
          * @param defaultValue Value returned if setting is missing or invalid
          */
-        public get<K extends keyof Inner>(key: K & string, defaultValue?: Inner[K]): any {
+        public get<K extends keyof Inner>(key: K & string, defaultValue?: Inner[K]) {
             try {
                 return this._getOrThrow(key, defaultValue)
             } catch (e) {
@@ -470,6 +471,48 @@ export interface ResetableMemento extends vscode.Memento {
     reset(): Promise<void>
 }
 
+// The below types are used to split-out 'sections' from `package.json`
+// Obviously not ideal, but the alternative is to generate the properties
+// from implementations. Using types requires basically no logic but lacks
+// precision. We still need to manually specify what type something should be,
+// at least for anything beyond primitive types.
+const settingsProps = packageJson.contributes.configuration.properties
+
+type SettingsProps = typeof settingsProps
+
+type Split<T, S extends string> = T extends `${infer L}${S}${infer R}` ? [L, ...Split<R, S>] : [T]
+type Pop<T> = T extends [...infer R, infer _] ? R : never
+type Intersection<T> = (T extends any ? (_: T) => any : never) extends (_: infer U) => any ? U : never
+
+type FromParts<T, K> = K extends [infer U, ...infer R]
+    ? [U, R] extends [string, string[]]
+        ? { [P in U & string]: FromParts<T, R> }
+        : T
+    : T
+
+type Format<T> = { [P in keyof T]: FromParts<TypeConstructor, Split<P, '.'>> }[keyof T]
+type Config = Intersection<Format<SettingsProps>>
+
+type Join<T extends string[], S extends string> = T['length'] extends 1
+    ? T[0]
+    : T extends [infer L, ...infer R]
+    ? L extends string
+        ? R extends string[]
+            ? `${L}${S}${Join<R, S>}`
+            : ''
+        : ''
+    : never
+
+type Select<T, K> = K extends [infer L, ...infer R]
+    ? L extends keyof T
+        ? R['length'] extends 0
+            ? T[L]
+            : Select<T[L], R>
+        : never
+    : never
+
+type Sections = { [P in keyof SettingsProps as Join<Pop<Split<P, '.'>>, '.'>]: Select<Config, Pop<Split<P, '.'>>> }
+
 /**
  * Creates a class for manipulating specific sections of settings specified in `package.json`.
  *
@@ -512,7 +555,10 @@ export interface ResetableMemento extends vscode.Memento {
  *
  * @returns A class that can be used as-is or inherited from
  */
-export function fromExtensionManifest(section: string, descriptor: any) {
+export function fromExtensionManifest<T extends TypeDescriptor & Partial<Sections[K]>, K extends keyof Sections>(
+    section: K,
+    descriptor: T
+) {
     // The function signature is intentionally loose to allow for partial implementations.
     // Runtime validation is required to ensure things are correct.
     //
@@ -522,16 +568,15 @@ export function fromExtensionManifest(section: string, descriptor: any) {
     //
     // As long as the above holds true, throwing an error here will always be caught by CI
 
-    /** TODO: restore/remove checking*/
-    // const resolved = keys(descriptor).map(k => `${section}.${k}`)
-    // const missing = resolved.filter(k => (settingsProps as Record<string, any>)[k] === undefined)
+    const resolved = keys(descriptor).map(k => `${section}.${k}`)
+    const missing = resolved.filter(k => (settingsProps as Record<string, any>)[k] === undefined)
 
-    // if (missing.length > 0) {
-    //     const message = `The following configuration keys were missing from package.json: ${missing.join(', ')}`
-    //     getLogger().error(`Settings (fromExtensionManifest): missing fields:\n${missing.map(k => `\t${k}`).join('\n')}`)
+    if (missing.length > 0) {
+        const message = `The following configuration keys were missing from package.json: ${missing.join(', ')}`
+        getLogger().error(`Settings (fromExtensionManifest): missing fields:\n${missing.map(k => `\t${k}`).join('\n')}`)
 
-    //     throw new Error(message)
-    // }
+        throw new Error(message)
+    }
 
     return Settings.define(section, descriptor)
 }
@@ -553,11 +598,14 @@ export function fromExtensionManifest(section: string, descriptor: any) {
  * }
  * ```
  */
-export class PromptSettings extends Settings.define(
-    'aws.{}.suppressPrompts',
-    toRecord(typeof '', () => Boolean)
+
+export const toolkitPrompts = settingsProps['aws.suppressPrompts'].properties
+type toolkitPromptName = keyof typeof toolkitPrompts
+export class ToolkitPromptSettings extends Settings.define(
+    'aws.suppressPrompts',
+    toRecord(keys(toolkitPrompts), () => Boolean)
 ) {
-    public async isPromptEnabled(promptName: string): Promise<boolean> {
+    public async isPromptEnabled(promptName: toolkitPromptName): Promise<boolean> {
         try {
             return !this._getOrThrow(promptName, false)
         } catch (e) {
@@ -568,18 +616,51 @@ export class PromptSettings extends Settings.define(
         }
     }
 
-    public async disablePrompt(promptName: string): Promise<void> {
+    public async disablePrompt(promptName: toolkitPromptName): Promise<void> {
         if (await this.isPromptEnabled(promptName)) {
             await this.update(promptName, true)
         }
     }
 
-    static #instance: PromptSettings
+    static #instance: ToolkitPromptSettings
 
     public static get instance() {
         return (this.#instance ??= new this())
     }
 }
+
+export const amazonQPrompts = settingsProps['aws.amazonq.suppressPrompts'].properties
+type amazonQPromptName = keyof typeof amazonQPrompts
+export class AmazonQPromptSettings extends Settings.define(
+    'aws.amazonq.suppressPrompts',
+    toRecord(keys(amazonQPrompts), () => Boolean)
+) {
+    public async isPromptEnabled(promptName: amazonQPromptName): Promise<boolean> {
+        try {
+            return !this._getOrThrow(promptName, false)
+        } catch (e) {
+            this._log('prompt check for "%s" failed: %s', promptName, (e as Error).message)
+            await this.reset()
+
+            return true
+        }
+    }
+
+    public async disablePrompt(promptName: amazonQPromptName): Promise<void> {
+        if (await this.isPromptEnabled(promptName)) {
+            await this.update(promptName, true)
+        }
+    }
+
+    static #instance: AmazonQPromptSettings
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+}
+
+const experiments = settingsProps['aws.experiments'].properties
+type ExperimentName = keyof typeof experiments
 
 /**
  * "Experiments" are for features that users must opt-in to use. Experimental implementations
@@ -606,9 +687,9 @@ export class PromptSettings extends Settings.define(
  */
 export class Experiments extends Settings.define(
     'aws.experiments',
-    toRecord(typeof '', () => Boolean)
+    toRecord(keys(experiments), () => Boolean)
 ) {
-    public async isExperimentEnabled(name: string): Promise<boolean> {
+    public async isExperimentEnabled(name: ExperimentName): Promise<boolean> {
         try {
             return this._getOrThrow(name, false)
         } catch (error) {
@@ -805,6 +886,6 @@ export async function migrateSetting<T, U = T>(
  *
  * This only works for keys that are considered "top-level", e.g. keys of {@link settingsProps}.
  */
-export async function openSettings(key: string): Promise<void> {
+export async function openSettings<K extends keyof SettingsProps>(key: K): Promise<void> {
     await vscode.commands.executeCommand('workbench.action.openSettings', `@id:${key}`)
 }

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -25,7 +25,7 @@ const TelemetryFlag = addTypeName('boolean', convertLegacy)
 
 export class TelemetryConfig extends fromExtensionManifest('aws', { telemetry: TelemetryFlag }) {
     public isEnabled(): boolean {
-        return this.get(`${globals.contextPrefix}telemetry`, true)
+        return this.get(`${globals.contextPrefix}telemetry` as any, true)
     }
 }
 

--- a/packages/core/src/test/cdk/explorer/awsCdkExplorer.test.ts
+++ b/packages/core/src/test/cdk/explorer/awsCdkExplorer.test.ts
@@ -19,8 +19,7 @@ describe('CdkRootNode', function () {
 
         sinon.stub(detectCdkProjects, 'detectCdkProjects').resolves([appLocation])
 
-        const rootNode = new CdkRootNode()
-        const treeNodes = await rootNode.getChildren()
+        const treeNodes = await CdkRootNode.instance.getChildren()
         assert.strictEqual(treeNodes.length, 1)
         assert.deepStrictEqual(treeNodes[0].resource, appLocation)
     })

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -56,8 +56,11 @@ import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletio
 describe('CodeWhisperer-basicCommands', function () {
     let targetCommand: Command<any> & vscode.Disposable
 
-    beforeEach(async function () {
+    before(async function () {
         tryRegister(refreshStatusBar)
+    })
+
+    beforeEach(async function () {
         await resetCodeWhispererGlobalVariables()
     })
 

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -8,7 +8,7 @@ import assert from 'assert'
 import * as sinon from 'sinon'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
 import { createCodeScanIssue, createMockDocument, resetCodeWhispererGlobalVariables } from '../testUtil'
-import { assertTelemetry, assertTelemetryCurried } from '../../testUtil'
+import { assertTelemetry, assertTelemetryCurried, tryRegister } from '../../testUtil'
 import {
     toggleCodeSuggestions,
     showSecurityScan,
@@ -51,11 +51,13 @@ import { CodeSuggestionsState } from '../../../codewhisperer/models/model'
 import { cwQuickPickSource } from '../../../codewhisperer/commands/types'
 import { switchToAmazonQNode, createSignIn } from '../../../amazonq/explorer/amazonQChildrenNodes'
 import { isTextEditor } from '../../../shared/utilities/editorUtilities'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
 
 describe('CodeWhisperer-basicCommands', function () {
     let targetCommand: Command<any> & vscode.Disposable
 
     beforeEach(async function () {
+        tryRegister(refreshStatusBar)
         await resetCodeWhispererGlobalVariables()
     })
 
@@ -301,6 +303,10 @@ describe('CodeWhisperer-basicCommands', function () {
         function genericItems() {
             return [createFeedbackNode(), createGitHubNode(), createDocumentationNode()]
         }
+
+        before(async function () {
+            tryRegister(listCodeWhispererCommands)
+        })
 
         it('shows expected items when not connected', async function () {
             sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)

--- a/packages/core/src/test/codewhisperer/service/completionProvider.test.ts
+++ b/packages/core/src/test/codewhisperer/service/completionProvider.test.ts
@@ -11,6 +11,8 @@ import { createMockDocument, resetCodeWhispererGlobalVariables } from '../testUt
 import { Recommendation } from '../../../codewhisperer/client/codewhisperer'
 import { RecommendationHandler } from '../../../codewhisperer/service/recommendationHandler'
 import { session } from '../../../codewhisperer/util/codeWhispererSession'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
+import { tryRegister } from '../../testUtil'
 
 describe('completionProviderService', function () {
     beforeEach(async function () {
@@ -19,6 +21,8 @@ describe('completionProviderService', function () {
 
     describe('getLabel', function () {
         it('should return correct label given recommendation longer than Constants.LABEL_LENGTH', function () {
+            tryRegister(refreshStatusBar)
+
             const mockLongRecommendation = `
             const metaDataFile = path.join(__dirname, 'nls.metadata.json');
             const locale = getUserDefinedLocale(argvConfig);`

--- a/packages/core/src/test/codewhisperer/service/inlineCompletionService.test.ts
+++ b/packages/core/src/test/codewhisperer/service/inlineCompletionService.test.ts
@@ -6,7 +6,11 @@
 import * as vscode from 'vscode'
 import assert from 'assert'
 import * as sinon from 'sinon'
-import { CodeWhispererStatusBar, InlineCompletionService } from '../../../codewhisperer/service/inlineCompletionService'
+import {
+    CodeWhispererStatusBar,
+    InlineCompletionService,
+    refreshStatusBar,
+} from '../../../codewhisperer/service/inlineCompletionService'
 import { createMockTextEditor, resetCodeWhispererGlobalVariables, createMockDocument } from '../testUtil'
 import { ReferenceInlineProvider } from '../../../codewhisperer/service/referenceInlineProvider'
 import { RecommendationHandler } from '../../../codewhisperer/service/recommendationHandler'
@@ -16,6 +20,7 @@ import { CWInlineCompletionItemProvider } from '../../../codewhisperer/service/i
 import { session } from '../../../codewhisperer/util/codeWhispererSession'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { listCodeWhispererCommandsId } from '../../../codewhisperer/ui/statusBarMenu'
+import { tryRegister } from '../../testUtil'
 
 describe('inlineCompletionService', function () {
     beforeEach(async function () {
@@ -42,6 +47,8 @@ describe('inlineCompletionService', function () {
         })
 
         it('should call checkAndResetCancellationTokens before showing inline and next token to be null', async function () {
+            tryRegister(refreshStatusBar)
+
             const mockEditor = createMockTextEditor()
             sinon.stub(RecommendationHandler.instance, 'getRecommendations').resolves({
                 result: 'Succeeded',
@@ -160,6 +167,8 @@ describe('CWInlineCompletionProvider', function () {
         })
 
         it('should return undefined if position is before RecommendationHandler start pos', async function () {
+            tryRegister(refreshStatusBar)
+
             const position = new vscode.Position(0, 0)
             const document = createMockDocument()
             const fakeContext = { triggerKind: 0, selectedCompletionInfo: undefined }
@@ -186,6 +195,10 @@ describe('codewhisperer status bar', function () {
             return this.statusBar
         }
     }
+
+    before(async function () {
+        tryRegister(refreshStatusBar)
+    })
 
     beforeEach(async function () {
         await resetCodeWhispererGlobalVariables()

--- a/packages/core/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/packages/core/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -14,7 +14,7 @@ import {
     DefaultDocumentChangedType,
 } from '../../../codewhisperer/service/keyStrokeHandler'
 import { createMockTextEditor, createTextDocumentChangeEvent, resetCodeWhispererGlobalVariables } from '../testUtil'
-import { InlineCompletionService } from '../../../codewhisperer/service/inlineCompletionService'
+import { InlineCompletionService, refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
 import * as EditorContext from '../../../codewhisperer/util/editorContext'
 import { RecommendationHandler } from '../../../codewhisperer/service/recommendationHandler'
 import { isInlineCompletionEnabled } from '../../../codewhisperer/util/commonUtil'
@@ -22,6 +22,7 @@ import { ClassifierTrigger } from '../../../codewhisperer/service/classifierTrig
 import { CodeWhispererUserGroupSettings } from '../../../codewhisperer/util/userGroupUtil'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
 import { RecommendationService } from '../../../codewhisperer/service/recommendationService'
+import { tryRegister } from '../../testUtil'
 
 describe('keyStrokeHandler', function () {
     const config: ConfigurationEntry = {
@@ -52,6 +53,8 @@ describe('keyStrokeHandler', function () {
         })
 
         it('Whatever the input is, should skip when automatic trigger is turned off, should not call invokeAutomatedTrigger', async function () {
+            tryRegister(refreshStatusBar)
+
             const mockEditor = createMockTextEditor()
             const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
                 mockEditor.document,

--- a/packages/core/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/packages/core/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import { DefaultCodeWhispererClient } from '../../../codewhisperer/client/codewhisperer'
-import { assertTelemetryCurried } from '../../testUtil'
+import { assertTelemetryCurried, tryRegister } from '../../testUtil'
 import { RecommendationsList } from '../../../codewhisperer/client/codewhisperer'
 import { ConfigurationEntry } from '../../../codewhisperer/models/model'
 import { createMockTextEditor, resetCodeWhispererGlobalVariables } from '../testUtil'
@@ -23,6 +23,7 @@ import { extensionVersion } from '../../../shared/vscode/env'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { session } from '../../../codewhisperer/util/codeWhispererSession'
 import { ReferenceInlineProvider } from '../../../codewhisperer/service/referenceInlineProvider'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
 
 describe('recommendationHandler', function () {
     const config: ConfigurationEntry = {
@@ -56,6 +57,8 @@ describe('recommendationHandler', function () {
         })
 
         it('should assign correct recommendations given input', async function () {
+            tryRegister(refreshStatusBar)
+
             assert.strictEqual(CodeWhispererCodeCoverageTracker.instances.size, 0)
             assert.strictEqual(
                 CodeWhispererCodeCoverageTracker.getTracker(mockEditor.document.languageId, fakeMemeto)

--- a/packages/core/src/test/codewhisperer/service/referenceHoverProvider.test.ts
+++ b/packages/core/src/test/codewhisperer/service/referenceHoverProvider.test.ts
@@ -8,6 +8,8 @@ import * as vscode from 'vscode'
 import { createMockDocument, resetCodeWhispererGlobalVariables } from '../testUtil'
 import { ReferenceHoverProvider } from '../../../codewhisperer/service/referenceHoverProvider'
 import { cast } from '../../../shared/utilities/typeConstructors'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
+import { tryRegister } from '../../testUtil'
 
 describe('referenceHoverProvider', function () {
     beforeEach(async function () {
@@ -15,6 +17,8 @@ describe('referenceHoverProvider', function () {
     })
     describe('provideHover', async function () {
         it('Should return a hover object that contains license name and repo name when reference code exists in document ', function () {
+            tryRegister(refreshStatusBar)
+
             const referenceHoverProvider = new ReferenceHoverProvider()
             const mockDocoument = createMockDocument('def two_sum(nums, target):\nfor', 'test.py', 'python')
             referenceHoverProvider.addCodeReferences(`def two_sum(nums, target)`, [

--- a/packages/core/src/test/codewhisperer/service/referenceInlineProvider.test.ts
+++ b/packages/core/src/test/codewhisperer/service/referenceInlineProvider.test.ts
@@ -5,6 +5,8 @@
 import assert from 'assert'
 import { resetCodeWhispererGlobalVariables } from '../testUtil'
 import { ReferenceInlineProvider } from '../../../codewhisperer/service/referenceInlineProvider'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
+import { tryRegister } from '../../testUtil'
 
 describe('referenceInlineProvider', function () {
     beforeEach(async function () {
@@ -12,6 +14,8 @@ describe('referenceInlineProvider', function () {
     })
     describe('setInlineReference', async function () {
         it('Reference codelens message should contain license name and Code Reference Log', function () {
+            tryRegister(refreshStatusBar)
+
             const referenceInlineProvider = new ReferenceInlineProvider()
             const fakeReferences = [
                 {

--- a/packages/core/src/test/codewhisperer/service/referenceLogViewProvider.test.ts
+++ b/packages/core/src/test/codewhisperer/service/referenceLogViewProvider.test.ts
@@ -6,6 +6,8 @@ import assert from 'assert'
 import { createMockTextEditor, resetCodeWhispererGlobalVariables } from '../testUtil'
 import { ReferenceLogViewProvider } from '../../../codewhisperer/service/referenceLogViewProvider'
 import { LicenseUtil } from '../../../codewhisperer/util/licenseUtil'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
+import { tryRegister } from '../../testUtil'
 
 describe('referenceLogViewProvider', function () {
     beforeEach(async function () {
@@ -13,6 +15,8 @@ describe('referenceLogViewProvider', function () {
     })
     describe('getReferenceLog', async function () {
         it('Should return expected reference log string with link to license if there is no url', function () {
+            tryRegister(refreshStatusBar)
+
             const currentTime = new Date()
             const currentTimeString = currentTime.toLocaleString()
             currentTime.setSeconds(currentTime.getSeconds() + 1)

--- a/packages/core/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/packages/core/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode'
 import { CodeWhispererCodeCoverageTracker } from '../../../codewhisperer/tracker/codewhispererCodeCoverageTracker'
 import { createMockDocument, createMockTextEditor, resetCodeWhispererGlobalVariables } from '../testUtil'
 import globals from '../../../shared/extensionGlobals'
-import { assertTelemetryCurried } from '../../testUtil'
+import { assertTelemetryCurried, tryRegister } from '../../testUtil'
 import { vsCodeState } from '../../../codewhisperer/models/model'
 import { FakeMemento } from '../../fakeExtensionContext'
 import { TelemetryHelper } from '../../../codewhisperer/util/telemetryHelper'
@@ -17,11 +17,16 @@ import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
 import { CodeWhispererUserGroupSettings } from '../../../codewhisperer/util/userGroupUtil'
 import { extensionVersion } from '../../../shared/vscode/env'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
 
 describe('codewhispererCodecoverageTracker', function () {
     const language = 'python'
 
     describe('test getTracker', function () {
+        before(async function () {
+            tryRegister(refreshStatusBar)
+        })
+
         afterEach(async function () {
             await resetCodeWhispererGlobalVariables()
             CodeWhispererCodeCoverageTracker.instances.clear()

--- a/packages/core/src/test/codewhisperer/tracker/codewhispererTracker.test.ts
+++ b/packages/core/src/test/codewhisperer/tracker/codewhispererTracker.test.ts
@@ -6,17 +6,19 @@
 import assert from 'assert'
 import * as sinon from 'sinon'
 import globals from '../../../shared/extensionGlobals'
-import { assertTelemetryCurried } from '../../testUtil'
+import { assertTelemetryCurried, tryRegister } from '../../testUtil'
 import { CodeWhispererTracker } from '../../../codewhisperer/tracker/codewhispererTracker'
 import { resetCodeWhispererGlobalVariables, createAcceptedSuggestionEntry } from '../testUtil'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
 import { CodeWhispererUserGroupSettings } from '../../../codewhisperer/util/userGroupUtil'
 import { extensionVersion } from '../../../shared/vscode/env'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
 
 describe('codewhispererTracker', function () {
     describe('enqueue', function () {
         beforeEach(async function () {
+            tryRegister(refreshStatusBar)
             await resetCodeWhispererGlobalVariables()
             await CodeWhispererTracker.getTracker().shutdown()
         })
@@ -44,6 +46,7 @@ describe('codewhispererTracker', function () {
 
     describe('flush', function () {
         beforeEach(async function () {
+            tryRegister(refreshStatusBar)
             await resetCodeWhispererGlobalVariables()
             await CodeWhispererTracker.getTracker().shutdown()
         })

--- a/packages/core/src/test/codewhisperer/tracker/codewhispererTracker.test.ts
+++ b/packages/core/src/test/codewhisperer/tracker/codewhispererTracker.test.ts
@@ -17,8 +17,11 @@ import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletio
 
 describe('codewhispererTracker', function () {
     describe('enqueue', function () {
-        beforeEach(async function () {
+        before(async function () {
             tryRegister(refreshStatusBar)
+        })
+
+        beforeEach(async function () {
             await resetCodeWhispererGlobalVariables()
             await CodeWhispererTracker.getTracker().shutdown()
         })
@@ -45,8 +48,11 @@ describe('codewhispererTracker', function () {
     })
 
     describe('flush', function () {
-        beforeEach(async function () {
+        before(async function () {
             tryRegister(refreshStatusBar)
+        })
+
+        beforeEach(async function () {
             await resetCodeWhispererGlobalVariables()
             await CodeWhispererTracker.getTracker().shutdown()
         })

--- a/packages/core/src/test/codewhisperer/util/editorContext.test.ts
+++ b/packages/core/src/test/codewhisperer/util/editorContext.test.ts
@@ -9,6 +9,8 @@ import * as EditorContext from '../../../codewhisperer/util/editorContext'
 import { createMockTextEditor, createMockClientRequest, resetCodeWhispererGlobalVariables } from '../testUtil'
 import globals from '../../../shared/extensionGlobals'
 import { GenerateCompletionsRequest } from '../../../codewhisperer/client/codewhispereruserclient'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
+import { tryRegister } from '../../testUtil'
 
 describe('editorContext', function () {
     let telemetryEnabledDefault: boolean
@@ -24,6 +26,8 @@ describe('editorContext', function () {
 
     describe('extractContextForCodeWhisperer', function () {
         it('Should return expected context', function () {
+            tryRegister(refreshStatusBar)
+
             const editor = createMockTextEditor('import math\ndef two_sum(nums, target):\n', 'test.py', 'python', 1, 17)
             const actual = EditorContext.extractContextForCodeWhisperer(editor)
             const expected: codewhispererClient.FileContext = {

--- a/packages/core/src/test/codewhisperer/util/editorContext.test.ts
+++ b/packages/core/src/test/codewhisperer/util/editorContext.test.ts
@@ -15,6 +15,10 @@ import { tryRegister } from '../../testUtil'
 describe('editorContext', function () {
     let telemetryEnabledDefault: boolean
 
+    before(async function () {
+        tryRegister(refreshStatusBar)
+    })
+
     beforeEach(async function () {
         await resetCodeWhispererGlobalVariables()
         telemetryEnabledDefault = globals.telemetry.telemetryEnabled
@@ -26,8 +30,6 @@ describe('editorContext', function () {
 
     describe('extractContextForCodeWhisperer', function () {
         it('Should return expected context', function () {
-            tryRegister(refreshStatusBar)
-
             const editor = createMockTextEditor('import math\ndef two_sum(nums, target):\n', 'test.py', 'python', 1, 17)
             const actual = EditorContext.extractContextForCodeWhisperer(editor)
             const expected: codewhispererClient.FileContext = {

--- a/packages/core/src/test/codewhisperer/util/globalStateUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/globalStateUtil.test.ts
@@ -15,6 +15,10 @@ import { tryRegister } from '../../testUtil'
 describe('globalStateUtil', function () {
     let loggerSpy: sinon.SinonSpy
 
+    before(async function () {
+        tryRegister(refreshStatusBar)
+    })
+
     beforeEach(async function () {
         await resetCodeWhispererGlobalVariables()
         vsCodeState.isIntelliSenseActive = true
@@ -26,8 +30,6 @@ describe('globalStateUtil', function () {
     })
 
     it('Should skip when CodeWhisperer is turned off', async function () {
-        tryRegister(refreshStatusBar)
-
         const isManualTriggerEnabled = false
         const isAutomatedTriggerEnabled = false
         resetIntelliSenseState(isManualTriggerEnabled, isAutomatedTriggerEnabled, true)

--- a/packages/core/src/test/codewhisperer/util/globalStateUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/globalStateUtil.test.ts
@@ -9,6 +9,8 @@ import { vsCodeState } from '../../../codewhisperer/models/model'
 import { resetIntelliSenseState } from '../../../codewhisperer/util/globalStateUtil'
 import { resetCodeWhispererGlobalVariables } from '../testUtil'
 import { getLogger } from '../../../shared/logger/logger'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
+import { tryRegister } from '../../testUtil'
 
 describe('globalStateUtil', function () {
     let loggerSpy: sinon.SinonSpy
@@ -24,6 +26,8 @@ describe('globalStateUtil', function () {
     })
 
     it('Should skip when CodeWhisperer is turned off', async function () {
+        tryRegister(refreshStatusBar)
+
         const isManualTriggerEnabled = false
         const isAutomatedTriggerEnabled = false
         resetIntelliSenseState(isManualTriggerEnabled, isAutomatedTriggerEnabled, true)

--- a/packages/core/src/test/codewhisperer/util/runtimeLanguageContext.test.ts
+++ b/packages/core/src/test/codewhisperer/util/runtimeLanguageContext.test.ts
@@ -15,6 +15,10 @@ import { tryRegister } from '../../testUtil'
 describe('runtimeLanguageContext', function () {
     const languageContext = new RuntimeLanguageContext()
 
+    before(async function () {
+        tryRegister(refreshStatusBar)
+    })
+
     describe('test isLanguageSupported', function () {
         const cases: [string, boolean][] = [
             ['java', true],

--- a/packages/core/src/test/codewhisperer/util/runtimeLanguageContext.test.ts
+++ b/packages/core/src/test/codewhisperer/util/runtimeLanguageContext.test.ts
@@ -9,6 +9,8 @@ import { runtimeLanguageContext, RuntimeLanguageContext } from '../../../codewhi
 import * as codewhispererClient from '../../../codewhisperer/client/codewhispererclient'
 import { CodewhispererLanguage } from '../../../shared/telemetry/telemetry.gen'
 import { PlatformLanguageId } from '../../../codewhisperer/models/constants'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
+import { tryRegister } from '../../testUtil'
 
 describe('runtimeLanguageContext', function () {
     const languageContext = new RuntimeLanguageContext()
@@ -296,6 +298,8 @@ describe('runtimeLanguageContext', function () {
 
         for (const [originalLanguage, mappedLanguage] of cases) {
             it(`convert ListRecommendationRequest - ${originalLanguage} should map to ${mappedLanguage}`, function () {
+                tryRegister(refreshStatusBar)
+
                 const originalRequest: codewhispererClient.ListRecommendationsRequest = {
                     fileContext: {
                         leftFileContent: leftFileContent,

--- a/packages/core/src/test/codewhisperer/util/showSsoPrompt.test.ts
+++ b/packages/core/src/test/codewhisperer/util/showSsoPrompt.test.ts
@@ -11,9 +11,14 @@ import { awsIdSignIn, showCodeWhispererConnectionPrompt } from '../../../codewhi
 import { getTestLogger } from '../../globalSetup.test'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { getTestWindow } from '../../shared/vscode/window'
-import { assertTelemetryCurried } from '../../testUtil'
+import { assertTelemetryCurried, tryRegister } from '../../testUtil'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
 
 describe('showConnectionPrompt', function () {
+    before(async function () {
+        tryRegister(refreshStatusBar)
+    })
+
     beforeEach(async function () {
         await resetCodeWhispererGlobalVariables()
     })

--- a/packages/core/src/test/codewhisperer/util/telemetryHelper.test.ts
+++ b/packages/core/src/test/codewhisperer/util/telemetryHelper.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { assertTelemetryCurried } from '../../testUtil'
+import { assertTelemetryCurried, tryRegister } from '../../testUtil'
 import { resetCodeWhispererGlobalVariables } from '../testUtil'
 import { TelemetryHelper } from '../../../codewhisperer/util/telemetryHelper'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
@@ -16,6 +16,7 @@ import {
 } from '../../../shared/telemetry/telemetry.gen'
 import { Completion } from '../../../codewhisperer/client/codewhispereruserclient'
 import { session } from '../../../codewhisperer/util/codeWhispererSession'
+import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
 
 // TODO: improve and move the following test utils to codewhisperer/testUtils.ts
 function aUserDecision(
@@ -46,6 +47,10 @@ function aCompletion(): Completion {
 describe('telemetryHelper', function () {
     describe('aggregateUserDecisionByRequest', function () {
         let sut: TelemetryHelper
+
+        before(async function () {
+            tryRegister(refreshStatusBar)
+        })
 
         beforeEach(function () {
             sut = new TelemetryHelper()

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -452,11 +452,6 @@ describe('Auth', function () {
     })
 
     describe('AuthNode', function () {
-        it('shows a message to create a connection if no connections exist', async function () {
-            const node = new AuthNode(auth)
-            await assertTreeItem(node, { label: 'Connect to AWS to Get Started...' })
-        })
-
         it('shows a login message if not connected', async function () {
             await auth.createConnection(ssoProfile)
             const node = new AuthNode(auth)

--- a/packages/core/src/test/ecs/commands.test.ts
+++ b/packages/core/src/test/ecs/commands.test.ts
@@ -7,13 +7,13 @@ import assert from 'assert'
 import * as vscode from 'vscode'
 import { DefaultEcsClient } from '../../shared/clients/ecsClient'
 import { TestSettings } from '../utilities/testSettingsConfiguration'
-import { PromptSettings } from '../../shared/settings'
+import { ToolkitPromptSettings } from '../../shared/settings'
 import { Service } from '../../ecs/model'
 import { stub } from '../utilities/stubber'
 import { EcsRunCommandPrompt, toggleExecuteCommandFlag } from '../../ecs/commands'
 
 describe('toggleExecuteCommandFlag', async function () {
-    const settings = new PromptSettings(new TestSettings())
+    const settings = new ToolkitPromptSettings(new TestSettings())
 
     before(async function () {
         await settings.disablePrompt(EcsRunCommandPrompt.Enable)
@@ -50,7 +50,7 @@ describe('toggleExecuteCommandFlag', async function () {
 })
 
 describe('openTaskInTerminal', async function () {
-    const settings = new PromptSettings(new TestSettings())
+    const settings = new ToolkitPromptSettings(new TestSettings())
 
     before(async function () {
         await settings.disablePrompt(EcsRunCommandPrompt.Enable)

--- a/packages/core/src/test/s3/util/fileViewerManager.test.ts
+++ b/packages/core/src/test/s3/util/fileViewerManager.test.ts
@@ -14,7 +14,7 @@ import { bufferToStream } from '../../../shared/utilities/streamUtilities'
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { SeverityLevel } from '../../shared/vscode/message'
 import { assertTelemetry, assertTextEditorContains } from '../../testUtil'
-import { PromptSettings } from '../../../shared/settings'
+import { ToolkitPromptSettings } from '../../../shared/settings'
 import { stub } from '../../utilities/stubber'
 import { assertHasProps } from '../../../shared/utilities/tsUtils'
 import { ToolkitError } from '../../../shared/errors'
@@ -198,7 +198,7 @@ describe('FileViewerManager', function () {
         s3 = createS3()
         fs = new VirtualFileSystem()
 
-        fileViewerManager = new S3FileViewerManager(() => s3.client, fs, new PromptSettings(), {
+        fileViewerManager = new S3FileViewerManager(() => s3.client, fs, new ToolkitPromptSettings(), {
             read: readScheme,
             edit: editScheme,
         })

--- a/packages/core/src/test/shared/settingsConfiguration.test.ts
+++ b/packages/core/src/test/shared/settingsConfiguration.test.ts
@@ -235,7 +235,9 @@ describe('Settings', function () {
             instance = new ProfileSettings(settings)
         })
 
-        it('throws if the setting does not exist', function () {
+        // TODO: fromExtensionManifest setting checks are disable as part of the standalone refactor.
+        // We should enable this test once setting validation can be re-introduced.
+        it.skip('throws if the setting does not exist', function () {
             assert.throws(() => fromExtensionManifest('aws', { foo: Boolean }))
         })
 

--- a/packages/core/src/test/shared/settingsConfiguration.test.ts
+++ b/packages/core/src/test/shared/settingsConfiguration.test.ts
@@ -10,7 +10,7 @@ import {
     DevSettings,
     Experiments,
     fromExtensionManifest,
-    PromptSettings,
+    ToolkitPromptSettings,
     Settings,
     testSetting,
 } from '../../shared/settings'
@@ -235,9 +235,7 @@ describe('Settings', function () {
             instance = new ProfileSettings(settings)
         })
 
-        // TODO: fromExtensionManifest setting checks are disable as part of the standalone refactor.
-        // We should enable this test once setting validation can be re-introduced.
-        it.skip('throws if the setting does not exist', function () {
+        it('throws if the setting does not exist', function () {
             assert.throws(() => fromExtensionManifest('aws', { foo: Boolean }))
         })
 
@@ -427,15 +425,15 @@ describe('DevSetting', function () {
 })
 
 describe('PromptSetting', function () {
-    const promptSettingKey = 'aws.toolkit.suppressPrompts'
+    const promptSettingKey = 'aws.suppressPrompts'
     const target = vscode.ConfigurationTarget.Workspace
 
     let settings: Settings
-    let sut: PromptSettings
+    let sut: ToolkitPromptSettings
 
     beforeEach(async function () {
         settings = new Settings(target)
-        sut = new PromptSettings(settings)
+        sut = new ToolkitPromptSettings(settings)
         await sut.reset()
     })
 

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -37,7 +37,7 @@ describe('tech debt', function () {
     })
 
     it('feature/standalone branch temporary debug log level for testing', async function () {
-        if ((process.env.GITHUB_HEAD_REF ?? '').includes('standalone')) {
+        if (!(process.env.GITHUB_BASE_REF ?? '').includes('master')) {
             this.skip()
         }
 

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -15,6 +15,7 @@ import { waitUntil } from '../shared/utilities/timeoutUtils'
 import { MetricName, MetricShapes } from '../shared/telemetry/telemetry'
 import { keys, selectFrom } from '../shared/utilities/tsUtils'
 import { fsCommon } from '../srcShared/fs'
+import { DeclaredCommand } from '../shared/vscode/commands2'
 
 const testTempDirs: string[] = []
 
@@ -472,4 +473,21 @@ export function shuffleList<T>(list: T[]): T[] {
     }
 
     return shuffledList
+}
+
+/**
+ * Try to register a command for tests, since some commands are only registered during
+ * extension activation. This criteria may not apply for unit tests, so they may need to be
+ * manually activated. Swallow already exists exceptions because these commands can persist
+ * across tests.
+ * TODO: Support arguments if needed.
+ */
+export function tryRegister(command: DeclaredCommand<() => Promise<any>>) {
+    try {
+        command.register()
+    } catch (err) {
+        if (!(err as Error).message.includes('already exists')) {
+            throw err
+        }
+    }
 }

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -482,7 +482,9 @@ export function shuffleList<T>(list: T[]): T[] {
  * Swallows 'already exists' exceptions because these commands can persist
  * across tests.
  *
- * TODO: Support arguments if needed.
+ * TODO: This is a workaround because some code being tested exists in multiple extensions.
+ * Activating/debugging multiple extensions at once is currently not functional.
+ * To avoid this, we should drop tests/code down to their respective extensions.
  */
 export function tryRegister(command: DeclaredCommand<() => Promise<any>>) {
     try {

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -476,10 +476,12 @@ export function shuffleList<T>(list: T[]): T[] {
 }
 
 /**
- * Try to register a command for tests, since some commands are only registered during
- * extension activation. This criteria may not apply for unit tests, so they may need to be
- * manually activated. Swallow already exists exceptions because these commands can persist
+ * Try to register a command for tests since some commands are only registered during
+ * extension activation. These commands will need to be manually activated here.
+ *
+ * Swallows 'already exists' exceptions because these commands can persist
  * across tests.
+ *
  * TODO: Support arguments if needed.
  */
 export function tryRegister(command: DeclaredCommand<() => Promise<any>>) {

--- a/packages/toolkit/scripts/build/handlePackageJson.ts
+++ b/packages/toolkit/scripts/build/handlePackageJson.ts
@@ -37,6 +37,14 @@ function main() {
         fs.copyFileSync(packageJsonFile, backupJsonFile)
         const packageJson = JSON.parse(fs.readFileSync(packageJsonFile, { encoding: 'utf-8' }))
         const coreLibPackageJson = JSON.parse(fs.readFileSync(coreLibPackageJsonFile, { encoding: 'utf-8' }))
+        const coreSettings = coreLibPackageJson.contributes.configuration.properties
+
+        // Remove Amazon Q extension settings stored in core
+        Object.keys(coreSettings).forEach(key => {
+            if (key.startsWith('aws.amazonq') || key.startsWith('aws.codeWhisperer')) {
+                delete coreSettings[key]
+            }
+        })
 
         packageJson.contributes = {
             ...coreLibPackageJson.contributes,


### PR DESCRIPTION
Squash and merge with commit message:

- Fix all unit tests.
- Enable the amazon q extension artifact for packaging tests
- Update tech debt test to only fail for master base branch
- Fix launch config for debugging so that it always executes the proper default task
- Restore settings type checking at compile time
- Sync settings to subprojects

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
