### PR TITLE
fix(amazonq): Fix various auto-installation issue

### DIFF
--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -233,7 +233,8 @@ export async function activate(context: ExtContext): Promise<void> {
          */
         acceptSuggestion.register(context),
 
-        connectWithCustomization()?.register() ?? { dispose() {} },
+        // direct CodeWhisperer connection setup with customization
+        connectWithCustomization.register(),
 
         // on text document close.
         vscode.workspace.onDidCloseTextDocument(e => {

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -280,6 +280,11 @@ export const installAmazonQExtension = Commands.declare(
     { id: 'aws.toolkit.installAmazonQExtension', logging: true },
     () => async () => {
         await vscode.commands.executeCommand('workbench.extensions.installExtension', VSCODE_EXTENSION_ID.amazonq)
+        // jump to Amazon Q extension view after install.
+        // this command won't work without a small delay post install
+        setTimeout(() => {
+            void vscode.commands.executeCommand('workbench.view.extension.amazonq')
+        }, 1000)
     }
 )
 

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -272,26 +272,14 @@ export const fetchFeatureConfigsCmd = Commands.declare(
 )
 
 /**
- * TODO: Actually install Amazon Q.
- *
- * For now, it just has a fake progress bar to simulate that it is installing.
+ * Actually install Amazon Q.
+ * Reload VS Code window after installation is necessary
+ * to properly activate extension.
  */
 export const installAmazonQExtension = Commands.declare(
     { id: 'aws.toolkit.installAmazonQExtension', logging: true },
     () => async () => {
-        await vscode.window.withProgress(
-            {
-                title: 'Installing Amazon Q...',
-                cancellable: true,
-                location: vscode.ProgressLocation.Notification,
-            },
-            async () => {
-                await vscode.commands.executeCommand(
-                    'workbench.extensions.installExtension',
-                    VSCODE_EXTENSION_ID.amazonq
-                )
-            }
-        )
+        await vscode.commands.executeCommand('workbench.extensions.installExtension', VSCODE_EXTENSION_ID.amazonq)
     }
 )
 

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -273,15 +273,15 @@ export const fetchFeatureConfigsCmd = Commands.declare(
 
 /**
  * Actually install Amazon Q.
- * Reload VS Code window after installation is necessary
- * to properly activate extension.
+ * Sometimes reload VS Code window after installation is necessary
+ * to properly activate extension. In that case, VS Code will prompt user to reload.
  */
 export const installAmazonQExtension = Commands.declare(
     { id: 'aws.toolkit.installAmazonQExtension', logging: true },
     () => async () => {
         await vscode.commands.executeCommand('workbench.extensions.installExtension', VSCODE_EXTENSION_ID.amazonq)
         // jump to Amazon Q extension view after install.
-        // this command won't work without a small delay post install
+        // this command won't work without a small delay after install
         setTimeout(() => {
             void vscode.commands.executeCommand('workbench.view.extension.amazonq')
         }, 1000)

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -139,70 +139,62 @@ export const showSsoSignIn = Commands.declare('aws.codeWhisperer.sso', () => asy
 // It can optionally set a customization too based on given values to match on
 
 // This command is only declared and registered in Amazon Q if Q exists
-export const connectWithCustomization = () => {
-    let cmd = undefined
-    try {
-        cmd = Commands.declare(
-            { id: 'aws.codeWhisperer.connect', compositeKey: { 0: 'source' } },
-            /**
-             * This command supports the following arguments:
-             * @param source - an identifier for who used this command. This value is not explicitly used in the function, but is used elsewhere.
-             * startUrl and region. If both arguments are provided they will be used, otherwise
-             *  the command prompts for them interactively.
-             * customizationArn: select customization by ARN. If provided, `customizationNamePrefix` is ignored.
-             * customizationNamePrefix: select customization by prefix, if `customizationArn` is `undefined`.
-             */
-            () =>
-                async (
-                    source: string,
-                    startUrl?: string,
-                    region?: string,
-                    customizationArn?: string,
-                    customizationNamePrefix?: string
-                ) => {
-                    if (startUrl && region) {
-                        await connectToEnterpriseSso(startUrl, region)
-                    } else {
-                        await getStartUrl()
-                    }
+export const connectWithCustomization = Commands.declare(
+    { id: 'aws.codeWhisperer.connect', compositeKey: { 0: 'source' } },
+    /**
+     * This command supports the following arguments:
+     * @param source - an identifier for who used this command. This value is not explicitly used in the function, but is used elsewhere.
+     * startUrl and region. If both arguments are provided they will be used, otherwise
+     *  the command prompts for them interactively.
+     * customizationArn: select customization by ARN. If provided, `customizationNamePrefix` is ignored.
+     * customizationNamePrefix: select customization by prefix, if `customizationArn` is `undefined`.
+     */
+    () =>
+        async (
+            source: string,
+            startUrl?: string,
+            region?: string,
+            customizationArn?: string,
+            customizationNamePrefix?: string
+        ) => {
+            if (startUrl && region) {
+                await connectToEnterpriseSso(startUrl, region)
+            } else {
+                await getStartUrl()
+            }
 
-                    // No customization match information given, exit early.
-                    if (!customizationArn && !customizationNamePrefix) {
-                        return
-                    }
+            // No customization match information given, exit early.
+            if (!customizationArn && !customizationNamePrefix) {
+                return
+            }
 
-                    let persistedCustomizations = getPersistedCustomizations()
+            let persistedCustomizations = getPersistedCustomizations()
 
-                    // Check if any customizations have already been persisted.
-                    // If not, call `notifyNewCustomizations` to handle it then recheck.
-                    if (persistedCustomizations.length === 0) {
-                        await notifyNewCustomizations()
-                        persistedCustomizations = getPersistedCustomizations()
-                    }
+            // Check if any customizations have already been persisted.
+            // If not, call `notifyNewCustomizations` to handle it then recheck.
+            if (persistedCustomizations.length === 0) {
+                await notifyNewCustomizations()
+                persistedCustomizations = getPersistedCustomizations()
+            }
 
-                    // If given an ARN, assume a specific customization is desired and find an entry that matches it. Ignores the prefix logic.
-                    // Otherwise if only a prefix is given, find an entry that matches it.
-                    // Backwards compatible with previous implementation.
-                    const match = customizationArn
-                        ? persistedCustomizations.find(c => c.arn === customizationArn)
-                        : persistedCustomizations.find(c => c.name?.startsWith(customizationNamePrefix as string))
+            // If given an ARN, assume a specific customization is desired and find an entry that matches it. Ignores the prefix logic.
+            // Otherwise if only a prefix is given, find an entry that matches it.
+            // Backwards compatible with previous implementation.
+            const match = customizationArn
+                ? persistedCustomizations.find(c => c.arn === customizationArn)
+                : persistedCustomizations.find(c => c.name?.startsWith(customizationNamePrefix as string))
 
-                    // If no match is found, nothing to do :)
-                    if (!match) {
-                        getLogger().error(
-                            `No customization match found: arn=${customizationArn} prefix=${customizationNamePrefix}`
-                        )
-                        return
-                    }
-                    // Since we selected based on a match, we'll reuse the persisted values.
-                    await selectCustomization(match)
-                }
-        )
-    } catch (e) {
-        getLogger().error(`Failed to declare command aws.codeWhisperer.connect ${e}`)
-    }
-    return cmd
-}
+            // If no match is found, nothing to do :)
+            if (!match) {
+                getLogger().error(
+                    `No customization match found: arn=${customizationArn} prefix=${customizationNamePrefix}`
+                )
+                return
+            }
+            // Since we selected based on a match, we'll reuse the persisted values.
+            await selectCustomization(match)
+        }
+)
 
 export const showLearnMore = Commands.declare(
     { id: 'aws.codeWhisperer.learnMore', compositeKey: { 0: 'source' } },

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -278,6 +278,7 @@ export const newCustomizationMessage = 'You have access to new CodeWhisperer cus
 export const newCustomizationsAvailableKey = 'aws.amazonq.codewhisperer.newCustomizations'
 
 export const amazonQDismissedKey = 'aws.toolkit.amazonq.dismissed'
+export const amazonQInstallDismissedKey = 'aws.toolkit.amazonqInstall.dismissed'
 
 // Amazon Q Code Transformation
 

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -178,7 +178,6 @@ export async function activate(context: vscode.ExtensionContext) {
                             'Amazon Q has moved to its own VSCode extension, which has been automatically installed.',
                             'OK'
                         )
-                        void vscode.commands.executeCommand(`workbench.view.extension.${VSCODE_EXTENSION_ID.amazonq}`)
                     } else {
                         const dismissedInstall = globals.context.globalState.get<boolean>(amazonQInstallDismissedKey)
                         if (!dismissedInstall) {
@@ -195,10 +194,7 @@ export async function activate(context: vscode.ExtensionContext) {
                                         await qExtensionPageCommand.execute()
                                     } else if (resp === 'Install') {
                                         await installAmazonQExtension.execute()
-                                        void vscode.commands.executeCommand(
-                                            `workbench.view.extension.${VSCODE_EXTENSION_ID.amazonq}`
-                                        )
-                                    } else {
+                                    } else if (resp === undefined) {
                                         // when user click x button to dismiss it
                                         await globals.context.globalState.update(amazonQInstallDismissedKey, true)
                                     }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -192,12 +192,12 @@ export async function activate(context: vscode.ExtensionContext) {
                                     if (resp === 'Learn More') {
                                         // Clicking learn more will open the q extension page
                                         await qExtensionPageCommand.execute()
+                                        return
                                     } else if (resp === 'Install') {
                                         await installAmazonQExtension.execute()
-                                    } else if (resp === undefined) {
-                                        // when user click x button to dismiss it
-                                        await globals.context.globalState.update(amazonQInstallDismissedKey, true)
                                     }
+                                    // If user dismisses, then we jump to here.
+                                    await globals.context.globalState.update(amazonQInstallDismissedKey, true)
                                 })
                         }
                     }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -57,8 +57,8 @@ import {
     switchToAmazonQCommand,
 } from './amazonq/explorer/amazonQChildrenNodes'
 import { AuthUtil, isPreviousQUser } from './codewhisperer/util/authUtil'
-import { connectWithCustomization, installAmazonQExtension } from './codewhisperer/commands/basicCommands'
-import { isExtensionActive, isExtensionInstalled, VSCODE_EXTENSION_ID } from './shared/utilities'
+import { installAmazonQExtension } from './codewhisperer/commands/basicCommands'
+import { isExtensionInstalled, VSCODE_EXTENSION_ID } from './shared/utilities'
 
 let localize: nls.LocalizeFunc
 
@@ -224,10 +224,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
         if (!isReleaseVersion()) {
             globals.telemetry.assertPassiveTelemetry(globals.didReload)
-        }
-        // Register the aws.CodeWhisperer.connect command if Amazon Q is not active
-        if (!isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq) || !isExtensionActive(VSCODE_EXTENSION_ID.amazonq)) {
-            context.subscriptions.push(connectWithCustomization()?.register() ?? { dispose() {} })
         }
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')


### PR DESCRIPTION
## Problem

1. [NEW FEATURE] Installing Amazon Q from toolkit should immediately open Q extension view.
2. [BUG FIX] aws.codewhisperer.connect command conflict when user first install toolkit then install Q.
3. [BUG FIX] 2 installation notification displayed at the same time
4. [NEW FEATURE] User can click dismiss (X) button when seeing the ask user to install Q notification.   If user does not click that button, there will be no resp. It is not considered as dismiss.


## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
