### PR TITLE
fix(amazonq): Fix aws.amazonq.refreshConnectionCallback' cmd not found

### DIFF
--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -18,7 +18,7 @@ import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
 import { AuthUtil, refreshToolkitQState } from '../util/authUtil'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { getLogger } from '../../shared/logger'
-import { isExtensionInstalled, openUrl } from '../../shared/utilities/vsCodeUtils'
+import { isExtensionActive, isExtensionInstalled, openUrl } from '../../shared/utilities/vsCodeUtils'
 import {
     getPersistedCustomizations,
     notifyNewCustomizations,
@@ -413,11 +413,12 @@ export const registerToolkitApiCallback = Commands.declare(
         // we need to do it manually here because the Toolkit would have been unable to call
         // this API if the Q/CW extension started afterwards (and this code block is running).
         if (isExtensionInstalled(VSCODE_EXTENSION_ID.awstoolkit)) {
-            getLogger().info(`Trying to register toolkit callback. Toolkit is installed.`)
+            getLogger().info(`Trying to register toolkit callback. Toolkit is installed, 
+                        toolkit activated = ${isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)}`)
             if (toolkitApi) {
                 // when this command is executed by AWS Toolkit activation
                 _toolkitApi = toolkitApi.getApi(VSCODE_EXTENSION_ID.amazonq)
-            } else {
+            } else if (isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)) {
                 // when this command is executed by Amazon Q activation
                 const toolkitExt = vscode.extensions.getExtension(VSCODE_EXTENSION_ID.awstoolkit)
                 _toolkitApi = toolkitExt?.exports.getApi(VSCODE_EXTENSION_ID.amazonq)


### PR DESCRIPTION
## Problem
When Q activates, if at that time toolkit is installed but not activated, Q will throw aws.amazonq.refreshConnectionCallback' cmd not found. Even though this is caught in a tryExecute, it will generate noise for debugging. 

This edge case can happen when reloading webview and both extension activates, Q activates first. 

## Solution

Avoid the throw by adding if-else to make sure grabbing the toolkit API must happen with a activated toolkit.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
