### PR TITLE
fix(amazonq): Quick Action commands are inconsistent between Q tabs and prompt input not getting focus after code sent to Q

### DIFF
--- a/.changes/next-release/Bug Fix-29f91f61-c02b-4010-81e4-91f29541a628.json
+++ b/.changes/next-release/Bug Fix-29f91f61-c02b-4010-81e4-91f29541a628.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q: Fixed quick action command list inconsistency between Q tabs"
+}

--- a/.changes/next-release/Bug Fix-ba11248f-2ea2-412d-a06e-7aaded483d8f.json
+++ b/.changes/next-release/Bug Fix-ba11248f-2ea2-412d-a06e-7aaded483d8f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q: Fixed cursor not focuses to prompt input when code is sent to Q Chat"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,9 +3607,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.4.3.tgz",
-            "integrity": "sha512-vOFsOtn862IHw1CElsaR1QHNERMeoTyuGNY39RTm/PL2VqQT2/tuZy+tV5E39VKuzEcPFs8H1lSmspA4b+BgcQ==",
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.5.4.tgz",
+            "integrity": "sha512-ZFJLLxybwzfBKhO5NKDzt++ntHbtf7bUqyAX//9pcvYVLHBHegGgqJcDECA1inYMUb2rybeVRIv7jpmjX7ks2g==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",
@@ -19677,7 +19677,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "4.4.3",
+                "@aws/mynah-ui": "4.5.4",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/shared-ini-file-loader": "^2.2.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4304,7 +4304,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "4.4.3",
+        "@aws/mynah-ui": "4.5.4",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/shared-ini-file-loader": "^2.2.8",

--- a/packages/core/src/amazonq/webview/ui/quickActions/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/generator.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { QuickActionCommandGroup } from '@aws/mynah-ui/dist/static'
+import { QuickActionCommand, QuickActionCommandGroup } from '@aws/mynah-ui/dist/static'
 import { TabType } from '../storages/tabsStorage'
 
 export interface QuickActionGeneratorProps {
@@ -21,51 +21,89 @@ export class QuickActionGenerator {
     }
 
     public generateForTab(tabType: TabType): QuickActionCommandGroup[] {
-        switch (tabType) {
-            case 'featuredev':
-                return []
-            default:
-                return [
-                    ...(this.isFeatureDevEnabled
-                        ? [
+        const quickActionCommands = [
+            ...(this.isFeatureDevEnabled
+                ? [
+                      {
+                          groupName: 'Application Development',
+                          commands: [
                               {
-                                  groupName: 'Application Development',
-                                  commands: [
-                                      {
-                                          command: '/dev',
-                                          placeholder: 'Briefly describe a task or issue',
-                                          description:
-                                              'Use all project files as context for code suggestions (increases latency).',
-                                      },
-                                  ],
+                                  command: '/dev',
+                                  placeholder: 'Briefly describe a task or issue',
+                                  description:
+                                      'Use all project files as context for code suggestions (increases latency).',
                               },
-                          ]
-                        : []),
-                    ...(this.isGumbyEnabled
-                        ? [
+                          ],
+                      },
+                  ]
+                : []),
+            ...(this.isGumbyEnabled
+                ? [
+                      {
+                          commands: [
                               {
-                                  commands: [
-                                      {
-                                          command: '/transform',
-                                          description: 'Transform your Java 8 or 11 Maven project to Java 17',
-                                      },
-                                  ],
+                                  command: '/transform',
+                                  description: 'Transform your Java 8 or 11 Maven project to Java 17',
                               },
-                          ]
-                        : []),
+                          ],
+                      },
+                  ]
+                : []),
+            {
+                commands: [
                     {
-                        commands: [
-                            {
-                                command: '/help',
-                                description: 'Learn more about Amazon Q',
-                            },
-                            {
-                                command: '/clear',
-                                description: 'Clear this session',
-                            },
-                        ],
+                        command: '/help',
+                        description: 'Learn more about Amazon Q',
                     },
-                ]
+                    {
+                        command: '/clear',
+                        description: 'Clear this session',
+                    },
+                ],
+            },
+        ]
+
+        const commandUnavailability: Record<
+            TabType,
+            {
+                description: string
+                unavailableItems: string[]
+            }
+        > = {
+            cwc: {
+                description: '',
+                unavailableItems: [],
+            },
+            featuredev: {
+                description: "This command isn't available in /dev",
+                unavailableItems: ['/dev', '/transform', '/help', '/clear'],
+            },
+            gumby: {
+                description: "This command isn't available in /transform",
+                unavailableItems: ['/dev', '/transform'],
+            },
+            unknown: {
+                description: "This command isn't available",
+                unavailableItems: ['/dev', '/transform', '/help', '/clear'],
+            },
         }
+
+        return quickActionCommands.map(commandGroup => {
+            return {
+                groupName: commandGroup.groupName,
+                commands: commandGroup.commands.map((commandItem: QuickActionCommand) => {
+                    const commandNotAvailable = commandUnavailability[tabType].unavailableItems.includes(
+                        commandItem.command
+                    )
+                    return {
+                        ...commandItem,
+                        disabled: commandNotAvailable,
+                        description: commandNotAvailable
+                            ? commandUnavailability[tabType].description
+                            : commandItem.description,
+                    }
+                }) as QuickActionCommand[],
+            }
+        }) as QuickActionCommandGroup[]
     }
 }


### PR DESCRIPTION
fixed quick action commands inconsistency between Q tabs

## Problem
- Quick action commands are inconsistent between Q tabs (`/dev`, `/transform` and q chat)
- Prompt input doesn't get focus when user sends code to Q chat

## Solution
- All quick action commands are now visible in all Q tab types. But depending on the tab type, some of them are disabled with description messages.
- Prompt input now gets auto focus after code is sent to Q chat. It is solved with [mynah-ui update](https://github.com/aws/mynah-ui/commit/402425c075908e5702b48be1bc2fd3498ce81b6b) to version [4.5.4](https://github.com/aws/mynah-ui/releases/tag/v4.5.4)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
