### PR TITLE
codewhisperer: pass upload intent to api

### DIFF
--- a/packages/core/src/codewhisperer/client/user-service-2.json
+++ b/packages/core/src/codewhisperer/client/user-service-2.json
@@ -1556,7 +1556,12 @@
         },
         "UploadIntent": {
             "type": "string",
-            "enum": ["TRANSFORMATION", "TASK_ASSIST_PLANNING"]
+            "enum": [
+                "TRANSFORMATION",
+                "TASK_ASSIST_PLANNING",
+                "AUTOMATIC_FILE_SECURITY_SCAN",
+                "FULL_PROJECT_SECURITY_SCAN"
+            ]
         },
         "UserContext": {
             "type": "structure",

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -134,7 +134,7 @@ export async function startSecurityScan(
         let artifactMap: ArtifactMap = {}
         const uploadStartTime = performance.now()
         try {
-            artifactMap = await getPresignedUrlAndUpload(client, zipMetadata)
+            artifactMap = await getPresignedUrlAndUpload(client, zipMetadata, scope)
         } catch (error) {
             getLogger().error('Failed to upload code artifacts', error)
             throw error

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -221,7 +221,11 @@ export const codeScanJavascriptPayloadSizeLimitBytes = 200 * Math.pow(2, 10) // 
 
 export const fileScanPayloadSizeLimitBytes = 200 * Math.pow(2, 10) // 200 KB
 
+export const fileScanUploadIntent = 'AUTOMATIC_FILE_SECURITY_SCAN'
+
 export const projectScanPayloadSizeLimitBytes = 5 * Math.pow(2, 30) // 5 GB
+
+export const projectScanUploadIntent = 'FULL_PROJECT_SECURITY_SCAN'
 
 export const codeScanTruncDirPrefix = 'codewhisperer_scan'
 

--- a/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
+++ b/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
@@ -91,11 +91,12 @@ describe('CodeWhisperer security scan', async function () {
         const uri = editor.document.uri
 
         const projectPath = zipUtil.getProjectPath(editor.document.uri)
-        const zipMetadata = await zipUtil.generateZip(uri, CodeWhispererConstants.CodeAnalysisScope.PROJECT)
+        const scope = CodeWhispererConstants.CodeAnalysisScope.PROJECT
+        const zipMetadata = await zipUtil.generateZip(uri, scope)
 
         let artifactMap
         try {
-            artifactMap = await getPresignedUrlAndUpload(client, zipMetadata)
+            artifactMap = await getPresignedUrlAndUpload(client, zipMetadata, scope)
         } finally {
             await zipUtil.removeTmpFiles(zipMetadata)
         }


### PR DESCRIPTION
## Problem

Need to tell createUploadUrl API which type of scan to perform

## Solution

Pass `uploadIntent` field to API which is either `AUTOMATIC_FILE_SECURITY_SCAN` or `FULL_PROJECT_SECURITY_SCAN`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
