### PR TITLE
fix(amazonFeatureDev): accepted files telemetry

### DIFF
--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -449,9 +449,15 @@ export class FeatureDevController {
         let session
         try {
             session = await this.sessionStorage.getSession(message.tabID)
+
+            const acceptedFiles = (paths?: { rejected: boolean }[]) => (paths || []).filter(i => !i.rejected).length
+
+            const amazonqNumberOfFilesAccepted =
+                acceptedFiles(session.state.filePaths) + acceptedFiles(session.state.deletedFiles)
+
             telemetry.amazonq_isAcceptedCodeChanges.emit({
                 amazonqConversationId: session.conversationId,
-                amazonqNumberOfFilesAccepted: session.state.filePaths?.filter(i => !i.rejected).length ?? -1,
+                amazonqNumberOfFilesAccepted,
                 enabled: true,
                 result: 'Succeeded',
             })


### PR DESCRIPTION
## Problem

File acceptance telemetry was not counting deleted files, i.e. the files that code generation marked to be deleted, even if they were rejected or not.

## Solution

Count deleted files for the metric and add tests to assure this.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
