### PR TITLE
feat(amazonq): Rename settings from CodeWhisperer to Amazon Q: part 2

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -113,23 +113,23 @@
                     },
                     "additionalProperties": false
                 },
-                "aws.codeWhisperer.includeSuggestionsWithCodeReferences": {
+                "aws.amazonQ.includeSuggestionsWithCodeReferences": {
                     "type": "boolean",
                     "markdownDescription": "%AWS.configuration.description.codewhisperer%",
                     "default": true
                 },
-                "aws.codeWhisperer.importRecommendation": {
+                "aws.amazonQ.importRecommendation": {
                     "type": "boolean",
                     "description": "%AWS.configuration.description.codewhisperer.importRecommendation%",
                     "default": true
                 },
-                "aws.codeWhisperer.shareCodeWhispererContentWithAWS": {
+                "aws.amazonQ.shareCodeWhispererContentWithAWS": {
                     "type": "boolean",
                     "markdownDescription": "%AWS.configuration.description.codewhisperer.shareCodeWhispererContentWithAWS%",
                     "default": true,
                     "scope": "application"
                 },
-                "aws.codeWhisperer.javaCompilationOutput": {
+                "aws.amazonQ.javaCompilationOutput": {
                     "type": "string",
                     "default": "",
                     "description": "Provide the ABSOLUTE path which is used to store java project compilation results."

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -48,14 +48,14 @@
     "contributes": {
         "configuration": {
             "type": "object",
-            "title": "%AWS.productName%",
+            "title": "%AWS.amazonq.productName%",
             "cloud9": {
                 "cn": {
-                    "title": "%AWS.productName.cn%"
+                    "title": "%AWS.amazonq.productName.cn%"
                 }
             },
             "properties": {
-                "aws.amazonq.logLevel": {
+                "aws.logLevel": {
                     "type": "string",
                     "default": "debug",
                     "enum": [
@@ -79,7 +79,7 @@
                         }
                     }
                 },
-                "aws.amazonq.telemetry": {
+                "aws.telemetry": {
                     "type": "boolean",
                     "default": true,
                     "markdownDescription": "%AWS.configuration.description.telemetry%",
@@ -89,7 +89,7 @@
                         }
                     }
                 },
-                "aws.amazonq.suppressPrompts": {
+                "aws.amazonQ.suppressPrompts": {
                     "type": "object",
                     "description": "%AWS.configuration.description.suppressPrompts%",
                     "default": {},

--- a/packages/amazonq/scripts/build/syncPackageJson.ts
+++ b/packages/amazonq/scripts/build/syncPackageJson.ts
@@ -26,7 +26,7 @@ function main() {
 
     const coreSettings = coreLibPackageJson.contributes.configuration.properties
     Object.keys(coreSettings).forEach(key => {
-        if (key.startsWith('aws.amazonQ') || key.startsWith('aws.codeWhisperer')) {
+        if (key.startsWith('aws.amazonQ')) {
             packageJson.contributes.configuration.properties[key] = coreSettings[key]
         }
     })

--- a/packages/amazonq/scripts/build/syncPackageJson.ts
+++ b/packages/amazonq/scripts/build/syncPackageJson.ts
@@ -26,7 +26,7 @@ function main() {
 
     const coreSettings = coreLibPackageJson.contributes.configuration.properties
     Object.keys(coreSettings).forEach(key => {
-        if (key.startsWith('aws.amazonq') || key.startsWith('aws.codeWhisperer')) {
+        if (key.startsWith('aws.amazonQ') || key.startsWith('aws.codeWhisperer')) {
             packageJson.contributes.configuration.properties[key] = coreSettings[key]
         }
     })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -292,23 +292,23 @@
                     },
                     "additionalProperties": false
                 },
-                "aws.codeWhisperer.includeSuggestionsWithCodeReferences": {
+                "aws.amazonQ.includeSuggestionsWithCodeReferences": {
                     "type": "boolean",
                     "markdownDescription": "%AWS.configuration.description.codewhisperer%",
                     "default": true
                 },
-                "aws.codeWhisperer.importRecommendation": {
+                "aws.amazonQ.importRecommendation": {
                     "type": "boolean",
                     "description": "%AWS.configuration.description.codewhisperer.importRecommendation%",
                     "default": true
                 },
-                "aws.codeWhisperer.shareCodeWhispererContentWithAWS": {
+                "aws.amazonQ.shareCodeWhispererContentWithAWS": {
                     "type": "boolean",
                     "markdownDescription": "%AWS.configuration.description.codewhisperer.shareCodeWhispererContentWithAWS%",
                     "default": true,
                     "scope": "application"
                 },
-                "aws.codeWhisperer.javaCompilationOutput": {
+                "aws.amazonQ.javaCompilationOutput": {
                     "type": "string",
                     "default": "",
                     "description": "Provide the ABSOLUTE path which is used to store java project compilation results."

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -234,41 +234,7 @@
                     "description": "%AWS.configuration.description.lambda.recentlyUploaded%",
                     "default": []
                 },
-                "aws.amazonq.logLevel": {
-                    "type": "string",
-                    "default": "debug",
-                    "enum": [
-                        "error",
-                        "warn",
-                        "info",
-                        "verbose",
-                        "debug"
-                    ],
-                    "enumDescriptions": [
-                        "Errors Only",
-                        "Errors and Warnings",
-                        "Errors, Warnings, and Info",
-                        "Errors, Warnings, Info, and Verbose",
-                        "Errors, Warnings, Info, Verbose, and Debug"
-                    ],
-                    "markdownDescription": "%AWS.configuration.description.logLevel%",
-                    "cloud9": {
-                        "cn": {
-                            "markdownDescription": "%AWS.configuration.description.logLevel.cn%"
-                        }
-                    }
-                },
-                "aws.amazonq.telemetry": {
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "%AWS.configuration.description.telemetry%",
-                    "cloud9": {
-                        "cn": {
-                            "markdownDescription": "%AWS.configuration.description.telemetry.cn%"
-                        }
-                    }
-                },
-                "aws.amazonq.suppressPrompts": {
+                "aws.amazonQ.suppressPrompts": {
                     "type": "object",
                     "description": "%AWS.configuration.description.suppressPrompts%",
                     "default": {},

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -3,6 +3,8 @@
     "AWS.title.cn": "Amazon",
     "AWS.productName": "AWS Toolkit",
     "AWS.productName.cn": "Amazon Toolkit",
+    "AWS.amazonq.productName": "Amazon Q",
+    "AWS.amazonq.productName.cn": "Amazon Q",
     "AWS.codecatalyst.submenu.title": "Manage CodeCatalyst",
     "AWS.configuration.profileDescription": "The name of the credential profile to obtain credentials from.",
     "AWS.configuration.description.lambda.recentlyUploaded": "Recently selected Lambda upload targets.",

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -113,9 +113,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 EditorContext.updateTabSize(getTabSizeSetting())
             }
 
-            if (
-                configurationChangeEvent.affectsConfiguration('aws.codeWhisperer.includeSuggestionsWithCodeReferences')
-            ) {
+            if (configurationChangeEvent.affectsConfiguration('aws.amazonQ.includeSuggestionsWithCodeReferences')) {
                 ReferenceLogViewProvider.instance.update()
                 if (auth.isEnterpriseSsoInUse()) {
                     await vscode.window
@@ -131,7 +129,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 }
             }
 
-            if (configurationChangeEvent.affectsConfiguration('aws.codeWhisperer.shareCodeWhispererContentWithAWS')) {
+            if (configurationChangeEvent.affectsConfiguration('aws.amazonQ.shareCodeWhispererContentWithAWS')) {
                 if (auth.isEnterpriseSsoInUse()) {
                     await vscode.window
                         .showInformationMessage(
@@ -170,10 +168,10 @@ export async function activate(context: ExtContext): Promise<void> {
             if (id === 'codewhisperer') {
                 await vscode.commands.executeCommand(
                     'workbench.action.openSettings',
-                    `@id:aws.codeWhisperer.includeSuggestionsWithCodeReferences`
+                    `@id:aws.amazonQ.includeSuggestionsWithCodeReferences`
                 )
             } else {
-                await vscode.commands.executeCommand('workbench.action.openSettings', `aws.codeWhisperer`)
+                await vscode.commands.executeCommand('workbench.action.openSettings', `aws.amazonQ`)
             }
         }),
         Commands.register('aws.codewhisperer.refreshAnnotation', async (forceProceed: boolean = false) => {

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -263,7 +263,7 @@ export function errorPromptHelper(error: Error) {
             )
             .then(async resp => {
                 if (resp === viewSettings) {
-                    openSettings('aws.codeWhisperer.javaCompilationOutput').catch(e => {
+                    openSettings('aws.amazonQ.javaCompilationOutput').catch(e => {
                         getLogger().error('openSettings failed: %s', (e as Error).message)
                     })
                 }

--- a/packages/core/src/codewhisperer/util/codewhispererSettings.ts
+++ b/packages/core/src/codewhisperer/util/codewhispererSettings.ts
@@ -9,7 +9,7 @@ const description = {
     importRecommendation: Boolean,
     shareCodeWhispererContentWithAWS: Boolean,
 }
-export class CodeWhispererSettings extends fromExtensionManifest('aws.codeWhisperer', description) {
+export class CodeWhispererSettings extends fromExtensionManifest('aws.amazonQ', description) {
     public isSuggestionsWithCodeReferencesEnabled(): boolean {
         return this.get(`includeSuggestionsWithCodeReferences`, false)
     }

--- a/packages/core/src/codewhisperer/util/dependencyGraph/javaDependencyGraph.ts
+++ b/packages/core/src/codewhisperer/util/dependencyGraph/javaDependencyGraph.ts
@@ -244,7 +244,7 @@ export class JavaDependencyGraph extends DependencyGraph {
     }
 
     private autoDetectClasspath(projectPath: string, projectName: string, extension: string) {
-        const compileOutput = vscode.workspace.getConfiguration('aws.codeWhisperer').get('javaCompilationOutput')
+        const compileOutput = vscode.workspace.getConfiguration('aws.amazonQ').get('javaCompilationOutput')
         if (compileOutput && typeof compileOutput === 'string') {
             this._outputDirs.add(compileOutput)
         }

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -637,10 +637,10 @@ export class ToolkitPromptSettings extends Settings.define(
     }
 }
 
-export const amazonQPrompts = settingsProps['aws.amazonq.suppressPrompts'].properties
+export const amazonQPrompts = settingsProps['aws.amazonQ.suppressPrompts'].properties
 type amazonQPromptName = keyof typeof amazonQPrompts
 export class AmazonQPromptSettings extends Settings.define(
-    'aws.amazonq.suppressPrompts',
+    'aws.amazonQ.suppressPrompts',
     toRecord(keys(amazonQPrompts), () => Boolean)
 ) {
     public async isPromptEnabled(promptName: amazonQPromptName): Promise<boolean> {

--- a/packages/toolkit/scripts/build/handlePackageJson.ts
+++ b/packages/toolkit/scripts/build/handlePackageJson.ts
@@ -41,7 +41,7 @@ function main() {
 
         // Remove Amazon Q extension settings stored in core
         Object.keys(coreSettings).forEach(key => {
-            if (key.startsWith('aws.amazonq') || key.startsWith('aws.codeWhisperer')) {
+            if (key.startsWith('aws.amazonQ') || key.startsWith('aws.codeWhisperer')) {
                 delete coreSettings[key]
             }
         })

--- a/packages/toolkit/scripts/build/handlePackageJson.ts
+++ b/packages/toolkit/scripts/build/handlePackageJson.ts
@@ -41,7 +41,7 @@ function main() {
 
         // Remove Amazon Q extension settings stored in core
         Object.keys(coreSettings).forEach(key => {
-            if (key.startsWith('aws.amazonQ') || key.startsWith('aws.codeWhisperer')) {
+            if (key.startsWith('aws.amazonQ')) {
                 delete coreSettings[key]
             }
         })


### PR DESCRIPTION
## Problem
Rename settings from CodeWhisperer to Amazon Q.


## Solution

<img width="1343" alt="Screenshot 2024-04-11 at 2 50 38 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/97199248/2f500dda-e21b-4ee1-8f22-6b2ad32d2a6d">
<img width="1344" alt="Screenshot 2024-04-11 at 2 51 43 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/97199248/dfde0e21-dac5-49c8-b7b5-4f1ae95a3ab7">


Note: 

1. Renaming customer facing commands will be part 3 or later PR. 

2. Log level and telemetry will now be aws level configurations. They are shared between toolkit & Q. 

3. Migrating old settings to new settings is not in scope of this PR. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
