### PR TITLE
fix(amazonq): Quick Action commands in new tabs are coming disabled

### DIFF
--- a/.changes/next-release/Bug Fix-f5a0ad13-60ce-4ee4-9da9-0687d0961466.json
+++ b/.changes/next-release/Bug Fix-f5a0ad13-60ce-4ee4-9da9-0687d0961466.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q: Fixed newly opening tabs have all quick actions disabled."
+}

--- a/packages/core/src/amazonq/webview/ui/quickActions/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/generator.ts
@@ -83,8 +83,8 @@ export class QuickActionGenerator {
                 unavailableItems: ['/dev', '/transform'],
             },
             unknown: {
-                description: "This command isn't available",
-                unavailableItems: ['/dev', '/transform', '/help', '/clear'],
+                description: '',
+                unavailableItems: [],
             },
         }
 


### PR DESCRIPTION
## Problem
- Quick actions in newly opened tabs are coming all disabled. Reported on the [jetbrains PR](https://github.com/aws/aws-toolkit-jetbrains/pull/4262#issuecomment-2052275174) by @mk-fan 
## Solution
- Unknown tab types follows the rules of Chat tabs for quick action disabled states since they are getting converted to chat tabs.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
