### PR TITLE
fix(amazonq): Update Client Name and User Agent

### DIFF
--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -387,6 +387,7 @@ class AuthFlowAuthorization extends SsoAccessTokenProvider {
     override async registerClient(): Promise<ClientRegistration> {
         const companyName = getIdeProperties().company
         return this.oidc.registerClient({
+            // All AWS extensions (Q, Toolkit) for a given IDE use the same client name.
             clientName: isCloud9() ? `${companyName} Cloud9` : `${companyName} IDE Extensions for VSCode`,
             clientType: clientRegistrationType,
             scopes: this.profile.scopes,

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -39,7 +39,6 @@ import { randomUUID, randomBytes, createHash } from 'crypto'
 import { UriHandler } from '../../shared/vscode/uriHandler'
 import { DevSettings } from '../../shared/settings'
 import { localize } from '../../shared/utilities/vsCodeUtils'
-import { VSCODE_EXTENSION_ID } from '../../shared/utilities'
 
 export const authenticationPath = 'sso/authenticated'
 
@@ -222,20 +221,6 @@ export abstract class SsoAccessTokenProvider {
      */
     protected abstract getValidatedClientRegistration(): Promise<ClientRegistration>
     protected abstract registerClient(): Promise<ClientRegistration>
-
-    public getClientNameForRegistration(): string {
-        const companyName = getIdeProperties().company
-        if (isCloud9()) {
-            return `${companyName} Cloud9`
-        } else if (globals.context.extension.id === VSCODE_EXTENSION_ID.amazonq) {
-            return 'Amazon Q'
-        } else if (globals.context.extension.id === VSCODE_EXTENSION_ID.awstoolkit) {
-            return `${companyName} Toolkit for VSCode`
-        }
-        throw new ToolkitError(`Unsupported extension for client registration ${globals.context.extension.id}`, {
-            code: 'UnsupportedExtension',
-        })
-    }
 
     public static create(
         profile: Pick<SsoProfile, 'startUrl' | 'region' | 'scopes' | 'identifier'>,

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -334,8 +334,9 @@ export class DeviceFlowAuthorization extends SsoAccessTokenProvider {
     }
 
     override async registerClient(): Promise<ClientRegistration> {
+        const companyName = getIdeProperties().company
         return this.oidc.registerClient({
-            clientName: this.getClientNameForRegistration(),
+            clientName: isCloud9() ? `${companyName} Cloud9` : `${companyName} IDE Extensions for VSCode`,
             clientType: clientRegistrationType,
             scopes: this.profile.scopes,
         })
@@ -399,8 +400,9 @@ class AuthFlowAuthorization extends SsoAccessTokenProvider {
     }
 
     override async registerClient(): Promise<ClientRegistration> {
+        const companyName = getIdeProperties().company
         return this.oidc.registerClient({
-            clientName: this.getClientNameForRegistration(),
+            clientName: isCloud9() ? `${companyName} Cloud9` : `${companyName} IDE Extensions for VSCode`,
             clientType: clientRegistrationType,
             scopes: this.profile.scopes,
             grantTypes: [authorizationGrantType, refreshGrantType],

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -16,6 +16,7 @@ import { Result } from './telemetry.gen'
 import { MetricDatum } from './clienttelemetry'
 import { isValidationExemptMetric } from './exemptMetrics'
 import { isCloud9, isSageMaker } from '../../shared/extensionUtilities'
+import { VSCODE_EXTENSION_ID } from '../utilities'
 
 const legacySettingsTelemetryValueDisable = 'Disable'
 const legacySettingsTelemetryValueEnable = 'Enable'
@@ -77,7 +78,10 @@ export async function getUserAgent(
     opt?: { includePlatform?: boolean; includeClientId?: boolean },
     globalState = globals.context.globalState
 ): Promise<string> {
-    const pairs = [`AWS-Toolkit-For-VSCode/${extensionVersion}`]
+    const pairs =
+        globals.context.extension.id === VSCODE_EXTENSION_ID.amazonq
+            ? [`AmazonQ-For-VSCode/${extensionVersion}`]
+            : [`AWS-Toolkit-For-VSCode/${extensionVersion}`]
 
     if (opt?.includePlatform) {
         pairs.push(platformPair())

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -16,7 +16,6 @@ import { Result } from './telemetry.gen'
 import { MetricDatum } from './clienttelemetry'
 import { isValidationExemptMetric } from './exemptMetrics'
 import { isCloud9, isSageMaker } from '../../shared/extensionUtilities'
-import { VSCODE_EXTENSION_ID } from '../utilities'
 
 const legacySettingsTelemetryValueDisable = 'Disable'
 const legacySettingsTelemetryValueEnable = 'Enable'
@@ -78,10 +77,7 @@ export async function getUserAgent(
     opt?: { includePlatform?: boolean; includeClientId?: boolean },
     globalState = globals.context.globalState
 ): Promise<string> {
-    const pairs =
-        globals.context.extension.id === VSCODE_EXTENSION_ID.amazonq
-            ? [`AmazonQ-For-VSCode/${extensionVersion}`]
-            : [`AWS-Toolkit-For-VSCode/${extensionVersion}`]
+    const pairs = [`AWS-Toolkit-For-VSCode/${extensionVersion}`]
 
     if (opt?.includePlatform) {
         pairs.push(platformPair())


### PR DESCRIPTION
## Problem
Amazon Q standalone needs a new client name

## Solution
Use different client name for registration

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
