### PR TITLE
feat(q-proactive-scan): remove file scans for Builder Id, add timeout limits

### DIFF
--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -283,7 +283,7 @@ export async function activate(context: ExtContext): Promise<void> {
         await notifyNewCustomizations()
     }
     if (auth.isBuilderIdInUse()) {
-        CodeScansState.instance.setScansEnabled(false)
+        await CodeScansState.instance.setScansEnabled(false)
     }
 
     function setSubscriptionsForAutoScans() {

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -282,12 +282,16 @@ export async function activate(context: ExtContext): Promise<void> {
     if (auth.isValidEnterpriseSsoInUse()) {
         await notifyNewCustomizations()
     }
+    if (auth.isBuilderIdInUse()) {
+        CodeScansState.instance.setScansEnabled(false)
+    }
 
     function setSubscriptionsForAutoScans() {
         // Initial scan when the editor opens for the first time
         const editor = vscode.window.activeTextEditor
         if (
             CodeScansState.instance.isScansEnabled() &&
+            !auth.isBuilderIdInUse() &&
             editor &&
             securityScanLanguageContext.isLanguageSupported(editor.document.languageId) &&
             editor.document.getText().length > 0
@@ -306,6 +310,7 @@ export async function activate(context: ExtContext): Promise<void> {
             vscode.window.onDidChangeActiveTextEditor(editor => {
                 if (
                     CodeScansState.instance.isScansEnabled() &&
+                    !auth.isBuilderIdInUse() &&
                     editor &&
                     securityScanLanguageContext.isLanguageSupported(editor.document.languageId)
                 ) {
@@ -334,6 +339,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 const editor = vscode.window.activeTextEditor
                 if (
                     CodeScansState.instance.isScansEnabled() &&
+                    !auth.isBuilderIdInUse() &&
                     editor &&
                     event.document === editor.document &&
                     securityScanLanguageContext.isLanguageSupported(editor.document.languageId) &&
@@ -355,6 +361,7 @@ export async function activate(context: ExtContext): Promise<void> {
             const editor = vscode.window.activeTextEditor
             if (
                 isScansEnabled &&
+                !auth.isBuilderIdInUse() &&
                 editor &&
                 securityScanLanguageContext.isLanguageSupported(editor.document.languageId) &&
                 editor.document.getText().length > 0

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -233,7 +233,9 @@ export const codeScanZipExt = '.zip'
 
 export const contextTruncationTimeoutSeconds = 10
 
-export const codeScanJobTimeoutSeconds = 50
+export const codeScanJobTimeoutSeconds = 60 * 10 //10 minutes
+
+export const codeFileScanJobTimeoutSeconds = 60 //1 minute
 
 export const projectSizeCalculateTimeoutSeconds = 10
 

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -123,12 +123,9 @@ export async function pollScanJobStatus(
         throwIfCancelled(scope)
         await sleep(CodeWhispererConstants.codeScanJobPollingIntervalSeconds * 1000)
         timer += CodeWhispererConstants.codeScanJobPollingIntervalSeconds
-        let timeoutSeconds;
-        if (scope == CodeWhispererConstants.CodeAnalysisScope.FILE) {
-        timeoutSeconds = CodeWhispererConstants.codeFileScanJobTimeoutSeconds;
-        } else {
-        timeoutSeconds = CodeWhispererConstants.codeScanJobTimeoutSeconds;
-        }
+        const timeoutSeconds = (scope === CodeWhispererConstants.CodeAnalysisScope.FILE) 
+            ? CodeWhispererConstants.codeFileScanJobTimeoutSeconds 
+            : CodeWhispererConstants.codeScanJobTimeoutSeconds;
         if (timer > timeoutSeconds) {
             getLogger().verbose(`Scan job status: ${status}`)
             getLogger().verbose(`Scan job timeout.`)

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -123,7 +123,13 @@ export async function pollScanJobStatus(
         throwIfCancelled(scope)
         await sleep(CodeWhispererConstants.codeScanJobPollingIntervalSeconds * 1000)
         timer += CodeWhispererConstants.codeScanJobPollingIntervalSeconds
-        if (timer > CodeWhispererConstants.codeScanJobTimeoutSeconds) {
+        let timeoutSeconds;
+        if (scope == CodeWhispererConstants.CodeAnalysisScope.FILE) {
+        timeoutSeconds = CodeWhispererConstants.codeFileScanJobTimeoutSeconds;
+        } else {
+        timeoutSeconds = CodeWhispererConstants.codeScanJobTimeoutSeconds;
+        }
+        if (timer > timeoutSeconds) {
             getLogger().verbose(`Scan job status: ${status}`)
             getLogger().verbose(`Scan job timeout.`)
             throw new Error('Scan job timeout.')

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -123,9 +123,10 @@ export async function pollScanJobStatus(
         throwIfCancelled(scope)
         await sleep(CodeWhispererConstants.codeScanJobPollingIntervalSeconds * 1000)
         timer += CodeWhispererConstants.codeScanJobPollingIntervalSeconds
-        const timeoutSeconds = (scope === CodeWhispererConstants.CodeAnalysisScope.FILE) 
-            ? CodeWhispererConstants.codeFileScanJobTimeoutSeconds 
-            : CodeWhispererConstants.codeScanJobTimeoutSeconds;
+        const timeoutSeconds =
+            scope === CodeWhispererConstants.CodeAnalysisScope.FILE
+                ? CodeWhispererConstants.codeFileScanJobTimeoutSeconds
+                : CodeWhispererConstants.codeScanJobTimeoutSeconds
         if (timer > timeoutSeconds) {
             getLogger().verbose(`Scan job status: ${status}`)
             getLogger().verbose(`Scan job timeout.`)

--- a/packages/core/src/codewhisperer/ui/statusBarMenu.ts
+++ b/packages/core/src/codewhisperer/ui/statusBarMenu.ts
@@ -51,7 +51,6 @@ function getAmazonQCodeWhispererNodes() {
             createFreeTierLimitMet('item'),
             createOpenReferenceLog(),
             createSeparator('Other Features'),
-            createAutoScans(autoScansEnabled),
             createSecurityScan(),
         ]
     }
@@ -66,6 +65,26 @@ function getAmazonQCodeWhispererNodes() {
         amazonq = require('../../amazonq/explorer/amazonQChildrenNodes')
     }
 
+    if (AuthUtil.instance.isBuilderIdInUse()) {
+        return [
+            // CodeWhisperer
+            createSeparator('Inline Suggestions'),
+            createAutoSuggestions(autoTriggerEnabled),
+            ...(AuthUtil.instance.isValidEnterpriseSsoInUse() && AuthUtil.instance.isCustomizationFeatureEnabled
+                ? [createSelectCustomization()]
+                : []),
+            createOpenReferenceLog(),
+            createGettingStarted(), // "Learn" node : opens Learn CodeWhisperer page
+    
+            // Security scans
+            createSeparator('Security Scans'),
+            createSecurityScan(),
+    
+            // Amazon Q + others
+            createSeparator('Other Features'),
+            ...(amazonq ? [amazonq.switchToAmazonQNode('item')] : []),
+        ]
+    }
     return [
         // CodeWhisperer
         createSeparator('Inline Suggestions'),

--- a/packages/core/src/codewhisperer/ui/statusBarMenu.ts
+++ b/packages/core/src/codewhisperer/ui/statusBarMenu.ts
@@ -75,11 +75,11 @@ function getAmazonQCodeWhispererNodes() {
                 : []),
             createOpenReferenceLog(),
             createGettingStarted(), // "Learn" node : opens Learn CodeWhisperer page
-    
+
             // Security scans
             createSeparator('Security Scans'),
             createSecurityScan(),
-    
+
             // Amazon Q + others
             createSeparator('Other Features'),
             ...(amazonq ? [amazonq.switchToAmazonQNode('item')] : []),


### PR DESCRIPTION
## Problem
Change Timeout limits for project scan and File scans. No Auto Scan status bar options for Free Users(BuilderId) and no file scans enabled for Builder Id users.
## Solution
- Added Timeout Limits for Project and File Scans.
- Disabled File scan for BuilderID users.
- Removed status bar Code scan toggle option for Builder Id Users.

Compiled and run a debug extension
<img width="976" alt="Screenshot 2024-04-15 at 11 04 43 AM" src="https://github.com/aws/aws-toolkit-vscode/assets/149003065/0029265e-f3ed-4b83-87b7-a5cb04b38086">
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
    Test Screenshots:

-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
