### PR TITLE
Added telemetry parameters to the Q chat events.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,9 +3607,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.5.5.tgz",
-            "integrity": "sha512-xvqr46XFfCWxcHsQURnDuHHs0GLJaCBanJpV22t9TBf/BNjzJN8aBM7AGYwXvZbykRKIGNpHnvQnKlMfVvr/aQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.6.1.tgz",
+            "integrity": "sha512-JdM8wC4auO98wq9F71cp53AQQDV6rYXI/1ZA5PRmhfkPqzQ5EM1qnt0fLvBr/VDueecsFC5UirBMtVOs0c10Yw==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",
@@ -19601,7 +19601,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.5.5",
+                "@aws/mynah-ui": "^4.5.6",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/shared-ini-file-loader": "^2.2.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4315,7 +4315,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.5.5",
+        "@aws/mynah-ui": "^4.5.6",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/shared-ini-file-loader": "^2.2.8",

--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -92,7 +92,10 @@ export class Connector {
         messageId: string,
         code?: string,
         type?: 'selection' | 'block',
-        codeReference?: CodeReference[]
+        codeReference?: CodeReference[],
+        eventId?: string,
+        codeBlockIndex?: number,
+        totalCodeBlocks?: number
     ): void => {
         this.sendMessageToExtension({
             tabID: tabID,
@@ -102,6 +105,9 @@ export class Connector {
             tabType: 'cwc',
             insertionTargetType: type,
             codeReference,
+            eventId,
+            codeBlockIndex,
+            totalCodeBlocks,
         })
     }
 
@@ -110,7 +116,10 @@ export class Connector {
         messageId: string,
         code?: string,
         type?: 'selection' | 'block',
-        codeReference?: CodeReference[]
+        codeReference?: CodeReference[],
+        eventId?: string,
+        codeBlockIndex?: number,
+        totalCodeBlocks?: number
     ): void => {
         this.sendMessageToExtension({
             tabID: tabID,
@@ -120,6 +129,9 @@ export class Connector {
             tabType: 'cwc',
             insertionTargetType: type,
             codeReference,
+            eventId,
+            codeBlockIndex,
+            totalCodeBlocks,
         })
     }
 

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -206,11 +206,23 @@ export class Connector {
         messageId: string,
         code?: string,
         type?: 'selection' | 'block',
-        codeReference?: CodeReference[]
+        codeReference?: CodeReference[],
+        eventId?: string,
+        codeBlockIndex?: number,
+        totalCodeBlocks?: number
     ): void => {
         switch (this.tabsStorage.getTab(tabID)?.type) {
             case 'cwc':
-                this.cwChatConnector.onCodeInsertToCursorPosition(tabID, messageId, code, type, codeReference)
+                this.cwChatConnector.onCodeInsertToCursorPosition(
+                    tabID,
+                    messageId,
+                    code,
+                    type,
+                    codeReference,
+                    eventId,
+                    codeBlockIndex,
+                    totalCodeBlocks
+                )
                 break
             case 'featuredev':
                 this.featureDevChatConnector.onCodeInsertToCursorPosition(tabID, code, type, codeReference)
@@ -223,11 +235,23 @@ export class Connector {
         messageId: string,
         code?: string,
         type?: 'selection' | 'block',
-        codeReference?: CodeReference[]
+        codeReference?: CodeReference[],
+        eventId?: string,
+        codeBlockIndex?: number,
+        totalCodeBlocks?: number
     ): void => {
         switch (this.tabsStorage.getTab(tabID)?.type) {
             case 'cwc':
-                this.cwChatConnector.onCopyCodeToClipboard(tabID, messageId, code, type, codeReference)
+                this.cwChatConnector.onCopyCodeToClipboard(
+                    tabID,
+                    messageId,
+                    code,
+                    type,
+                    codeReference,
+                    eventId,
+                    codeBlockIndex,
+                    totalCodeBlocks
+                )
                 break
             case 'featuredev':
                 this.featureDevChatConnector.onCopyCodeToClipboard(tabID, code, type, codeReference)

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -367,8 +367,26 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
             })
         },
         onCodeInsertToCursorPosition: connector.onCodeInsertToCursorPosition,
-        onCopyCodeToClipboard: (tabId, messageId, code, type, referenceTrackerInfo) => {
-            connector.onCopyCodeToClipboard(tabId, messageId, code, type, referenceTrackerInfo)
+        onCopyCodeToClipboard: (
+            tabId,
+            messageId,
+            code,
+            type,
+            referenceTrackerInfo,
+            eventId,
+            codeBlockIndex,
+            totalCodeBlocks
+        ) => {
+            connector.onCopyCodeToClipboard(
+                tabId,
+                messageId,
+                code,
+                type,
+                referenceTrackerInfo,
+                eventId,
+                codeBlockIndex,
+                totalCodeBlocks
+            )
             mynahUI.notify({
                 type: NotificationType.SUCCESS,
                 content: 'Selected code is copied to clipboard',

--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -41,6 +41,9 @@ export interface InsertCodeAtCursorPosition {
     code: string
     insertionTargetType: string | undefined
     codeReference: CodeReference[] | undefined
+    eventId: string
+    codeBlockIndex: number
+    totalCodeBlocks: number
 }
 
 export interface CopyCodeToClipboard {
@@ -50,6 +53,9 @@ export interface CopyCodeToClipboard {
     code: string
     insertionTargetType: string | undefined
     codeReference: CodeReference[] | undefined
+    eventId: string
+    codeBlockIndex: number
+    totalCodeBlocks: number
 }
 
 export type ChatPromptCommandType =

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -160,6 +160,8 @@ export class CWCTelemetryHelper {
                     cwsprChatAcceptedCharactersLength: message.code.length,
                     cwsprChatInteractionTarget: message.insertionTargetType,
                     cwsprChatHasReference: message.codeReference && message.codeReference.length > 0,
+                    cwsprChatCodeBlockIndex: message.codeBlockIndex,
+                    cwsprChatTotalCodeBlocks: message.totalCodeBlocks,
                 }
                 break
             case 'code_was_copied_to_clipboard':
@@ -173,6 +175,8 @@ export class CWCTelemetryHelper {
                     cwsprChatAcceptedCharactersLength: message.code.length,
                     cwsprChatInteractionTarget: message.insertionTargetType,
                     cwsprChatHasReference: message.codeReference && message.codeReference.length > 0,
+                    cwsprChatCodeBlockIndex: message.codeBlockIndex,
+                    cwsprChatTotalCodeBlocks: message.totalCodeBlocks,
                 }
                 break
             case 'follow-up-was-clicked':

--- a/packages/core/src/codewhispererChat/view/messages/messageListener.ts
+++ b/packages/core/src/codewhispererChat/view/messages/messageListener.ts
@@ -157,6 +157,9 @@ export class UIMessageListener {
             code: msg.code,
             insertionTargetType: msg.insertionTargetType,
             codeReference: msg.codeReference,
+            eventId: msg.eventId,
+            codeBlockIndex: msg.codeBlockIndex,
+            totalCodeBlocks: msg.totalCodeBlocks,
         })
     }
 
@@ -168,6 +171,9 @@ export class UIMessageListener {
             code: msg.code,
             insertionTargetType: msg.insertionTargetType,
             codeReference: msg.codeReference,
+            eventId: msg.eventId,
+            codeBlockIndex: msg.codeBlockIndex,
+            totalCodeBlocks: msg.totalCodeBlocks,
         })
     }
 

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -257,6 +257,16 @@
             "description": "Identifies the entity within the message that user interacts with."
         },
         {
+            "name": "cwsprChatCodeBlockIndex",
+            "type": "int",
+            "description": "Index of the code block inside a message in the conversation."
+        },
+        {
+            "name": "cwsprChatTotalCodeBlocks",
+            "type": "int",
+            "description": "Total number of code blocks inside a message in the conversation."
+        },
+        {
             "name": "cwsprChatAcceptedCharactersLength",
             "type": "int",
             "description": "Count of code characters copied to the editor"
@@ -822,6 +832,14 @@
                 },
                 {
                     "type": "cwsprChatHasReference",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatCodeBlockIndex",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatTotalCodeBlocks",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem
- Missing parameters in `onCopyCodeToClipboard` and `onCodeInsertToCursorPosition` events for telemetry.
## Solution
- Added `cwsprChatCodeBlockIndex` and `cwsprChatTotalCodeBlocks` parameters to the `onCopyCodeToClipboard` and `onCodeInsertToCursorPosition` events.
- `cwsprChatCodeBlockIndex` - Provides the index of that code block, when a user interacts with a code block within a message in the conversation, 
- `cwsprChatTotalCodeBlocks` - Total number of code blocks inside a generated message.
- Passed these two parameters to `insert_code_at_cursor_position` and `code_was_copied_to_clipboard` telemetry events.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
