### PR TITLE
fix(amazonq): Fix codewhisperer manual trigger not working in Q

### DIFF
--- a/packages/core/src/shared/vscode/commands2.ts
+++ b/packages/core/src/shared/vscode/commands2.ts
@@ -637,7 +637,6 @@ async function runCommand<T extends Callback>(fn: T, info: CommandInfo<T>): Prom
     try {
         if (info.autoconnect === true) {
             const prefix = globals.context.extension.id === VSCODE_EXTENSION_ID.amazonq ? 'amazonq' : 'toolkit'
-            // HACK: this only occurs for the explorer case, which is in toolkit
             await vscode.commands.executeCommand(`_aws.${prefix}.auth.autoConnect`)
         }
 

--- a/packages/core/src/shared/vscode/commands2.ts
+++ b/packages/core/src/shared/vscode/commands2.ts
@@ -15,6 +15,7 @@ import { ToolkitError } from '../errors'
 import crypto from 'crypto'
 import { keysAsInt } from '../utilities/tsUtils'
 import { partialClone } from '../utilities/collectionUtils'
+import { VSCODE_EXTENSION_ID } from '../utilities'
 
 type Callback = (...args: any[]) => any
 type CommandFactory<T extends Callback, U extends any[]> = (...parameters: U) => T
@@ -635,8 +636,9 @@ async function runCommand<T extends Callback>(fn: T, info: CommandInfo<T>): Prom
 
     try {
         if (info.autoconnect === true) {
+            const prefix = globals.context.extension.id === VSCODE_EXTENSION_ID.amazonq ? 'amazonq' : 'toolkit'
             // HACK: this only occurs for the explorer case, which is in toolkit
-            await vscode.commands.executeCommand('_aws.toolkit.auth.autoConnect')
+            await vscode.commands.executeCommand(`_aws.${prefix}.auth.autoConnect`)
         }
 
         return await (instrumenter ? instrumenter(fn, ...args) : fn(...args))


### PR DESCRIPTION
## Problem
codewhisperer manual trigger not working in Q

## Solution

Correct the command name prefix. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
