### PR TITLE
Amazon Q CodeTransform: Trim leading and trailing whitespace from user provided JAVA_HOME.

### DIFF
--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -346,6 +346,7 @@ export class GumbyController {
  * Examples:
  * ```
  * extractPath("./some/path/here") => "C:/some/root/some/path/here"
+ * extractPath(" ./some/path/here\n") => "C:/some/root/some/path/here"
  * extractPath("C:/some/nonexistent/path/here") => undefined
  * extractPath("C:/some/filepath/.txt") => undefined
  * ```
@@ -354,6 +355,6 @@ export class GumbyController {
  * @returns the absolute path if path points to existing folder, otherwise undefined
  */
 function extractPath(text: string): string | undefined {
-    const resolvedPath = path.resolve(text)
+    const resolvedPath = path.resolve(text.trim())
     return fs.existsSync(resolvedPath) && fs.lstatSync(resolvedPath).isDirectory() ? resolvedPath : undefined
 }


### PR DESCRIPTION
## Problem
Users can provide a JAVA_HOME with trailing or leading whitespaces, this causes issues when resolving the JAVA_HOME. 

## Solution

Using `.trim()` to do preliminary cleanup of the string.
Would prefer to do UT as fast follow since I have limited bandwidth for this PR currently.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
