### PR TITLE
fix: only bind auth server to 127.0.0.1

### DIFF
--- a/packages/core/src/auth/sso/server.ts
+++ b/packages/core/src/auth/sso/server.ts
@@ -134,8 +134,12 @@ export class AuthSSOServer {
         return `${this.baseUrl}:${this.getPort()}`
     }
 
+    public getAddress() {
+        return this.server.address()
+    }
+
     private getPort(): number {
-        const addr = this.server.address()
+        const addr = this.getAddress()
         if (addr instanceof Object) {
             return addr.port
         } else if (typeof addr === 'string') {

--- a/packages/core/src/auth/sso/server.ts
+++ b/packages/core/src/auth/sso/server.ts
@@ -107,7 +107,7 @@ export class AuthSSOServer {
                 resolve()
             })
 
-            this.server.listen()
+            this.server.listen(0, '127.0.0.1')
         })
     }
 

--- a/packages/core/src/test/credentials/sso/server.test.ts
+++ b/packages/core/src/test/credentials/sso/server.test.ts
@@ -105,4 +105,13 @@ describe('AuthSSOServer', function () {
         const token = await server.waitForAuthorization()
         assert.deepStrictEqual(code, token)
     })
+
+    it('address is bound to localhost', function () {
+        const address = server.getAddress()
+        if (address instanceof Object) {
+            assert.deepStrictEqual(address.address, '127.0.0.1')
+            return
+        }
+        assert.fail('Expected address 127.0.0.1')
+    })
 })


### PR DESCRIPTION
## Problem
- Auth server was being bound to all interfaces

## Solution
- Bind it only to 127.0.0.1

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
