### PR TITLE
test: update to require problem matcher extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["amodio.tsl-problem-matcher", "dbaeumer.vscode-eslint"]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,8 @@ To develop this project, install these dependencies:
 -   [Git](https://git-scm.com/downloads)
     -   (optional) Set `git blame` to ignore noise-commits: `git config blame.ignoreRevsFile .git-blame-ignore-revs`
 -   [AWS `git secrets`](https://github.com/awslabs/git-secrets)
--   (required for Web mode) [TypeScript + Webpack Problem Matcher](https://marketplace.visualstudio.com/items?itemName=amodio.tsl-problem-matcher)
+-   [TypeScript + Webpack Problem Matcher](https://marketplace.visualstudio.com/items?itemName=amodio.tsl-problem-matcher)
+    -   Not installing will result in the following error during building: `Error: Invalid problemMatcher reference: $ts-webpack-watch`
 -   (optional) [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
 -   (optional) [Docker](https://docs.docker.com/get-docker/)
 

--- a/packages/amazonq/.vscode/extensions.json
+++ b/packages/amazonq/.vscode/extensions.json
@@ -1,5 +1,0 @@
-{
-    // See http://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
-    "recommendations": ["dbaeumer.vscode-eslint"]
-}

--- a/packages/core/.vscode/extensions.json
+++ b/packages/core/.vscode/extensions.json
@@ -1,5 +1,0 @@
-{
-    // See http://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
-    "recommendations": ["dbaeumer.vscode-eslint"]
-}

--- a/packages/toolkit/.vscode/extensions.json
+++ b/packages/toolkit/.vscode/extensions.json
@@ -1,5 +1,0 @@
-{
-    // See http://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
-    "recommendations": ["dbaeumer.vscode-eslint"]
-}


### PR DESCRIPTION
When we build locally this problem matcher helps the IDE detect that a webpack watch execution is finished so that the build scripts can progress. It is now required but there isn't a good mechanism to force developers to install it.

### SOLUTION: 
- The extension is required so we now mention this in the docs
- We set it as recommended extension for developers in `extension.json`.
- Remove the old duplicated `extensions.json` files for a singular one in the root

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
