### PR TITLE
fix(amazonq): Let CodeCatalyst reuse connections in Amazon Q

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -926,10 +926,11 @@ export class Auth implements AuthService, ConnectionManager {
         } as SsoProfile
         if (profile === undefined) {
             await this.store.addProfile(id, newProfile)
+            await this.store.updateMetadata(id, { label: connection.label, connectionState: connection.state })
         } else {
             await this.store.updateProfile(connection.id, newProfile)
+            await this.updateConnectionState(id, connection.state)
         }
-        await this.updateConnectionState(id, connection.state)
     }
 
     // Used by Amazon Q to update connection status & scope when this connection is updated by AWS Toolkit

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -374,7 +374,7 @@ const registerToolkitApiCallbackOnce = once(async () => {
                     startUrl: conn.startUrl,
                     state: e.state,
                     id: id,
-                    label: conn.label,
+                    label: `AmazonQ ${conn.label}`,
                 } as AwsConnection)
             }
         }

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -81,7 +81,7 @@
                 </svg>
             </button>
             <div class="auth-container-section">
-                <div class="existing-logins" v-if="existingLogins.length > 0 && app === 'AMAZONQ'">
+                <div class="existing-logins" v-if="existingLogins.length > 0">
                     <div class="title">Connect with an existing account:</div>
                     <div v-for="(existingLogin, index) in existingLogins" :key="index">
                         <SelectableItem

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -393,12 +393,13 @@ export default defineComponent({
         async emitUpdate(cause?: string) {},
         async updateExistingConnections() {
             // fetch existing connections of aws toolkit in Amazon Q
-            // Only used by Amazon Q to reuse connections in AWS Toolkit
-            const toolkitConnections = await client.fetchConnections()
-            toolkitConnections?.forEach((connection, index) => {
+            // or fetch existing connections of Amazon Q in AWS Toolkit
+            // to reuse connections in AWS Toolkit & Amazon Q
+            const sharedConnections = await client.fetchConnections()
+            sharedConnections?.forEach((connection, index) => {
                 this.existingLogins.push({
                     id: LoginOption.EXISTING_LOGINS + index,
-                    text: 'Used by AWS Toolkit',
+                    text: this.app === 'TOOLKIT' ? 'Used by AWS Toolkit' : 'Used by Amazon Q',
                     title: isBuilderId(connection.startUrl)
                         ? 'AWS Builder ID'
                         : `IAM Identity Center ${connection.startUrl}`,
@@ -415,8 +416,8 @@ export default defineComponent({
 
             // If Amazon Q has no connections while Toolkit has connections
             // Auto connect Q using toolkit connection.
-            if (connections.length === 0 && toolkitConnections && toolkitConnections.length > 0) {
-                const conn = await client.findConnection(toolkitConnections)
+            if (connections.length === 0 && sharedConnections && sharedConnections.length > 0) {
+                const conn = await client.findConnection(sharedConnections)
                 if (conn) {
                     await client.useConnection(conn.id)
                 }

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -77,8 +77,22 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
     }
 
     async fetchConnections(): Promise<AwsConnection[] | undefined> {
-        //This does not need to be implement in aws toolkit vue backend
-        return undefined
+        const connections: AwsConnection[] = []
+        const _connections = await Auth.instance.listConnections()
+        _connections.forEach(c => {
+            const status = Auth.instance.getConnectionState({ id: c.id })
+            if (c.label.startsWith('AmazonQ') && c.type === 'sso' && status) {
+                connections.push({
+                    id: c.id,
+                    label: c.label,
+                    type: c.type,
+                    ssoRegion: c.ssoRegion,
+                    startUrl: c.startUrl,
+                    state: status,
+                } as AwsConnection)
+            }
+        })
+        return connections
     }
 
     async useConnection(connectionId: string): Promise<AuthError | undefined> {


### PR DESCRIPTION
## Problem

 CodeCatalyst cannot reuse connections in Amazon Q

## Solution

Let CodeCatalyst reuse connections in Amazon Q

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
