### PR TITLE
amazonq: habit building features

### DIFF
--- a/.changes/next-release/Feature-0fb1a891-a6c4-48a4-9229-879019b7831a.json
+++ b/.changes/next-release/Feature-0fb1a891-a6c4-48a4-9229-879019b7831a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q: cmd + i to open chat"
+}

--- a/.changes/next-release/Feature-18b63901-6443-4fc2-80e7-8dd85077b3e1.json
+++ b/.changes/next-release/Feature-18b63901-6443-4fc2-80e7-8dd85077b3e1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q: Right Click + no code selected shows Q context menu"
+}

--- a/.changes/next-release/Feature-dd0b3f2a-ad7d-420f-9efb-d5c678daf392.json
+++ b/.changes/next-release/Feature-dd0b3f2a-ad7d-420f-9efb-d5c678daf392.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q: brief CodeLens to advertise chat"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3831,6 +3831,12 @@
         ],
         "keybindings": [
             {
+                "command": "_aws.amazonq.focusChat.keybinding",
+                "win": "win+i",
+                "mac": "cmd+i",
+                "linux": "meta+i"
+            },
+            {
                 "command": "aws.amazonq.explainCode",
                 "win": "win+alt+e",
                 "mac": "cmd+alt+e",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1503,8 +1503,7 @@
             "editor/context": [
                 {
                     "submenu": "amazonqEditorContextSubmenu",
-                    "group": "cw_chat",
-                    "when": "editorHasSelection"
+                    "group": "cw_chat"
                 }
             ],
             "view/item/context": [
@@ -3835,29 +3834,25 @@
                 "command": "aws.amazonq.explainCode",
                 "win": "win+alt+e",
                 "mac": "cmd+alt+e",
-                "linux": "meta+alt+e",
-                "when": "editorHasSelection"
+                "linux": "meta+alt+e"
             },
             {
                 "command": "aws.amazonq.refactorCode",
                 "win": "win+alt+u",
                 "mac": "cmd+alt+u",
-                "linux": "meta+alt+u",
-                "when": "editorHasSelection"
+                "linux": "meta+alt+u"
             },
             {
                 "command": "aws.amazonq.fixCode",
                 "win": "win+alt+y",
                 "mac": "cmd+alt+y",
-                "linux": "meta+alt+y",
-                "when": "editorHasSelection"
+                "linux": "meta+alt+y"
             },
             {
                 "command": "aws.amazonq.optimizeCode",
                 "win": "win+alt+a",
                 "mac": "cmd+alt+a",
-                "linux": "meta+alt+a",
-                "when": "editorHasSelection"
+                "linux": "meta+alt+a"
             },
             {
                 "command": "aws.amazonq.sendToPrompt",

--- a/packages/core/src/amazonq/activation.ts
+++ b/packages/core/src/amazonq/activation.ts
@@ -15,7 +15,7 @@ import { welcome } from './onboardingPage'
 import { learnMoreAmazonQCommand, switchToAmazonQCommand } from './explorer/amazonQChildrenNodes'
 import { activateBadge } from './util/viewBadgeHandler'
 import { telemetry } from '../shared/telemetry/telemetry'
-import { focusAmazonQPanel } from '../codewhispererChat/commands/registerCommands'
+import { focusAmazonQPanel, focusAmazonQPanelKeybinding } from '../codewhispererChat/commands/registerCommands'
 
 export async function activate(context: ExtensionContext) {
     const appInitContext = DefaultAmazonQAppInitContext.instance
@@ -37,7 +37,8 @@ export async function activate(context: ExtensionContext) {
                 retainContextWhenHidden: true,
             },
         }),
-        focusAmazonQPanel.register()
+        focusAmazonQPanel.register(),
+        focusAmazonQPanelKeybinding.register()
     )
 
     amazonQWelcomeCommand.register(context, cwcWebViewToAppsPublisher)

--- a/packages/core/src/amazonq/activation.ts
+++ b/packages/core/src/amazonq/activation.ts
@@ -16,6 +16,7 @@ import { learnMoreAmazonQCommand, switchToAmazonQCommand } from './explorer/amaz
 import { activateBadge } from './util/viewBadgeHandler'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { focusAmazonQPanel, focusAmazonQPanelKeybinding } from '../codewhispererChat/commands/registerCommands'
+import { TryChatCodeLensProvider, tryChatCodeLensCommand } from '../codewhispererChat/editor/codelens'
 
 export async function activate(context: ExtensionContext) {
     const appInitContext = DefaultAmazonQAppInitContext.instance
@@ -31,6 +32,8 @@ export async function activate(context: ExtensionContext) {
 
     const cwcWebViewToAppsPublisher = appInitContext.getWebViewToAppsMessagePublishers().get('cwc')!
 
+    await TryChatCodeLensProvider.register()
+
     context.subscriptions.push(
         window.registerWebviewViewProvider(AmazonQChatViewProvider.viewType, provider, {
             webviewOptions: {
@@ -38,7 +41,8 @@ export async function activate(context: ExtensionContext) {
             },
         }),
         focusAmazonQPanel.register(),
-        focusAmazonQPanelKeybinding.register()
+        focusAmazonQPanelKeybinding.register(),
+        tryChatCodeLensCommand.register()
     )
 
     amazonQWelcomeCommand.register(context, cwcWebViewToAppsPublisher)

--- a/packages/core/src/codewhispererChat/commands/registerCommands.ts
+++ b/packages/core/src/codewhispererChat/commands/registerCommands.ts
@@ -17,6 +17,16 @@ export const focusAmazonQPanel = Commands.declare(
     }
 )
 
+/** 
+ * {@link focusAmazonQPanel} but only used for the keybinding since we cannot
+ * explicitly set the `source` in the package.json definition
+ */
+export const focusAmazonQPanelKeybinding = Commands.declare(
+    '_aws.amazonq.focusChat.keybinding', () => async () => {
+        await focusAmazonQPanel.execute(placeholder, 'keybinding')
+    }
+)
+
 const getCommandTriggerType = (data: any): EditorContextCommandTriggerType => {
     // data is undefined when commands triggered from keybinding or command palette. Currently no
     // way to differentiate keybinding and command palette, so both interactions are recorded as keybinding

--- a/packages/core/src/codewhispererChat/commands/registerCommands.ts
+++ b/packages/core/src/codewhispererChat/commands/registerCommands.ts
@@ -17,15 +17,13 @@ export const focusAmazonQPanel = Commands.declare(
     }
 )
 
-/** 
+/**
  * {@link focusAmazonQPanel} but only used for the keybinding since we cannot
  * explicitly set the `source` in the package.json definition
  */
-export const focusAmazonQPanelKeybinding = Commands.declare(
-    '_aws.amazonq.focusChat.keybinding', () => async () => {
-        await focusAmazonQPanel.execute(placeholder, 'keybinding')
-    }
-)
+export const focusAmazonQPanelKeybinding = Commands.declare('_aws.amazonq.focusChat.keybinding', () => async () => {
+    await focusAmazonQPanel.execute(placeholder, 'keybinding')
+})
 
 const getCommandTriggerType = (data: any): EditorContextCommandTriggerType => {
     // data is undefined when commands triggered from keybinding or command palette. Currently no

--- a/packages/core/src/codewhispererChat/editor/codelens.ts
+++ b/packages/core/src/codewhispererChat/editor/codelens.ts
@@ -1,0 +1,143 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import vscode from 'vscode'
+import globals from '../../shared/extensionGlobals'
+import { ToolkitError } from '../../shared/errors'
+import { Commands, placeholder } from '../../shared/vscode/commands2'
+import { platform } from 'os'
+import { focusAmazonQPanel } from '../commands/registerCommands'
+
+/** When the user clicks the CodeLens that prompts user to try Amazon Q chat */
+export const tryChatCodeLensCommand = Commands.declare(`_aws.amazonq.tryChatCodeLens`, () => async () => {
+    await focusAmazonQPanel.execute(placeholder, 'codeLens')
+})
+
+/**
+ * As part of hinting at users to use Amazon Q Chat, we will show codelenses
+ * prompting them a certain amount of time/uses. Then after
+ * a certain amount of times we will never show it again.
+ *
+ * This codelens appears above every clicked line.
+ */
+export class TryChatCodeLensProvider implements vscode.CodeLensProvider {
+    private _onDidChangeCodeLenses = new vscode.EventEmitter<void>()
+    onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event
+
+    /** How many times we've shown the CodeLens */
+    private count: number = 0
+    /** How many times we want to show the CodeLens */
+    static readonly maxCount = 10
+    static readonly debounceMillis: number = 700
+    static readonly showCodeLensId = `aws.amazonq.showTryChatCodeLens`
+
+    private static providerDisposable: vscode.Disposable | undefined = undefined
+    private disposables: vscode.Disposable[] = []
+
+    constructor(private readonly cursorPositionIfValid = () => TryChatCodeLensProvider._resolveCursorPosition()) {
+        // when we want to recalculate the codelens
+        this.disposables.push(
+            vscode.window.onDidChangeActiveTextEditor(() => this._onDidChangeCodeLenses.fire()),
+            vscode.window.onDidChangeTextEditorSelection(() => this._onDidChangeCodeLenses.fire())
+        )
+    }
+
+    static async register(): Promise<boolean> {
+        const shouldShow = globals.context.globalState.get(this.showCodeLensId, true)
+        if (!shouldShow) {
+            return false
+        }
+
+        if (this.providerDisposable) {
+            throw new ToolkitError(`${this.name} can only be registered once.`)
+        }
+
+        const provider = new TryChatCodeLensProvider()
+        this.providerDisposable = vscode.languages.registerCodeLensProvider({ scheme: 'file' }, provider)
+        globals.context.subscriptions.push(provider)
+        return true
+    }
+
+    provideCodeLenses(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.CodeLens[]> {
+        return new Promise(async resolve => {
+            token.onCancellationRequested(() => resolve([]))
+
+            if (this.count >= TryChatCodeLensProvider.maxCount) {
+                // We only want to show this code lens a certain amount of times
+                // to not annoy customers. The following ensures it is never shown again.
+                this.dispose()
+                return resolve([])
+            }
+
+            // We use a timeout as a leading debounce so that the user must
+            // wait on a specific line for a certain amount of time until we show the codelens.
+            // This prevents spamming code lenses if the user changes multiple lines quickly.
+            globals.clock.setTimeout(() => {
+                const position = this.cursorPositionIfValid()
+                if (token.isCancellationRequested || position === undefined) {
+                    return resolve([])
+                }
+
+                resolve([
+                    {
+                        range: new vscode.Range(position, position),
+                        isResolved: true,
+                        command: {
+                            command: tryChatCodeLensCommand.id,
+                            title: `Amazon Q: open chat with (${resolveModifierKey()} + i) - showing ${
+                                TryChatCodeLensProvider.maxCount - this.count
+                            } more times`,
+                        },
+                    },
+                ])
+
+                this.count++
+            }, TryChatCodeLensProvider.debounceMillis)
+        })
+    }
+
+    /**
+     * Resolves the current cursor position in the active document
+     * if the criteria are met.
+     */
+    private static _resolveCursorPosition(): vscode.Position | undefined {
+        const activeEditor = vscode.window.activeTextEditor
+        const activeDocument = activeEditor?.document
+        const textSelection = activeEditor?.selection
+        if (
+            !activeEditor ||
+            !activeDocument ||
+            activeEditor.selections.length > 1 || // is multi-cursor select
+            !textSelection?.isSingleLine ||
+            activeDocument.lineAt(textSelection.start.line).text.length === 0 // is empty line
+        ) {
+            return undefined
+        }
+
+        return textSelection.start
+    }
+
+    dispose() {
+        void globals.context.globalState.update(TryChatCodeLensProvider.showCodeLensId, false)
+        TryChatCodeLensProvider.providerDisposable?.dispose()
+        this.disposables.forEach(d => d.dispose())
+    }
+}
+
+export function resolveModifierKey() {
+    const platformName = platform()
+    switch (platformName) {
+        case 'win32':
+            return 'ctrl'
+        case 'linux':
+            return 'meta'
+        case 'darwin':
+            return 'cmd'
+        default:
+            return 'ctrl'
+    }
+}

--- a/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
+++ b/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
@@ -36,7 +36,8 @@ export class FocusAreaContextExtractor {
 
         // It means we don't really have a selection, but cursor position only
         if (!this.isCodeBlockSelected(editor)) {
-            importantRange = editor.visibleRanges[0]
+            // Select the whole line
+            importantRange = editor.document.lineAt(importantRange.start.line).range
         }
 
         const names = await this.findNamesInRange(editor.document.getText(), importantRange, editor.document.languageId)

--- a/packages/core/src/test/codewhispererChat/editor/codelens.test.ts
+++ b/packages/core/src/test/codewhispererChat/editor/codelens.test.ts
@@ -1,0 +1,81 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import vscode from 'vscode'
+import {
+    TryChatCodeLensProvider,
+    resolveModifierKey,
+    tryChatCodeLensCommand,
+} from '../../../codewhispererChat/editor/codelens'
+import { assertTelemetry, installFakeClock } from '../../testUtil'
+import { InstalledClock } from '@sinonjs/fake-timers'
+import globals from '../../../shared/extensionGlobals'
+import { focusAmazonQPanel } from '../../../codewhispererChat/commands/registerCommands'
+
+describe('TryChatCodeLensProvider', () => {
+    let instance: TryChatCodeLensProvider = new TryChatCodeLensProvider()
+    let cancellationTokenSource: vscode.CancellationTokenSource
+    let clock: InstalledClock
+    const codeLensPosition = new vscode.Position(1, 2)
+
+    beforeEach(function () {
+        instance = new TryChatCodeLensProvider(() => codeLensPosition)
+        clock = installFakeClock()
+    })
+
+    afterEach(function () {
+        instance.dispose()
+        cancellationTokenSource?.dispose()
+        clock.uninstall()
+    })
+
+    it('keeps returning a code lense until it hits the max times it should show', async function () {
+        let codeLensCount = 0
+        const modifierKey = resolveModifierKey()
+        while (codeLensCount < 10) {
+            cancellationTokenSource = new vscode.CancellationTokenSource()
+            const resultPromise = instance.provideCodeLenses({} as any, cancellationTokenSource.token)
+            clock.tick(TryChatCodeLensProvider.debounceMillis) // skip debounce
+
+            assert.deepStrictEqual(await resultPromise, [
+                {
+                    range: new vscode.Range(codeLensPosition, codeLensPosition),
+                    command: {
+                        title: `Amazon Q: open chat with (${modifierKey} + i) - showing ${
+                            TryChatCodeLensProvider.maxCount - codeLensCount
+                        } more times`,
+                        command: tryChatCodeLensCommand.id,
+                    },
+                    isResolved: true,
+                },
+            ])
+
+            codeLensCount++
+        }
+        const emptyResult = await instance.provideCodeLenses({} as any, new vscode.CancellationTokenSource().token)
+        assert.deepStrictEqual(emptyResult, [])
+    })
+
+    it('does not register the provider if we do not want to show the code lens', async function () {
+        // indicate we do not want to show it
+        await globals.context.globalState.update(TryChatCodeLensProvider.showCodeLensId, false)
+        // ensure we do not show it
+        assert.deepStrictEqual(await TryChatCodeLensProvider.register(), false)
+
+        // indicate we want to show it
+        await globals.context.globalState.update(TryChatCodeLensProvider.showCodeLensId, true)
+        // The general toolkit activation will have already registered this provider, so it throws when we try again
+        // But if it throws it implies it tried to register it.
+        await assert.rejects(TryChatCodeLensProvider.register(), {
+            message: `${TryChatCodeLensProvider.name} can only be registered once.`,
+        })
+    })
+
+    it('outputs expected telemetry', async function () {
+        await tryChatCodeLensCommand.execute()
+        assertTelemetry('vscode_executeCommand', { command: focusAmazonQPanel.id, source: 'codeLens' })
+    })
+})


### PR DESCRIPTION
## Problem

We want more ways for users to use Amazon Q chat.

## Solution

This adds the following features:
- For first time users will show a CodeLens(small grey text above the current line) that prompts users to try Q Chat, and if clicked will open it
  - We only show this codelens 10 times (can adjust if necessary). Then never show it again. We do not want to annoy the user.
- A new keyboard shortcut `cmd` + `i` which will open Q chat
- The right click `Send to Amazon Q` menu will always show now, before it only showed when a line was highlighted.
  - If the user does a right click but no highlight, the entire line will be used in the command

<img width="748" alt="Screenshot 2024-04-22 at 12 06 37 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/118216176/b6fa1f96-1fa0-45fe-9115-0b86ab727d73">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
