### PR TITLE
fix(amazonFeatureDev): change Timeouts values

### DIFF
--- a/packages/core/src/testE2E/amazonq/featureDev.test.ts
+++ b/packages/core/src/testE2E/amazonq/featureDev.test.ts
@@ -19,11 +19,11 @@ describe('Amazon Q Feature Dev', function () {
     let framework: qTestingFramework
     let tab: Messenger
 
-    const maxTestDuration = 300000
+    const maxTestDuration = 900000
     const prompt = 'Implement fibonacci in python'
     const iterateApproachPrompt = prompt + ' and add a unit test'
     const codegenApproachPrompt = prompt + ' and add a readme that describes the changes'
-    const tooManyRequestsWaitTime = 600000
+    const tooManyRequestsWaitTime = 900000
 
     before(async function () {
         /**

--- a/packages/core/src/testE2E/amazonq/featureDev.test.ts
+++ b/packages/core/src/testE2E/amazonq/featureDev.test.ts
@@ -19,11 +19,11 @@ describe('Amazon Q Feature Dev', function () {
     let framework: qTestingFramework
     let tab: Messenger
 
-    const maxTestDuration = 600000
+    const maxTestDuration = 300000
     const prompt = 'Implement fibonacci in python'
     const iterateApproachPrompt = prompt + ' and add a unit test'
     const codegenApproachPrompt = prompt + ' and add a readme that describes the changes'
-    const tooManyRequestsWaitTime = 100000
+    const tooManyRequestsWaitTime = 600000
 
     before(async function () {
         /**
@@ -88,8 +88,8 @@ describe('Amazon Q Feature Dev', function () {
                 return tab.getChatItems().some(chatItem => chatItem.body === text)
             },
             {
-                waitIntervalInMs: 250,
-                waitTimeoutInMs: 2000,
+                waitIntervalInMs: 2500,
+                waitTimeoutInMs: 20000,
             }
         )
     }


### PR DESCRIPTION
## Problem

Why those lines of code are removed:
```
describe('Moves directly from approach to codegen', () => {
  codegenTests()
})
```
Current set up:
approach phase -> moves Moves directly from approach to codegen (generate code -> insert changes -> generate code-> work on the new task -> generate code -> CloseSession) -> iterate on approach => when trying iterate on approach when task is finished, task cannot be continued and the following error is shown ->  `Amazon Q feature development: failed to generate presigned url: Resource is in an invalid state`

Set up after this fix:
approach phase ->  iterate on approach->code gen started -> code gen iterated -> code gen accepted -> coden gen new task -> session closed


----
Why those lines of code are removed:
```
describe('Clicks accept code', () => {
   insertCodeTests()
})
```
Current setup:
```
function codegenTests(){
  ...
   insertCodeTests()
   describe('Iterates on codegen', () => {
      ... 
       insertCodeTests()
   })
}
```
 insertCodeTests() calls  `tab.clickButton(FollowUpTypes.CloseSession)` => which means Iterate on codegen on the code gen won't be possible with the same error:
 
`Amazon Q feature development: failed to generate presigned url: Resource is in an invalid state`


Tested:
```
11 passing (33m)
globalSetup: after()
No test coverage found
```




## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
