### PR TITLE
Q Code Transformation - Reset state between sequential job runs 

### DIFF
--- a/.changes/next-release/Bug Fix-621c779b-2052-4373-9db0-6d02bec363d7.json
+++ b/.changes/next-release/Bug Fix-621c779b-2052-4373-9db0-6d02bec363d7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Code Transformation - Proposed changes not updated when multiple transformation jobs run in sequence."
+}

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -292,9 +292,7 @@ export async function getValidCandidateProjects(): Promise<TransformationCandida
 
 export async function setTransformationToRunningState() {
     await setContextVariables()
-    getLogger().info(`In startTransformByQ about to reset project`)
     await vscode.commands.executeCommand('aws.amazonq.transformationHub.reviewChanges.reset')
-    getLogger().info(`In startTransformByQ project reset`)
     transformByQState.setToRunning()
     sessionPlanProgress['startJob'] = StepProgress.Pending
     sessionPlanProgress['buildCode'] = StepProgress.Pending

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -54,10 +54,6 @@ import { sleep } from '../../shared/utilities/timeoutUtils'
 
 let sessionJobHistory: { timestamp: string; module: string; status: string; duration: string; id: string }[] = []
 
-export async function startTransformByQWithProgress() {
-    await startTransformByQ()
-}
-
 export async function processTransformFormInput(
     pathToProject: string,
     fromJDKVersion: JDKVersion,
@@ -296,7 +292,9 @@ export async function getValidCandidateProjects(): Promise<TransformationCandida
 
 export async function setTransformationToRunningState() {
     await setContextVariables()
-
+    getLogger().info(`In startTransformByQ about to reset project`)
+    await vscode.commands.executeCommand('aws.amazonq.transformationHub.reviewChanges.reset')
+    getLogger().info(`In startTransformByQ project reset`)
     transformByQState.setToRunning()
     sessionPlanProgress['startJob'] = StepProgress.Pending
     sessionPlanProgress['buildCode'] = StepProgress.Pending


### PR DESCRIPTION
## Problem
Customers who ran multiple jobs after each other without accepting / rejecting changes could not see proposed changes for the subsequent job.
(have videos with behaviour, but too large for github upload)

## Solution
Reset state when new job is submitted + streamline reset logic into one piece of code (previously scattered in two places)

### Testing

1. Ran three jobs in a row and verified the proposed changes could be downloaded each time.
(have videos with behaviour, but too large for github upload)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
