### PR TITLE
fix: About extension message always shows AWS Toolkit

### DIFF
--- a/packages/core/src/shared/extensionUtilities.ts
+++ b/packages/core/src/shared/extensionUtilities.ts
@@ -13,6 +13,7 @@ import { Ec2MetadataClient } from './clients/ec2MetadataClient'
 import { DefaultEc2MetadataClient } from './clients/ec2MetadataClient'
 import { extensionVersion, getCodeCatalystDevEnvId } from './vscode/env'
 import { DevSettings } from './settings'
+import globals from './extensionGlobals'
 
 const localize = nls.loadMessageBundle()
 
@@ -264,6 +265,12 @@ export async function aboutExtension(): Promise<void> {
     }
 }
 
+function getProductName(): string {
+    return globals.context.extension.id === VSCODE_EXTENSION_ID.amazonq
+        ? 'Amazon Q Toolkit'
+        : `${getIdeProperties().company} Toolkit`
+}
+
 /**
  * Returns a string that includes the OS, extension, and VS Code versions.
  */
@@ -277,13 +284,13 @@ export function getExtEnvironmentDetails(): string {
 
     const envDetails = localize(
         'AWS.message.toolkitInfo',
-        'OS: {0} {1} {2}\n{3} extension host:  {4}\n{5} Toolkit:  {6}\n{7}{8}',
+        'OS: {0} {1} {2}\n{3} extension host:  {4}\n{5}:  {6}\n{7}{8}',
         osType,
         osArch,
         osRelease,
         getIdeProperties().longName,
         vsCodeVersion,
-        getIdeProperties().company,
+        getProductName(),
         extensionVersion,
         node,
         electron


### PR DESCRIPTION
## Problem
- If you are using the about from the amazon q extension it shows AWS Toolkit. e.g. "AWS Toolkit: 0.10.0"

## Solution
- If you are using the q extension then show Amazon Q Toolkit

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
