### PR TITLE
amazonq: command to show the chat window

### DIFF
--- a/packages/core/src/amazonq/activation.ts
+++ b/packages/core/src/amazonq/activation.ts
@@ -9,13 +9,13 @@ import { init as cwChatAppInit } from '../codewhispererChat/app'
 import { init as featureDevChatAppInit } from '../amazonqFeatureDev/app'
 import { init as gumbyChatAppInit } from '../amazonqGumby/app'
 import { AmazonQAppInitContext, DefaultAmazonQAppInitContext } from './apps/initContext'
-import { Commands, VsCodeCommandArg } from '../shared/vscode/commands2'
+import { Commands, VsCodeCommandArg, placeholder } from '../shared/vscode/commands2'
 import { MessagePublisher } from './messages/messagePublisher'
 import { welcome } from './onboardingPage'
 import { learnMoreAmazonQCommand, switchToAmazonQCommand } from './explorer/amazonQChildrenNodes'
 import { activateBadge } from './util/viewBadgeHandler'
 import { telemetry } from '../shared/telemetry/telemetry'
-import { focusAmazonQPanel } from '../auth/ui/vue/show'
+import { focusAmazonQPanel } from '../codewhispererChat/commands/registerCommands'
 
 export async function activate(context: ExtensionContext) {
     const appInitContext = DefaultAmazonQAppInitContext.instance
@@ -36,7 +36,8 @@ export async function activate(context: ExtensionContext) {
             webviewOptions: {
                 retainContextWhenHidden: true,
             },
-        })
+        }),
+        focusAmazonQPanel.register()
     )
 
     amazonQWelcomeCommand.register(context, cwcWebViewToAppsPublisher)
@@ -56,7 +57,7 @@ export const amazonQWelcomeCommand = Commands.declare(
     { id: 'aws.amazonq.welcome', compositeKey: { 1: 'source' } },
     (context: ExtensionContext, publisher: MessagePublisher<any>) => (_: VsCodeCommandArg, source: string) => {
         telemetry.ui_click.run(() => {
-            void focusAmazonQPanel()
+            void focusAmazonQPanel.execute(placeholder, 'welcome')
             welcome(context, publisher)
             telemetry.record({ elementId: 'toolkit_openedWelcomeToAmazonQPage', source })
         })

--- a/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
+++ b/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
@@ -11,9 +11,9 @@ import { reconnect } from '../../codewhisperer/commands/basicCommands'
 import { amazonQHelpUrl } from '../../shared/constants'
 import { cwTreeNodeSource } from '../../codewhisperer/commands/types'
 import { telemetry } from '../../shared/telemetry/telemetry'
-import { focusAmazonQPanel } from '../../auth/ui/vue/show'
 import { DataQuickPickItem } from '../../shared/ui/pickerPrompter'
 import { TreeNode } from '../../shared/treeview/resourceTreeDataProvider'
+import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
 
 const localize = nls.loadMessageBundle()
 
@@ -33,7 +33,7 @@ export const switchToAmazonQCommand = Commands.declare('_aws.amazonq.focusView',
         elementId: 'amazonq_switchToQChat',
         passive: false,
     })
-    void focusAmazonQPanel()
+    void focusAmazonQPanel.execute(placeholder, 'switchToQChat')
 })
 
 export function switchToAmazonQNode(type: 'item'): DataQuickPickItem<'openChatPanel'>

--- a/packages/core/src/amazonq/onboardingPage/index.ts
+++ b/packages/core/src/amazonq/onboardingPage/index.ts
@@ -8,8 +8,9 @@ import globals from '../../shared/extensionGlobals'
 import path from 'path'
 import { MessagePublisher } from '../messages/messagePublisher'
 import { telemetry } from '../../shared/telemetry/telemetry'
-import { focusAmazonQPanel } from '../../auth/ui/vue/show'
 import { getLogger } from '../../shared/logger'
+import { placeholder } from '../../shared/vscode/commands2'
+import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
 
 export function welcome(context: vscode.ExtensionContext, cwcWebViewToAppsPublisher: MessagePublisher<any>): void {
     const panel = vscode.window.createWebviewPanel(
@@ -35,7 +36,7 @@ export function welcome(context: vscode.ExtensionContext, cwcWebViewToAppsPublis
                 switch (message.command) {
                     case 'sendToQ':
                         telemetry.record({ elementId: 'amazonq_meet_askq' })
-                        focusAmazonQPanel().then(
+                        focusAmazonQPanel.execute(placeholder, 'sendToQ').then(
                             () => {
                                 cwcWebViewToAppsPublisher.publish({
                                     type: 'onboarding-page-cwc-button-clicked',

--- a/packages/core/src/auth/ui/vue/show.ts
+++ b/packages/core/src/auth/ui/vue/show.ts
@@ -54,6 +54,7 @@ import { debounce } from 'lodash'
 import { submitFeedback } from '../../../feedback/vue/submitFeedback'
 import { InvalidGrantException } from '@aws-sdk/client-sso-oidc'
 import { isWeb } from '../../../common/webUtils'
+import { focusAmazonQPanel } from '../../../codewhispererChat/commands/registerCommands'
 
 export class AuthWebview extends VueWebview {
     public static readonly sourcePath: string = 'src/auth/ui/vue/index.js'
@@ -183,7 +184,7 @@ export class AuthWebview extends VueWebview {
     }
 
     async showAmazonQChat(): Promise<void> {
-        return focusAmazonQPanel()
+        return focusAmazonQPanel.execute(placeholder, 'addConnectionPage')
     }
 
     async getIdentityCenterRegion(): Promise<Region | undefined> {
@@ -857,12 +858,4 @@ export async function emitWebviewClosed(authWebview: ClassToInterfaceType<AuthWe
 
         return result
     }
-}
-
-/**
- * Forces focus to Amazon Q panel - USE THIS SPARINGLY (don't betray customer trust by hijacking the IDE)
- * Used on first load, and any time we want to directly populate chat.
- */
-export async function focusAmazonQPanel(): Promise<void> {
-    await vscode.commands.executeCommand('aws.AmazonQChatView.focus')
 }

--- a/packages/core/src/codewhispererChat/commands/registerCommands.ts
+++ b/packages/core/src/codewhispererChat/commands/registerCommands.ts
@@ -3,9 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { focusAmazonQPanel } from '../../auth/ui/vue/show'
-import { Commands } from '../../shared/vscode/commands2'
+import { Commands, VsCodeCommandArg, placeholder } from '../../shared/vscode/commands2'
 import { ChatControllerMessagePublishers } from '../controllers/chat/controller'
+import vscode from 'vscode'
+
+/**
+ * Opens the Amazon Q chat window.
+ */
+export const focusAmazonQPanel = Commands.declare(
+    { id: `aws.amazonq.focusChat`, compositeKey: { 1: 'source' } },
+    () => async (_: VsCodeCommandArg, source: string) => {
+        await vscode.commands.executeCommand('aws.AmazonQChatView.focus')
+    }
+)
 
 const getCommandTriggerType = (data: any): EditorContextCommandTriggerType => {
     // data is undefined when commands triggered from keybinding or command palette. Currently no
@@ -15,7 +25,7 @@ const getCommandTriggerType = (data: any): EditorContextCommandTriggerType => {
 
 export function registerCommands(controllerPublishers: ChatControllerMessagePublishers) {
     Commands.register('aws.amazonq.explainCode', async data => {
-        return focusAmazonQPanel().then(() => {
+        return focusAmazonQPanel.execute(placeholder, 'amazonq.explainCode').then(() => {
             controllerPublishers.processContextMenuCommand.publish({
                 type: 'aws.amazonq.explainCode',
                 triggerType: getCommandTriggerType(data),
@@ -23,7 +33,7 @@ export function registerCommands(controllerPublishers: ChatControllerMessagePubl
         })
     })
     Commands.register('aws.amazonq.refactorCode', async data => {
-        return focusAmazonQPanel().then(() => {
+        return focusAmazonQPanel.execute(placeholder, 'amazonq.refactorCode').then(() => {
             controllerPublishers.processContextMenuCommand.publish({
                 type: 'aws.amazonq.refactorCode',
                 triggerType: getCommandTriggerType(data),
@@ -31,7 +41,7 @@ export function registerCommands(controllerPublishers: ChatControllerMessagePubl
         })
     })
     Commands.register('aws.amazonq.fixCode', async data => {
-        return focusAmazonQPanel().then(() => {
+        return focusAmazonQPanel.execute(placeholder, 'amazonq.fixCode').then(() => {
             controllerPublishers.processContextMenuCommand.publish({
                 type: 'aws.amazonq.fixCode',
                 triggerType: getCommandTriggerType(data),
@@ -39,7 +49,7 @@ export function registerCommands(controllerPublishers: ChatControllerMessagePubl
         })
     })
     Commands.register('aws.amazonq.optimizeCode', async data => {
-        return focusAmazonQPanel().then(() => {
+        return focusAmazonQPanel.execute(placeholder, 'amazonq.optimizeCode').then(() => {
             controllerPublishers.processContextMenuCommand.publish({
                 type: 'aws.amazonq.optimizeCode',
                 triggerType: getCommandTriggerType(data),
@@ -47,7 +57,7 @@ export function registerCommands(controllerPublishers: ChatControllerMessagePubl
         })
     })
     Commands.register('aws.amazonq.sendToPrompt', async data => {
-        return focusAmazonQPanel().then(() => {
+        return focusAmazonQPanel.execute(placeholder, 'amazonq.sendToPrompt').then(() => {
             controllerPublishers.processContextMenuCommand.publish({
                 type: 'aws.amazonq.sendToPrompt',
                 triggerType: getCommandTriggerType(data),


### PR DESCRIPTION
Before, we had a function to show the chat webview or used the vscode generated show chat command.

Now we have a single command which can be used anywhere. This will allow us to get better metrics on when the chat window is opened. It has a `source` property so users must indicate where it came from.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
