### PR TITLE
codewhisperer: telemetry(requestHeaders property) and error handling for uploadArtifactS3Url

### DIFF
--- a/packages/core/src/codewhisperer/client/user-service-2.json
+++ b/packages/core/src/codewhisperer/client/user-service-2.json
@@ -603,7 +603,10 @@
             "members": {
                 "uploadId": { "shape": "UploadId" },
                 "uploadUrl": { "shape": "PreSignedUrl" },
-                "kmsKeyArn": { "shape": "ResourceArn" }
+                "kmsKeyArn": { "shape": "ResourceArn" },
+                "requestHeaders": {
+                    "shape": "RequestHeaders"
+                }
             }
         },
         "CursorState": {
@@ -1141,6 +1144,27 @@
             "max": 1224,
             "min": 0,
             "pattern": "arn:([-.a-z0-9]{1,63}:){2}([-.a-z0-9]{0,63}:){2}([a-zA-Z0-9-_:/]){1,1023}"
+        },
+        "RequestHeaderKey": {
+            "type": "string",
+            "max": 64,
+            "min": 1
+        },
+        "RequestHeaderValue": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+        },
+        "RequestHeaders": {
+            "type": "map",
+            "key": {
+                "shape": "RequestHeaderKey"
+            },
+            "value": {
+                "shape": "RequestHeaderValue"
+            },
+            "max": 16,
+            "min": 1
         },
         "ResourceNotFoundException": {
             "type": "structure",

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -228,7 +228,7 @@ export async function uploadArtifactToS3(fileName: string, resp: CreateUploadUrl
     try {
         const response = await request.fetch('PUT', resp.uploadUrl, {
             body: readFileSync(fileName),
-            headers: resp.requestHeaders !== undefined ? resp.requestHeaders : headersObj,
+            headers: resp?.requestHeaders ?? headersObj,
         }).response
         getLogger().debug(`StatusCode: ${response.status}, Text: ${response.statusText}`)
     } catch (error) {

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -225,9 +225,18 @@ export async function uploadArtifactToS3(fileName: string, resp: CreateUploadUrl
         headersObj['x-amz-server-side-encryption-aws-kms-key-id'] = resp.kmsKeyArn
     }
 
-    const response = await request.fetch('PUT', resp.uploadUrl, {
-        body: readFileSync(fileName),
-        headers: headersObj,
-    }).response
-    getLogger().debug(`StatusCode: ${response.status}, Text: ${response.statusText}`)
+    try {
+        const response = await request.fetch('PUT', resp.uploadUrl, {
+            body: readFileSync(fileName),
+            headers: resp.requestHeaders !== undefined ? resp.requestHeaders : headersObj,
+        }).response
+        getLogger().debug(`StatusCode: ${response.status}, Text: ${response.statusText}`)
+    } catch (error) {
+        getLogger().error(
+            `Amazon Q is unable to upload workspace artifacts to Amazon S3 for security scans. For more information, see the Amazon Q documentation or contact your network or organization administrator.`
+        )
+        throw new Error(
+            `Amazon Q is unable to upload workspace artifacts to Amazon S3 for security scans. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security_iam_manage-access-with-policies.html) or contact your network or organization administrator.`
+        )
+    }
 }


### PR DESCRIPTION

- Adding dynamic requestHeaders for `uploadArtifactToS3`.
- Adding try/catch block for `uploadArtifactToS3 ` to catch any exception and show the error message.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
