### PR TITLE
codewhisperer: add code scan name to api calls

### DIFF
--- a/packages/core/src/codewhisperer/client/user-service-2.json
+++ b/packages/core/src/codewhisperer/client/user-service-2.json
@@ -414,6 +414,13 @@
             "type": "string",
             "enum": ["Completed", "Pending", "Failed"]
         },
+        "CodeAnalysisUploadContext": {
+            "type": "structure",
+            "required": ["codeScanName"],
+            "members": {
+                "codeScanName": { "shape": "CodeScanName" }
+            }
+        },
         "CodeCoverageEvent": {
             "type": "structure",
             "required": ["programmingLanguage", "acceptedCharacterCount", "totalCharacterCount", "timestamp"],
@@ -458,6 +465,12 @@
         },
         "CodeScanJobId": {
             "type": "string",
+            "max": 128,
+            "min": 1
+        },
+        "CodeScanName": {
+            "type": "string",
+            "documentation": "<p>Code analysis scan name</p>",
             "max": 128,
             "min": 1
         },
@@ -1243,7 +1256,8 @@
                 "clientToken": {
                     "shape": "StartCodeAnalysisRequestClientTokenString",
                     "idempotencyToken": true
-                }
+                },
+                "codeScanName": { "shape": "CodeScanName" }
             }
         },
         "StartCodeAnalysisRequestClientTokenString": {
@@ -1570,7 +1584,8 @@
         "UploadContext": {
             "type": "structure",
             "members": {
-                "taskAssistPlanningUploadContext": { "shape": "TaskAssistPlanningUploadContext" }
+                "taskAssistPlanningUploadContext": { "shape": "TaskAssistPlanningUploadContext" },
+                "codeAnalysisUploadContext": { "shape": "CodeAnalysisUploadContext" }
             },
             "union": true
         },


### PR DESCRIPTION
## Problem

CreateUploadUrl and CreateCodeScan APIs now require CodeScanName field

## Solution

Pass a random UUID to the APIs

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
