### PR TITLE
QFeatureDev- handled upload failure with specific message

### DIFF
--- a/packages/core/src/amazonq/webview/ui/texts/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/texts/constants.ts
@@ -27,3 +27,5 @@ export const uiComponentsTexts = {
 }
 
 export const userGuideURL = 'https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/getting-started.html'
+export const manageAccessGuideURL =
+    'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security_iam_manage-access-with-policies.html'

--- a/packages/core/src/amazonqFeatureDev/errors.ts
+++ b/packages/core/src/amazonqFeatureDev/errors.ts
@@ -5,6 +5,7 @@
 
 import { ToolkitError } from '../shared/errors'
 import { featureName } from './constants'
+import { uploadCodeError } from './userFacingText'
 
 export class ConversationIdNotFoundError extends ToolkitError {
     constructor() {
@@ -57,7 +58,7 @@ export class PrepareRepoFailedError extends ToolkitError {
 
 export class UploadCodeError extends ToolkitError {
     constructor(statusCode: string) {
-        super('Unable to upload code', { code: `UploadCode-${statusCode}` })
+        super(uploadCodeError, { code: `UploadCode-${statusCode}` })
     }
 }
 

--- a/packages/core/src/amazonqFeatureDev/userFacingText.ts
+++ b/packages/core/src/amazonqFeatureDev/userFacingText.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { manageAccessGuideURL } from '../amazonq/webview/ui/texts/constants'
 import { userGuideURL } from '../amazonq/webview/ui/texts/constants'
 
 export const examples = `
@@ -19,3 +20,4 @@ export const approachCreation = 'Ok, let me create a plan. This may take a few m
 export const updateCode = 'Code has been updated. Would you like to work on another task?'
 export const sessionClosed = 'Your session is now closed.'
 export const newTaskChanges = 'What change would you like to make?'
+export const uploadCodeError = `Amazon Q is unable to upload workspace artifacts to S3 for feature development. For more information, see the [Amazon Q documentation](${manageAccessGuideURL}) or contact your network or organization administrator.`


### PR DESCRIPTION
## Problem
Currently for Q Feature development, users are not informed with an appropriate message in case of failures to upload user artifacts to S3.

## Solution
Updated the error message to show upload failures to customers.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
