### PR TITLE
test: fik flaky fs test

### DIFF
--- a/packages/core/src/test/srcShared/fs.test.ts
+++ b/packages/core/src/test/srcShared/fs.test.ts
@@ -170,13 +170,13 @@ describe('FileSystem', function () {
         paths.forEach(async function (p) {
             it(`creates folder but uses the "fs" module if in C9: '${p}'`, async function () {
                 sandbox.stub(extensionUtilities, 'isCloud9').returns(true)
-                const mkdirSpy = sandbox.spy(fsPromises, 'mkdir')
                 const dirPath = createTestPath(p)
+                const mkdirSpy = sandbox.spy(fsPromises, 'mkdir')
 
                 await fsCommon.mkdir(dirPath)
 
                 assert(existsSync(dirPath))
-                assert.deepStrictEqual(mkdirSpy.args, [[dirPath, { recursive: true }]])
+                assert.deepStrictEqual(mkdirSpy.args[0], [dirPath, { recursive: true }])
             })
         })
     })


### PR DESCRIPTION
## Problem
Our mkdir() spy was sometimes catching an unexpected mkdir() call and causing the test to fail.

## Solution
So instead we are just checking that the first mkdir() call has the expected args





<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
