### PR TITLE
fix: User is able to create a dev environment inside of a dev environment

### DIFF
--- a/.changes/next-release/Bug Fix-51277dc2-c134-450c-8394-b0937055969b.json
+++ b/.changes/next-release/Bug Fix-51277dc2-c134-450c-8394-b0937055969b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Codecatalyst: User can create a dev environment inside a dev environment"
+}


### PR DESCRIPTION
## Problem
- Currently a user is able to create a dev environment inside a dev environment

## Solution
- Throw an error is a user is trying to create a dev environment inside of a dev environment. This is because the token used is derived from whatever token initiated the "Start" API causing issues in a downstream service

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
