### PR TITLE
feat(amazonq): Add accepted lines of code of Q chat telemetry

### DIFF
--- a/packages/core/src/codewhisperer/client/user-service-2.json
+++ b/packages/core/src/codewhisperer/client/user-service-2.json
@@ -362,6 +362,7 @@
                 "interactionType": { "shape": "ChatMessageInteractionType" },
                 "interactionTarget": { "shape": "String" },
                 "acceptedCharacterCount": { "shape": "Integer" },
+                "acceptedLineCount": { "shape": "Integer" },
                 "acceptedSnippetHasReference": { "shape": "Boolean" }
             }
         },

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -2,7 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { UserIntent } from '@amzn/codewhisperer-streaming'
 import {
     AmazonqAddMessage,
@@ -158,6 +157,7 @@ export class CWCTelemetryHelper {
                     cwsprChatMessageId: message.messageId,
                     cwsprChatInteractionType: 'insertAtCursor',
                     cwsprChatAcceptedCharactersLength: message.code.length,
+                    cwsprChatAcceptedNumberOfLines: message.code.split('\n').length,
                     cwsprChatInteractionTarget: message.insertionTargetType,
                     cwsprChatHasReference: message.codeReference && message.codeReference.length > 0,
                     cwsprChatCodeBlockIndex: message.codeBlockIndex,
@@ -249,6 +249,7 @@ export class CWCTelemetryHelper {
                         interactionType: this.getCWClientTelemetryInteractionType(event.cwsprChatInteractionType),
                         interactionTarget: event.cwsprChatInteractionTarget,
                         acceptedCharacterCount: event.cwsprChatAcceptedCharactersLength,
+                        acceptedLineCount: event.cwsprChatAcceptedNumberOfLines,
                         acceptedSnippetHasReference: false,
                     },
                 },

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -272,6 +272,11 @@
             "description": "Count of code characters copied to the editor"
         },
         {
+            "name": "cwsprChatAcceptedNumberOfLines",
+            "type": "int",
+            "description": "Count of lines of code copied to the editor"
+        },
+        {
             "name": "cwsprChatHasReference",
             "type": "boolean",
             "description": "True if the code snippet that user interacts with has a reference."
@@ -828,6 +833,10 @@
                 },
                 {
                     "type": "cwsprChatAcceptedCharactersLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatAcceptedNumberOfLines",
                     "required": false
                 },
                 {


### PR DESCRIPTION
## Problem
In q chat telemetry, lines of inserted code is not included.


## Solution

Add lines of inserted code of Q chat in the telemetry event. 

This is not customer facing and this does not introduce a new telemetry event, so I am not adding a change log. 

Relevant JB PR:
https://github.com/aws/aws-toolkit-jetbrains/pull/4337

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
