### PR TITLE
Change in Error message for Gumby for CreateArtifactToS3 upload url

### DIFF
--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -406,12 +406,12 @@ export const failedToStartJobTooManyJobsNotification =
     "Amazon Q couldn't begin the transformation. You have too many active transformations running. Please try again after your other transformations have completed."
 
 export const failedToUploadProjectChatMessage =
-    'Amazon Q is unable to upload workspace artifacts to Amazon S3 for Code Transformation. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security_iam_manage-access-with-policies.html) or contact your network or organization administrator.'
+    "Sorry, I couldn't upload your project to Amazon S3 for Code Transformation. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security_iam_manage-access-with-policies.html) or contact your network or organization administrator."
 
 export const noOngoingJobMessage = 'No job is in-progress at the moment'
 
 export const failedToUploadProjectNotification =
-    'Amazon Q is unable to upload workspace artifacts to Amazon S3 for Code Transformation. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security_iam_manage-access-with-policies.html) or contact your network or organization administrator.'
+    'Amazon Q is unable to upload your project to Amazon S3 for Code Transformation. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security_iam_manage-access-with-policies.html) or contact your network or organization administrator.'
 
 export const failedToGetPlanChatMessage =
     "Sorry, I couldn't create the transformation plan to upgrade your project. Please try starting the transformation again."

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -406,12 +406,12 @@ export const failedToStartJobTooManyJobsNotification =
     "Amazon Q couldn't begin the transformation. You have too many active transformations running. Please try again after your other transformations have completed."
 
 export const failedToUploadProjectChatMessage =
-    "Sorry, I couldn't upload your project. Please try starting the transformation again."
+    'Amazon Q is unable to upload workspace artifacts to Amazon S3 for Code Transformation. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security_iam_manage-access-with-policies.html) or contact your network or organization administrator.'
 
 export const noOngoingJobMessage = 'No job is in-progress at the moment'
 
 export const failedToUploadProjectNotification =
-    "Amazon Q couldn't upload your project. Please try starting the transformation again."
+    'Amazon Q is unable to upload workspace artifacts to Amazon S3 for Code Transformation. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security_iam_manage-access-with-policies.html) or contact your network or organization administrator.'
 
 export const failedToGetPlanChatMessage =
     "Sorry, I couldn't create the transformation plan to upgrade your project. Please try starting the transformation again."


### PR DESCRIPTION
## Problem
- Existing error message is generic and provide little context for upload artifact failure.
## Solution
- Change in Error message for `uploadArtifactToS3` in Gumby . 
- Provides information about the error with link in both chat and notification.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
