### PR TITLE
fix(auth): delay PKCE server close

### DIFF
--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -449,7 +449,11 @@ class AuthFlowAuthorization extends SsoAccessTokenProvider {
 
             return this.formatToken(token, registration)
         } finally {
-            await authServer.close()
+            // Temporary delay to make sure the auth ui was displayed to the user before closing
+            // inspired by https://github.com/microsoft/vscode/blob/a49c81edea6647684eee87d204e50feed9c455f6/extensions/github-authentication/src/flows.ts#L262
+            setTimeout(() => {
+                void authServer.close()
+            }, 5000)
         }
     }
 


### PR DESCRIPTION
## Problem
- Right now we are relying on the auth server page load time to take less than the create token request. In the case where the auth server page load takes more time then the create token request the auth server will already be closed and won't be able to serve the ui

**note:** in practice this should actually never happen. This is just extra insurance that if it _does_ happen we are protected

## Solution
- delay for 5000ms

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
