### PR TITLE
fix: copy auth page to amazon q extension

### DIFF
--- a/packages/amazonq/scripts/build/copyFiles.ts
+++ b/packages/amazonq/scripts/build/copyFiles.ts
@@ -32,6 +32,10 @@ const tasks: CopyTask[] = [
 
     { target: path.join('../core', 'resources'), destination: path.join('..', 'resources') },
     { target: path.join('../core', 'package.nls.json'), destination: path.join('..', 'package.nls.json') },
+    {
+        target: '../core/src/auth/sso/vue',
+        destination: 'src/auth/sso/vue',
+    },
 
     // Vue
     {

--- a/packages/amazonq/scripts/build/copyFiles.ts
+++ b/packages/amazonq/scripts/build/copyFiles.ts
@@ -32,12 +32,12 @@ const tasks: CopyTask[] = [
 
     { target: path.join('../core', 'resources'), destination: path.join('..', 'resources') },
     { target: path.join('../core', 'package.nls.json'), destination: path.join('..', 'package.nls.json') },
+
+    // Vue
     {
         target: '../core/src/auth/sso/vue',
         destination: 'src/auth/sso/vue',
     },
-
-    // Vue
     {
         target: path.join('../core', 'resources', 'js', 'vscode.js'),
         destination: path.join('libs', 'vscode.js'),


### PR DESCRIPTION
## Problem
- Amazon q extension doesn't have the resources for the auth page

## Solution
- Copy them in

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
