### PR TITLE
fix: disable codecatalyst manageConnections from command palette

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -796,6 +796,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.codecatalyst.manageConnections",
+                    "when": "false"
+                },
+                {
                     "command": "aws.codecatalyst.openDevEnv",
                     "when": "!isCloud9"
                 },


### PR DESCRIPTION

## Problem
- toolkit auth and codecatalyst manageConnections both show "Add New Connection" in the command palette

## Solution
- we can hide codecatalyst manageConnections because it's a wrapper around the toolkit auth command that sets the source

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
