### PR TITLE
amazonq: reauthentication page

### DIFF
--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -144,15 +144,18 @@ export class AuthUtil {
     })
 
     public async setVscodeContextProps() {
-        if (!isCloud9()) {
-            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.connected', this.isConnected())
-            await vscode.commands.executeCommand('setContext', 'aws.amazonq.showLoginView', !this.isConnected())
-            await vscode.commands.executeCommand(
-                'setContext',
-                'aws.codewhisperer.connectionExpired',
-                this.isConnectionExpired()
-            )
+        if (isCloud9()) {
+            return
         }
+
+        await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.connected', this.isConnected())
+        const doShowAmazonQLoginView = !this.isConnected() || this.isConnectionExpired()
+        await vscode.commands.executeCommand('setContext', 'aws.amazonq.showLoginView', doShowAmazonQLoginView)
+        await vscode.commands.executeCommand(
+            'setContext',
+            'aws.codewhisperer.connectionExpired',
+            this.isConnectionExpired()
+        )
     }
 
     /* Callback used by Amazon Q to delete connection status & scope when this deletion is made by AWS Toolkit

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode'
-import { scopesCodeWhispererChat, AwsConnection } from '../../../../auth/connection'
+import { scopesCodeWhispererChat, AwsConnection, Connection } from '../../../../auth/connection'
 import { AuthUtil, amazonQScopes } from '../../../../codewhisperer/util/authUtil'
-import { AuthError, CommonAuthWebview } from '../backend'
+import { AuthError, CommonAuthWebview, userCancelled } from '../backend'
 import { awsIdSignIn } from '../../../../codewhisperer/util/showSsoPrompt'
 import { connectToEnterpriseSso } from '../../../../codewhisperer/util/getStartUrl'
 import { activateExtension, isExtensionInstalled } from '../../../../shared/utilities/vsCodeUtils'
@@ -13,13 +13,19 @@ import { VSCODE_EXTENSION_ID } from '../../../../shared/extensions'
 import { getLogger } from '../../../../shared/logger'
 import { Auth } from '../../../../auth'
 import { ToolkitError } from '../../../../shared/errors'
+import { debounce } from 'lodash'
+import { AuthFlowState } from '../types'
 
 export class AmazonQLoginWebview extends CommonAuthWebview {
     public override id: string = 'aws.amazonq.AmazonCommonAuth'
     public static sourcePath: string = 'vue/src/login/webview/vue/amazonq/index.js'
 
+    override onActiveConnectionModified = new vscode.EventEmitter<void>()
+
     constructor() {
         super(AmazonQLoginWebview.sourcePath)
+
+        this.setupConnectionEventEmitter()
     }
 
     async fetchConnections(): Promise<AwsConnection[] | undefined> {
@@ -117,6 +123,64 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
         })
     }
 
+    async reauthenticateConnection(): Promise<void> {
+        this.isReauthenticating = true
+        this.reauthError = undefined
+
+        try {
+            /**
+             * IMPORTANT: During this process {@link this.onActiveConnectionModified} is triggered. This
+             * causes the reauth page to refresh before the user is actually done the whole reauth flow.
+             */
+            this.reauthError = await this.ssoSetup('reauthenticate', async () => AuthUtil.instance.reauthenticate(true))
+        } finally {
+            this.isReauthenticating = false
+        }
+
+        if (this.reauthError?.id === userCancelled) {
+            // Since reauth was not successful it did not trigger an update in the connection.
+            // We need to pretend it changed so our frontend triggers an update.
+            this.onActiveConnectionModified.fire()
+        }
+    }
+
+    private reauthError: AuthError | undefined = undefined
+    override async getReauthError(): Promise<AuthError | undefined> {
+        return this.reauthError
+    }
+
+    async getActiveConnection(): Promise<Connection | undefined> {
+        return AuthUtil.instance.conn
+    }
+
+    /**
+     * `true` if the actual reauth flow is in progress.
+     *
+     * We need this state since the reauth process triggers
+     * {@link this.onActiveConnectionModified} before it is actually done.
+     * This causes the UI to refresh, and we need to remember that we are
+     * still in the process of reauthenticating.
+     */
+    isReauthenticating: boolean = false
+    private authState: AuthFlowState = 'LOGIN'
+    override async refreshAuthState(): Promise<void> {
+        const featureAuthStates = await AuthUtil.instance.getChatAuthState()
+        if (featureAuthStates.amazonQ === 'expired') {
+            this.authState = this.isReauthenticating ? 'REAUTHENTICATING' : 'REAUTHNEEDED'
+            return
+        }
+        this.authState = 'LOGIN'
+    }
+
+    override async getAuthState(): Promise<AuthFlowState> {
+        return this.authState
+    }
+
+    override async signout(): Promise<void> {
+        await AuthUtil.instance.secondaryAuth.deleteConnection()
+        this.reauthError = undefined
+    }
+
     async errorNotification(e: AuthError) {
         await vscode.window.showInformationMessage(`${e.text}`)
     }
@@ -131,4 +195,19 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
 
     /** If users are unauthenticated in Q/CW, we should always display the auth screen. */
     async quitLoginScreen() {}
+
+    private setupConnectionEventEmitter(): void {
+        // allows the frontend to listen to Amazon Q auth events from the backend
+        const codeWhispererConnectionChanged = createThrottle(() => this.onActiveConnectionModified.fire())
+        AuthUtil.instance.secondaryAuth.onDidChangeActiveConnection(codeWhispererConnectionChanged)
+
+        /**
+         * Multiple events can be received in rapid succession and if
+         * we execute on the first one it is possible to get a stale
+         * state.
+         */
+        function createThrottle(callback: () => void) {
+            return debounce(callback, 500)
+        }
+    }
 }

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -15,6 +15,7 @@ import { InvalidGrantException } from '@aws-sdk/client-sso-oidc'
 import { AwsConnection, Connection } from '../../../auth/connection'
 import { Auth } from '../../../auth/auth'
 import { StaticProfile, StaticProfileKeyErrorMessage } from '../../../auth/credentials/types'
+import { AuthFlowState } from './types'
 
 export type AuthError = { id: string; text: string }
 export const userCancelled = 'userCancelled'
@@ -87,6 +88,9 @@ export abstract class CommonAuthWebview extends VueWebview {
         }
     }
 
+    /** Allows the frontend to subscribe to events emitted by the backend regarding the ACTIVE auth connection changing in some way. */
+    abstract onActiveConnectionModified: vscode.EventEmitter<void>
+
     abstract startBuilderIdSetup(app: string): Promise<AuthError | undefined>
 
     abstract startEnterpriseSetup(startUrl: string, region: string, app: string): Promise<AuthError | undefined>
@@ -114,6 +118,22 @@ export abstract class CommonAuthWebview extends VueWebview {
     abstract errorNotification(e: AuthError): void
 
     abstract quitLoginScreen(): Promise<void>
+
+    /**
+     * NOTE: If we eventually need to be able to specify the connection to reauth, it should
+     * be an arg in this function
+     */
+    abstract reauthenticateConnection(): Promise<void>
+    abstract getReauthError(): Promise<AuthError | undefined>
+
+    abstract getActiveConnection(): Promise<Connection | undefined>
+
+    /** Refreshes the current state of the auth flow, determining what you see in the UI */
+    abstract refreshAuthState(): Promise<void>
+    /** Use {@link refreshAuthState} first to ensure this returns the latest state */
+    abstract getAuthState(): Promise<AuthFlowState>
+
+    abstract signout(): Promise<void>
 
     async listConnections(): Promise<Connection[]> {
         return Auth.instance.listConnections()

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -438,9 +438,6 @@ export default defineComponent({
     flex-direction: row;
     justify-content: left;
     align-items: flex-start;
-    padding-top: 130px;
-    padding-bottom: 2px;
-    padding-left: 10px;
     height: auto;
 }
 .hint {
@@ -454,6 +451,16 @@ export default defineComponent({
 }
 .vscode-dark .hint {
     color: #c6c6c6;
+}
+
+.auth-container {
+    display: flex;
+    flex-direction: column;
+
+    /* Stretches our overall container to the whole screen */
+    height: 100%;
+    /* Centers all content in to middle of page since the height is the whole screen*/
+    justify-content: center;
 }
 
 .title {
@@ -543,7 +550,6 @@ export default defineComponent({
 }
 #logo {
     fill: var(--vscode-button-foreground);
-    padding-top: 0.2em;
 }
 body.vscode-dark #logo-text {
     fill: white;

--- a/packages/core/src/login/webview/vue/reauthenticate.vue
+++ b/packages/core/src/login/webview/vue/reauthenticate.vue
@@ -1,0 +1,212 @@
+<!-- This Vue File is a template for AWS Toolkit Reauthentication, configure app to TOOLKIT if for toolkit login
+configure app to AMAZONQ if for Amazon Q login.
+
+DESIGN:
+
+The goal is to have all state managed outside of this Vue file. Instead all state is determined in the backend code
+and the final results are retrieved by the frontend. For this Component to update the root Component must refresh it.
+-->
+<template>
+    <div v-show="doShow" id="reauthenticate-container">
+        <!-- Icon -->
+        <div id="icon-container">
+            <svg
+                v-if="app === 'AMAZONQ'"
+                width="100"
+                height="100"
+                viewBox="0 0 71 71"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <g clip-path="url(#clip0_331_37336)">
+                    <path
+                        d="M30.1307 1.46438L8.83068 13.7563C5.45818 15.7087 3.37256 19.3031 3.37256 23.2081V47.8067C3.37256 51.6969 5.45818 55.306 8.83068 57.2585L30.1307 69.5504C33.5032 71.5029 37.6596 71.5029 41.0321 69.5504L62.3321 57.2585C65.7046 55.306 67.7903 51.7117 67.7903 47.8067V23.2081C67.7903 19.3179 65.7046 15.7087 62.3321 13.7563L41.0321 1.46438C37.6596 -0.488125 33.5032 -0.488125 30.1307 1.46438Z"
+                        fill="url(#paint0_linear_331_37336)"
+                    />
+                    <path
+                        d="M54.1966 21.6843L38.2364 12.469C37.5116 12.0401 36.5354 11.833 35.5739 11.833C34.6124 11.833 33.651 12.0401 32.9114 12.469L16.9512 21.6843C15.4868 22.5274 14.2887 24.5982 14.2887 26.2845V44.7149C14.2887 46.4011 15.4868 48.472 16.9512 49.3151L32.9114 58.5303C33.6362 58.9593 34.6124 59.1663 35.5739 59.1663C36.5354 59.1663 37.4968 58.9593 38.2364 58.5303L54.1966 49.3151C55.661 48.472 56.8591 46.4011 56.8591 44.7149V26.2845C56.8591 24.5982 55.661 22.5274 54.1966 21.6843ZM36.0029 54.7141C36.0029 54.7141 35.7958 54.7584 35.5887 54.7584C35.3816 54.7584 35.2337 54.7288 35.1745 54.7141L19.1699 45.4693C19.0072 45.3213 18.8002 44.9515 18.7558 44.7445V26.2549C18.8002 26.0478 19.022 25.678 19.1699 25.5301L35.1745 16.2853C35.1745 16.2853 35.3816 16.2409 35.5887 16.2409C35.7958 16.2409 35.9437 16.2705 36.0029 16.2853L52.0075 25.5301C52.1702 25.678 52.3772 26.0478 52.4216 26.2549V42.6588L40.0262 35.4997V33.5472C40.0262 33.1626 39.8191 32.8224 39.4937 32.6301L36.1212 30.6776C35.9585 30.5888 35.7662 30.5297 35.5887 30.5297C35.4112 30.5297 35.2189 30.574 35.0562 30.6776L31.6837 32.6301C31.3583 32.8224 31.1512 33.1774 31.1512 33.5472V37.4374C31.1512 37.822 31.3583 38.1622 31.6837 38.3545L35.0562 40.307C35.2189 40.3957 35.4112 40.4549 35.5887 40.4549C35.7662 40.4549 35.9585 40.4105 36.1212 40.307L37.8074 39.3307L50.2029 46.4899L36.0029 54.6845V54.7141Z"
+                        fill="white"
+                    />
+                </g>
+                <defs>
+                    <linearGradient
+                        id="paint0_linear_331_37336"
+                        x1="64.1515"
+                        y1="-5.31021"
+                        x2="10.5465"
+                        y2="71.2515"
+                        gradientUnits="userSpaceOnUse"
+                    >
+                        <stop stop-color="#A7F8FF" />
+                        <stop offset="0.03" stop-color="#9DF1FF" />
+                        <stop offset="0.08" stop-color="#84E1FF" />
+                        <stop offset="0.15" stop-color="#5AC7FF" />
+                        <stop offset="0.22" stop-color="#21A2FF" />
+                        <stop offset="0.26" stop-color="#008DFF" />
+                        <stop offset="0.66" stop-color="#7F33FF" />
+                        <stop offset="0.99" stop-color="#39127D" />
+                    </linearGradient>
+                    <clipPath id="clip0_331_37336">
+                        <rect width="71" height="71" fill="white" />
+                    </clipPath>
+                </defs>
+            </svg>
+        </div>
+
+        <div id="content-container">
+            <template v-if="state === 'REAUTHNEEDED'">
+                <div>
+                    <div id="title">Connection to {{ name }} Expired</div>
+                    <div id="call-to-action">Please re-authenticate to continue</div>
+                </div>
+
+                <div>
+                    <button id="reauthenticate" v-on:click="reauthenticate">Re-authenticate</button>
+                    <div v-if="errorMessage" id="error-message" style="color: red">{{ errorMessage }}</div>
+                </div>
+
+                <button id="signout" v-on:click="signout">Sign Out</button>
+            </template>
+            <template v-else-if="state === 'REAUTHENTICATING'">
+                <div>Re-authentication in progress</div>
+            </template>
+        </div>
+    </div>
+</template>
+<script lang="ts">
+import { PropType, defineComponent } from 'vue'
+import { FeatureId } from './types'
+import { WebviewClientFactory } from '../../../webviews/client'
+import { CommonAuthWebview } from './backend'
+import { AuthFlowStates } from './types'
+
+const client = WebviewClientFactory.create<CommonAuthWebview>()
+
+const FeatureNames: { [key in FeatureId]: string } = {
+    AMAZONQ: 'Amazon Q',
+    TOOLKIT: 'Toolkit',
+} as const
+type FeatureName = (typeof FeatureNames)[keyof typeof FeatureNames]
+
+type ReauthenticationStates = Pick<typeof AuthFlowStates, 'REAUTHNEEDED' | 'REAUTHENTICATING'>
+type ReauthenticationState = ReauthenticationStates[keyof ReauthenticationStates]
+
+export default defineComponent({
+    name: 'Reauthenticate',
+    data() {
+        return {
+            name: '' as FeatureName,
+            errorMessage: '' as String,
+            doShow: false,
+        }
+    },
+    props: {
+        app: {
+            type: String as PropType<FeatureId>,
+            required: true,
+        },
+        state: {
+            type: String as PropType<ReauthenticationState>,
+            required: true,
+        },
+    },
+    async created() {
+        this.name = FeatureNames[this.app]
+
+        const error = await client.getReauthError()
+        this.errorMessage = error ? error.text : ''
+
+        this.doShow = true
+    },
+    methods: {
+        async reauthenticate() {
+            // NOTE: the following puts the underlying connection in to an "authenticating" state
+            // which triggers our connection change event listener. This triggers the UI to refresh
+            // before it is actually done.
+            await client.reauthenticateConnection()
+        },
+        async signout() {
+            await client.signout()
+        },
+    },
+})
+</script>
+<style>
+#reauthenticate-container {
+    display: flex;
+    flex-direction: column;
+    /* All items are centered vertically */
+    justify-content: center;
+    /* The full height of the screen */
+    height: 100%;
+    width: 100%;
+}
+
+/* Immediate children */
+#reauthenticate-container > * {
+    margin-bottom: 2rem;
+}
+
+#content-container {
+    display: flex;
+    flex-direction: column;
+    /* All items are centered vertically */
+    justify-content: space-between;
+    /** The overall height of the container, then spacing is automatic between child elements */
+    height: 7rem;
+}
+
+#content-container > * {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+#icon-container {
+    display: flex;
+    flex-direction: column;
+    /* justify-content: center; */
+    align-items: center;
+}
+
+#text-container {
+    display: flex;
+    flex-direction: column;
+}
+
+#button-container {
+    display: flex;
+    flex-direction: column;
+}
+
+button#reauthenticate {
+    cursor: pointer;
+    background-color: var(--vscode-button-background);
+    color: white;
+    border-radius: 3px;
+    border: none;
+    padding: 0.3rem;
+    width: 80%;
+    user-select: none;
+}
+
+button#signout {
+    cursor: pointer;
+    color: var(--vscode-textLink-foreground);
+    border: none;
+    background: none;
+    user-select: none;
+}
+
+#title {
+    font-weight: bold;
+}
+
+#call-to-action {
+    font-weight: normal;
+}
+
+#error-message {
+    text-align: center;
+}
+</style>

--- a/packages/core/src/login/webview/vue/root.vue
+++ b/packages/core/src/login/webview/vue/root.vue
@@ -2,34 +2,72 @@
 configure app to AMAZONQ if for Amazon Q login
 -->
 <template>
-    <div>
-        <!-- Body -->
-        <div class="body">
-            <!-- Functionality -->
-            <Login :disabled="false" :app="app"></Login>
-        </div>
+    <!-- Body -->
+    <div class="body" style="height: 100vh">
+        <!-- Functionality -->
+        <Login v-if="authFlowState === 'LOGIN'" :app="app"></Login>
+        <Reauthenticate
+            v-else-if="authFlowState === 'REAUTHNEEDED' || authFlowState === 'REAUTHENTICATING'"
+            :app="app"
+            :state="authFlowState"
+            :key="refreshKey"
+        ></Reauthenticate>
     </div>
 </template>
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { PropType, defineComponent } from 'vue'
 import Login from './login.vue'
+import Reauthenticate from './reauthenticate.vue'
+import { AuthFlowState, FeatureId } from './types'
+import { WebviewClientFactory } from '../../../webviews/client'
+import { CommonAuthWebview } from './backend'
+
+const client = WebviewClientFactory.create<CommonAuthWebview>()
 
 export default defineComponent({
     name: 'auth',
     components: {
         Login,
+        Reauthenticate,
     },
     data() {
-        return {}
+        return {
+            // Where the user is in the Auth process, this impacts what they see
+            authFlowState: '' as AuthFlowState,
+            // When the value changes the component is forced to rebuild
+            refreshKey: 0,
+        }
     },
     props: {
         app: {
-            type: String,
+            type: String as PropType<FeatureId>,
             required: true,
         },
     },
-    mounted() {},
-    methods: {},
+    async created() {
+        // Any backend auth changes will trigger the webview to refresh
+        client.onActiveConnectionModified(() => {
+            this.refreshAuthState()
+        })
+
+        await this.refreshAuthState()
+    },
+    methods: {
+        async refreshAuthState() {
+            await client.refreshAuthState()
+            this.authFlowState = await client.getAuthState()
+            this.refreshKey += 1
+        },
+    },
 })
 </script>
-<style></style>
+<style>
+.body {
+    /* The container takes up the entire height of the screen */
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    /* All items are centered horizontally */
+    align-items: center;
+}
+</style>

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -89,11 +89,12 @@ export default defineComponent({
 }
 
 .item-container {
-    border: 1px solid #625f5f;
+    border: 2px solid #625f5f;
+    border-radius: 3px;
 }
 
 .selected {
-    border: 1px solid #0e639c;
+    border: 2px solid #0e639c;
     user-select: none;
 }
 

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -7,14 +7,17 @@ import * as vscode from 'vscode'
 import { tryAddCredentials } from '../../../../auth/utils'
 import { getLogger } from '../../../../shared/logger'
 import { AuthError, CommonAuthWebview } from '../backend'
-import { AwsConnection, createSsoProfile } from '../../../../auth/connection'
+import { AwsConnection, Connection, createSsoProfile } from '../../../../auth/connection'
 import { Auth } from '../../../../auth/auth'
 import { CodeCatalystAuthenticationProvider } from '../../../../codecatalyst/auth'
+import { AuthFlowState } from '../types'
 
 export class ToolkitLoginWebview extends CommonAuthWebview {
     public override id: string = 'aws.toolkit.AmazonCommonAuth'
     public static sourcePath: string = 'vue/src/login/webview/vue/toolkit/index.js'
     private isCodeCatalystLogin = false
+
+    override onActiveConnectionModified: vscode.EventEmitter<void> = new vscode.EventEmitter()
 
     constructor(private readonly codeCatalystAuth: CodeCatalystAuthenticationProvider) {
         super(ToolkitLoginWebview.sourcePath)
@@ -87,6 +90,27 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
 
     findConnection(connections: AwsConnection[]): AwsConnection | undefined {
         return undefined
+    }
+
+    override reauthenticateConnection(): Promise<undefined> {
+        throw new Error('Method not implemented.')
+    }
+    override getActiveConnection(): Promise<Connection | undefined> {
+        throw new Error('Method not implemented.')
+    }
+
+    override async refreshAuthState(): Promise<void> {}
+    override async getAuthState(): Promise<AuthFlowState> {
+        // No need for a reauth page yet, so always show login
+        return 'LOGIN'
+    }
+
+    override signout(): Promise<void> {
+        throw new Error('Method not implemented.')
+    }
+
+    override getReauthError(): Promise<AuthError | undefined> {
+        throw new Error('Method not implemented.')
     }
 
     async quitLoginScreen() {

--- a/packages/core/src/login/webview/vue/types.ts
+++ b/packages/core/src/login/webview/vue/types.ts
@@ -1,0 +1,33 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Types that can be used by both the backend and frontend files
+ */
+
+/**
+ * The identifiers for the different features that use Auth.
+ *
+ * These are important as they represent the specific feature for all parts of the
+ * auth sign setup flows.
+ */
+export const FeatureIds = {
+    TOOLKIT: 'TOOLKIT',
+    AMAZONQ: 'AMAZONQ',
+} as const
+export type FeatureId = (typeof FeatureIds)[keyof typeof FeatureIds]
+
+/**
+ * The type of Auth flows that the user could see.
+ */
+export const AuthFlowStates = {
+    /** User needs to select/setup a connection */
+    LOGIN: 'LOGIN',
+    /**  User has a connection but just needs to reauthenticate it */
+    REAUTHNEEDED: 'REAUTHNEEDED',
+    /**  Reauthentication is currently in progress */
+    REAUTHENTICATING: 'REAUTHENTICATING',
+} as const
+export type AuthFlowState = (typeof AuthFlowStates)[keyof typeof AuthFlowStates]


### PR DESCRIPTION
New reauth page for Amazon Q

- When we detect the login page must be shown, we will then determine if a reauth is required. If so, we show the reauth page. Otherwise, we show the login page
- In the root.vue is where we determine which "auth flow" we are in and then show the appropriate auth page (currently Login vs Reauth)
- The Reauth page is designed to have all state determined outside of the Vue file itself, and instead managed in the backend code. Our front end connects to an event emitter from the backend. When emitter fires on a change with the auth connection, the frontend will refresh itself, pulling in all the current state data from the backend. This allows us to have more control in the backend over what we show and it centralizes our state to a single place.
- Did some realignment in the CSS of the Login vue to center it


Steps in video:
- Do a regular sign in
- Use our Developer Tools to force the connection to be expired
- Reauthenticate the connection
- Go to chat

https://github.com/aws/aws-toolkit-vscode/assets/118216176/89978f39-0c47-45f6-acb9-6f2cc1201aad


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
