### PR TITLE
package: increase minimum vscode to 1.83

### DIFF
--- a/.changes/next-release/Deprecation-a9089a93-8d74-482d-ad05-a7e160e8f646.json
+++ b/.changes/next-release/Deprecation-a9089a93-8d74-482d-ad05-a7e160e8f646.json
@@ -1,0 +1,4 @@
+{
+	"type": "Deprecation",
+	"description": "Minimum required VS Code version is now 1.83"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19707,7 +19707,7 @@
             },
             "engines": {
                 "npm": "^10.1.0",
-                "vscode": "^1.68.0"
+                "vscode": "^1.83.0"
             }
         },
         "packages/core/node_modules/@types/node": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
     "license": "Apache-2.0",
     "engines": {
         "npm": "^10.1.0",
-        "vscode": "^1.68.0"
+        "vscode": "^1.83.0"
     },
     "activationEvents": [
         "onStartupFinished",

--- a/packages/core/src/shared/filesystemUtilities.ts
+++ b/packages/core/src/shared/filesystemUtilities.ts
@@ -232,35 +232,6 @@ export async function hasFileWithSuffix(dir: string, suffix: string, exclude?: v
 }
 
 /**
- * TEMPORARY SHIM for vscode.workspace.findFiles() on Cloud9.
- *
- * @param dir Directory to search
- * @param fileName Name of file to locate
- * @returns  List of one or zero Uris (for compat with vscode.workspace.findFiles())
- */
-export async function cloud9Findfile(dir: string, fileName: string): Promise<vscode.Uri[]> {
-    getLogger().debug('cloud9Findfile: %s', dir)
-    const files = await fsCommon.readdir(dir)
-    const subDirs: vscode.Uri[] = []
-    for (const file of files) {
-        const [currentFileName] = file
-        const filePath = path.join(dir, currentFileName)
-        if (filePath === path.join(dir, fileName)) {
-            return [vscode.Uri.file(filePath)]
-        }
-        if (await fsCommon.existsDir(filePath)) {
-            subDirs.push(vscode.Uri.file(filePath))
-        }
-    }
-    for (const d of subDirs) {
-        const found = await cloud9Findfile(d.fsPath, fileName)
-        if (found.length > 0) {
-            return found
-        }
-    }
-    return []
-}
-/**
  * @returns  A string path to the last locally stored download location. If none, returns the users 'Downloads' directory path.
  */
 export async function getDefaultDownloadPath(): Promise<string> {

--- a/packages/core/src/test/lambda/commands/uploadLambda.test.ts
+++ b/packages/core/src/test/lambda/commands/uploadLambda.test.ts
@@ -43,11 +43,6 @@ describe('uploadLambda', async function () {
             (await findApplicationJsonFile(folderUri))?.fsPath ?? '',
             path.join(tempFolder, '.application.json')
         )
-        // Also test Cloud9 temporary workaround.
-        assertEqualPaths(
-            (await findApplicationJsonFile(folderUri, true))?.fsPath ?? '',
-            path.join(tempFolder, '.application.json')
-        )
     })
 
     it('finds application.json file from dir path - nested', async function () {
@@ -56,8 +51,6 @@ describe('uploadLambda', async function () {
         await toFile('top secret data', appjsonPath)
 
         assertEqualPaths((await findApplicationJsonFile(folderUri))?.fsPath ?? '', appjsonPath)
-        // Also test Cloud9 temporary workaround.
-        assertEqualPaths((await findApplicationJsonFile(folderUri, true))?.fsPath ?? '', appjsonPath)
     })
 
     it('finds application.json file from template file path', async function () {
@@ -67,8 +60,6 @@ describe('uploadLambda', async function () {
         await toFile('top secret data', appjsonPath)
 
         assertEqualPaths((await findApplicationJsonFile(templateUri))?.fsPath ?? '', appjsonPath)
-        // Also test Cloud9 temporary workaround.
-        assertEqualPaths((await findApplicationJsonFile(templateUri, true))?.fsPath ?? '', appjsonPath)
     })
 
     it('lists functions from .application.json', async function () {

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -14,12 +14,7 @@ describe('tech debt', function () {
         const minVscode = env.getMinVscodeVersion()
 
         assert.ok(
-            semver.lt(minVscode, '1.75.0'),
-            'remove filesystemUtilities.findFile(), use vscode.workspace.findFiles() instead (after Cloud9 VFS fixes bug)'
-        )
-
-        assert.ok(
-            semver.lt(minVscode, '1.75.0'),
+            semver.lt(minVscode, '1.84.0'),
             'remove AsyncLocalStorage polyfill used in `spans.ts` if Cloud9 is on node 14+'
         )
     })


### PR DESCRIPTION
## Problem

Minimum vscode version is really old and new features require node 16

## Solution

- Increase minimum vscode to 1.83
- Remove old polyfills

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
