### PR TITLE
fix(amazonq): duplicate command registration 'aws.amazonq.showTransformationPlanInHub'

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -639,11 +639,6 @@
                 "command": "aws.amazonq.showHistoryInHub",
                 "title": "Show Job Status",
                 "icon": "$(history)"
-            },
-            {
-                "command": "aws.amazonq.showTransformationPlanInHub",
-                "title": "Show Transformation Plan",
-                "enablement": "gumby.isPlanAvailable"
             }
         ],
         "keybindings": [


### PR DESCRIPTION
problem: command is declared twice in package.json. This results in an error in the extension page under runtime status.

solution: remove extra command from package.json

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
