### PR TITLE
fix: ignore q css files in feature dev e2e tests

### DIFF
--- a/packages/core/src/testE2E/amazonq/featureDev.test.ts
+++ b/packages/core/src/testE2E/amazonq/featureDev.test.ts
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { overrideRequire, resetRequire } from './framework/setup'
+overrideRequire()
+
 import assert from 'assert'
 import { qTestingFramework } from './framework/framework'
 import sinon from 'sinon'
@@ -50,6 +53,10 @@ describe('Amazon Q Feature Dev', function () {
         framework.removeTab(tab.tabID)
         framework.dispose()
         sinon.restore()
+    })
+
+    after(() => {
+        resetRequire()
     })
 
     describe('quick action availability', () => {

--- a/packages/core/src/testE2E/amazonq/framework/setup.ts
+++ b/packages/core/src/testE2E/amazonq/framework/setup.ts
@@ -1,0 +1,29 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Module from 'module'
+
+const originalRequire = Module.prototype.require
+
+export function overrideRequire() {
+    Module.prototype.require = new Proxy(Module.prototype.require, {
+        apply(target, thisArg, argArray) {
+            const name = argArray[0]
+
+            /**
+             * HACK: css can't be loaded into jsdom so we have to ignore it
+             */
+            if (name.endsWith('amazonq-webview.css')) {
+                return {}
+            }
+
+            return Reflect.apply(target, thisArg, argArray)
+        },
+    })
+}
+
+export function resetRequire() {
+    Module.prototype.require = originalRequire
+}


### PR DESCRIPTION
## Problem
- a css file was added into mynah ui in https://github.com/aws/aws-toolkit-vscode/pull/4800 and jsdom can't load external css files so the e2e tests fail to load

## Solution
- HACK: ignore amazonq-webview.css in the module loader

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
