### PR TITLE
fix(amazonq): suppress errors for file scans

### DIFF
--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -217,7 +217,7 @@ export async function startSecurityScan(
         if (codeScanState.isCancelling()) {
             codeScanTelemetryEntry.result = 'Cancelled'
         } else {
-            errorPromptHelper(error as Error)
+            errorPromptHelper(error as Error, scope)
             codeScanTelemetryEntry.result = 'Failed'
         }
 
@@ -287,8 +287,10 @@ export async function emitCodeScanTelemetry(editor: vscode.TextEditor, codeScanT
     telemetry.codewhisperer_securityScan.emit(codeScanTelemetryEntry)
 }
 
-export function errorPromptHelper(error: Error) {
-    void vscode.window.showWarningMessage(`Security scan failed. ${error}`, ok)
+export function errorPromptHelper(error: Error, scope: CodeAnalysisScope) {
+    if (scope === CodeAnalysisScope.PROJECT) {
+        void vscode.window.showWarningMessage(`Security scan failed. ${error}`, ok)
+    }
 }
 
 function populateCodeScanLogStream(scannedFiles: Set<string>) {

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -233,7 +233,7 @@ export async function startSecurityScan(
                 scope === CodeAnalysisScope.FILE &&
                 error.message.includes(CodeWhispererConstants.fileScansThrottlingMessage)
             ) {
-                void vscode.window.showErrorMessage(CodeWhispererConstants.fileScansLimitReached)
+                getLogger().error(CodeWhispererConstants.fileScansLimitReached)
                 CodeScansState.instance.setMonthlyQuotaExceeded()
             }
         }

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -251,7 +251,6 @@ describe('startSecurityScan', function () {
         getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
         const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
         const securityScanStoppedErrorSpy = sinon.spy(model, 'CodeScanStoppedError')
-        const testWindow = getTestWindow()
         await model.CodeScansState.instance.setScansEnabled(true)
         const scanPromise = startSecurityScan.startSecurityScan(
             mockSecurityPanelViewProvider,
@@ -264,8 +263,6 @@ describe('startSecurityScan', function () {
         await scanPromise
         assert.ok(securityScanRenderSpy.notCalled)
         assert.ok(securityScanStoppedErrorSpy.calledOnce)
-        const warnings = testWindow.shownMessages.filter(m => m.severity === SeverityLevel.Warning)
-        assert.ok(warnings.map(m => m.message).includes('Security scan failed. Error: Security scan stopped by user.'))
     })
 
     it('Should highlight files after scan is completed', async function () {


### PR DESCRIPTION
## Problem

File scans should run in the background and not show any errors.

## Solution

- Only show scan failed error notification if scope is Project.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
