### PR TITLE
fix(amazonq): CSS adjustment: Make login view wider;use rectangular login item border

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -461,6 +461,7 @@ export default defineComponent({
 
     /* Stretches our overall container to the whole screen */
     height: 100%;
+    width: 100%;
     /* Centers all content in to middle of page since the height is the whole screen*/
     justify-content: center;
 }

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -102,7 +102,6 @@ export default defineComponent({
 
 .item-container {
     border: 2px solid #625f5f;
-    border-radius: 3px;
 }
 
 .hovering {


### PR DESCRIPTION
## Problem
CSS adjustments. 

## Solution
Make login view wider; use rectangular login item border


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
