### PR TITLE
codecatalyst: fix extension activation in new dev environments

### DIFF
--- a/.changes/next-release/Bug Fix-5d2dc465-bf49-4808-94a1-bf8006af3b96.json
+++ b/.changes/next-release/Bug Fix-5d2dc465-bf49-4808-94a1-bf8006af3b96.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "codecatalyst: fix extension activation in new dev environments"
+}

--- a/.changes/next-release/Bug Fix-5e2f465c-e15e-4ec9-b60c-053c7046769c.json
+++ b/.changes/next-release/Bug Fix-5e2f465c-e15e-4ec9-b60c-053c7046769c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "codecatalyst: fix heartbeat activity registration"
+}

--- a/packages/core/src/codecatalyst/auth.ts
+++ b/packages/core/src/codecatalyst/auth.ts
@@ -371,17 +371,22 @@ export class CodeCatalystAuthenticationProvider {
         }
     }
 
-    private getState(): Record<string, ConnectionState> {
+    private getStates(): Record<string, ConnectionState> {
         return this.memento.get(this.mementoKey, {} as Record<string, ConnectionState>)
     }
 
     public getConnectionState(conn: SsoConnection): ConnectionState {
-        return this.getState()[conn.id]
+        return (
+            this.getStates()[conn.id] ?? {
+                onboarded: false,
+                scopeExpired: false,
+            }
+        )
     }
 
     private async setConnectionState(conn: SsoConnection, state: ConnectionState) {
         await this.memento.update(this.mementoKey, {
-            ...this.getState(),
+            ...this.getStates(),
             [conn.id]: state,
         })
     }


### PR DESCRIPTION
## Problem
- The extension fails to activate in new dev environments: `TypeError: Cannot read properties of undefined (reading 'scopeExpired')
	at pe.isScopeExpired`
- The issue also cascades to existing dev environment where things like activity heartbeat fails to activate because thisDevenv on codecatalyst/activation #L80 ends up being undefined

## Solution
- Provide a default for connection states if they aren't found. The reason this is neccessary is on #L96 in codecatalyst/auth.ts we are making a call to this.isConnectionValid(), which then checks if the scopes are expired. This happens BEFORE the scopesExpired is available in the global state for 'codecatalyst.connections' causing the issue

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
