### PR TITLE
fix(amazonq): Various css updates to login page

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -521,6 +521,7 @@ export default defineComponent({
 
     /* Stretches our overall container to the whole screen */
     height: 100%;
+    width: 100%;
     /* Centers all content in to middle of page since the height is the whole screen*/
     justify-content: center;
 }

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -72,7 +72,7 @@
             </svg>
         </div>
         <template v-if="stage === 'START'">
-            <button class="back-button" v-if="app === 'TOOLKIT'" @click="handleBackButtonClick">
+            <button class="back-button bottomMargin" v-if="app === 'TOOLKIT'" @click="handleBackButtonClick">
                 <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path
                         d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
@@ -151,7 +151,7 @@
                 </svg>
             </button>
             <div class="auth-container-section">
-                <div class="header">Sign in with SSO:</div>
+                <div class="header">Sign in with AWS IAM Identity Center:</div>
                 <div class="code-catalyst-login" v-if="app === 'TOOLKIT'">
                     <div style="margin-bottom: 4px"></div>
                     <div class="h4">
@@ -594,53 +594,58 @@ export default defineComponent({
 .urlInput {
     background-color: var(--vscode-input-background);
     width: 244px;
-    height: 15px;
-    color: white;
+    height: 28px;
+    box-sizing: border-box;
     border: none;
     padding-left: 8px;
     padding-right: 8px;
     padding-top: 6px;
     padding-bottom: 6px;
+    font-size: 13px;
+    font-weight: 400;
 }
-.vscode-light .urlInput {
+body.vscode-light .urlInput {
     color: black;
 }
-.vscode-dark .urlInput {
-    color: white;
+body.vscode-dark .urlInput {
+    color: #cccccc;
 }
 .iamInput {
     background-color: var(--vscode-input-background);
     width: 244px;
-    height: 15px;
-    color: white;
+    height: 28px;
+    box-sizing: border-box;
     border: none;
     padding-left: 8px;
     padding-right: 8px;
     padding-top: 6px;
     padding-bottom: 6px;
+    font-size: 13px;
+    font-weight: 400;
 }
-.vscode-light .iamInput {
+body.vscode-light .iamInput {
     color: black;
 }
-.vscode-dark .iamInput {
-    color: white;
+body.vscode-dark .iamInput {
+    color: #cccccc;
 }
 .regionSelect {
     background-color: var(--vscode-input-background);
     width: 244px;
-    color: white;
     margin-bottom: 5px;
     margin-top: 2px;
     padding-left: 8px;
     padding-right: 8px;
     padding-top: 6px;
     padding-bottom: 6px;
+    font-size: 13px;
+    font-weight: 400;
 }
-.vscode-light .regionSelect {
+body.vscode-light .regionSelect {
     color: black;
 }
-.vscode-dark .regionSelect {
-    color: white;
+body.vscode-dark .regionSelect {
+    color: #cccccc;
 }
 .start-url-error {
     color: #ff0000;

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -6,8 +6,8 @@
 
             <svg
                 v-if="app === 'AMAZONQ' && stage !== 'CONNECTED'"
-                width="100"
-                height="100"
+                width="71"
+                height="71"
                 viewBox="0 0 71 71"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
@@ -71,20 +71,20 @@
                 />
             </svg>
         </div>
+        <div style="margin-bottom: 12px"></div>
         <template v-if="stage === 'START'">
-            <div>
-                <button class="back-button" v-if="app === 'TOOLKIT'" @click="handleBackButtonClick">
-                    <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path
-                            d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
-                            fill="#21A2FF"
-                        />
-                    </svg>
-                </button>
-            </div>
+            <button class="back-button" v-if="app === 'TOOLKIT'" @click="handleBackButtonClick">
+                <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
+                        fill="#21A2FF"
+                    />
+                </svg>
+            </button>
             <div class="auth-container-section">
                 <div class="existing-logins" v-if="existingLogins.length > 0">
                     <div class="header">Connect with an existing account:</div>
+                    <div style="margin-bottom: 12px"></div>
                     <div v-for="(existingLogin, index) in existingLogins" :key="index">
                         <SelectableItem
                             @toggle="toggleItemSelection"
@@ -94,10 +94,12 @@
                             :itemTitle="existingLogin.title"
                             class="selectable-item"
                         ></SelectableItem>
+                        <div style="margin-bottom: 12px"></div>
                     </div>
                     <div class="header">Or, choose a sign-in option:</div>
                 </div>
                 <div class="header" v-if="existingLogins.length == 0">Choose a sign-in option:</div>
+                <div style="margin-bottom: 12px"></div>
                 <SelectableItem
                     v-if="app === 'AMAZONQ'"
                     @toggle="toggleItemSelection"
@@ -107,6 +109,7 @@
                     :itemTitle="'Use For Free'"
                     class="selectable-item"
                 ></SelectableItem>
+                <div v-if="app === 'AMAZONQ'" style="margin-bottom: 12px"></div>
                 <SelectableItem
                     v-if="app === 'AMAZONQ'"
                     @toggle="toggleItemSelection"
@@ -125,6 +128,7 @@
                     :itemTitle="'Workforce'"
                     class="selectable-item"
                 ></SelectableItem>
+                <div v-if="app === 'TOOLKIT'" style="margin-bottom: 12px"></div>
                 <SelectableItem
                     v-if="app === 'TOOLKIT'"
                     @toggle="toggleItemSelection"
@@ -134,6 +138,7 @@
                     :itemTitle="'IAM Credentials'"
                     class="selectable-item"
                 ></SelectableItem>
+                <div style="margin-bottom: 12px"></div>
                 <button
                     class="continue-button"
                     :disabled="selectedLoginOption === 0"
@@ -144,24 +149,25 @@
             </div>
         </template>
         <template v-if="stage === 'SSO_FORM'">
-            <div>
-                <button class="back-button" @click="handleBackButtonClick">
-                    <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path
-                            d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
-                            fill="#21A2FF"
-                        />
-                    </svg>
-                </button>
-            </div>
+            <button class="back-button" @click="handleBackButtonClick">
+                <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
+                        fill="#21A2FF"
+                    />
+                </svg>
+            </button>
+            <div style="margin-bottom: 12px"></div>
             <div class="auth-container-section">
-                <div class="header" style="padding-bottom: 5%">Sign in with SSO:</div>
+                <div class="header">Sign in with SSO:</div>
                 <div class="code-catalyst-login" v-if="app === 'TOOLKIT'">
+                    <div style="margin-bottom: 4px"></div>
                     <div class="h4">
                         Using CodeCatalyst with AWS Builder ID?
                         <a href="#" @click="handleCodeCatalystSignin()">Skip to sign-in</a>
                     </div>
                 </div>
+                <div style="margin-bottom: 12px"></div>
                 <div class="title">Start URL</div>
                 <div class="hint">URL for your organization, provided by an admin or help desk</div>
                 <input
@@ -173,6 +179,8 @@
                     v-model="startUrl"
                 />
                 <h4 class="start-url-error">{{ startUrlError }}</h4>
+
+                <div style="margin-bottom: 12px"></div>
                 <div class="title">Region</div>
                 <div class="hint">AWS Region that hosts identity directory</div>
                 <select
@@ -186,6 +194,7 @@
                         {{ `${region.name} (${region.id})` }}
                     </option>
                 </select>
+                <div style="margin-bottom: 12px"></div>
                 <button
                     class="continue-button"
                     :disabled="startUrl.length == 0 || startUrlError.length > 0 || !selectedRegion"
@@ -200,32 +209,40 @@
             <div class="auth-container-section">
                 <div v-if="app === 'TOOLKIT' && profileName.length > 0" class="header">Connecting to IAM...</div>
                 <div v-else class="header">Authenticating in browser...</div>
-                <button class="continue-button" v-on:click="handleCancelButton()">Cancel</button>
+                <button
+                    class="continue-button"
+                    v-on:click="handleCancelButtom()"
+                    style="color: #6f6f6f; background-color: var(--vscode-input-background)"
+                >
+                    Cancel
+                </button>
             </div>
         </template>
 
         <template v-if="stage === 'CONNECTED'"> </template>
         <template v-if="stage === 'AWS_PROFILE'">
-            <div>
-                <button class="back-button" @click="handleBackButtonClick">
-                    <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path
-                            d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
-                            fill="#21A2FF"
-                        />
-                    </svg>
-                </button>
-            </div>
+            <button class="back-button" @click="handleBackButtonClick">
+                <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
+                        fill="#21A2FF"
+                    />
+                </svg>
+            </button>
+            <div style="margin-bottom: 12px"></div>
             <div class="header">IAM Credentials:</div>
             <div class="hint">Credentials will be added to the appropriate ~/.aws/ files</div>
-            <div style="margin-bottom: 8px"></div>
+            <div style="margin-bottom: 12px"></div>
             <div class="title">Profile Name</div>
             <div class="hint">The identifier for these credentials</div>
             <input class="iamInput" type="text" id="profileName" name="profileName" v-model="profileName" />
+            <div style="margin-bottom: 12px"></div>
             <div class="title">Access Key</div>
             <input class="iamInput" type="text" id="accessKey" name="accessKey" v-model="accessKey" />
+            <div style="margin-bottom: 12px"></div>
             <div class="title">Secret Key</div>
             <input class="iamInput" type="text" id="secretKey" name="secretKey" v-model="secretKey" />
+            <div style="margin-bottom: 12px"></div>
             <button
                 class="continue-button"
                 :disabled="profileName.length <= 0 || accessKey.length <= 0 || secretKey.length <= 0"
@@ -518,17 +535,14 @@ export default defineComponent({
 .auth-container {
     display: flex;
     flex-direction: column;
-
     /* Stretches our overall container to the whole screen */
     height: 100%;
-    width: 100%;
+    width: 260px;
     /* Centers all content in to middle of page since the height is the whole screen*/
     justify-content: center;
 }
 
 .header {
-    margin-bottom: 3px;
-    margin-top: 3px;
     font-size: 12px;
     font-weight: bold;
 }
@@ -542,7 +556,7 @@ export default defineComponent({
 .title {
     margin-bottom: 3px;
     margin-top: 3px;
-    font-size: 12px;
+    font-size: 11px;
 }
 .title.vscode-dark {
     color: white;
@@ -572,8 +586,13 @@ export default defineComponent({
     border: none;
     cursor: pointer;
     color: var(--vscode-button-foreground);
-    padding: 7.5% 0 10% 0;
     height: 13px;
+    display: flex;
+    align-items: center;
+    padding-left: 0;
+}
+.back-button svg {
+    margin-left: 0px;
 }
 .continue-button:disabled {
     background-color: var(--vscode-input-background);
@@ -582,10 +601,14 @@ export default defineComponent({
 }
 .urlInput {
     background-color: var(--vscode-input-background);
-    width: 100%;
+    width: 244px;
     height: 15px;
     color: white;
     border: none;
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 6px;
+    padding-bottom: 6px;
 }
 .vscode-light .urlInput {
     color: black;
@@ -595,12 +618,14 @@ export default defineComponent({
 }
 .iamInput {
     background-color: var(--vscode-input-background);
-    width: 100%;
+    width: 244px;
     height: 15px;
     color: white;
     border: none;
-    margin-bottom: 5px;
-    margin-top: 2px;
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 6px;
+    padding-bottom: 6px;
 }
 .vscode-light .iamInput {
     color: black;
@@ -610,10 +635,14 @@ export default defineComponent({
 }
 .regionSelect {
     background-color: var(--vscode-input-background);
-    width: 100%;
+    width: 244px;
     color: white;
     margin-bottom: 5px;
     margin-top: 2px;
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 6px;
+    padding-bottom: 6px;
 }
 .vscode-light .regionSelect {
     color: black;

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -1,7 +1,7 @@
 <!-- This Vue File is the login webview of AWS Toolkit and Amazon Q.-->
 <template>
     <div v-bind:class="[disabled ? 'disabled-form' : '']" class="auth-container" @click="handleDocumentClick">
-        <div class="logoIcon">
+        <div class="logoIcon bottomMargin">
             <!-- Icon -->
 
             <svg
@@ -71,7 +71,6 @@
                 />
             </svg>
         </div>
-        <div style="margin-bottom: 12px"></div>
         <template v-if="stage === 'START'">
             <button class="back-button" v-if="app === 'TOOLKIT'" @click="handleBackButtonClick">
                 <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -83,8 +82,7 @@
             </button>
             <div class="auth-container-section">
                 <div class="existing-logins" v-if="existingLogins.length > 0">
-                    <div class="header">Connect with an existing account:</div>
-                    <div style="margin-bottom: 12px"></div>
+                    <div class="header bottomMargin">Connect with an existing account:</div>
                     <div v-for="(existingLogin, index) in existingLogins" :key="index">
                         <SelectableItem
                             @toggle="toggleItemSelection"
@@ -92,14 +90,12 @@
                             :itemId="LoginOption.EXISTING_LOGINS + index"
                             :itemText="existingLogin.text"
                             :itemTitle="existingLogin.title"
-                            class="selectable-item"
+                            class="selectable-item bottomMargin"
                         ></SelectableItem>
-                        <div style="margin-bottom: 12px"></div>
                     </div>
                     <div class="header">Or, choose a sign-in option:</div>
                 </div>
-                <div class="header" v-if="existingLogins.length == 0">Choose a sign-in option:</div>
-                <div style="margin-bottom: 12px"></div>
+                <div class="header bottomMargin" v-if="existingLogins.length == 0">Choose a sign-in option:</div>
                 <SelectableItem
                     v-if="app === 'AMAZONQ'"
                     @toggle="toggleItemSelection"
@@ -107,9 +103,8 @@
                     :itemId="LoginOption.BUILDER_ID"
                     :itemText="'No AWS account required'"
                     :itemTitle="'Use For Free'"
-                    class="selectable-item"
+                    class="selectable-item bottomMargin"
                 ></SelectableItem>
-                <div v-if="app === 'AMAZONQ'" style="margin-bottom: 12px"></div>
                 <SelectableItem
                     v-if="app === 'AMAZONQ'"
                     @toggle="toggleItemSelection"
@@ -117,7 +112,7 @@
                     :itemId="LoginOption.ENTERPRISE_SSO"
                     :itemText="'Sign in to AWS with single sign-on'"
                     :itemTitle="'Use Professional License'"
-                    class="selectable-item"
+                    class="selectable-item bottomMargin"
                 ></SelectableItem>
                 <SelectableItem
                     v-if="app === 'TOOLKIT'"
@@ -126,9 +121,8 @@
                     :itemId="LoginOption.ENTERPRISE_SSO"
                     :itemText="'Sign in to AWS with single sign-on'"
                     :itemTitle="'Workforce'"
-                    class="selectable-item"
+                    class="selectable-item bottomMargin"
                 ></SelectableItem>
-                <div v-if="app === 'TOOLKIT'" style="margin-bottom: 12px"></div>
                 <SelectableItem
                     v-if="app === 'TOOLKIT'"
                     @toggle="toggleItemSelection"
@@ -136,9 +130,8 @@
                     :itemId="LoginOption.IAM_CREDENTIAL"
                     :itemText="'Store keys for use with AWS CLI tools'"
                     :itemTitle="'IAM Credentials'"
-                    class="selectable-item"
+                    class="selectable-item bottomMargin"
                 ></SelectableItem>
-                <div style="margin-bottom: 12px"></div>
                 <button
                     class="continue-button"
                     :disabled="selectedLoginOption === 0"
@@ -149,7 +142,7 @@
             </div>
         </template>
         <template v-if="stage === 'SSO_FORM'">
-            <button class="back-button" @click="handleBackButtonClick">
+            <button class="back-button bottomMargin" @click="handleBackButtonClick">
                 <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path
                         d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
@@ -157,7 +150,6 @@
                     />
                 </svg>
             </button>
-            <div style="margin-bottom: 12px"></div>
             <div class="auth-container-section">
                 <div class="header">Sign in with SSO:</div>
                 <div class="code-catalyst-login" v-if="app === 'TOOLKIT'">
@@ -167,8 +159,7 @@
                         <a href="#" @click="handleCodeCatalystSignin()">Skip to sign-in</a>
                     </div>
                 </div>
-                <div style="margin-bottom: 12px"></div>
-                <div class="title">Start URL</div>
+                <div class="title topMargin">Start URL</div>
                 <div class="hint">URL for your organization, provided by an admin or help desk</div>
                 <input
                     class="urlInput"
@@ -179,9 +170,7 @@
                     v-model="startUrl"
                 />
                 <h4 class="start-url-error">{{ startUrlError }}</h4>
-
-                <div style="margin-bottom: 12px"></div>
-                <div class="title">Region</div>
+                <div class="title topMargin">Region</div>
                 <div class="hint">AWS Region that hosts identity directory</div>
                 <select
                     class="regionSelect"
@@ -194,9 +183,8 @@
                         {{ `${region.name} (${region.id})` }}
                     </option>
                 </select>
-                <div style="margin-bottom: 12px"></div>
                 <button
-                    class="continue-button"
+                    class="continue-button topMargin"
                     :disabled="startUrl.length == 0 || startUrlError.length > 0 || !selectedRegion"
                     v-on:click="handleContinueClick()"
                 >
@@ -207,9 +195,10 @@
 
         <template v-if="stage === 'AUTHENTICATING'">
             <div class="auth-container-section">
-                <div v-if="app === 'TOOLKIT' && profileName.length > 0" class="header">Connecting to IAM...</div>
-                <div v-else class="header">Authenticating in browser...</div>
-                <div style="margin-bottom: 12px"></div>
+                <div v-if="app === 'TOOLKIT' && profileName.length > 0" class="header bottomMargin">
+                    Connecting to IAM...
+                </div>
+                <div v-else class="header bottomMargin">Authenticating in browser...</div>
                 <button
                     class="continue-button"
                     v-on:click="handleCancelButtom()"
@@ -222,7 +211,7 @@
 
         <template v-if="stage === 'CONNECTED'"> </template>
         <template v-if="stage === 'AWS_PROFILE'">
-            <button class="back-button" @click="handleBackButtonClick">
+            <button class="back-button bottomMargin" @click="handleBackButtonClick">
                 <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path
                         d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
@@ -230,20 +219,21 @@
                     />
                 </svg>
             </button>
-            <div style="margin-bottom: 12px"></div>
             <div class="header">IAM Credentials:</div>
             <div class="hint">Credentials will be added to the appropriate ~/.aws/ files</div>
-            <div style="margin-bottom: 12px"></div>
-            <div class="title">Profile Name</div>
+            <div class="title topMargin">Profile Name</div>
             <div class="hint">The identifier for these credentials</div>
-            <input class="iamInput" type="text" id="profileName" name="profileName" v-model="profileName" />
-            <div style="margin-bottom: 12px"></div>
+            <input
+                class="iamInput bottomMargin"
+                type="text"
+                id="profileName"
+                name="profileName"
+                v-model="profileName"
+            />
             <div class="title">Access Key</div>
-            <input class="iamInput" type="text" id="accessKey" name="accessKey" v-model="accessKey" />
-            <div style="margin-bottom: 12px"></div>
+            <input class="iamInput bottomMargin" type="text" id="accessKey" name="accessKey" v-model="accessKey" />
             <div class="title">Secret Key</div>
-            <input class="iamInput" type="text" id="secretKey" name="secretKey" v-model="secretKey" />
-            <div style="margin-bottom: 12px"></div>
+            <input class="iamInput bottomMargin" type="text" id="secretKey" name="secretKey" v-model="secretKey" />
             <button
                 class="continue-button"
                 :disabled="profileName.length <= 0 || accessKey.length <= 0 || secretKey.length <= 0"
@@ -664,5 +654,11 @@ body.vscode-dark #logo-text {
 }
 body.vscode-light #logo-text {
     fill: #232f3e; /* squid ink */
+}
+.bottomMargin {
+    margin-bottom: 12px;
+}
+.topMargin {
+    margin-top: 12px;
 }
 </style>

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -209,6 +209,7 @@
             <div class="auth-container-section">
                 <div v-if="app === 'TOOLKIT' && profileName.length > 0" class="header">Connecting to IAM...</div>
                 <div v-else class="header">Authenticating in browser...</div>
+                <div style="margin-bottom: 12px"></div>
                 <button
                     class="continue-button"
                     v-on:click="handleCancelButtom()"
@@ -557,6 +558,7 @@ export default defineComponent({
     margin-bottom: 3px;
     margin-top: 3px;
     font-size: 11px;
+    font-weight: 500;
 }
 .title.vscode-dark {
     color: white;

--- a/packages/core/src/login/webview/vue/reauthenticate.vue
+++ b/packages/core/src/login/webview/vue/reauthenticate.vue
@@ -12,8 +12,8 @@ and the final results are retrieved by the frontend. For this Component to updat
         <div id="icon-container">
             <svg
                 v-if="app === 'AMAZONQ'"
-                width="100"
-                height="100"
+                width="71"
+                height="71"
                 viewBox="0 0 71 71"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/core/src/login/webview/vue/root.vue
+++ b/packages/core/src/login/webview/vue/root.vue
@@ -69,5 +69,7 @@ export default defineComponent({
     flex-direction: column;
     /* All items are centered horizontally */
     align-items: center;
+    position: absolute;
+    left: 20px;
 }
 </style>

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -132,7 +132,8 @@ export default defineComponent({
     color: black;
 }
 .icon {
-    padding-right: 10px;
+    padding-left: 8px;
+    padding-right: 11px;
     display: flex;
     align-items: center;
 }

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -101,7 +101,7 @@ export default defineComponent({
 }
 
 .item-container {
-    border: 2px solid #625f5f;
+    border: 1px solid #625f5f;
 }
 
 .hovering {
@@ -110,7 +110,7 @@ export default defineComponent({
 }
 
 .selected {
-    border: 2px solid #3675f4;
+    border: 1px solid #3675f4;
     user-select: none;
 }
 

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -102,7 +102,6 @@ export default defineComponent({
 
 .item-container {
     border: 2px solid #625f5f;
-    border-radius: 3px;
 }
 
 .hovering {


### PR DESCRIPTION
## Problem
VSCode CSS issues for new auth page:

1. Q icon should be 71px, not 100px
2. First page: Looks like the width of buttons is wrapping to fit the contents - can we set the width of the sign in buttons and continue button 260px?
3. First page: Each of the elements should have a margin of 12px, buttons should have a padding of 12px
4. SSO/IAM Creds page: Back button is center aligned now for some reason
5. SSO/IAM Creds page: Padding and size of input fields are off (width: 244px; padding: 6px 8px;)
6. SSO/IAM Creds page: Margin should be 12px between groups
7. SSO/IAM Creds page: Field labels (ex. 'Start URL') should be 11px, with a weight of 500
8. In progress page: 12px margin between elements
9. In progress page: Cancel button should be secondary grey color
10. change to 'Sign in with AWS IAM Identity Center'
11. Styling of the region dropdown input text should match mocks
12. Should have max width for the input boxes (see mocks and JB implementation)


## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
