### PR TITLE
fix(amazonq): settings text

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -204,7 +204,7 @@
     "AWS.command.resources.copyIdentifier": "Copy Identifier",
     "AWS.command.resources.configure": "Show Resources...",
     "AWS.command.codewhisperer.introduction": "What is Amazon Q?",
-    "AWS.command.codewhisperer.configure": "Amazon Q Settings",
+    "AWS.command.codewhisperer.configure": "Settings",
     "AWS.command.codewhisperer.signout": "Sign Out",
     "AWS.command.codewhisperer.reconnect": "Reconnect",
     "AWS.command.codewhisperer.openReferencePanel": "Open Code Reference Log",

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -189,7 +189,7 @@ export const referenceLogText = (
     `with code ${code} provided with reference under ${license} from repository ${repository}. Added to ${filePath} ${lineInfo}.`
 
 export const referenceLogPromptText = `Don\'t want suggestions that include code with references? Uncheck this option in
-    <a href="#" onclick="openSettings();return false;">Amazon Q Settings</a>`
+    <a href="#" onclick="openSettings();return false;">Amazon Q: Settings</a>`
 
 export const referenceLogPromptTextEnterpriseSSO =
     'Your organization controls whether suggestions include code with references. To update these settings, please contact your admin.'


### PR DESCRIPTION
## Problem
Previously, Settings command was displayed as `Amazon Q: Amazon Q Settings`, where `Amazon Q` was duplicated.

## Solution
Updated the command text to `Amazon Q: Settings` 
![Screenshot 2024-04-24 at 9 11 01 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/0431affc-a026-4bfc-ba60-bdaa2ccfbf3d)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
