### PR TITLE
fix(q): Handle monthly conversation limit error for Q Feature development

### DIFF
--- a/.changes/next-release/Bug Fix-e2494f30-8d61-4b13-97a1-e7631f92412c.json
+++ b/.changes/next-release/Bug Fix-e2494f30-8d61-4b13-97a1-e7631f92412c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Feature Development: Update error message for monthly conversation limit reach"
+}

--- a/packages/core/src/amazonqFeatureDev/client/featureDev.ts
+++ b/packages/core/src/amazonqFeatureDev/client/featureDev.ts
@@ -17,6 +17,7 @@ import {
     ApiError,
     CodeIterationLimitError,
     ContentLengthError,
+    MonthlyConversationLimitError,
     PlanIterationLimitError,
     UnknownApiError,
 } from '../errors'
@@ -78,6 +79,9 @@ export class FeatureDevClient {
                 getLogger().error(
                     `${featureName}: failed to start conversation: ${e.message} RequestId: ${e.requestId}`
                 )
+                if (e.code === 'ServiceQuotaExceededException') {
+                    throw new MonthlyConversationLimitError(e.message)
+                }
                 throw new ApiError(e.message, 'CreateConversation', e.code, e.statusCode ?? 400)
             }
 

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -14,6 +14,7 @@ import { featureDevScheme } from '../../constants'
 import {
     CodeIterationLimitError,
     ContentLengthError,
+    MonthlyConversationLimitError,
     PlanIterationLimitError,
     SelectedFolderNotInWorkspaceFolderError,
     createUserFacingErrorMessage,
@@ -242,6 +243,8 @@ export class FeatureDevController {
                         },
                     ],
                 })
+            } else if (err instanceof MonthlyConversationLimitError) {
+                this.messenger.sendErrorMessage(err.message, message.tabID, 0, undefined, true)
             } else if (err instanceof PlanIterationLimitError) {
                 this.messenger.sendErrorMessage(err.message, message.tabID, this.retriesRemaining(session))
                 this.messenger.sendAnswer({

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -244,7 +244,7 @@ export class FeatureDevController {
                     ],
                 })
             } else if (err instanceof MonthlyConversationLimitError) {
-                this.messenger.sendErrorMessage(err.message, message.tabID, 0, undefined, true)
+                this.messenger.sendMonthlyLimitError(err.message, message.tabID)
             } else if (err instanceof PlanIterationLimitError) {
                 this.messenger.sendErrorMessage(err.message, message.tabID, this.retriesRemaining(session))
                 this.messenger.sendAnswer({

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -244,7 +244,8 @@ export class FeatureDevController {
                     ],
                 })
             } else if (err instanceof MonthlyConversationLimitError) {
-                this.messenger.sendMonthlyLimitError(err.message, message.tabID)
+                this.messenger.sendMonthlyLimitError(message.tabID)
+                this.messenger.sendChatInputEnabled(message.tabID, false)
             } else if (err instanceof PlanIterationLimitError) {
                 this.messenger.sendErrorMessage(err.message, message.tabID, this.retriesRemaining(session))
                 this.messenger.sendAnswer({

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -245,7 +245,6 @@ export class FeatureDevController {
                 })
             } else if (err instanceof MonthlyConversationLimitError) {
                 this.messenger.sendMonthlyLimitError(message.tabID)
-                this.messenger.sendChatInputEnabled(message.tabID, false)
             } else if (err instanceof PlanIterationLimitError) {
                 this.messenger.sendErrorMessage(err.message, message.tabID, this.retriesRemaining(session))
                 this.messenger.sendAnswer({

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -46,7 +46,20 @@ export class Messenger {
         )
     }
 
-    public sendErrorMessage(errorMessage: string, tabID: string, retries: number, phase?: SessionStatePhase) {
+    public sendErrorMessage(
+        errorMessage: string,
+        tabID: string,
+        retries: number,
+        phase?: SessionStatePhase,
+        monthlyLimitError: boolean = false
+    ) {
+        if (monthlyLimitError) {
+            this.dispatcher.sendErrorMessage(
+                new ErrorMessage(`Sorry, we encountered a problem when processing your request.`, errorMessage, tabID)
+            )
+            return
+        }
+
         if (retries === 0) {
             this.dispatcher.sendErrorMessage(
                 new ErrorMessage(

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -46,20 +46,13 @@ export class Messenger {
         )
     }
 
-    public sendErrorMessage(
-        errorMessage: string,
-        tabID: string,
-        retries: number,
-        phase?: SessionStatePhase,
-        monthlyLimitError: boolean = false
-    ) {
-        if (monthlyLimitError) {
-            this.dispatcher.sendErrorMessage(
-                new ErrorMessage(`Sorry, we encountered a problem when processing your request.`, errorMessage, tabID)
-            )
-            return
-        }
+    public sendMonthlyLimitError(errorMessage: string, tabID: string) {
+        this.dispatcher.sendErrorMessage(
+            new ErrorMessage(`Sorry, we encountered a problem when processing your request.`, errorMessage, tabID)
+        )
+    }
 
+    public sendErrorMessage(errorMessage: string, tabID: string, retries: number, phase?: SessionStatePhase) {
         if (retries === 0) {
             this.dispatcher.sendErrorMessage(
                 new ErrorMessage(

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -46,10 +46,13 @@ export class Messenger {
         )
     }
 
-    public sendMonthlyLimitError(errorMessage: string, tabID: string) {
-        this.dispatcher.sendErrorMessage(
-            new ErrorMessage(`Sorry, we encountered a problem when processing your request.`, errorMessage, tabID)
-        )
+    public sendMonthlyLimitError(tabID: string) {
+        this.sendAnswer({
+            type: 'answer',
+            tabID: tabID,
+            message: `Sorry, you have reached the monthly limit for feature development. You can try again next month.`,
+        })
+        this.sendUpdatePlaceholder(tabID, 'Chat input is disabled')
     }
 
     public sendErrorMessage(errorMessage: string, tabID: string, retries: number, phase?: SessionStatePhase) {

--- a/packages/core/src/amazonqFeatureDev/errors.ts
+++ b/packages/core/src/amazonqFeatureDev/errors.ts
@@ -95,6 +95,12 @@ export class CodeIterationLimitError extends ToolkitError {
     }
 }
 
+export class MonthlyConversationLimitError extends ToolkitError {
+    constructor(message: string) {
+        super(message, { code: 'MonthlyConversationLimitError' })
+    }
+}
+
 export class UnknownApiError extends ToolkitError {
     constructor(message: string, api: string) {
         super(message, { code: `${api}-Unknown` })


### PR DESCRIPTION
## Problem
Currently, on reaching monthly conversation limit for QFeature development, Retry button was incorrectly shown which would degrade customer experience as clicking on Retry would render them the same error again and again.

## Solution
- Handled ServiceQuotaExceeded error correctly to not show Retry button on reaching monthly conversation limit.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
