### PR TITLE
fix Amazon Q import

### DIFF
--- a/packages/amazonq/src/extensionShared.ts
+++ b/packages/amazonq/src/extensionShared.ts
@@ -32,11 +32,10 @@ import { initializeAuth, CredentialsStore, LoginManager, AuthUtils } from 'aws-c
 import { makeEndpointsProvider, registerCommands } from 'aws-core-vscode'
 import { activate as activateCWChat } from 'aws-core-vscode/amazonq'
 import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
-import { CommonAuthViewProvider } from 'aws-core-vscode/login'
+import { CommonAuthViewProvider, CommonAuthWebview } from 'aws-core-vscode/login'
 import { isExtensionActive, VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
 import { registerSubmitFeedback } from 'aws-core-vscode/feedback'
 import { telemetry, ExtStartUpSources } from 'aws-core-vscode/telemetry'
-import { CommonAuthWebview } from '../../core/dist/src/login/webview/vue/backend'
 
 export async function activateShared(context: vscode.ExtensionContext, isWeb: boolean) {
     initialize(context, isWeb)

--- a/packages/core/src/login/webview/index.ts
+++ b/packages/core/src/login/webview/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { CommonAuthViewProvider } from './commonAuthViewProvider'
+export { CommonAuthWebview } from './vue/backend'


### PR DESCRIPTION
Import was directly from the `core` module, but needed to first be exported by it, then consumed as a `core` module export.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
