### PR TITLE
fix(auth): stronger validation of sso url

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -250,7 +250,8 @@ const client = WebviewClientFactory.create<CommonAuthWebview>()
 type Stage = 'START' | 'SSO_FORM' | 'CONNECTED' | 'AUTHENTICATING' | 'AWS_PROFILE'
 
 function validateSsoUrlFormat(url: string) {
-    const regex = /^(https?:\/\/(.+)\.awsapps\.com\/start|https?:\/\/identitycenter\.amazonaws\.com\/ssoins-.*)$/
+    const regex =
+        /^(https?:\/\/(.+)\.awsapps\.com\/start|https?:\/\/identitycenter\.amazonaws\.com\/ssoins-[\da-zA-Z]{16})$/
     return regex.test(url)
 }
 


### PR DESCRIPTION
## Problem
- any characters can be present after the issuer url

## Solution
- only allow 16 alphanumeric characters after ssoins-

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
