### PR TITLE
fix(auth): log AuthSSOServer.close() failure

### DIFF
--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -448,7 +448,13 @@ class AuthFlowAuthorization extends SsoAccessTokenProvider {
             // Temporary delay to make sure the auth ui was displayed to the user before closing
             // inspired by https://github.com/microsoft/vscode/blob/a49c81edea6647684eee87d204e50feed9c455f6/extensions/github-authentication/src/flows.ts#L262
             setTimeout(() => {
-                void authServer.close()
+                authServer.close().catch(e => {
+                    getLogger().error(
+                        'AuthFlowAuthorization: AuthSSOServer.close() failed: %s: %s',
+                        (e as Error).name,
+                        (e as Error).message
+                    )
+                })
             }, 5000)
         }
     }


### PR DESCRIPTION
`void` should usually be avoided if a potential failure in the invoked function is not otherwise handled or logged. Especially in timers, failures will not surface in any other way.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
