### PR TITLE
fix(systemUtilities): check for path exists in getHomeDirectory

### DIFF
--- a/packages/core/src/auth/credentials/sharedCredentialsFile.ts
+++ b/packages/core/src/auth/credentials/sharedCredentialsFile.ts
@@ -4,19 +4,31 @@
  *
  * This module focuses on the i/o of the credentials/config files
  */
-
-import { join } from 'path'
+import fs from 'fs'
+import { join, resolve } from 'path'
 import { EnvironmentVariables } from '../../shared/environmentVariables'
 import { SystemUtilities } from '../../shared/systemUtilities'
 
 export function getCredentialsFilename(): string {
     const env = process.env as EnvironmentVariables
 
-    return env.AWS_SHARED_CREDENTIALS_FILE || join(SystemUtilities.getHomeDirectory(), '.aws', 'credentials')
+    if (
+        env.AWS_SHARED_CREDENTIALS_FILE &&
+        env.AWS_SHARED_CREDENTIALS_FILE?.length !== 0 &&
+        fs.existsSync(resolve(env.AWS_SHARED_CREDENTIALS_FILE))
+    ) {
+        return env.AWS_SHARED_CREDENTIALS_FILE
+    }
+
+    return join(SystemUtilities.getHomeDirectory(), '.aws', 'credentials')
 }
 
 export function getConfigFilename(): string {
     const env = process.env as EnvironmentVariables
 
-    return env.AWS_CONFIG_FILE || join(SystemUtilities.getHomeDirectory(), '.aws', 'config')
+    if (env.AWS_CONFIG_FILE && env.AWS_CONFIG_FILE?.length !== 0 && fs.existsSync(resolve(env.AWS_CONFIG_FILE))) {
+        return env.AWS_CONFIG_FILE
+    }
+
+    return join(SystemUtilities.getHomeDirectory(), '.aws', 'config')
 }

--- a/packages/core/src/shared/systemUtilities.ts
+++ b/packages/core/src/shared/systemUtilities.ts
@@ -60,13 +60,17 @@ export class SystemUtilities {
 
         const env = process.env as EnvironmentVariables
 
-        if (env.HOME !== undefined) {
+        if (env.HOME !== undefined && env.HOME?.length !== 0 && fs.existsSync(path.resolve(env.HOME))) {
             return env.HOME
         }
-        if (env.USERPROFILE !== undefined) {
+        if (
+            env.USERPROFILE !== undefined &&
+            env.USERPROFILE?.length !== 0 &&
+            fs.existsSync(path.resolve(env.USERPROFILE))
+        ) {
             return env.USERPROFILE
         }
-        if (env.HOMEPATH !== undefined) {
+        if (env.HOMEPATH !== undefined && env.HOMEPATH?.length !== 0 && fs.existsSync(path.resolve(env.HOMEPATH))) {
             const homeDrive: string = env.HOMEDRIVE || 'C:'
 
             return path.join(homeDrive, env.HOMEPATH)


### PR DESCRIPTION
## Problem
- There are 3 login strategies, Idc, Builder ID and IAM. 
- A Customer logged an issue related to Signing in, in windows.

## Solution
- Introduce Conditionals to verify the path of environment variables exists before setting up.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
