### PR TITLE
fix(amazonq): use unsaved content for project scans

### DIFF
--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -122,7 +122,7 @@ export class ZipUtil {
             const isFileOpenAndDirty = this.isFileOpenAndDirty(file.fileUri)
             const fileContent = isFileOpenAndDirty ? await this.getTextContent(file.fileUri) : file.fileContent
 
-            const fileSize = new Blob([fileContent]).size
+            const fileSize = Buffer.from(fileContent).length
             if (this.isJavaClassFile(file.fileUri)) {
                 this._pickedBuildFiles.add(file.fileUri.fsPath)
                 this._totalBuildSize += fileSize

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -91,14 +91,11 @@ export class ZipUtil {
     protected async zipFile(uri: vscode.Uri) {
         const zip = new admZip()
 
-        const projectName = this.getProjectName(uri)
-        const relativePath = vscode.workspace.asRelativePath(uri)
-
         const content = await this.getTextContent(uri)
 
-        zip.addFile(path.join(projectName, relativePath), Buffer.from(content, 'utf-8'))
+        zip.addFile(this.getZipPath(uri), Buffer.from(content, 'utf-8'))
 
-        this._pickedSourceFiles.add(relativePath)
+        this._pickedSourceFiles.add(uri.fsPath)
         this._totalSize += (await fsCommon.stat(uri.fsPath)).size
         this._totalLines += content.split(ZipConstants.newlineRegex).length
 
@@ -114,7 +111,6 @@ export class ZipUtil {
     protected async zipProject(uri: vscode.Uri) {
         const zip = new admZip()
 
-        const projectName = this.getProjectName(uri)
         const projectPath = this.getProjectPath(uri)
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
         if (!workspaceFolder) {
@@ -123,7 +119,10 @@ export class ZipUtil {
 
         const files = await collectFiles([projectPath], [workspaceFolder])
         for (const file of files) {
-            const fileSize = (await fsCommon.stat(file.fileUri.fsPath)).size
+            const isFileOpenAndDirty = this.isFileOpenAndDirty(file.fileUri)
+            const fileContent = isFileOpenAndDirty ? await this.getTextContent(file.fileUri) : file.fileContent
+
+            const fileSize = new Blob([fileContent]).size
             if (this.isJavaClassFile(file.fileUri)) {
                 this._pickedBuildFiles.add(file.fileUri.fsPath)
                 this._totalBuildSize += fileSize
@@ -136,14 +135,29 @@ export class ZipUtil {
                 }
                 this._pickedSourceFiles.add(file.fileUri.fsPath)
                 this._totalSize += fileSize
-                this._totalLines += file.fileContent.split(ZipConstants.newlineRegex).length
+                this._totalLines += fileContent.split(ZipConstants.newlineRegex).length
             }
-            zip.addLocalFile(file.fileUri.fsPath, path.join(projectName, path.dirname(file.zipFilePath)))
+
+            if (isFileOpenAndDirty) {
+                zip.addFile(this.getZipPath(file.fileUri), Buffer.from(fileContent, 'utf-8'))
+            } else {
+                zip.addLocalFile(file.fileUri.fsPath, path.dirname(this.getZipPath(file.fileUri)))
+            }
         }
 
         const zipFilePath = this.getZipDirPath() + CodeWhispererConstants.codeScanZipExt
         zip.writeZip(zipFilePath)
         return zipFilePath
+    }
+
+    protected isFileOpenAndDirty(uri: vscode.Uri) {
+        return vscode.workspace.textDocuments.some(document => document.uri.fsPath === uri.fsPath && document.isDirty)
+    }
+
+    protected getZipPath(uri: vscode.Uri) {
+        const projectName = this.getProjectName(uri)
+        const relativePath = vscode.workspace.asRelativePath(uri)
+        return path.join(projectName, relativePath)
     }
 
     protected getZipDirPath(): string {

--- a/packages/core/src/test/codewhisperer/util/zipUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/zipUtil.test.ts
@@ -117,5 +117,21 @@ describe('zipUtil', function () {
                 new ToolkitError('Unknown code analysis scope: unknown')
             )
         })
+
+        it('Should read file content instead of from disk if file is dirty', async function () {
+            const zipMetadata = await zipUtil.generateZip(vscode.Uri.file(appCodePath), CodeAnalysisScope.PROJECT)
+
+            const document = await vscode.workspace.openTextDocument(appCodePath)
+            await vscode.window.showTextDocument(document)
+            void vscode.window.activeTextEditor?.edit(editBuilder => {
+                editBuilder.insert(new vscode.Position(0, 0), '// a comment\n')
+            })
+
+            const zipMetadata2 = await new ZipUtil().generateZip(
+                vscode.Uri.file(appCodePath),
+                CodeAnalysisScope.PROJECT
+            )
+            assert.equal(zipMetadata2.lines, zipMetadata.lines + 1)
+        })
     })
 })


### PR DESCRIPTION
## Problem

When running project scans, the version on disk is used which could be outdated if there are unsaved changes in the workspace.

## Solution

- Check if the file is open and dirty, if it is then use `getTextContent` instead of reading from disk

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
