### PR TITLE
feat(telemetry): improve login page telemetry

### DIFF
--- a/packages/core/src/auth/connection.ts
+++ b/packages/core/src/auth/connection.ts
@@ -60,7 +60,7 @@ export const isValidCodeCatalystConnection = (conn?: Connection): conn is SsoCon
     isSsoConnection(conn) && hasScopes(conn, scopesCodeCatalyst)
 
 export function hasScopes(target: SsoConnection | SsoProfile | string[], scopes: string[]): boolean {
-    return scopes?.every(s => (Array.isArray(target) ? target : target.scopes!).includes(s))
+    return scopes?.every(s => (Array.isArray(target) ? target : target.scopes)?.includes(s))
 }
 
 export function createBuilderIdProfile(

--- a/packages/core/src/auth/connection.ts
+++ b/packages/core/src/auth/connection.ts
@@ -59,8 +59,8 @@ export const isBuilderIdConnection = (conn?: Connection): conn is SsoConnection 
 export const isValidCodeCatalystConnection = (conn?: Connection): conn is SsoConnection =>
     isSsoConnection(conn) && hasScopes(conn, scopesCodeCatalyst)
 
-export function hasScopes(target: SsoConnection | SsoProfile, scopes: string[]): boolean {
-    return scopes?.every(s => target.scopes?.includes(s))
+export function hasScopes(target: SsoConnection | SsoProfile | string[], scopes: string[]): boolean {
+    return scopes?.every(s => (Array.isArray(target) ? target : target.scopes!).includes(s))
 }
 
 export function createBuilderIdProfile(

--- a/packages/core/src/login/webview/commonAuthViewProvider.ts
+++ b/packages/core/src/login/webview/commonAuthViewProvider.ts
@@ -94,9 +94,16 @@ export class CommonAuthViewProvider implements WebviewViewProvider {
 
                 // Count leaving the webview as a user cancellation.
                 const authState = await this.webView!.server.getAuthState()
-                this.webView!.server.emitCancelledMetric(
-                    authState === AuthFlowStates.REAUTHNEEDED || authState === AuthFlowStates.REAUTHENTICATING
-                )
+                this.webView!.server.storeMetricMetadata({ result: 'Cancelled' })
+                if (authState === AuthFlowStates.REAUTHNEEDED || authState === AuthFlowStates.REAUTHENTICATING) {
+                    this.webView!.server.storeMetricMetadata({
+                        isReAuth: true,
+                        ...this.webView!.server.getMetadataForExistingConn(),
+                    })
+                } else {
+                    this.webView!.server.storeMetricMetadata({ isReAuth: false })
+                }
+                this.webView!.server.emitAuthMetric()
 
                 // Set after emitting. If users use side bar to return to login, this source is correct
                 // for the next iteration. Otherwise, other sources will be set accordingly by whatever

--- a/packages/core/src/login/webview/vue/types.ts
+++ b/packages/core/src/login/webview/vue/types.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { AuthAddConnection } from '../../../shared/telemetry/telemetry'
+
 /**
  * Types that can be used by both the backend and frontend files
  */
@@ -60,3 +62,9 @@ export type AuthUiClick =
     | 'amazonq_switchToQSignIn'
 
 export const userCancelled = 'userCancelled'
+
+export type AuthEnabledFeatures = 'awsExplorer' | 'codewhisperer' | 'codecatalyst'
+
+type Writeable<T> = { -readonly [U in keyof T]: T[U] }
+export type TelemetryMetadata = Partial<Writeable<AuthAddConnection>>
+export type AuthError = { id: string; text: string }


### PR DESCRIPTION
- refactor to allow for better telemetry state handling
- reauthenticate page keeps more informative state + more informative cancellation
- cancellation keeps better state about current auth status
- properly check scopes for what features are enabled
- add telemetry for using an existing connection (not autoconnect)
- fixed bug that prevented logging in with builder id emitting telemetry

todo:
- toolkit needs auth_userState emitted
- auto-connect for Q from toolkit needs to be reworked, its not captured in the initial auth_userState because it occurs on UI side

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
