### PR TITLE
fix(amazonq): Fix telemetry id sharing

### DIFF
--- a/packages/core/src/shared/telemetry/activation.ts
+++ b/packages/core/src/shared/telemetry/activation.ts
@@ -18,6 +18,8 @@ import { TelemetryConfig, setupTelemetryId } from './util'
 import { isAutomation, isReleaseVersion } from '../vscode/env'
 import { AWSProduct } from './clienttelemetry'
 import { DefaultTelemetryClient } from './telemetryClient'
+import { Commands } from '../vscode/commands2'
+import { VSCODE_EXTENSION_ID } from '../utilities'
 
 export const noticeResponseViewSettings = localize('AWS.telemetry.notificationViewSettings', 'Settings')
 export const noticeResponseOk = localize('AWS.telemetry.notificationOk', 'OK')
@@ -55,6 +57,14 @@ export async function activate(
                 }
             })
         )
+
+        if (extensionContext.extension.id === VSCODE_EXTENSION_ID.amazonq) {
+            extensionContext.subscriptions.push(
+                Commands.register('aws.amazonq.setupTelemetryId', async () => {
+                    await setupTelemetryId(extensionContext)
+                })
+            )
+        }
 
         // Prompt user about telemetry if they haven't been
         if (!isCloud9() && !hasUserSeenTelemetryNotice(extensionContext)) {

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -180,8 +180,8 @@ export async function setupTelemetryId(extensionContext: vscode.ExtensionContext
                     getLogger().debug(`telemetry: Store telemetry client id to env ${currentClientId}`)
                     process.env[telemetryClientIdEnvKey] = currentClientId
                 } else if (extensionContext.extension.id === VSCODE_EXTENSION_ID.amazonq) {
-                    getLogger().debug(`telemetry: Set telemetry client id to ${currentClientId}`)
-                    await globals.context.globalState.update(telemetryClientIdGlobalStatekey, currentClientId)
+                    getLogger().debug(`telemetry: Set telemetry client id to ${storedClientId}`)
+                    await globals.context.globalState.update(telemetryClientIdGlobalStatekey, storedClientId)
                 } else {
                     getLogger().error(`Unexpected extension id ${extensionContext.extension.id}`)
                 }

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -16,8 +16,9 @@ import { Result } from './telemetry.gen'
 import { MetricDatum } from './clienttelemetry'
 import { isValidationExemptMetric } from './exemptMetrics'
 import { isCloud9, isSageMaker } from '../../shared/extensionUtilities'
-import { VSCODE_EXTENSION_ID } from '../utilities'
+import { isExtensionInstalled, VSCODE_EXTENSION_ID } from '../utilities'
 import { randomUUID } from '../../common/crypto'
+import { activateExtension } from '../utilities/vsCodeUtils'
 const legacySettingsTelemetryValueDisable = 'Disable'
 const legacySettingsTelemetryValueEnable = 'Enable'
 
@@ -179,10 +180,13 @@ export async function setupTelemetryId(extensionContext: vscode.ExtensionContext
                     getLogger().debug(`telemetry: Store telemetry client id to env ${currentClientId}`)
                     process.env[telemetryClientIdEnvKey] = currentClientId
                     // notify amazon q to use this stored client id
-                    // if amazon q activates first.
-                    setTimeout(() => {
-                        vscode.commands.executeCommand('aws.amazonq.setupTelemetryId')
-                    }, 3000)
+                    // if amazon q activates first. Do not block on activate amazon q
+                    if (isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq)) {
+                        void activateExtension(VSCODE_EXTENSION_ID.amazonq).then(async () => {
+                            getLogger().debug(`telemetry: notifying Amazon Q to adopt client id ${currentClientId}`)
+                            await vscode.commands.executeCommand('aws.amazonq.setupTelemetryId')
+                        })
+                    }
                 } else if (extensionContext.extension.id === VSCODE_EXTENSION_ID.amazonq) {
                     getLogger().debug(`telemetry: Set telemetry client id to ${storedClientId}`)
                     await globals.context.globalState.update(telemetryClientIdGlobalStatekey, storedClientId)

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -18,7 +18,6 @@ import { isValidationExemptMetric } from './exemptMetrics'
 import { isCloud9, isSageMaker } from '../../shared/extensionUtilities'
 import { VSCODE_EXTENSION_ID } from '../utilities'
 import { randomUUID } from '../../common/crypto'
-
 const legacySettingsTelemetryValueDisable = 'Disable'
 const legacySettingsTelemetryValueEnable = 'Enable'
 
@@ -179,6 +178,11 @@ export async function setupTelemetryId(extensionContext: vscode.ExtensionContext
                 if (extensionContext.extension.id === VSCODE_EXTENSION_ID.awstoolkit) {
                     getLogger().debug(`telemetry: Store telemetry client id to env ${currentClientId}`)
                     process.env[telemetryClientIdEnvKey] = currentClientId
+                    // notify amazon q to use this stored client id
+                    // if amazon q activates first.
+                    setTimeout(() => {
+                        vscode.commands.executeCommand('aws.amazonq.setupTelemetryId')
+                    }, 3000)
                 } else if (extensionContext.extension.id === VSCODE_EXTENSION_ID.amazonq) {
                     getLogger().debug(`telemetry: Set telemetry client id to ${storedClientId}`)
                     await globals.context.globalState.update(telemetryClientIdGlobalStatekey, storedClientId)


### PR DESCRIPTION
## Problem

In the previous PR https://github.com/aws/aws-toolkit-vscode/pull/4698,

Below cases are handled:
1. After toolkit fully activates, activate Q extension, then Q uses toolkit client id
2. After Q fully activates, install a new toolkit as new user, then toolkit uses Q client id. 

However, it cannot handle below case:
1. When toolkit and Q activates at the same time but Q  managed to write the client id to env var before toolkit does.



## Solution

When toolkit and Q activates at the same time.

1. If Q first write the client id to env var, toolkit reads it, if this toolkit already has its client id, then toolkit is the lead (master). Toolkit decides that Q should use the client id of toolkit. Therefore, toolkit write its own client id to the env var, emit a command to let Q set its telemetry client id again.

2. If toolkit first write the client id to env var, Q reads it, Q will adopt it as its client id. (This was implemented in previous PR but I named the variable incorrectly!!)

When I test this PR:

1. Amazon Q first activates, it does not detect a env var written, so it writes to env var.
`2024-04-26 12:39:33.015 [info] telemetry: Write telemetry client id to env 7a190acf-a4fb-499c-877c-b5d334ecebbe
`
2. Then Toolkit activates, it 
`2024-04-26 12:39:32.997 [info] telemetry: Store telemetry client id to env 7a190acf-a4fb-499c-877c-b5d334ecebbe`

3. then it notify Amazon Q

`2024-04-26 12:39:35.171 [info] telemetry: notifying Amazon Q to adopt client id 7a190acf-a4fb-499c-877c-b5d334ecebbe`

4. then Amazon Q
`
2024-04-26 12:39:35.171 [info] telemetry: Set telemetry client id to 7a190acf-a4fb-499c-877c-b5d334ecebbe`

It is working as expected

The only scenario when toolkit uses Q client id is: When Q activates first, user install toolkit as a completely new user. 

For all other cases: Q always attempt to use the client id in toolkit. This attempt is made at every extension reload.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
