### PR TITLE
fix(amazonq): Fix the small font size in login screen

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -160,7 +160,7 @@
                     </div>
                 </div>
                 <div class="title topMargin">Start URL</div>
-                <div class="hint">URL for your organization, provided by an admin or help desk</div>
+                <div class="hint">Provided by your admin or help desk</div>
                 <input
                     class="urlInput"
                     type="text"
@@ -515,7 +515,8 @@ export default defineComponent({
     color: #c6c6c6;
     margin-bottom: 5px;
     margin-top: 5px;
-    font-size: 8px;
+    font-size: 10px;
+    font-weight: 500;
 }
 .vscode-light .hint {
     color: #3d3a3a;


### PR DESCRIPTION
## Problem
8px is too small for some login text.


## Solution

Update text description && use larger font. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
