### PR TITLE
feat(dev): enable dev mode for amazon q if toolkit is installed

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -259,7 +259,7 @@
                     "when": "false"
                 },
                 {
-                    "command": "aws.dev.openMenu",
+                    "command": "amazonq.dev.openMenu",
                     "when": "aws.isDevMode || isCloud9"
                 },
                 {
@@ -607,15 +607,10 @@
                 "category": "%AWS.amazonq.title%"
             },
             {
-                "command": "aws.dev.openMenu",
+                "command": "amazonq.dev.openMenu",
                 "title": "Open Developer Menu",
-                "category": "AWS (Developer)",
+                "category": "Amazon Q (Developer)",
                 "enablement": "aws.isDevMode"
-            },
-            {
-                "command": "aws.dev.viewLogs",
-                "title": "Watch Logs",
-                "category": "AWS (Developer)"
             },
             {
                 "command": "aws.amazonq.startTransformationInHub",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,8 @@
         "./login": "./dist/src/login/webview/index.js",
         "./utils": "./dist/src/shared/utilities/index.js",
         "./feedback": "./dist/src/feedback/index.js",
-        "./telemetry": "./dist/src/shared/telemetry/index.js"
+        "./telemetry": "./dist/src/shared/telemetry/index.js",
+        "./dev": "./dist/src/dev/index.js"
     },
     "contributes": {
         "configuration": {

--- a/packages/core/src/dev/index.ts
+++ b/packages/core/src/dev/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { DevFunction, updateDevMode } from './activation'


### PR DESCRIPTION
- Toolkit owns dev mode, amazon q just sends state data to it for display and editing.
- This will help us debug and test the remaining items, since we can now edit state for amazon Q, e.g. expire connections, show welcome message again, etc.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
