### PR TITLE
feat(release): separate ext release tags/titles

### DIFF
--- a/buildspec/release/10changeversion.yml
+++ b/buildspec/release/10changeversion.yml
@@ -33,7 +33,8 @@ phases:
                 git add package-lock.json
                 git commit -m "Release $VERSION"
                 echo "tagging commit"
-                git tag -a "v$VERSION" -m "version $VERSION $DATE"
+                # e.g. amazonq/v1.0.0
+                git tag -a "${TARGET_EXTENSION}/v${VERSION}" -m "${TARGET_EXTENSION} version $VERSION $DATE"
                 # cleanup
                 git clean -fxd
                 git reset HEAD --hard

--- a/buildspec/release/50githubrelease.yml
+++ b/buildspec/release/50githubrelease.yml
@@ -37,7 +37,7 @@ phases:
             - PKG_DISPLAY_NAME=$(grep -m 1 displayName packages/${TARGET_EXTENSION}/package.json | grep -o '[a-zA-z][^\"]\+' | tail -n1)
             - RELEASE_MESSAGE="${PKG_DISPLAY_NAME} for VS Code $VERSION"
             - |
-                if [ "$STAGE" = "prod" ] && [ "$TARGET_EXTENSION" = "toolkit" ]; then
+                if [ "$STAGE" = "prod" ]; then
                   gh release create --repo $REPO --title "$PKG_DISPLAY_NAME $VERSION" --notes "$RELEASE_MESSAGE" -- "v$VERSION" "$UPLOAD_TARGET" "$HASH_UPLOAD_TARGET"
                 else
                   echo "SKIPPED: 'gh release create --repo $REPO'"

--- a/buildspec/release/50githubrelease.yml
+++ b/buildspec/release/50githubrelease.yml
@@ -34,10 +34,11 @@ phases:
             - echo "Writing hash to $HASH_UPLOAD_TARGET"
             - echo $HASH > $HASH_UPLOAD_TARGET
             - echo "posting $VERSION with sha384 hash $HASH to GitHub"
-            - RELEASE_MESSAGE="AWS Toolkit for VS Code $VERSION"
+            - PKG_DISPLAY_NAME=$(grep -m 1 displayName packages/${TARGET_EXTENSION}/package.json | grep -o '[a-zA-z][^\"]\+' | tail -n1)
+            - RELEASE_MESSAGE="${PKG_DISPLAY_NAME} for VS Code $VERSION"
             - |
                 if [ "$STAGE" = "prod" ] && [ "$TARGET_EXTENSION" = "toolkit" ]; then
-                  gh release create --repo $REPO --title "$VERSION" --notes "$RELEASE_MESSAGE" -- "v$VERSION" "$UPLOAD_TARGET" "$HASH_UPLOAD_TARGET"
+                  gh release create --repo $REPO --title "$PKG_DISPLAY_NAME $VERSION" --notes "$RELEASE_MESSAGE" -- "v$VERSION" "$UPLOAD_TARGET" "$HASH_UPLOAD_TARGET"
                 else
                   echo "SKIPPED: 'gh release create --repo $REPO'"
                 fi


### PR DESCRIPTION
Now that we will be releasing multiple extensions, we will need to have separate tags and release titles in github.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
