### PR TITLE
fix(amazonq): Switch UI when CC reused Q connection

### DIFF
--- a/packages/core/src/codecatalyst/auth.ts
+++ b/packages/core/src/codecatalyst/auth.ts
@@ -379,10 +379,12 @@ export class CodeCatalystAuthenticationProvider {
         if (isValidCodeCatalystConnection(conn)) {
             getLogger().info(`auth: re-use connection from existing connection id ${connId}`)
             await this.secondaryAuth.useNewConnection(conn)
+            await this.isConnectionOnboarded(conn, true)
         } else {
             getLogger().info(`auth: re-use(new scope) to connection from existing connection id ${connId}`)
             const newConn = await this.secondaryAuth.addScopes(conn, scopesCodeCatalyst)
             await this.secondaryAuth.useNewConnection(newConn)
+            await this.isConnectionOnboarded(newConn, true)
         }
     }
 


### PR DESCRIPTION
## Problem
`IsOnboarded` status of CC connection is not checked when CC reuses Q connection

## Solution

Force Toolkit check `IsOnboarded` status of CC connection. 

This is a fix that has minimal blast radius. It only affects the flow when CC reuses Q connection. However, the connection state management of CC should be able to intelligently forcing the `IsOnboarded` status update using the CC API when necessary and do not perform the update when not necessary ( like UI updates). 

https://github.com/aws/aws-toolkit-vscode/assets/97199248/234c44ca-95be-473b-9959-79b9322b29cf






<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
