### PR TITLE
chore(settings): rename amazon q settings

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -84,12 +84,12 @@
                         }
                     }
                 },
-                "aws.amazonQ.telemetry": {
+                "amazonQ.telemetry": {
                     "type": "boolean",
                     "default": true,
                     "markdownDescription": "%AWS.configuration.description.amazonq.telemetry%"
                 },
-                "aws.amazonQ.suppressPrompts": {
+                "amazonQ.suppressPrompts": {
                     "type": "object",
                     "description": "%AWS.configuration.description.suppressPrompts%",
                     "default": {},
@@ -113,17 +113,17 @@
                     },
                     "additionalProperties": false
                 },
-                "aws.amazonQ.showInlineCodeSuggestionsWithCodeReferences": {
+                "amazonQ.showInlineCodeSuggestionsWithCodeReferences": {
                     "type": "boolean",
                     "markdownDescription": "%AWS.configuration.description.amazonq%",
                     "default": true
                 },
-                "aws.amazonQ.importRecommendationForInlineCodeSuggestions": {
+                "amazonQ.importRecommendationForInlineCodeSuggestions": {
                     "type": "boolean",
                     "description": "%AWS.configuration.description.amazonq.importRecommendation%",
                     "default": true
                 },
-                "aws.amazonQ.shareContentWithAWS": {
+                "amazonQ.shareContentWithAWS": {
                     "type": "boolean",
                     "markdownDescription": "%AWS.configuration.description.amazonq.shareContentWithAWS%",
                     "default": true,

--- a/packages/amazonq/scripts/build/syncPackageJson.ts
+++ b/packages/amazonq/scripts/build/syncPackageJson.ts
@@ -26,7 +26,7 @@ function main() {
 
     const coreSettings = coreLibPackageJson.contributes.configuration.properties
     Object.keys(coreSettings).forEach(key => {
-        if (key.startsWith('aws.amazonQ')) {
+        if (key.startsWith('amazonQ')) {
             packageJson.contributes.configuration.properties[key] = coreSettings[key]
         }
     })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -124,11 +124,6 @@
                         }
                     }
                 },
-                "aws.amazonQ.telemetry": {
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "%AWS.configuration.description.amazonq.telemetry%"
-                },
                 "aws.stepfunctions.asl.format.enable": {
                     "type": "boolean",
                     "scope": "window",
@@ -243,7 +238,12 @@
                     "description": "%AWS.configuration.description.lambda.recentlyUploaded%",
                     "default": []
                 },
-                "aws.amazonQ.suppressPrompts": {
+                "amazonQ.telemetry": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "%AWS.configuration.description.amazonq.telemetry%"
+                },
+                "amazonQ.suppressPrompts": {
                     "type": "object",
                     "description": "%AWS.configuration.description.suppressPrompts%",
                     "default": {},
@@ -267,17 +267,17 @@
                     },
                     "additionalProperties": false
                 },
-                "aws.amazonQ.showInlineCodeSuggestionsWithCodeReferences": {
+                "amazonQ.showInlineCodeSuggestionsWithCodeReferences": {
                     "type": "boolean",
                     "markdownDescription": "%AWS.configuration.description.amazonq%",
                     "default": true
                 },
-                "aws.amazonQ.importRecommendationForInlineCodeSuggestions": {
+                "amazonQ.importRecommendationForInlineCodeSuggestions": {
                     "type": "boolean",
                     "description": "%AWS.configuration.description.amazonq.importRecommendation%",
                     "default": true
                 },
-                "aws.amazonQ.shareContentWithAWS": {
+                "amazonQ.shareContentWithAWS": {
                     "type": "boolean",
                     "markdownDescription": "%AWS.configuration.description.amazonq.shareContentWithAWS%",
                     "default": true,

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -176,10 +176,10 @@ export async function activate(context: ExtContext): Promise<void> {
             if (id === 'codewhisperer') {
                 await vscode.commands.executeCommand(
                     'workbench.action.openSettings',
-                    `@id:aws.amazonQ.includeSuggestionsWithCodeReferences`
+                    `@id:amazonQ.includeSuggestionsWithCodeReferences`
                 )
             } else {
-                await vscode.commands.executeCommand('workbench.action.openSettings', `aws.amazonQ`)
+                await vscode.commands.executeCommand('workbench.action.openSettings', `amazonQ`)
             }
         }),
         Commands.register('aws.amazonq.refreshAnnotation', async (forceProceed: boolean = false) => {

--- a/packages/core/src/codewhisperer/util/codewhispererSettings.ts
+++ b/packages/core/src/codewhisperer/util/codewhispererSettings.ts
@@ -12,7 +12,7 @@ const description = {
     shareContentWithAWS: Boolean,
 }
 
-export class CodeWhispererSettings extends fromExtensionManifest('aws.amazonQ', description) {
+export class CodeWhispererSettings extends fromExtensionManifest('amazonQ', description) {
     public async importSettings() {
         if (globals.context.globalState.get<boolean>(codewhispererSettingsImportedKey)) {
             return
@@ -20,15 +20,15 @@ export class CodeWhispererSettings extends fromExtensionManifest('aws.amazonQ', 
 
         await migrateSetting(
             { key: 'aws.codeWhisperer.includeSuggestionsWithCodeReferences', type: Boolean },
-            { key: 'aws.amazonQ.showInlineCodeSuggestionsWithCodeReferences' }
+            { key: 'amazonQ.showInlineCodeSuggestionsWithCodeReferences' }
         )
         await migrateSetting(
             { key: 'aws.codeWhisperer.importRecommendation', type: Boolean },
-            { key: 'aws.amazonQ.importRecommendationForInlineCodeSuggestions' }
+            { key: 'amazonQ.importRecommendationForInlineCodeSuggestions' }
         )
         await migrateSetting(
             { key: 'aws.codeWhisperer.shareCodeWhispererContentWithAWS', type: Boolean },
-            { key: 'aws.amazonQ.shareContentWithAWS' }
+            { key: 'amazonQ.shareContentWithAWS' }
         )
 
         await globals.context.globalState.update(codewhispererSettingsImportedKey, true)

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -637,7 +637,7 @@ export class ToolkitPromptSettings extends Settings.define(
     }
 }
 
-export const amazonQPrompts = settingsProps['aws.amazonQ.suppressPrompts'].properties
+export const amazonQPrompts = settingsProps['amazonQ.suppressPrompts'].properties
 type amazonQPromptName = keyof typeof amazonQPrompts
 export class AmazonQPromptSettings extends Settings.define(
     'aws.amazonQ.suppressPrompts',

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -640,7 +640,7 @@ export class ToolkitPromptSettings extends Settings.define(
 export const amazonQPrompts = settingsProps['amazonQ.suppressPrompts'].properties
 type amazonQPromptName = keyof typeof amazonQPrompts
 export class AmazonQPromptSettings extends Settings.define(
-    'aws.amazonQ.suppressPrompts',
+    'amazonQ.suppressPrompts',
     toRecord(keys(amazonQPrompts), () => Boolean)
 ) {
     public async isPromptEnabled(promptName: amazonQPromptName): Promise<boolean> {

--- a/packages/core/src/shared/telemetry/activation.ts
+++ b/packages/core/src/shared/telemetry/activation.ts
@@ -53,13 +53,10 @@ export async function activate(
         globals.telemetry.telemetryEnabled = config.isEnabled()
 
         extensionContext.subscriptions.push(
-            config.onDidChange(event => {
-                if (globals.context.extension.id === VSCODE_EXTENSION_ID.amazonq) {
-                    if (event.key === 'amazonQ.telemetry') {
-                        globals.telemetry.telemetryEnabled = config.isEnabled()
-                    }
-                    return
-                }
+            (globals.context.extension.id === VSCODE_EXTENSION_ID.amazonq
+                ? config.amazonQConfig
+                : config.toolkitConfig
+            ).onDidChange(event => {
                 if (event.key === 'telemetry') {
                     globals.telemetry.telemetryEnabled = config.isEnabled()
                 }

--- a/packages/core/src/test/shared/telemetry/util.test.ts
+++ b/packages/core/src/test/shared/telemetry/util.test.ts
@@ -21,7 +21,7 @@ describe('TelemetryConfig', function () {
     })
 
     afterEach(async function () {
-        await sut.reset()
+        await sut.toolkitConfig.reset()
     })
 
     const scenarios = [


### PR DESCRIPTION
- 'AWS > Amazon Q: ...' --> 'Amazon Q: ...'
- updated setting migrations
- also updated how TelemetryConfig is handled

todo:
**- havent tested this yet, I will shortly.**

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
