### PR TITLE
tests: skip E2E tests

### DIFF
--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -25,7 +25,8 @@ phases:
             # - '>/dev/null apt-get -qq update'
             # - '>/dev/null apt-get -qq install -y ca-certificates'
             # - 'apt-get install --reinstall ca-certificates'
-            - bash buildspec/shared/linux-install.sh
+            # - bash buildspec/shared/linux-install.sh
+            - echo 'skipped until failure is fixed \#4804'
 
     pre_build:
         commands:


### PR DESCRIPTION
Problem:
e2e tests always fail because of a css resource failure (but also, throttling...):

    Error: Cannot find module '../../../../resources/css/amazonq-webview.css'
    Require stack:
    - /codebuild/output/src201842960/src/github.com/aws/aws-toolkit-vscode/packages/core/dist/src/amazonq/webview/ui/main.js
    - /codebuild/output/src201842960/src/github.com/aws/aws-toolkit-vscode/packages/core/dist/src/testE2E/amazonq/framework/framework.js
    - /codebuild/output/src201842960/src/github.com/aws/aws-toolkit-vscode/packages/core/dist/src/testE2E/amazonq/featureDev.test.js
    - /codebuild/output/src201842960/src/github.com/aws/aws-toolkit-vscode/node_modules/mocha/lib/mocha.js
    - /codebuild/output/src201842960/src/github.com/aws/aws-toolkit-vscode/node_modules/mocha/index.js
    - /codebuild/output/src201842960/src/github.com/aws/aws-toolkit-vscode/packages/core/dist/src/test/testRunner.js
    - /codebuild/output/src201842960/src/github.com/aws/aws-toolkit-vscode/packages/core/dist/src/testE2E/index.js
    - /tmp/.vscode-test/vscode-linux-x64-1.88.1/resources/app/out/vs/loader.js
    - /tmp/.vscode-test/vscode-linux-x64-1.88.1/resources/app/out/bootstrap-amd.js
    - /tmp/.vscode-test/vscode-linux-x64-1.88.1/resources/app/out/bootstrap-fork.js
        at Module._resolveFilename (node:internal/modules/cjs/loader:1084:15)
        at Function.i._resolveFilename (node:electron/js2c/utility_init:2:13405)
        at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (/codebuild/output/src201842960/src/github.com/aws/aws-toolkit-vscode/node_modules/@cspotcode/source-map-support/source-map-support.js:811:30)
        at Module._load (node:internal/modules/cjs/loader:929:27)
        at Function.c._load (node:electron/js2c/node_init:2:13672)
        at Function.h._load (/tmp/.vscode-test/vscode-linux-x64-1.88.1/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:175:5602)
        at Function.i._load (/tmp/.vscode-test/vscode-linux-x64-1.88.1/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:172:29719)
        at Function.t._load (/tmp/.vscode-test/vscode-linux-x64-1.88.1/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:137:35279)
        at Module.require (node:internal/modules/cjs/loader:1150:19)

Solution:
Skip the tests until these issues are fixed. #4804


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
