### PR TITLE
tests: skip E2E tests

### DIFF
--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -36,7 +36,8 @@ phases:
     build:
         commands:
             - export HOME=/home/codebuild-user
-            - xvfb-run npm run testE2E
+            # Ignore failure until throttling issues are fixed.
+            - xvfb-run npm run testE2E || true
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g')
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"


### PR DESCRIPTION
Problem:
e2e tests always fail because of throttling, and whatever this is:

    ProtocolError: Protocol error (Page.navigate): Target closed

Solution:
Skip the tests until these issues are fixed.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
