### PR TITLE
fix(gumby): resume transformation job to get partial success when error occurs in HIL

### DIFF
--- a/packages/core/src/amazonqGumby/errors.ts
+++ b/packages/core/src/amazonqGumby/errors.ts
@@ -47,3 +47,9 @@ export class JobStoppedError extends Error {
         super('Job was rejected, stopped, or failed')
     }
 }
+
+export class ModuleUploadError extends Error {
+    constructor() {
+        super('Failed to upload module to S3')
+    }
+}


### PR DESCRIPTION
## Problem
If we exited the [Human in the Loop](https://github.com/aws/aws-toolkit-vscode/pull/4607) feature early - due to user cancellation or an error - the chat was getting stuck in a state where the user could neither get the partial transformation of their flow or start a new transformation. 

## Solution
We enter the status polling loop when we terminate HIL early, so that the backend can continue to give us progress on the transformation job. 


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
