### PR TITLE
fix(amazonq): reduce logs for file scans

### DIFF
--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -18,6 +18,7 @@ import {
     pollScanJobStatus,
     listScanResults,
     throwIfCancelled,
+    getLoggerForScope,
 } from '../service/securityScanHandler'
 import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
 import { AggregatedCodeScanIssue, CodeScansState, codeScanState, CodeScanTelemetryEntry } from '../models/model'
@@ -34,7 +35,6 @@ import { debounce } from 'lodash'
 import { once } from '../../shared/utilities/functionUtils'
 import { randomUUID } from '../../common/crypto'
 import { CodeAnalysisScope } from '../models/constants'
-import { getNullLogger } from '../../shared/logger/logger'
 
 const localize = nls.loadMessageBundle()
 export const stopScanButton = localize('aws.codewhisperer.stopscan', 'Stop Scan')
@@ -82,10 +82,6 @@ export const debounceStartSecurityScan = debounce(
     startSecurityScan,
     CodeWhispererConstants.autoScanDebounceDelaySeconds * 1000
 )
-
-export function getLoggerForScope(scope: CodeAnalysisScope) {
-    return scope === CodeAnalysisScope.FILE ? getNullLogger() : getLogger()
-}
 
 export async function startSecurityScan(
     securityPanelViewProvider: SecurityPanelViewProvider,

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -23,7 +23,7 @@ import {
 import { TelemetryHelper } from '../util/telemetryHelper'
 import request from '../../common/request'
 import { ZipMetadata } from '../util/zipUtil'
-import { getLoggerForScope } from '../commands/startSecurityScan'
+import { getNullLogger } from '../../shared/logger/logger'
 
 export async function listScanResults(
     client: DefaultCodeWhispererClient,
@@ -264,4 +264,8 @@ export async function uploadArtifactToS3(
             `Amazon Q is unable to upload workspace artifacts to Amazon S3 for security scans. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security_iam_manage-access-with-policies.html) or contact your network or organization administrator.`
         )
     }
+}
+
+export function getLoggerForScope(scope: CodeWhispererConstants.CodeAnalysisScope) {
+    return scope === CodeWhispererConstants.CodeAnalysisScope.FILE ? getNullLogger() : getLogger()
 }

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -11,7 +11,7 @@ import * as CodeWhispererConstants from '../models/constants'
 import { ToolkitError } from '../../shared/errors'
 import { fsCommon } from '../../srcShared/fs'
 import { collectFiles } from '../../amazonqFeatureDev/util/files'
-import { getLoggerForScope } from '../commands/startSecurityScan'
+import { getLoggerForScope } from '../service/securityScanHandler'
 
 export interface ZipMetadata {
     rootDir: string

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -11,6 +11,7 @@ import * as CodeWhispererConstants from '../models/constants'
 import { ToolkitError } from '../../shared/errors'
 import { fsCommon } from '../../srcShared/fs'
 import { collectFiles } from '../../amazonqFeatureDev/util/files'
+import { getLoggerForScope } from '../commands/startSecurityScan'
 
 export interface ZipMetadata {
     rootDir: string
@@ -182,7 +183,7 @@ export class ZipUtil {
                 throw new ToolkitError(`Unknown code analysis scope: ${scope}`)
             }
 
-            getLogger().debug(`Picked source files: [${[...this._pickedSourceFiles].join(', ')}]`)
+            getLoggerForScope(scope).debug(`Picked source files: [${[...this._pickedSourceFiles].join(', ')}]`)
             const zipFileSize = (await fsCommon.stat(zipFilePath)).size
             return {
                 rootDir: zipDirPath,
@@ -199,10 +200,11 @@ export class ZipUtil {
         }
     }
 
-    public async removeTmpFiles(zipMetadata: ZipMetadata) {
-        getLogger().verbose(`Cleaning up temporary files...`)
+    public async removeTmpFiles(zipMetadata: ZipMetadata, scope: CodeWhispererConstants.CodeAnalysisScope) {
+        const logger = getLoggerForScope(scope)
+        logger.verbose(`Cleaning up temporary files...`)
         await fsCommon.delete(zipMetadata.zipFilePath)
         await fsCommon.delete(zipMetadata.rootDir)
-        getLogger().verbose(`Complete cleaning up temporary files.`)
+        logger.verbose(`Complete cleaning up temporary files.`)
     }
 }

--- a/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
+++ b/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
@@ -100,7 +100,7 @@ describe('CodeWhisperer security scan', async function () {
         try {
             artifactMap = await getPresignedUrlAndUpload(client, zipMetadata, scope, codeScanName)
         } finally {
-            await zipUtil.removeTmpFiles(zipMetadata)
+            await zipUtil.removeTmpFiles(zipMetadata, scope)
         }
         return {
             artifactMap: artifactMap,
@@ -135,7 +135,8 @@ describe('CodeWhisperer security scan', async function () {
             client,
             scanJob.jobId,
             CodeWhispererConstants.codeScanFindingsSchema,
-            projectPath
+            projectPath,
+            scope
         )
 
         assert.deepStrictEqual(jobStatus, 'Completed')
@@ -169,7 +170,8 @@ describe('CodeWhisperer security scan', async function () {
             client,
             scanJob.jobId,
             CodeWhispererConstants.codeScanFindingsSchema,
-            projectPath
+            projectPath,
+            scope
         )
 
         assert.deepStrictEqual(jobStatus, 'Completed')


### PR DESCRIPTION
## Problem

File scans logs are too noisy

## Solution

- Use NullLogger for file scans except for errors

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
