### PR TITLE
fix(amazonq): register webview error handler in Amazon Q

### DIFF
--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode'
+import * as nls from 'vscode-nls'
 import { getTabSizeSetting } from '../shared/utilities/editorUtilities'
 import { KeyStrokeHandler } from './service/keyStrokeHandler'
 import * as EditorContext from './util/editorContext'
@@ -67,9 +68,12 @@ import { Container } from './service/serviceContainer'
 import { debounceStartSecurityScan } from './commands/startSecurityScan'
 import { securityScanLanguageContext } from './util/securityScanLanguageContext'
 import { registerWebviewErrorHandler } from '../webviews/server'
-import { logAndShowWebviewError } from '../extensionShared'
+import { logAndShowWebviewError } from '../shared/utilities/logAndShowUtils'
+
+let localize: nls.LocalizeFunc
 
 export async function activate(context: ExtContext): Promise<void> {
+    localize = nls.loadMessageBundle()
     const codewhispererSettings = CodeWhispererSettings.instance
 
     // Import old CodeWhisperer settings into Amazon Q
@@ -103,7 +107,7 @@ export async function activate(context: ExtContext): Promise<void> {
      * Register the webview error handler for Amazon Q
      */
     registerWebviewErrorHandler((error: unknown, webviewId: string, command: string) => {
-        logAndShowWebviewError(error, webviewId, command)
+        logAndShowWebviewError(localize, error, webviewId, command)
     })
 
     /**

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -66,6 +66,8 @@ import { updateUserProxyUrl } from './client/agent'
 import { Container } from './service/serviceContainer'
 import { debounceStartSecurityScan } from './commands/startSecurityScan'
 import { securityScanLanguageContext } from './util/securityScanLanguageContext'
+import { registerWebviewErrorHandler } from '../webviews/server'
+import { logAndShowWebviewError } from '../extensionShared'
 
 export async function activate(context: ExtContext): Promise<void> {
     const codewhispererSettings = CodeWhispererSettings.instance
@@ -96,6 +98,13 @@ export async function activate(context: ExtContext): Promise<void> {
      */
     const securityPanelViewProvider = new SecurityPanelViewProvider(context.extensionContext)
     activateSecurityScan()
+
+    /**
+     * Register the webview error handler for Amazon Q
+     */
+    registerWebviewErrorHandler((error: unknown, webviewId: string, command: string) => {
+        logAndShowWebviewError(error, webviewId, command)
+    })
 
     /**
      * Service control

--- a/packages/core/src/extensionShared.ts
+++ b/packages/core/src/extensionShared.ts
@@ -223,7 +223,7 @@ async function logAndShowError(error: unknown, topic: string, defaultMessage: st
  * @param webviewId Arbitrary value that identifies which webview had the error
  * @param command The high level command/function that was run which triggered the error
  */
-function logAndShowWebviewError(err: unknown, webviewId: string, command: string) {
+export function logAndShowWebviewError(err: unknown, webviewId: string, command: string) {
     // HACK: The following implementation is a hack, influenced by the implementation of handleError().
     // The userFacingError message will be seen in the UI, and the detailedError message will provide the
     // detailed information in the logs.

--- a/packages/core/src/extensionShared.ts
+++ b/packages/core/src/extensionShared.ts
@@ -16,6 +16,7 @@ import { join } from 'path'
 import { Commands } from './shared/vscode/commands2'
 import { documentationUrl, endpointsFileUrl, githubCreateIssueUrl, githubUrl } from './shared/constants'
 import { getIdeProperties, aboutExtension, isCloud9 } from './shared/extensionUtilities'
+import { logAndShowError, logAndShowWebviewError } from './shared/utilities/logAndShowUtils'
 import { telemetry } from './shared/telemetry/telemetry'
 import { openUrl } from './shared/utilities/vsCodeUtils'
 import { activateViewsShared } from './awsexplorer/activationShared'
@@ -33,10 +34,6 @@ import { initializeAwsCredentialsStatusBarItem } from './auth/ui/statusBarItem'
 import { RegionProvider, getEndpointsFromFetcher } from './shared/regions/regionProvider'
 import { getMachineId } from './shared/vscode/env'
 import { registerErrorHandler as registerCommandErrorHandler } from './shared/vscode/commands2'
-import { ToolkitError, isUserCancelledError, resolveErrorMessageToDisplay } from './shared/errors'
-import { getLogger } from './shared/logger'
-import { showMessageWithUrl } from './shared/utilities/messages'
-import { Logging } from './shared/logger/commands'
 import { registerWebviewErrorHandler } from './webviews/server'
 import { showQuickStartWebview } from './shared/extensionStartup'
 import { ExtContext } from './shared/extensions'
@@ -73,11 +70,11 @@ export async function activateShared(
 
     registerCommandErrorHandler((info, error) => {
         const defaultMessage = localize('AWS.generic.message.error', 'Failed to run command: {0}', info.id)
-        void logAndShowError(error, info.id, defaultMessage)
+        void logAndShowError(localize, error, info.id, defaultMessage)
     })
 
     registerWebviewErrorHandler((error: unknown, webviewId: string, command: string) => {
-        logAndShowWebviewError(error, webviewId, command)
+        logAndShowWebviewError(localize, error, webviewId, command)
     })
 
     // Setup the logger
@@ -180,58 +177,6 @@ export function registerCommands(extensionContext: vscode.ExtensionContext, cont
             await aboutExtension()
         })
     )
-}
-
-/**
- * Logs the error. Then determines what kind of error message should be shown, if
- * at all.
- *
- * @param error The error itself
- * @param topic The prefix of the error message
- * @param defaultMessage The message to show if once cannot be resolved from the given error
- *
- * SIDE NOTE:
- * This is only being used for errors from commands and webview, there's plenty of other places
- * (explorer, nodes, ...) where it could be used. It needs to be apart of some sort of `core`
- * module that is guaranteed to initialize prior to every other Toolkit component.
- * Logging and telemetry would fit well within this core module.
- */
-async function logAndShowError(error: unknown, topic: string, defaultMessage: string) {
-    if (isUserCancelledError(error)) {
-        getLogger().verbose(`${topic}: user cancelled`)
-        return
-    }
-    const logsItem = localize('AWS.generic.message.viewLogs', 'View Logs...')
-    const logId = getLogger().error(`${topic}: %s`, error)
-    const message = resolveErrorMessageToDisplay(error, defaultMessage)
-
-    if (error instanceof ToolkitError && error.documentationUri) {
-        await showMessageWithUrl(message, error.documentationUri, 'View Documentation', 'error')
-    } else {
-        await vscode.window.showErrorMessage(message, logsItem).then(async resp => {
-            if (resp === logsItem) {
-                await Logging.instance.viewLogsAtMessage.execute(logId)
-            }
-        })
-    }
-}
-
-/**
- * Show a webview related error to the user + button that links to the logged error
- *
- * @param err The error that was thrown in the backend
- * @param webviewId Arbitrary value that identifies which webview had the error
- * @param command The high level command/function that was run which triggered the error
- */
-export function logAndShowWebviewError(err: unknown, webviewId: string, command: string) {
-    // HACK: The following implementation is a hack, influenced by the implementation of handleError().
-    // The userFacingError message will be seen in the UI, and the detailedError message will provide the
-    // detailed information in the logs.
-    const detailedError = ToolkitError.chain(err, `Webview backend command failed: "${command}()"`)
-    const userFacingError = ToolkitError.chain(detailedError, 'Webview error')
-    logAndShowError(userFacingError, `webviewId="${webviewId}"`, 'Webview error').catch(e => {
-        getLogger().error('logAndShowError failed: %s', (e as Error).message)
-    })
 }
 
 /**

--- a/packages/core/src/shared/utilities/logAndShowUtils.ts
+++ b/packages/core/src/shared/utilities/logAndShowUtils.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as nls from 'vscode-nls'
+import { ToolkitError, isUserCancelledError, resolveErrorMessageToDisplay } from '../errors'
+import { getLogger } from '../logger'
+import { showMessageWithUrl } from './messages'
+import { Logging } from '../logger/commands'
+
+/**
+ * Logs the error. Then determines what kind of error message should be shown, if
+ * at all.
+ *
+ * @param error The error itself
+ * @param topic The prefix of the error message
+ * @param defaultMessage The message to show if once cannot be resolved from the given error
+ *
+ * SIDE NOTE:
+ * This is only being used for errors from commands and webview, there's plenty of other places
+ * (explorer, nodes, ...) where it could be used. It needs to be apart of some sort of `core`
+ * module that is guaranteed to initialize prior to every other Toolkit component.
+ * Logging and telemetry would fit well within this core module.
+ */
+export async function logAndShowError(
+    localize: nls.LocalizeFunc,
+    error: unknown,
+    topic: string,
+    defaultMessage: string
+) {
+    if (isUserCancelledError(error)) {
+        getLogger().verbose(`${topic}: user cancelled`)
+        return
+    }
+    const logsItem = localize('AWS.generic.message.viewLogs', 'View Logs...')
+    const logId = getLogger().error(`${topic}: %s`, error)
+    const message = resolveErrorMessageToDisplay(error, defaultMessage)
+
+    if (error instanceof ToolkitError && error.documentationUri) {
+        await showMessageWithUrl(message, error.documentationUri, 'View Documentation', 'error')
+    } else {
+        await vscode.window.showErrorMessage(message, logsItem).then(async resp => {
+            if (resp === logsItem) {
+                await Logging.instance.viewLogsAtMessage.execute(logId)
+            }
+        })
+    }
+}
+
+/**
+ * Show a webview related error to the user + button that links to the logged error
+ *
+ * @param err The error that was thrown in the backend
+ * @param webviewId Arbitrary value that identifies which webview had the error
+ * @param command The high level command/function that was run which triggered the error
+ */
+export function logAndShowWebviewError(localize: nls.LocalizeFunc, err: unknown, webviewId: string, command: string) {
+    // HACK: The following implementation is a hack, influenced by the implementation of handleError().
+    // The userFacingError message will be seen in the UI, and the detailedError message will provide the
+    // detailed information in the logs.
+    const detailedError = ToolkitError.chain(err, `Webview backend command failed: "${command}()"`)
+    const userFacingError = ToolkitError.chain(detailedError, 'Webview error')
+    logAndShowError(localize, userFacingError, `webviewId="${webviewId}"`, 'Webview error').catch(e => {
+        getLogger().error('logAndShowError failed: %s', (e as Error).message)
+    })
+}


### PR DESCRIPTION
## Problem

When login view of Q goes wrong,  for example: When attempting to login with a user id whose access was revoked, the login failure error message was not properly displayed to user. 

Root cause: 

The webview error handler was registered in `extensionShared.ts`. However, `extensionShared.ts`is not shared, it only actives in AWS Toolkit. 


## Solution

register webview error handler in Amazon Q

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
