### PR TITLE
fix(explorer): try to fix rare cases where amazonq tree is not hidden

### DIFF
--- a/packages/amazonq/src/extensionShared.ts
+++ b/packages/amazonq/src/extensionShared.ts
@@ -26,6 +26,7 @@ import {
     RegionProvider,
     getLogger,
     getMachineId,
+    Commands,
 } from 'aws-core-vscode/shared'
 import { initializeAuth, CredentialsStore, LoginManager, AuthUtils } from 'aws-core-vscode/auth'
 import { makeEndpointsProvider, registerCommands } from 'aws-core-vscode'
@@ -130,6 +131,7 @@ export async function activateShared(context: vscode.ExtensionContext, isWeb: bo
 
     // Hide the Amazon Q tree in toolkit explorer
     await vscode.commands.executeCommand('setContext', amazonQDismissedKey, true)
+    await Commands.tryExecute('_aws.amazonq.refreshRootNode')
 
     // reload webviews
     await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction')

--- a/packages/amazonq/src/extensionShared.ts
+++ b/packages/amazonq/src/extensionShared.ts
@@ -130,8 +130,12 @@ export async function activateShared(context: vscode.ExtensionContext, isWeb: bo
     await updateDevMode()
 
     // Hide the Amazon Q tree in toolkit explorer
-    await vscode.commands.executeCommand('setContext', amazonQDismissedKey, true)
-    await Commands.tryExecute('_aws.amazonq.refreshRootNode')
+    try {
+        // Commands.tryExcute only works on commands registered by this extension
+        getLogger().debug('hiding Amazon Q view in Toolkit, if it is installed.')
+        await vscode.commands.executeCommand('setContext', amazonQDismissedKey, true)
+        await vscode.commands.executeCommand('_aws.amazonq.refreshRootNode')
+    } catch {}
 
     // reload webviews
     await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction')

--- a/packages/core/src/amazonq/explorer/amazonQTreeNode.ts
+++ b/packages/core/src/amazonq/explorer/amazonQTreeNode.ts
@@ -69,12 +69,6 @@ export class AmazonQNode implements TreeNode {
     }
 }
 
-/**
- * Refreshes the Amazon Q Tree node. If Amazon Q's connection state is provided, it will also internally
- * update the connection state.
- *
- * This command is meant to be called by Amazon Q. It doesn't serve much purpose being called otherwise.
- */
 export const refreshAmazonQ = (provider?: ResourceTreeDataProvider) =>
     Commands.register({ id: '_aws.toolkit.amazonq.refreshTreeNode', logging: false }, () => {
         AmazonQNode.instance.refresh()

--- a/packages/core/src/amazonq/explorer/amazonQTreeNode.ts
+++ b/packages/core/src/amazonq/explorer/amazonQTreeNode.ts
@@ -8,6 +8,9 @@ import { ResourceTreeDataProvider, TreeNode } from '../../shared/treeview/resour
 import { AuthState, isPreviousQUser } from '../../codewhisperer/util/authUtil'
 import { createLearnMoreNode, createInstallQNode, createDismissNode } from './amazonQChildrenNodes'
 import { Commands } from '../../shared/vscode/commands2'
+import { isExtensionInstalled } from '../../shared/utilities/vsCodeUtils'
+import { amazonQDismissedKey } from '../../codewhisperer/models/constants'
+import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
 
 export class AmazonQNode implements TreeNode {
     public readonly id = 'amazonq'
@@ -81,7 +84,10 @@ export const refreshAmazonQ = (provider?: ResourceTreeDataProvider) =>
     })
 
 export const refreshAmazonQRootNode = (provider?: ResourceTreeDataProvider) =>
-    Commands.register({ id: '_aws.amazonq.refreshRootNode', logging: false }, () => {
+    Commands.register({ id: '_aws.amazonq.refreshRootNode', logging: false }, async () => {
+        if (isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq)) {
+            await vscode.commands.executeCommand('setContext', amazonQDismissedKey, true)
+        }
         AmazonQNode.instance.refreshRootNode()
         if (provider) {
             provider.refresh()

--- a/packages/core/src/awsexplorer/activation.ts
+++ b/packages/core/src/awsexplorer/activation.ts
@@ -113,14 +113,13 @@ export async function activate(args: {
             globals.context.globalState.get<boolean>(amazonQDismissedKey)
         ) {
             await vscode.commands.executeCommand('setContext', amazonQDismissedKey, true)
+        } else {
+            amazonQViewNode.push({
+                nodes: [AmazonQNode.instance],
+                view: 'aws.amazonq.codewhisperer',
+                refreshCommands: [refreshAmazonQ, refreshAmazonQRootNode],
+            })
         }
-
-        // We should create the tree even if it's dismissed, in case the user installs Amazon Q later.
-        amazonQViewNode.push({
-            nodes: [AmazonQNode.instance],
-            view: 'aws.amazonq.codewhisperer',
-            refreshCommands: [refreshAmazonQ, refreshAmazonQRootNode],
-        })
     }
     const viewNodes: ToolView[] = [
         ...amazonQViewNode,


### PR DESCRIPTION
Although I can't reproduce, there seems to be some cases where the explorer tree for amazonq won't hide if amazonq is installed after the toolkit has activated. At best this should fix the issue, at worst it does nothing.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
