### PR TITLE
fix(amazonq): apply fix without save

### DIFF
--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -128,3 +128,19 @@ function getLineOffset(range: vscode.Range, text: string) {
     const changedLines = text.split('\n').length
     return changedLines - originLines
 }
+
+export function removeDiagnostic(uri: vscode.Uri, issue: CodeScanIssue) {
+    const currentSecurityDiagnostics = securityScanRender.securityDiagnosticCollection?.get(uri)
+    if (currentSecurityDiagnostics) {
+        const newSecurityDiagnostics = currentSecurityDiagnostics.filter(diagnostic => {
+            return (
+                typeof diagnostic.code !== 'string' &&
+                typeof diagnostic.code !== 'number' &&
+                diagnostic.code?.value !== issue.detectorId &&
+                diagnostic.message !== issue.title &&
+                diagnostic.range !== new vscode.Range(issue.startLine, 0, issue.endLine, 0)
+            )
+        })
+        securityScanRender.securityDiagnosticCollection?.set(uri, newSecurityDiagnostics)
+    }
+}

--- a/packages/core/src/codewhisperer/service/securityIssueProvider.ts
+++ b/packages/core/src/codewhisperer/service/securityIssueProvider.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import { AggregatedCodeScanIssue, CodeScansState } from '../models/model'
+import { AggregatedCodeScanIssue, CodeScanIssue, CodeScansState } from '../models/model'
 export abstract class SecurityIssueProvider {
     private _issues: AggregatedCodeScanIssue[] = []
     public get issues() {
@@ -63,5 +63,17 @@ export abstract class SecurityIssueProvider {
         const originLines = range.end.line - range.start.line + 1
         const changedLines = text.split('\n').length
         return changedLines - originLines
+    }
+
+    public removeIssue(uri: vscode.Uri, issue: CodeScanIssue) {
+        this._issues = this._issues.map(group => {
+            if (group.filePath !== uri.fsPath) {
+                return group
+            }
+            return {
+                ...group,
+                issues: group.issues.filter(i => i.findingId !== issue.findingId),
+            }
+        })
     }
 }


### PR DESCRIPTION
## Problem

Scans can now run without saving the file to disk. No need to save the file to apply fix.

## Solution

- Use WorkspaceEdit to apply fix
- If auto-scans is enabled, immediately remove the issue from hover and diagnostics after fixing it

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
