### PR TITLE
feat(logging): use OutputChannel log level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -315,9 +315,14 @@ The `aws.dev.forceDevMode` setting enables or disables Toolkit "dev mode". Witho
 
 ### Logging
 
--   Use the `aws.dev.logfile` setting to set the logfile path to a fixed location, so you can easily
-    follow and filter the logfile using shell tools like `tail` and `grep`. For example in
-    settings.json,
+-   Use `getLogger()` to log debugging messages, warnings, etc.
+    -   Example: `getLogger().error('topic: widget failed: %O', { foo: 'bar', baz: 42 })`
+-   Log messages are written to the extension Output channel, which you can view in vscode by visiting the "Output" panel and selecting `AWS Toolkit Logs` or `Amazon Q Logs`.
+-   While viewing the Output channel (`AWS Toolkit Logs` or `Amazon Q Logs`) in vscode:
+    -   Click the "gear" icon to [select a log level](https://github.com/aws/aws-toolkit-vscode/pull/4859) ("Debug", "Info", "Error", …).
+    -   Click the "..." icon to open the log file.
+-   Use the `aws.dev.logfile` setting to set the logfile path to a fixed location, so you can follow
+    and filter logs using shell tools like `tail` and `grep`. For example in settings.json,
     ```
     "aws.dev.logfile": "~/awstoolkit.log",
     ```
@@ -328,7 +333,6 @@ The `aws.dev.forceDevMode` setting enables or disables Toolkit "dev mode". Witho
 -   Use the `AWS (Developer): Watch Logs` command to watch and filter Toolkit logs (including
     telemetry) in VSCode.
     -   Only available if you enabled "dev mode" (`aws.dev.forceDevMode` setting, see above).
-    -   Sets `aws.logLevel` to "debug".
     -   Enter text in the Debug Console filter box to show only log messages with that text. <br/>
         <img src="./docs/images/debug-console-filter.png" alt="VSCode Debug Console" width="320"/>
 

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -60,30 +60,6 @@
                 }
             },
             "properties": {
-                "aws.logLevel": {
-                    "type": "string",
-                    "default": "debug",
-                    "enum": [
-                        "error",
-                        "warn",
-                        "info",
-                        "verbose",
-                        "debug"
-                    ],
-                    "enumDescriptions": [
-                        "Errors Only",
-                        "Errors and Warnings",
-                        "Errors, Warnings, and Info",
-                        "Errors, Warnings, Info, and Verbose",
-                        "Errors, Warnings, Info, Verbose, and Debug"
-                    ],
-                    "markdownDescription": "%AWS.configuration.description.logLevel%",
-                    "cloud9": {
-                        "cn": {
-                            "markdownDescription": "%AWS.configuration.description.logLevel.cn%"
-                        }
-                    }
-                },
                 "amazonQ.telemetry": {
                     "type": "boolean",
                     "default": true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -90,30 +90,6 @@
                     "default": false,
                     "markdownDescription": "%AWS.configuration.description.samcli.legacyDeploy%"
                 },
-                "aws.logLevel": {
-                    "type": "string",
-                    "default": "debug",
-                    "enum": [
-                        "error",
-                        "warn",
-                        "info",
-                        "verbose",
-                        "debug"
-                    ],
-                    "enumDescriptions": [
-                        "Errors Only",
-                        "Errors and Warnings",
-                        "Errors, Warnings, and Info",
-                        "Errors, Warnings, Info, and Verbose",
-                        "Errors, Warnings, Info, Verbose, and Debug"
-                    ],
-                    "markdownDescription": "%AWS.configuration.description.logLevel%",
-                    "cloud9": {
-                        "cn": {
-                            "markdownDescription": "%AWS.configuration.description.logLevel.cn%"
-                        }
-                    }
-                },
                 "aws.telemetry": {
                     "type": "boolean",
                     "default": true,

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -9,8 +9,6 @@
     "AWS.configuration.profileDescription": "The name of the credential profile to obtain credentials from.",
     "AWS.configuration.description.lambda.recentlyUploaded": "Recently selected Lambda upload targets.",
     "AWS.configuration.description.ecs.openTerminalCommand": "The command to run when starting a new interactive terminal session.",
-    "AWS.configuration.description.logLevel": "AWS IDE Extensions log level (changes reflected on restart)",
-    "AWS.configuration.description.logLevel.cn": "The Amazon Toolkit's log level (changes reflected on restart)",
     "AWS.configuration.description.iot.maxItemsPerPage": "Controls how many IoT Things, Certificates, or Policies are listed before showing a node to `Load More...`.",
     "AWS.configuration.description.s3.maxItemsPerPage": "Controls how many S3 items are listed before showing a node to `Load More...`.\nThis corresponds to the `MaxKeys` requested in a single call to S3. [Learn More](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#AmazonS3-ListObjectsV2-response-MaxKeys)",
     "AWS.configuration.description.samcli.lambdaTimeout": "Maximum time (in milliseconds) to wait for SAM output while starting a Local Lambda session",

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -69,6 +69,7 @@ import { debounceStartSecurityScan } from './commands/startSecurityScan'
 import { securityScanLanguageContext } from './util/securityScanLanguageContext'
 import { registerWebviewErrorHandler } from '../webviews/server'
 import { logAndShowWebviewError } from '../shared/utilities/logAndShowUtils'
+import { openSettings } from '../shared/settings'
 
 let localize: nls.LocalizeFunc
 
@@ -190,7 +191,7 @@ export async function activate(context: ExtContext): Promise<void> {
                     `@id:amazonQ.showInlineCodeSuggestionsWithCodeReferences`
                 )
             } else {
-                await vscode.commands.executeCommand('workbench.action.openSettings', `amazonQ`)
+                await openSettings('amazonQ')
             }
         }),
         Commands.register('aws.amazonq.refreshAnnotation', async (forceProceed: boolean = false) => {

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -49,6 +49,7 @@ export const stopScanButton = localize('aws.codewhisperer.stopscan', 'Stop Scan'
 const getLogOutputChan = once(() => {
     const codeScanOutpuChan = vscode.window.createOutputChannel('Amazon Q Security Scan Logs')
     const codeScanLogger = makeLogger({
+        logLevel: 'info',
         outputChannels: [codeScanOutpuChan],
     })
     return [codeScanLogger, codeScanOutpuChan] as const

--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -5,15 +5,13 @@
 
 import * as vscode from 'vscode'
 import { Logger, LogLevel, getLogger } from '.'
-import { setLogger } from './logger'
+import { fromVscodeLogLevel, setLogger } from './logger'
 import { WinstonToolkitLogger } from './winstonToolkitLogger'
 import { Settings } from '../settings'
 import { Logging } from './commands'
 import { resolvePath } from '../utilities/pathUtils'
 import { fsCommon } from '../../srcShared/fs'
-import globals, { isWeb } from '../extensionGlobals'
-
-export const defaultLogLevel: LogLevel = 'debug'
+import { isWeb } from '../extensionGlobals'
 
 /**
  * Activate Logger functionality for the extension.
@@ -27,43 +25,41 @@ export async function activate(
     const settings = Settings.instance.getSection('aws')
     const devLogfile = settings.get('dev.logfile', '')
     const logUri = devLogfile ? vscode.Uri.file(resolvePath(devLogfile)) : undefined
+    const chanLogLevel = fromVscodeLogLevel(logChannel.logLevel)
 
     await fsCommon.mkdir(extensionContext.logUri)
 
-    const mainLogger = makeLogger(
-        {
-            logPaths: logUri ? [logUri] : undefined,
-            outputChannels: [logChannel],
-            useConsoleLog: isWeb(),
-        },
-        extensionContext.subscriptions
-    )
+    const mainLogger = makeLogger({
+        logLevel: chanLogLevel,
+        logPaths: logUri ? [logUri] : undefined,
+        outputChannels: [logChannel],
+        useConsoleLog: isWeb(),
+    })
+    logChannel.onDidChangeLogLevel?.(logLevel => {
+        const newLogLevel = fromVscodeLogLevel(logLevel)
+        mainLogger.setLogLevel(newLogLevel) // Also logs a message.
+    })
 
     setLogger(mainLogger)
-    getLogger().info(`log level: ${getLogLevel()}`)
+    getLogger().info(`Log level: ${chanLogLevel}`)
 
     // Logs to "AWS Toolkit" output channel.
     setLogger(
-        makeLogger(
-            {
-                logPaths: logUri ? [logUri] : undefined,
-                outputChannels: [outputChannel, logChannel],
-            },
-            extensionContext.subscriptions
-        ),
+        makeLogger({
+            logLevel: chanLogLevel,
+            logPaths: logUri ? [logUri] : undefined,
+            outputChannels: [outputChannel, logChannel],
+        }),
         'channel'
     )
 
     // Logs to vscode Debug Console.
     setLogger(
-        makeLogger(
-            {
-                staticLogLevel: 'debug',
-                outputChannels: [outputChannel, logChannel],
-                useDebugConsole: true,
-            },
-            extensionContext.subscriptions
-        ),
+        makeLogger({
+            logLevel: chanLogLevel,
+            outputChannels: [outputChannel, logChannel],
+            useDebugConsole: true,
+        }),
         'debugConsole'
     )
 
@@ -75,25 +71,20 @@ export async function activate(
 
 /**
  * Creates a logger off of specified params
- * @param opts Specified parameters, all optional:
- * @param opts.staticLogLevel Static log level, overriding config value. Will persist overridden config value even if the config value changes.
+ * @param opts.logLevel Log messages at or above this level
  * @param opts.logPaths Array of paths to output log entries to
  * @param opts.outputChannels Array of output channels to log entries to
  * @param opts.useDebugConsole If true, outputs log entries to `vscode.debug.activeDebugConsole`
  * @param opts.useConsoleLog If true, outputs log entries to the nodejs or browser devtools console.
- * @param disposables Array of disposables to add a subscription to
  */
-export function makeLogger(
-    opts: {
-        staticLogLevel?: LogLevel
-        logPaths?: vscode.Uri[]
-        outputChannels?: vscode.OutputChannel[]
-        useDebugConsole?: boolean
-        useConsoleLog?: boolean
-    },
-    disposables?: vscode.Disposable[]
-): Logger {
-    const logger = new WinstonToolkitLogger(opts.staticLogLevel ?? getLogLevel())
+export function makeLogger(opts: {
+    logLevel: LogLevel
+    logPaths?: vscode.Uri[]
+    outputChannels?: vscode.OutputChannel[]
+    useDebugConsole?: boolean
+    useConsoleLog?: boolean
+}): Logger {
+    const logger = new WinstonToolkitLogger(opts.logLevel)
     // debug console can show ANSI colors, output channels can not
     const stripAnsi = opts.useDebugConsole ?? false
     for (const logPath of opts.logPaths ?? []) {
@@ -109,23 +100,5 @@ export function makeLogger(
         logger.logToConsole()
     }
 
-    if (!opts.staticLogLevel) {
-        vscode.workspace.onDidChangeConfiguration(
-            configurationChangeEvent => {
-                if (configurationChangeEvent.affectsConfiguration('aws.logLevel')) {
-                    const newLogLevel = getLogLevel()
-                    logger.setLogLevel(newLogLevel)
-                }
-            },
-            undefined,
-            disposables
-        )
-    }
-
     return logger
-}
-
-function getLogLevel(): LogLevel {
-    const configuration = Settings.instance.getSection('aws')
-    return configuration.get(`${globals.contextPrefix}logLevel`, defaultLogLevel)
 }

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Uri } from 'vscode'
+import * as vscode from 'vscode'
 import globals from '../extensionGlobals'
 
 const toolkitLoggers: {
@@ -26,7 +26,7 @@ export interface Logger {
     setLogLevel(logLevel: LogLevel): void
     /** Returns true if the given log level is being logged.  */
     logLevelEnabled(logLevel: LogLevel): boolean
-    getLogById(logID: number, file: Uri): string | undefined
+    getLogById(logID: number, file: vscode.Uri): string | undefined
     /** HACK: Enables logging to vscode Debug Console. */
     enableDebugConsole(): void
 }
@@ -47,6 +47,27 @@ const logLevels = new Map<LogLevel, number>([
 ])
 
 export type LogLevel = 'error' | 'warn' | 'info' | 'verbose' | 'debug'
+
+export function fromVscodeLogLevel(logLevel: vscode.LogLevel): LogLevel {
+    if (!vscode.LogLevel) {
+        // vscode version <= 1.73
+        return 'info'
+    }
+
+    switch (logLevel) {
+        case vscode.LogLevel.Trace:
+        case vscode.LogLevel.Debug:
+            return 'debug'
+        case vscode.LogLevel.Info:
+            return 'info'
+        case vscode.LogLevel.Warning:
+            return 'warn'
+        case vscode.LogLevel.Error:
+        case vscode.LogLevel.Off:
+        default:
+            return 'error'
+    }
+}
 
 /**
  * Compares log levels.
@@ -96,7 +117,7 @@ export class NullLogger implements Logger {
     public error(message: string | Error, ...meta: any[]): number {
         return 0
     }
-    public getLogById(logID: number, file: Uri): string | undefined {
+    public getLogById(logID: number, file: vscode.Uri): string | undefined {
         return undefined
     }
     public enableDebugConsole(): void {}
@@ -131,7 +152,7 @@ export class ConsoleLogger implements Logger {
         console.error(message, ...meta)
         return 0
     }
-    public getLogById(logID: number, file: Uri): string | undefined {
+    public getLogById(logID: number, file: vscode.Uri): string | undefined {
         return undefined
     }
     public enableDebugConsole(): void {}

--- a/packages/core/src/shared/logger/outputChannelTransport.ts
+++ b/packages/core/src/shared/logger/outputChannelTransport.ts
@@ -64,13 +64,7 @@ export class OutputChannelTransport extends Transport {
                 } else if (loglevel === 'warn') {
                     c.warn(msg)
                 } else if (loglevel === 'debug' || loglevel === 'verbose') {
-                    // XXX: `vscode.LogOutputChannel` loglevel is currently readonly:
-                    //      https://github.com/microsoft/vscode/issues/170450
-                    //      https://github.com/PowerShell/vscode-powershell/issues/4441
-                    // So debug() will just drop messages unless the user configures vscode (via
-                    // `code --log …` or `.vscode/argv.json` https://stackoverflow.com/a/77257398/152142).
-                    // Use info() until vscode adds a way to set the loglevel.
-                    c.info(msg)
+                    c.debug(msg)
                 } else {
                     c.info(msg)
                 }

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -894,11 +894,16 @@ export async function migrateSetting<T, U = T>(
     await migrateForScope(vscode.ConfigurationTarget.Global)
 }
 
+/** Opens the settings UI filtered by the given prefix. */
+export async function openSettings(prefix: string): Promise<void> {
+    await vscode.commands.executeCommand('workbench.action.openSettings', prefix)
+}
+
 /**
  * Opens the settings UI at the specified key.
  *
  * This only works for keys that are considered "top-level", e.g. keys of {@link settingsProps}.
  */
-export async function openSettings<K extends keyof SettingsProps>(key: K): Promise<void> {
+export async function openSettingsId<K extends keyof SettingsProps>(key: K): Promise<void> {
     await vscode.commands.executeCommand('workbench.action.openSettings', `@id:${key}`)
 }

--- a/packages/core/src/shared/telemetry/activation.ts
+++ b/packages/core/src/shared/telemetry/activation.ts
@@ -13,7 +13,7 @@ import { AwsContext } from '../awsContext'
 import { DefaultTelemetryService } from './telemetryService'
 import { getLogger } from '../logger'
 import { getComputeRegion, isAmazonQ, isCloud9, productName } from '../extensionUtilities'
-import { openSettings, Settings } from '../settings'
+import { openSettingsId, Settings } from '../settings'
 import { TelemetryConfig, setupTelemetryId } from './util'
 import { isAutomation, isReleaseVersion } from '../vscode/env'
 import { AWSProduct } from './clienttelemetry'
@@ -133,7 +133,7 @@ export async function handleTelemetryNoticeResponse(
         // noticeResponseOk is a no-op
 
         if (response === noticeResponseViewSettings) {
-            await openSettings(isAmazonQ() ? 'amazonQ.telemetry' : 'aws.telemetry')
+            await openSettingsId(isAmazonQ() ? 'amazonQ.telemetry' : 'aws.telemetry')
         }
     } catch (err) {
         getLogger().error('Error while handling response from telemetry notice: %O', err as Error)

--- a/packages/core/src/test/shared/logger/activation.test.ts
+++ b/packages/core/src/test/shared/logger/activation.test.ts
@@ -18,7 +18,7 @@ describe('makeLogger', function () {
     before(async function () {
         tempFolder = await makeTemporaryToolkitFolder()
         const logPath = vscode.Uri.joinPath(vscode.Uri.file(tempFolder), 'log.txt')
-        testLogger = makeLogger({ staticLogLevel: 'debug', logPaths: [logPath] })
+        testLogger = makeLogger({ logLevel: 'debug', logPaths: [logPath] })
     })
 
     after(async function () {

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -6,8 +6,6 @@
 import assert from 'assert'
 import * as semver from 'semver'
 import * as env from '../shared/vscode/env'
-import { defaultLogLevel } from '../shared/logger/activation'
-import packageJson from '../../package.json'
 
 // Checks project config and dependencies, to remind us to remove old things
 // when possible.
@@ -33,24 +31,6 @@ describe('tech debt', function () {
         assert.ok(
             semver.lt(minNodejs, '18.0.0'),
             'with node16+, we can now use AbortController to cancel Node things (child processes, HTTP requests, etc.)'
-        )
-    })
-
-    it('feature/standalone branch temporary debug log level for testing', async function () {
-        if (!(process.env.GITHUB_BASE_REF ?? '').includes('master')) {
-            this.skip()
-        }
-
-        assert.strictEqual(
-            defaultLogLevel,
-            'info',
-            'set loglevel defaults back to info for src/shared/logger/activation.ts. (revert this commit)'
-        )
-
-        assert.strictEqual(
-            packageJson.contributes.configuration.properties['aws.logLevel'].default,
-            'info',
-            'set loglevel defaults back to info for packages/amazonq/package.json, packages/toolkit/package.json. (revert this commit)'
         )
     })
 })


### PR DESCRIPTION
## Problem

- aws.logLevel setting is unnecessary, because vscode now lets users control the log level by visiting the "AWS Toolkit Logs" output channel.
- aws.logLevel setting may cause Q to show a `Cannot register 'aws.logLevel'` error.

## Solution

Use the AWS Toolkit Logs" output channel log-level as the source of truth.

![image](https://github.com/aws/aws-toolkit-vscode/assets/55561878/15fa4aa1-1104-40ec-8c53-30d1edf1a3ec)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
