### PR TITLE
feat(telemetry): add auth_userState to toolkit ext

### DIFF
--- a/packages/amazonq/src/extensionShared.ts
+++ b/packages/amazonq/src/extensionShared.ts
@@ -166,7 +166,7 @@ export async function activateShared(context: vscode.ExtensionContext, isWeb: bo
         }
         telemetry.record({
             authStatus: authState === 'connected' || authState === 'expired' ? authState : 'notConnected',
-            enabledAuthConnections: authKinds.join(','),
+            authEnabledConnections: authKinds.join(','),
         })
     })
 }

--- a/packages/core/src/auth/ui/vue/authForms/types.ts
+++ b/packages/core/src/auth/ui/vue/authForms/types.ts
@@ -11,6 +11,7 @@ export type AuthFormId =
     | 'identityCenterCodeCatalyst'
     | 'identityCenterExplorer'
     | 'aggregateExplorer'
+    | 'unknown'
 
 export function isBuilderIdAuth(id: AuthFormId): boolean {
     return id.startsWith('builderId')
@@ -24,4 +25,5 @@ export const AuthFormDisplayName: Record<AuthFormId, string> = {
     identityCenterCodeWhisperer: 'Amazon Q with IAM Identity Center',
     identityCenterExplorer: 'AWS Explorer with IAM Identity Center',
     aggregateExplorer: '',
+    unknown: '',
 } as const

--- a/packages/core/src/auth/ui/vue/types.ts
+++ b/packages/core/src/auth/ui/vue/types.ts
@@ -35,4 +35,5 @@ export const authFormTelemetryMapping: {
     identityCenterCodeCatalyst: { featureType: 'codecatalyst', authType: 'iamIdentityCenter' },
     identityCenterExplorer: { featureType: 'awsExplorer', authType: 'iamIdentityCenter' },
     aggregateExplorer: { featureType: 'awsExplorer', authType: 'other' }, // this should never actually be used
+    unknown: { featureType: 'unknown', authType: 'other' }, // this should never actually be used
 }

--- a/packages/core/src/auth/utils.ts
+++ b/packages/core/src/auth/utils.ts
@@ -685,7 +685,9 @@ export class ExtensionUse {
 }
 
 /**
- *  Simple readable ID for telemetry reporting
+ * @deprecated
+ * Remove in favor of AuthFormId
+ * Simple readable ID for telemetry reporting
  */
 export type AuthSimpleId =
     | 'sharedCredentials'

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -49,7 +49,7 @@ import { isReleaseVersion } from './shared/vscode/env'
 import { telemetry } from './shared/telemetry/telemetry'
 import { Auth } from './auth/auth'
 import { registerSubmitFeedback } from './feedback/vue/submitFeedback'
-import { activateShared, deactivateShared } from './extensionShared'
+import { activateShared, deactivateShared, emitUserState } from './extensionShared'
 import { learnMoreAmazonQCommand, qExtensionPageCommand, dismissQTree } from './amazonq/explorer/amazonQChildrenNodes'
 import { AuthUtil, isPreviousQUser } from './codewhisperer/util/authUtil'
 import { installAmazonQExtension } from './codewhisperer/commands/basicCommands'
@@ -248,6 +248,8 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!isReleaseVersion()) {
             globals.telemetry.assertPassiveTelemetry(globals.didReload)
         }
+
+        await emitUserState()
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')
         // truncate if the stacktrace is unusually long

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -20,6 +20,17 @@ import { isExtensionInstalled, VSCODE_EXTENSION_ID } from '../utilities'
 import { randomUUID } from '../../common/crypto'
 import { activateExtension } from '../utilities/vsCodeUtils'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
+import {
+    Connection,
+    hasScopes,
+    isBuilderIdConnection,
+    isIamConnection,
+    isIdcSsoConnection,
+    isValidCodeCatalystConnection,
+    scopesSsoAccountAccess,
+} from '../../auth/connection'
+import { AuthFormId } from '../../auth/ui/vue/authForms/types'
+import { isValidAmazonQConnection } from '../../codewhisperer/util/authUtil'
 
 const legacySettingsTelemetryValueDisable = 'Disable'
 const legacySettingsTelemetryValueEnable = 'Enable'
@@ -257,3 +268,33 @@ export const ExtStartUpSources = {
 } as const
 
 export type ExtStartUpSource = (typeof ExtStartUpSources)[keyof typeof ExtStartUpSources]
+
+/**
+ * Returns readable auth Ids for a connection, which are used by telemetry.
+ */
+export function getAuthFormIdsFromConnection(conn: Connection): AuthFormId[] {
+    const authIds: AuthFormId[] = []
+    let connType: 'builderId' | 'identityCenter'
+
+    if (isIamConnection(conn)) {
+        return ['credentials']
+    } else if (isBuilderIdConnection(conn)) {
+        connType = 'builderId'
+    } else if (isIdcSsoConnection(conn)) {
+        connType = 'identityCenter'
+        if (hasScopes(conn, scopesSsoAccountAccess)) {
+            authIds.push('identityCenterExplorer')
+        }
+    } else {
+        return ['unknown']
+    }
+
+    if (isValidCodeCatalystConnection(conn)) {
+        authIds.push(`${connType}CodeCatalyst`)
+    }
+    if (isValidAmazonQConnection(conn)) {
+        authIds.push(`${connType}CodeWhisperer`)
+    }
+
+    return authIds
+}

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -319,6 +319,11 @@
             "description": "Comma-delimited list of features for which auth is enabled."
         },
         {
+            "name": "authEnabledConnections",
+            "type": "string",
+            "description": "Comma-delimited list of enabled auths."
+        },
+        {
             "name": "region",
             "type": "string",
             "description": "An AWS region."
@@ -1112,7 +1117,7 @@
                     "required": true
                 },
                 {
-                    "type": "enabledAuthConnections",
+                    "type": "authEnabledConnections",
                     "required": true
                 }
             ],


### PR DESCRIPTION
- also, to match the spec we rename metric field from 'enabledAuthConnections' to 'authEnabledConnections'

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
