### PR TITLE
fix(amazonq): get most occurring language from project

### DIFF
--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -131,6 +131,9 @@ export async function startSecurityScan(
         codeScanTelemetryEntry.codewhispererCodeScanBuildPayloadBytes = zipMetadata.buildPayloadSizeInBytes
         codeScanTelemetryEntry.codewhispererCodeScanSrcZipFileBytes = zipMetadata.zipFileSizeInBytes
         codeScanTelemetryEntry.codewhispererCodeScanLines = zipMetadata.lines
+        if (zipMetadata.language) {
+            codeScanTelemetryEntry.codewhispererLanguage = zipMetadata.language
+        }
 
         /**
          * Step 2: Get presigned Url, upload and clean up

--- a/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -181,6 +181,17 @@ export class RuntimeLanguageContext {
     }
 
     /**
+     *
+     * @param fileExtension File extension i.e. py, js, java
+     * @returns The corresponding {@link CodewhispererLanguage} of the file extension
+     */
+    public getLanguageFromFileExtension(fileExtension: string): CodewhispererLanguage | undefined {
+        return [...this.supportedLanguageExtensionMap.entries()].find(
+            ([, extension]) => extension === fileExtension
+        )?.[0]
+    }
+
+    /**
      * Mapping the field ProgrammingLanguage of codewhisperer generateRecommendationRequest | listRecommendationRequest to
      * its Codewhisperer runtime language e.g. jsx -> typescript, typescript -> typescript
      * @param request : cwspr generateRecommendationRequest | ListRecommendationRequest

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -12,6 +12,8 @@ import { ToolkitError } from '../../shared/errors'
 import { fsCommon } from '../../srcShared/fs'
 import { collectFiles } from '../../amazonqFeatureDev/util/files'
 import { getLoggerForScope } from '../service/securityScanHandler'
+import { runtimeLanguageContext } from './runtimeLanguageContext'
+import { CodewhispererLanguage } from '../../shared/telemetry/telemetry.gen'
 
 export interface ZipMetadata {
     rootDir: string
@@ -21,6 +23,7 @@ export interface ZipMetadata {
     buildPayloadSizeInBytes: number
     zipFileSizeInBytes: number
     lines: number
+    language: CodewhispererLanguage | undefined
 }
 
 export const ZipConstants = {
@@ -38,6 +41,7 @@ export class ZipUtil {
     protected _zipDir: string = ''
     protected _totalLines: number = 0
     protected _fetchedDirs: Set<string> = new Set<string>()
+    protected _language: CodewhispererLanguage | undefined
 
     constructor() {}
 
@@ -119,6 +123,7 @@ export class ZipUtil {
         }
 
         const files = await collectFiles([projectPath], [workspaceFolder])
+        const languageCount = new Map<CodewhispererLanguage, number>()
         for (const file of files) {
             const isFileOpenAndDirty = this.isFileOpenAndDirty(file.fileUri)
             const fileContent = isFileOpenAndDirty ? await this.getTextContent(file.fileUri) : file.fileContent
@@ -137,6 +142,13 @@ export class ZipUtil {
                 this._pickedSourceFiles.add(file.fileUri.fsPath)
                 this._totalSize += fileSize
                 this._totalLines += fileContent.split(ZipConstants.newlineRegex).length
+
+                const language = runtimeLanguageContext.getLanguageFromFileExtension(
+                    path.extname(file.fileUri.fsPath).slice(1)
+                )
+                if (language) {
+                    languageCount.set(language, (languageCount.get(language) || 0) + 1)
+                }
             }
 
             if (isFileOpenAndDirty) {
@@ -146,6 +158,10 @@ export class ZipUtil {
             }
         }
 
+        if (languageCount.size === 0) {
+            throw new ToolkitError('Project does not contain valid files to scan')
+        }
+        this._language = [...languageCount.entries()].reduce((a, b) => (b[1] > a[1] ? b : a))[0]
         const zipFilePath = this.getZipDirPath() + CodeWhispererConstants.codeScanZipExt
         zip.writeZip(zipFilePath)
         return zipFilePath
@@ -193,6 +209,7 @@ export class ZipUtil {
                 zipFileSizeInBytes: zipFileSize,
                 buildPayloadSizeInBytes: this._totalBuildSize,
                 lines: this._totalLines,
+                language: this._language,
             }
         } catch (error) {
             getLogger().error('Zip error caused by:', error)

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -284,7 +284,7 @@ describe('startSecurityScan', function () {
             CodeAnalysisScope.PROJECT
         )
         assertTelemetry('codewhisperer_securityScan', {
-            codewhispererLanguage: 'python',
+            codewhispererLanguage: 'yaml',
             codewhispererCodeScanTotalIssues: 1,
             codewhispererCodeScanIssuesWithFixes: 0,
         } as CodewhispererSecurityScan)


### PR DESCRIPTION
## Problem

Project scans fail server side validation if the active file is an unsupported codewhisperer language, even if there are other supported files in the project.

## Solution

Get the highest occurring language from file extension when preparing the zip file and use that as the language

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
