### PR TITLE
fix(amazonq): hide auto-scans for builder id

### DIFF
--- a/packages/core/src/codewhisperer/ui/statusBarMenu.ts
+++ b/packages/core/src/codewhisperer/ui/statusBarMenu.ts
@@ -71,7 +71,7 @@ function getAmazonQCodeWhispererNodes() {
 
         // Security scans
         createSeparator('Security Scans'),
-        createAutoScans(autoScansEnabled),
+        ...(AuthUtil.instance.isBuilderIdInUse() ? [] : [createAutoScans(autoScansEnabled)]),
         createSecurityScan(),
 
         // Amazon Q + others

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -41,6 +41,7 @@ import {
     createReconnect,
     createSecurityScan,
     createSelectCustomization,
+    createSeparator,
     createSettingsNode,
     createSignIn,
     createSignout,
@@ -387,6 +388,31 @@ describe('CodeWhisperer-basicCommands', function () {
                 e.dispose() // skip needing to select an item to continue
             })
 
+            await listCodeWhispererCommands.execute()
+        })
+
+        it('should not show auto-scans if using builder id', async function () {
+            sinon.stub(AuthUtil.instance, 'isConnected').returns(true)
+            sinon.stub(AuthUtil.instance, 'isBuilderIdInUse').returns(true)
+
+            getTestWindow().onDidShowQuickPick(async e => {
+                e.assertItems([
+                    createSeparator('Inline Suggestions'),
+                    createAutoSuggestions(false),
+                    createOpenReferenceLog(),
+                    createGettingStarted(),
+                    createSeparator('Security Scans'),
+                    createSecurityScan(),
+                    createSeparator('Other Features'),
+                    switchToAmazonQNode(),
+                    createSeparator('Connect / Help'),
+                    ...genericItems(),
+                    createSeparator(),
+                    createSettingsNode(),
+                    createSignout(),
+                ])
+                e.dispose() // skip needing to select an item to continue
+            })
             await listCodeWhispererCommands.execute()
         })
     })


### PR DESCRIPTION
## Problem

Auto-scans toggle needs to be hidden for BuilderID users (got removed while resolving merge conflicts).

## Solution

Don't show Auto-scans toggle in status bar menu if BuilderID is in use.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
