### PR TITLE
fix(amazonq): CodeCatalyst login text too small

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -154,7 +154,7 @@
                 <div class="header bottomMargin">Sign in with AWS IAM Identity Center:</div>
                 <div class="code-catalyst-login" v-if="app === 'TOOLKIT'">
                     <div style="margin-bottom: 4px"></div>
-                    <div class="h4">
+                    <div class="subHeader">
                         Using AWS Builder ID?
                         <a href="#" @click="handleCodeCatalystSignin()">Skip to sign-in</a>
                     </div>
@@ -565,7 +565,7 @@ export default defineComponent({
     color: black;
 }
 
-.h4 {
+.subHeader {
     font-size: 10px;
 }
 .continue-button {

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -566,7 +566,7 @@ export default defineComponent({
 }
 
 .h4 {
-    font-size: 8px;
+    font-size: 10px;
     margin-bottom: 8px;
 }
 .continue-button {

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -155,7 +155,7 @@
                 <div class="code-catalyst-login" v-if="app === 'TOOLKIT'">
                     <div style="margin-bottom: 4px"></div>
                     <div class="h4">
-                        Using CodeCatalyst with AWS Builder ID?
+                        Using AWS Builder ID?
                         <a href="#" @click="handleCodeCatalystSignin()">Skip to sign-in</a>
                     </div>
                 </div>

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -151,7 +151,7 @@
                 </svg>
             </button>
             <div class="auth-container-section">
-                <div class="header">Sign in with AWS IAM Identity Center:</div>
+                <div class="header bottomMargin">Sign in with AWS IAM Identity Center:</div>
                 <div class="code-catalyst-login" v-if="app === 'TOOLKIT'">
                     <div style="margin-bottom: 4px"></div>
                     <div class="h4">
@@ -567,7 +567,6 @@ export default defineComponent({
 
 .h4 {
     font-size: 10px;
-    margin-bottom: 8px;
 }
 .continue-button {
     background-color: var(--vscode-button-background);

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -105,7 +105,7 @@ export default defineComponent({
 }
 
 .hovering {
-    border: 1px solid #0e639c;
+    border: 2px solid #0e639c;
     user-select: none;
 }
 

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -105,7 +105,7 @@ export default defineComponent({
 }
 
 .hovering {
-    border: 2px solid #0e639c;
+    border: 1px solid #0e639c;
     user-select: none;
 }
 


### PR DESCRIPTION
## Problem



## Solution


Fix font size of CC login. Also make the gap between start url and CC login to 12px.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
