### PR TITLE
fix(amazonq): duplicate hover for project scans

### DIFF
--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -268,8 +268,8 @@ export function showSecurityScanResults(
             void vscode.commands.executeCommand('workbench.action.problems.focus')
         }
     }
-    populateCodeScanLogStream(zipMetadata.scannedFiles)
     if (scope === CodeWhispererConstants.CodeAnalysisScope.PROJECT) {
+        populateCodeScanLogStream(zipMetadata.scannedFiles)
         showScanCompletedNotification(totalIssues, zipMetadata.scannedFiles, false)
     }
 }

--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -36,19 +36,18 @@ export function initSecurityScanRender(
     }
     securityRecommendationList.forEach(securityRecommendation => {
         updateSecurityDiagnosticCollection(securityRecommendation)
+        updateSecurityIssueHoverAndCodeActions(securityRecommendation)
     })
     securityScanRender.initialized = true
-    updateSecurityIssueHoverAndCodeActions(securityRecommendationList, editor)
     securityScanRender.lastUpdated = codeScanStartTime
 }
 
-function updateSecurityIssueHoverAndCodeActions(
-    securityRecommendationList: AggregatedCodeScanIssue[],
-    editor: vscode.TextEditor
-) {
+function updateSecurityIssueHoverAndCodeActions(securityRecommendation: AggregatedCodeScanIssue) {
     const updatedSecurityRecommendationList = [
-        ...SecurityIssueHoverProvider.instance.issues.filter(group => group.filePath !== editor.document.uri.fsPath),
-        ...securityRecommendationList,
+        ...SecurityIssueHoverProvider.instance.issues.filter(
+            group => group.filePath !== securityRecommendation.filePath
+        ),
+        securityRecommendation,
     ]
     SecurityIssueHoverProvider.instance.issues = updatedSecurityRecommendationList
     SecurityIssueCodeActionProvider.instance.issues = updatedSecurityRecommendationList


### PR DESCRIPTION
## Problem

Duplicate hover and code actions are appearing for project scans because only the active file's issues are getting replaced.

## Solution

Update every security recommendation by file path instead of only the active file.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
