### PR TITLE
amazonq: string change "Pro license"

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -110,8 +110,8 @@
                     @toggle="toggleItemSelection"
                     :isSelected="selectedLoginOption === LoginOption.ENTERPRISE_SSO"
                     :itemId="LoginOption.ENTERPRISE_SSO"
-                    :itemText="'Sign in to AWS with single sign-on'"
-                    :itemTitle="'Use Professional License'"
+                    :itemText="''"
+                    :itemTitle="'Use with Pro license'"
                     class="selectable-item bottomMargin"
                 ></SelectableItem>
                 <SelectableItem

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -23,7 +23,7 @@
                 />
             </svg>
             <svg
-                v-if="itemTitle == 'Workforce' || itemTitle == 'Use Professional License'"
+                v-if="itemTitle == 'Workforce' || itemTitle == 'Use with Pro license'"
                 width="16"
                 height="16"
                 viewBox="0 0 16 16"
@@ -55,7 +55,7 @@
         </div>
         <div class="text">
             <div class="title">{{ itemTitle }}</div>
-            <div class="p">{{ itemText }}</div>
+            <div class="p" v-if="itemText">{{ itemText }}</div>
         </div>
     </div>
 </template>
@@ -96,12 +96,13 @@ export default defineComponent({
 
 <style scoped>
 .item-container-base {
-    padding: 5px;
     display: flex;
     border-width: 1px;
     border-style: solid;
     border-color: #625f5f;
     user-select: none;
+    /* Some items do not have itemText, so we need a consistent height for all items */
+    height: 50px;
 }
 
 .hovering {
@@ -121,6 +122,7 @@ export default defineComponent({
     display: flex;
     flex-direction: column;
     font-size: 12px;
+    justify-content: center;
 }
 
 .text.vscode-dark {


### PR DESCRIPTION
- Updated our strings for the Amazon Q Pro License
- Removed sub string message, per docs
- Updated CSS to handle SelectableItem with no itemText

## Before
<img width="489" alt="Screenshot 2024-04-28 at 5 22 32 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/118216176/dab8a5f6-b55b-4dfc-9e9e-6f017f8fc99f">


## After
<img width="469" alt="Screenshot 2024-04-28 at 5 15 57 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/118216176/f3f3559a-edcd-4fd0-9aac-9dd9d814d5e2">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
