### PR TITLE
fix(codecatalyst): menu command fails after using tree node

### DIFF
--- a/packages/core/src/codecatalyst/commands.ts
+++ b/packages/core/src/codecatalyst/commands.ts
@@ -12,7 +12,7 @@ import * as vscode from 'vscode'
 import { selectCodeCatalystRepository, selectCodeCatalystResource } from './wizards/selectResource'
 import { openCodeCatalystUrl } from './utils'
 import { CodeCatalystAuthenticationProvider } from './auth'
-import { Commands, placeholder } from '../shared/vscode/commands2'
+import { Commands, VsCodeCommandArg, placeholder } from '../shared/vscode/commands2'
 import { CodeCatalystClient, CodeCatalystResource, createClient } from '../shared/clients/codecatalystClient'
 import { DevEnvironmentId, getConnectedDevEnv, openDevEnv } from './model'
 import { showConfigureDevEnv } from './vue/configure/backend'
@@ -226,11 +226,11 @@ export class CodeCatalystCommands {
         return listCommands()
     }
 
-    public cloneRepository(...args: WithClient<typeof cloneCodeCatalystRepo>) {
+    public cloneRepo(_?: VsCodeCommandArg, ...args: WithClient<typeof cloneCodeCatalystRepo>) {
         return this.withClient(cloneCodeCatalystRepo, ...args)
     }
 
-    public createDevEnv(): Promise<void> {
+    public createDevEnv(_?: VsCodeCommandArg): Promise<void> {
         if (isRemoteWorkspace() && isInDevEnv()) {
             throw new RemoteContextError()
         }
@@ -276,6 +276,7 @@ export class CodeCatalystCommands {
     }
 
     public async openDevEnv(
+        _?: VsCodeCommandArg,
         id?: DevEnvironmentId,
         targetPath?: string,
         connection?: { startUrl: string; region: string }
@@ -337,7 +338,7 @@ export class CodeCatalystCommands {
         deleteDevEnv: Commands.from(this).declareDeleteDevEnv('aws.codecatalyst.deleteDevEnv'),
         openDevEnvSettings: Commands.from(this).declareOpenDevEnvSettings('aws.codecatalyst.openDevEnvSettings'),
         openDevfile: Commands.from(this).declareOpenDevfile('aws.codecatalyst.openDevfile'),
-        cloneRepo: Commands.from(this).declareCloneRepository({
+        cloneRepo: Commands.from(this).declareCloneRepo({
             id: 'aws.codecatalyst.cloneRepo',
             telemetryName: 'codecatalyst_localClone',
         }),

--- a/packages/core/src/codecatalyst/uriHandlers.ts
+++ b/packages/core/src/codecatalyst/uriHandlers.ts
@@ -27,7 +27,7 @@ export function register(
 ) {
     async function cloneHandler(params: ReturnType<typeof parseCloneParams>) {
         if (params.url.authority.endsWith(getCodeCatalystConfig().gitHostname)) {
-            await commands.cloneRepo.execute(params.url)
+            await commands.cloneRepo.execute(undefined, params.url)
         } else {
             await vscode.commands.executeCommand('git.clone', params.url.toString())
         }
@@ -35,6 +35,7 @@ export function register(
 
     async function connectHandler(params: ConnectParams) {
         await commands.openDevEnv.execute(
+            undefined,
             {
                 id: params.devEnvironmentId,
                 org: { name: params.spaceName },

--- a/packages/core/src/codecatalyst/vue/create/backend.ts
+++ b/packages/core/src/codecatalyst/vue/create/backend.ts
@@ -183,7 +183,7 @@ export class CodeCatalystCreateWebview extends VueWebview {
 
     public async submit(settings: DevEnvironmentSettings, source: SourceResponse) {
         const devenv = await this.createDevEnvOfType(settings, source)
-        void this.commands.openDevEnv.execute(devenv)
+        void this.commands.openDevEnv.execute(undefined, devenv)
     }
 
     public async createDevEnvOfType(settings: DevEnvironmentSettings, source: SourceResponse) {

--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -63,7 +63,7 @@ export async function activate(
         'debugConsole'
     )
 
-    getLogger().debug(`Logging started: ${logUri}`)
+    getLogger().debug(`Logging started: ${logUri ?? '(no file)'}`)
 
     Logging.init(logUri, mainLogger, contextPrefix)
     extensionContext.subscriptions.push(Logging.instance.viewLogs, Logging.instance.viewLogsAtMessage)

--- a/packages/core/src/test/codecatalyst/uriHandlers.test.ts
+++ b/packages/core/src/test/codecatalyst/uriHandlers.test.ts
@@ -100,7 +100,7 @@ describe('CodeCatalyst handlers', function () {
         it('returns builder ID SSO if IdC params are not present', async function () {
             await handler.handleUri(createConnectUri(params))
             assert.ok(
-                openDevEnvMock.calledWith(devenvId, undefined, {
+                openDevEnvMock.calledWith(sinon.match.any, devenvId, undefined, {
                     startUrl: builderIdStartUrl,
                     region: defaultSsoRegion,
                 })
@@ -111,7 +111,12 @@ describe('CodeCatalyst handlers', function () {
             const ssoStartUrl = 'https://my-url'
             const ssoRegion = 'us-west-2'
             await handler.handleUri(createConnectUri({ ...params, sso_start_url: ssoStartUrl, sso_region: ssoRegion }))
-            assert.ok(openDevEnvMock.calledWith(devenvId, undefined, { startUrl: ssoStartUrl, region: ssoRegion }))
+            assert.ok(
+                openDevEnvMock.calledWith(sinon.match.any, devenvId, undefined, {
+                    startUrl: ssoStartUrl,
+                    region: ssoRegion,
+                })
+            )
         })
 
         it('checks that the environment exists', async function () {


### PR DESCRIPTION
## Problem:
The codecatalyst commands:

    "Open Dev Environment"
    "Clone Repository"

fail if their menu forms are used AFTER the treenode forms.

### Steps to reproduce:
1. click the "Open Dev Environment" tree node in the codecatalyst panel.
2. close the wizard.
3. in the codecatalyst panel, expand the "..." root menu and choose "Open CodeCatalyst Dev Environment"
4. it fails because the TreeNode from step (1) is passed as the first arg, which breaks `openDevEnv()`.

## Solution:
Follow the instructions from the `VsCodeCommandArg` docstring: https://github.com/aws/aws-toolkit-vscode/blob/4decdf6341a38c58db0e9f778ba57b5514434b0b/packages/core/src/shared/vscode/commands2.ts#L23-L41

### TODO:
Note that the bug does NOT occur if you use the "..." menu command FIRST. It seems like the TreeNode is stored as state on the `CommandResource`; is that actually necessary?



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
