### PR TITLE
fix(amazonq): Use correct URL for Q telemetry settings

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -16,7 +16,7 @@
     "AWS.configuration.description.samcli.legacyDeploy": "Use the legacy SAM deploy experience, disabling all SAM sync functionality.",
     "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS. [Details](https://docs.aws.amazon.com/sdkref/latest/guide/support-maint-idetoolkits.html)",
     "AWS.configuration.description.telemetry.cn": "Enable Amazon Toolkit to send usage data to Amazon.",
-    "AWS.configuration.description.amazonq.telemetry": "Enable Amazon Q to send usage data to AWS. [Details](https://docs.aws.amazon.com/sdkref/latest/guide/support-maint-idetoolkits.html)",
+    "AWS.configuration.description.amazonq.telemetry": "Enable Amazon Q to send usage data to AWS. [Details](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/opt-out-IDE.html)",
     "AWS.configuration.description.suppressPrompts": "Prompts which ask for confirmation. Checking an item suppresses the prompt.",
     "AWS.configuration.enableCodeLenses": "Enable SAM hints in source code and template.yaml files",
     "AWS.configuration.description.resources.enabledResources": "AWS resources to display in the 'Resources' portion of the explorer.",


### PR DESCRIPTION
## Problem
Use correct URL for Q telemetry settings
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
