### PR TITLE
fix(amazonq): acquire Toolkit api on-demand

### DIFF
--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -41,7 +41,7 @@ import {
     signoutCodeWhisperer,
     fetchFeatureConfigsCmd,
     toggleCodeScans,
-    registerToolkitApiCallback,
+    registerToolkitApiCallbacksOnce,
 } from './commands/basicCommands'
 import { sleep } from '../shared/utilities/timeoutUtils'
 import { ReferenceLogViewProvider } from './service/referenceLogViewProvider'
@@ -122,8 +122,6 @@ export async function activate(context: ExtContext): Promise<void> {
     ImportAdderProvider.instance
 
     context.extensionContext.subscriptions.push(
-        // register toolkit api callback
-        registerToolkitApiCallback.register(),
         signoutCodeWhisperer.register(auth),
         /**
          * Configuration change
@@ -590,8 +588,8 @@ export async function activate(context: ExtContext): Promise<void> {
         )
     }
 
-    await Commands.tryExecute('aws.amazonq.refreshConnectionCallback')
     container.ready()
+    registerToolkitApiCallbacksOnce()
 }
 
 export async function shutdown() {

--- a/packages/toolkit/src/main.ts
+++ b/packages/toolkit/src/main.ts
@@ -6,13 +6,10 @@
 import type { ExtensionContext } from 'vscode'
 import { activate as activateCore, deactivate as deactivateCore } from 'aws-core-vscode'
 import { awsToolkitApi } from './api'
-import { Commands } from 'aws-core-vscode/shared'
 
 export async function activate(context: ExtensionContext) {
     await activateCore(context)
 
-    // after toolkit is activated, ask Amazon Q to register toolkit api callbacks
-    await Commands.tryExecute('aws.amazonq.refreshConnectionCallback', awsToolkitApi)
     return awsToolkitApi
 }
 


### PR DESCRIPTION
(This can wait until after release)

## Problem:
The logic to get the Toolkit API is spread around and involves:
- a "aws.amazonq.refreshConnectionCallback" command (silent failures, not strongly typed, etc)
- numerous attempts to "eagerly" activate Toolkit
- Toolkit's own startup passes the toolkit API as an object via the "aws.amazonq.refreshConnectionCallback" command
  - this might not work if the object doesn't serialize correctly, e.g. for web workers or when the vscode "extensions.experimental.affinity" behavior is enabled.

## Solution:
Instead of trying to eagerly activate Toolkit, just get the Toolkit API on-demand. This avoids complexity and is more reliable.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
