### PR TITLE
fix(amazonq): Disable Tsx.findNames and findNamesWithInExtent

### DIFF
--- a/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
+++ b/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Java, Python, TypeScript, Tsx } from '@aws/fully-qualified-names'
+import { Java, Python, TypeScript } from '@aws/fully-qualified-names'
 import { extractContextFromJavaImports } from './javaImportReader'
 
 export async function readImports(text: string, languageId: string): Promise<string[]> {

--- a/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
+++ b/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
@@ -15,8 +15,11 @@ export async function readImports(text: string, languageId: string): Promise<str
         case 'javascript':
         case 'javascriptreact':
         case 'typescriptreact':
-            names = await Tsx.findNames(text)
-            break
+            // Disable Tsx.findNames because promise Tsx.findNames
+            // may not resolve and can cause chat to hang
+            //names = await Tsx.findNames(text)
+            //break
+            return []
         case 'python':
             names = await Python.findNames(text)
             break

--- a/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
+++ b/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
@@ -5,7 +5,7 @@
 
 import { TextEditor, Selection, TextDocument, Range } from 'vscode'
 
-import { Extent, Java, Python, Tsx, TypeScript, Location } from '@aws/fully-qualified-names'
+import { Extent, Java, Python, TypeScript, Location } from '@aws/fully-qualified-names'
 import { FocusAreaContext, FullyQualifiedName } from './model'
 
 const focusAreaCharLimit = 9_000
@@ -235,7 +235,10 @@ export class FocusAreaContextExtractor {
             case 'javascript':
             case 'javascriptreact':
             case 'typescriptreact':
-                names = await Tsx.findNamesWithInExtent(fileText, extent)
+                // Disable Tsx.findNamesWithInExtent because promise Tsx.findNamesWithInExtent
+                // may not resolve and can cause chat to hang
+                //names = await Tsx.findNamesWithInExtent(fileText, extent)
+                names = undefined
                 break
             case 'python':
                 names = await Python.findNamesWithInExtent(fileText, extent)


### PR DESCRIPTION
## Problem

Q chat hangs if current open file is javascript because Tsx.findNames and Tsx.findNamesWithInExtent hangs. (Promise does not resolve)

## Solution

Disable Tsx.findNames and Tsx.findNamesWithInExtent. 

The fully qualified names library is used to help service build prompts with variable names in user's IDE to reduce hallucination. The chat function works fine without such additional prompt.  This PR does not remove this function for other programming languages.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
