### PR TITLE
fix(applicationcomposer): support out of workspace file watching

### DIFF
--- a/.changes/next-release/Bug Fix-de3f475e-93a7-4ba6-8b26-90b655e563ca.json
+++ b/.changes/next-release/Bug Fix-de3f475e-93a7-4ba6-8b26-90b655e563ca.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "support template file watching out of workspace"
+}

--- a/.changes/next-release/Bug Fix-de3f475e-93a7-4ba6-8b26-90b655e563ca.json
+++ b/.changes/next-release/Bug Fix-de3f475e-93a7-4ba6-8b26-90b655e563ca.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "support template file watching out of workspace"
+	"description": "support template file watching out of workspace for Application Composer"
 }

--- a/packages/core/src/applicationcomposer/messageHandlers/addFileWatchMessageHandler.ts
+++ b/packages/core/src/applicationcomposer/messageHandlers/addFileWatchMessageHandler.ts
@@ -22,7 +22,7 @@ export async function addFileWatchMessageHandler(request: AddFileWatchRequestMes
         }
         const filePath = context.defaultTemplatePath
         const fileName = context.defaultTemplateName
-        const fileWatch = vscode.workspace.createFileSystemWatcher(filePath)
+        const fileWatch = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(filePath, '*'))
         context.disposables.push(fileWatch)
 
         fileWatch.onDidChange(async () => {


### PR DESCRIPTION
fix(applicationcomposer): support out of workspace file watching

Problem:
- We found a bug: File watch is not working on template files which out side workspace

Solution:
- use a [complex glob pattern](https://code.visualstudio.com/api/references/vscode-api#RelativePattern) instead of a string as the parameter of [`createFileSystemWatcher` function](https://vscode-api.js.org/modules/vscode.workspace.html#createFileSystemWatcher)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
