### PR TITLE
fix(amazonq): file scan support for c, cpp, php

### DIFF
--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -261,6 +261,9 @@ export const securityScanLanguageIds = [
     'packer',
     'plaintext',
     'jsonc',
+    'c',
+    'cpp',
+    'php',
 ] as const
 
 export type SecurityScanLanguageId = (typeof securityScanLanguageIds)[number]

--- a/packages/core/src/codewhisperer/util/securityScanLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/securityScanLanguageContext.ts
@@ -31,6 +31,9 @@ export class SecurityScanLanguageContext {
             terragrunt: 'tf',
             packer: 'tf',
             plaintext: 'plaintext',
+            c: 'c',
+            cpp: 'cpp',
+            php: 'php',
         })
     }
 


### PR DESCRIPTION
## Problem

Code scans support new languages

## Solution

Add c, cpp, php to support languages list

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
