### PR TITLE
fix(build): vscode warning "Couldn't find message"

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -416,8 +416,7 @@
                 "category": "%AWS.amazonq.title%",
                 "cloud9": {
                     "cn": {
-                        "title": "%AWS.command.login.cn%",
-                        "category": "%AWS.amazonq.title.cn%"
+                        "title": "%AWS.command.login.cn%"
                     }
                 },
                 "enablement": "false"
@@ -426,33 +425,18 @@
                 "command": "aws.amazonq.credentials.profile.create",
                 "title": "%AWS.command.credentials.profile.create%",
                 "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                },
                 "enablement": "false"
             },
             {
                 "command": "aws.amazonq.credentials.edit",
                 "title": "%AWS.command.credentials.edit%",
                 "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                },
                 "enablement": "false"
             },
             {
                 "command": "aws.amazonq.logout",
                 "title": "%AWS.command.logout%",
                 "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                },
                 "enablement": "false"
             },
             {
@@ -518,24 +502,14 @@
             {
                 "command": "aws.amazonq.createIssueOnGitHub",
                 "title": "%AWS.command.createIssueOnGitHub%",
-                "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                }
+                "category": "%AWS.amazonq.title%"
             },
             {
                 "command": "aws.amazonq.submitFeedback",
                 "title": "%AWS.command.submitFeedback%",
                 "enablement": "!aws.isWebExtHost",
                 "category": "%AWS.amazonq.title%",
-                "icon": "$(comment)",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                }
+                "icon": "$(comment)"
             },
             {
                 "command": "aws.amazonq.viewLogs",
@@ -545,12 +519,7 @@
             {
                 "command": "aws.amazonq.github",
                 "title": "%AWS.command.github%",
-                "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                }
+                "category": "%AWS.amazonq.title%"
             },
             {
                 "command": "aws.amazonq.aboutExtension",
@@ -566,12 +535,7 @@
                 "command": "aws.amazonq.configure",
                 "title": "%AWS.command.codewhisperer.configure%",
                 "category": "%AWS.amazonq.title%",
-                "icon": "$(gear)",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                }
+                "icon": "$(gear)"
             },
             {
                 "command": "aws.amazonq.introduction",

--- a/packages/core/src/shared/localizedText.ts
+++ b/packages/core/src/shared/localizedText.ts
@@ -35,7 +35,7 @@ export function connectionExpired(name: string) {
 export const checklogs = () =>
     localize(
         'AWS.error.check.logs',
-        'Check the logs by running the "View {0} Toolkit Logs" command from the {1}.',
+        'Check the logs by running the "{0}: View Logs" command from the {1}.',
         getIdeProperties().company,
         getIdeProperties().commandPalette
     )


### PR DESCRIPTION
## Problem:
vscode logs (Output > Shared) show a warning (many times):

    2024-04-29 15:17:47.034 [warning] [amazon-q-vscode]: Couldn't find message for key AWS.amazonq.title.cn.

## Solution:
Remove references to `AWS.amazonq.title.cn`. Because "Amazon Q" has the same name in China, don't need a `.cn` variant of the "Amazon Q" title.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
