### PR TITLE
fix(release): correct tag for 'gh release create' command

### DIFF
--- a/buildspec/release/10changeversion.yml
+++ b/buildspec/release/10changeversion.yml
@@ -33,7 +33,7 @@ phases:
                 git add package-lock.json
                 git commit -m "Release $VERSION"
                 echo "tagging commit"
-                # e.g. amazonq/v1.0.0
+                # e.g. amazonq/v1.0.0. Ensure this tag is up to date with 50githubrelease.yml
                 git tag -a "${TARGET_EXTENSION}/v${VERSION}" -m "${TARGET_EXTENSION} version $VERSION $DATE"
                 # cleanup
                 git clean -fxd

--- a/buildspec/release/50githubrelease.yml
+++ b/buildspec/release/50githubrelease.yml
@@ -38,7 +38,8 @@ phases:
             - RELEASE_MESSAGE="${PKG_DISPLAY_NAME} for VS Code $VERSION"
             - |
                 if [ "$STAGE" = "prod" ]; then
-                  gh release create --repo $REPO --title "$PKG_DISPLAY_NAME $VERSION" --notes "$RELEASE_MESSAGE" -- "v$VERSION" "$UPLOAD_TARGET" "$HASH_UPLOAD_TARGET"
+                  # note: the tag arg passed here should match what is in 10changeversion.yml
+                  gh release create --repo $REPO --title "$PKG_DISPLAY_NAME $VERSION" --notes "$RELEASE_MESSAGE" -- "${TARGET_EXTENSION}/v${VERSION}" "$UPLOAD_TARGET" "$HASH_UPLOAD_TARGET"
                 else
                   echo "SKIPPED: 'gh release create --repo $REPO'"
                 fi


### PR DESCRIPTION
Problem: The tag name passed to this function doesn't match the tag that we created earlier. So, it will attempt to create a new tag. Since Amazon Q is starting at 1.0.0, this will conflict with existing toolkit releases

Solution: Add extension to tag, e.g. amazonq/v1.0.0 instead of just v.1.0.0

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
