### PR TITLE
fix(amazonq): Markdown parsing inside list items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,9 +3607,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.6.4",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.6.4.tgz",
-            "integrity": "sha512-gHwCAWZmP5ssL0TN+7Qo7suC3BbTqeKSEver/mHPimI9yTEI0EIBTuA8sirZcdCEe4BZWfGuOYlBcrQWpLgtYg==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.7.0.tgz",
+            "integrity": "sha512-Tr30CRijaJEfcLj5e8v+BymaqZrY9/4COaTgWZhx9H6OslEgs5oumH7jfDTz+ZStMz1NyWL7Te2Z0NozFAYZDQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",
@@ -19604,7 +19604,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.6.4",
+                "@aws/mynah-ui": "^4.7.0",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/shared-ini-file-loader": "^2.2.8",

--- a/packages/amazonq/.changes/next-release/Bug Fix-1d12cfc3-e729-419d-a15b-deb1326459df.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-1d12cfc3-e729-419d-a15b-deb1326459df.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Fixed markdown is not getting parsed inside list items."
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4031,7 +4031,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.6.4",
+        "@aws/mynah-ui": "^4.7.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/shared-ini-file-loader": "^2.2.8",


### PR DESCRIPTION
## Problem
Incoming markdown is strings are not getting parsed properly for the list items. 
<img width="498" alt="Screenshot 2024-04-30 at 08 02 09" src="https://github.com/aws/aws-toolkit-vscode/assets/116281103/ed28f252-b570-4586-b004-bbaa2fe2967a">

## Solution
Implemented a solution through [mynah-ui version 4..7.0](https://github.com/aws/mynah-ui/releases/tag/v4.7.0) which parses the list items again with `marked.parse`.
<img width="604" alt="Screenshot 2024-04-30 at 08 14 32" src="https://github.com/aws/aws-toolkit-vscode/assets/116281103/af42c05a-88ef-46f8-8700-78519e44704c">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
