### PR TITLE
fix(featureDev): Prevent crash on large repos or unsupported encoding during file collection

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-f5decdc1-1202-45f7-891c-b89643214089.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-f5decdc1-1202-45f7-891c-b89643214089.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fixed a crash when trying to use Q /dev on large projects or projects containing files with unsupported encoding."
+}

--- a/packages/core/src/amazonqFeatureDev/constants.ts
+++ b/packages/core/src/amazonqFeatureDev/constants.ts
@@ -14,6 +14,9 @@ export const featureDevChat = 'featureDevChat'
 
 export const featureName = 'Amazon Q feature development'
 
+// Max allowed size for file collection
+export const maxRepoSizeBytes = 200 * 1024 * 1024
+
 // License text that's used in codewhisperer reference log
 export const referenceLogText = (reference: CodeReference) =>
     `[${new Date().toLocaleString()}] Accepted recommendation from Amazon Q. Code provided with reference under <a href="${LicenseUtil.getLicenseHtml(


### PR DESCRIPTION
## Problem
There are currently 2 problems in featureDev when doing collection of repository files:
- Trying to decode binary files might crash the extension host, and 
- too large repos might make the extension run out of available memory.

## Solution
This CR fixes both problems by:
- Adding a maximum allowed repo size of 200mb for collection
- Changing the behavior of the TextDecoder to replace the unsupported characters instead of throwing TypeError

Users who try to use featureDev on a codebase larger than 200mb will see a message asking for a different workspace to be selected.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
