### PR TITLE
fix: installation error when installing amazon q in remote AND you have the extension locally

### DIFF
--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -323,7 +323,6 @@ export const installAmazonQExtension = Commands.declare(
                     return SystemUtilities.tryRun(vscPath, ['--install-extension', VSCODE_EXTENSION_ID.amazonq])
                 }
             )
-            await AuthUtil.instance.setVscodeContextProps()
             return
         }
         await vscode.commands.executeCommand('workbench.extensions.installExtension', VSCODE_EXTENSION_ID.amazonq)

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -39,6 +39,8 @@ import { removeDiagnostic } from '../service/diagnosticsProvider'
 import { SecurityIssueHoverProvider } from '../service/securityIssueHoverProvider'
 import { SecurityIssueCodeActionProvider } from '../service/securityIssueCodeActionProvider'
 import { SsoAccessTokenProvider } from '../../auth/sso/ssoAccessTokenProvider'
+import { SystemUtilities } from '../../shared/systemUtilities'
+import { ToolkitError } from '../../shared/errors'
 
 export const toggleCodeSuggestions = Commands.declare(
     { id: 'aws.amazonq.toggleCodeSuggestion', compositeKey: { 1: 'source' } },
@@ -299,7 +301,33 @@ export const fetchFeatureConfigsCmd = Commands.declare(
 export const installAmazonQExtension = Commands.declare(
     { id: 'aws.toolkit.installAmazonQExtension', logging: true },
     () => async () => {
+        if (vscode.env.remoteName === 'ssh-remote') {
+            /**
+             * due to a bug in https://github.com/microsoft/vscode/pull/206381/files#diff-efa08c29460835c0ffa740d751c34078033fd6cb6c7b031500fb31f524655de2R360
+             * installExtension will fail on remote environments when the amazon q extension is already installed locally.
+             * Until thats fixed we need to manually install the amazon q extension using the cli
+             */
+            const vscPath = await SystemUtilities.getVscodeCliPath()
+            if (!vscPath) {
+                throw new ToolkitError('installAmazonQ: Unable to find VSCode CLI path', {
+                    code: 'CodeCLINotFound',
+                })
+            }
+            await vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    cancellable: false,
+                },
+                (progress, token) => {
+                    progress.report({ message: 'Installing Amazon Q' })
+                    return SystemUtilities.tryRun(vscPath, ['--install-extension', VSCODE_EXTENSION_ID.amazonq])
+                }
+            )
+            await AuthUtil.instance.setVscodeContextProps()
+            return
+        }
         await vscode.commands.executeCommand('workbench.extensions.installExtension', VSCODE_EXTENSION_ID.amazonq)
+
         // jump to Amazon Q extension view after install.
         // this command won't work without a small delay after install
         setTimeout(() => {

--- a/packages/toolkit/.changes/next-release/Bug Fix-8d3c99b7-280e-41af-8f32-b52495610be0.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-8d3c99b7-280e-41af-8f32-b52495610be0.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Installation error when installing amazon q in remote AND you have the extension locally"
+}


### PR DESCRIPTION
## Problem
- due to a bug in https://github.com/microsoft/vscode/pull/206381/files#diff-efa08c29460835c0ffa740d751c34078033fd6cb6c7b031500fb31f524655de2R360 installExtension will fail on remote environments when the amazon q extension is already installed locally

## Solution
- install the amazon q extension using the vscode cli

## Alternatives considered
- Installing directly from github releases if they're on a remote environment. Its unclear though if the user will always be able to reach github (vs marketplace which is required to install extensions anyways)

## Drawbacks
- If the user doesn't have the vscode cli (though I think it autoinstalls in remotes?) then this won't work

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
