### PR TITLE
settings: remove global state check for amazonq migration

### DIFF
--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -364,7 +364,6 @@ export const validStatesForCheckingDownloadUrl = [
     'REJECTED',
 ]
 
-export const codewhispererSettingsImportedKey = 'aws.amazonq.codewhispererSettingsImported'
 export const amazonQDismissedKey = 'aws.toolkit.amazonq.dismissed'
 export const amazonQInstallDismissedKey = 'aws.toolkit.amazonqInstall.dismissed'
 

--- a/packages/core/src/codewhisperer/util/codewhispererSettings.ts
+++ b/packages/core/src/codewhisperer/util/codewhispererSettings.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { fromExtensionManifest, migrateSetting } from '../../shared/settings'
-import globals from '../../shared/extensionGlobals'
-import { codewhispererSettingsImportedKey } from '../models/constants'
 
 const description = {
     showInlineCodeSuggestionsWithCodeReferences: Boolean, // eslint-disable-line id-length
@@ -13,11 +11,8 @@ const description = {
 }
 
 export class CodeWhispererSettings extends fromExtensionManifest('amazonQ', description) {
+    // TODO: Remove after a few releases
     public async importSettings() {
-        if (globals.context.globalState.get<boolean>(codewhispererSettingsImportedKey)) {
-            return
-        }
-
         await migrateSetting(
             { key: 'aws.codeWhisperer.includeSuggestionsWithCodeReferences', type: Boolean },
             { key: 'amazonQ.showInlineCodeSuggestionsWithCodeReferences' }
@@ -30,8 +25,6 @@ export class CodeWhispererSettings extends fromExtensionManifest('amazonQ', desc
             { key: 'aws.codeWhisperer.shareCodeWhispererContentWithAWS', type: Boolean },
             { key: 'amazonQ.shareContentWithAWS' }
         )
-
-        await globals.context.globalState.update(codewhispererSettingsImportedKey, true)
     }
 
     public isSuggestionsWithCodeReferencesEnabled(): boolean {

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -874,8 +874,16 @@ export async function migrateSetting<T, U = T>(
         const logPrefix = `Settings migration ("${from.key}" -> "${to.key}"), (scope: ${valueProp})`
 
         const oldSettingProps = config.inspect(from.key)
-        if (hasLatest || !oldSettingProps || oldSettingProps[valueProp] === undefined) {
-            getLogger().debug(`${logPrefix}: skipping, no migration needed`)
+        if (hasLatest) {
+            getLogger().debug(`skipping: ${logPrefix}, the latest setting is already defined for this scope.`)
+            return
+        }
+        if (!oldSettingProps) {
+            getLogger().debug(`skipping: ${logPrefix}, the old setting does not exist.`)
+            return
+        }
+        if (oldSettingProps[valueProp] === undefined) {
+            getLogger().debug(`skipping: ${logPrefix}, the old setting is not defined for this scope.`)
             return
         }
 

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -62,7 +62,8 @@ export class TelemetryConfig {
         if (globals.context.globalState.get<boolean>(this.amazonQSettingMigratedKey)) {
             return
         }
-        // aws.telemetry isn't deprecated, we are just initializing amazonQ.telemetry with its value
+        // aws.telemetry isn't deprecated, we are just initializing amazonQ.telemetry with its value.
+        // This is also why we need to check that we only try this migration once.
         await migrateSetting({ key: 'aws.telemetry', type: Boolean }, { key: 'amazonQ.telemetry' })
         await globals.context.globalState.update(this.amazonQSettingMigratedKey, true)
     }


### PR DESCRIPTION
- Improve setting migration logging.
- Remove global state check for migrating codewhisperer settings. With the current state of the setting migration code, this shouldn't be needed. The old values will never overwrite what is already defined.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
