### PR TITLE
fix(amazonq): Copy to clipboard doesn't work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,9 +3607,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.7.0.tgz",
-            "integrity": "sha512-Tr30CRijaJEfcLj5e8v+BymaqZrY9/4COaTgWZhx9H6OslEgs5oumH7jfDTz+ZStMz1NyWL7Te2Z0NozFAYZDQ==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.7.1.tgz",
+            "integrity": "sha512-IfsXvq1VOdINCyNHgcyf9MdoikIIONCGAOwoysIk++7NbNHFcpMIWPtSEVdvv6Z/vZRF2Op2ZjhTNVWa/PiMuA==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",
@@ -19604,7 +19604,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.7.0",
+                "@aws/mynah-ui": "^4.7.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/shared-ini-file-loader": "^2.2.8",

--- a/packages/amazonq/.changes/next-release/Bug Fix-700e4ec0-f012-405a-9073-b0a0478bd154.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-700e4ec0-f012-405a-9073-b0a0478bd154.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Copy to clipboard on code blocks doesn't work"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4031,7 +4031,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.7.0",
+        "@aws/mynah-ui": "^4.7.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/shared-ini-file-loader": "^2.2.8",


### PR DESCRIPTION
## Problem
Copy to clipboard on code blocks in q chat doesn't work
## Solution
Fixed with [mynah-ui v4.7.1](https://github.com/aws/mynah-ui/releases/tag/v4.7.1)
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
