### PR TITLE
fix(settings): only migrate telemetry setting if we are in amazon q

### DIFF
--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -59,7 +59,7 @@ export class TelemetryConfig {
     }
 
     public async initAmazonQSetting() {
-        if (globals.context.globalState.get<boolean>(this.amazonQSettingMigratedKey)) {
+        if (!isAmazonQ() || globals.context.globalState.get<boolean>(this.amazonQSettingMigratedKey)) {
             return
         }
         // aws.telemetry isn't deprecated, we are just initializing amazonQ.telemetry with its value.


### PR DESCRIPTION
We attempt to migrate in both extensions, even though we should only do so in the amazon q setting. The toolkit attempt fails, but it still pollutes the state with the stored keys.
This isn't expected to have an effect because the states of the 2 exts are presumed to be separate, but maybe there is a subtle bug revolving around stating here.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
