### PR TITLE
lint: add no-await-on-vscode-msg custom rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -149,7 +149,10 @@ module.exports = {
             },
             { lineEndings: 'unix' },
         ],
+
         'aws-toolkits/no-only-in-tests': 'error',
+        'aws-toolkits/no-await-on-vscode-msg': 'error',
+
         // The following will place an error on the `fs-extra` import since we do not want it to be used for browser compatibility reasons.
         // "no-restricted-imports": [
         //     "error",

--- a/packages/core/src/auth/deprecated/loginManager.ts
+++ b/packages/core/src/auth/deprecated/loginManager.ts
@@ -181,7 +181,7 @@ export async function loginWithMostRecentCredentials(
             }
             getLogger().info('autoconnect: connected: %O', asString(creds))
             if (popup) {
-                await vscode.window.showInformationMessage(
+                void vscode.window.showInformationMessage(
                     localize(
                         'AWS.message.credentials.connected',
                         'Connected to {0} with {1}',

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -427,7 +427,7 @@ export class ProposedTransformationExplorer {
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.acceptChanges', async () => {
             diffModel.saveChanges()
             telemetry.ui_click.emit({ elementId: 'transformationHub_acceptChanges' })
-            await vscode.window.showInformationMessage(CodeWhispererConstants.changesAppliedNotification)
+            void vscode.window.showInformationMessage(CodeWhispererConstants.changesAppliedNotification)
             transformByQState.getChatControllers()?.transformationFinished.fire({
                 message: CodeWhispererConstants.changesAppliedChatMessage,
                 tabID: ChatSessionManager.Instance.getSession().tabID,

--- a/packages/core/src/eventSchemas/vue/searchSchemas.ts
+++ b/packages/core/src/eventSchemas/vue/searchSchemas.ts
@@ -113,7 +113,7 @@ export async function createSearchSchemasWebView(context: ExtContext, node: Regi
         const client = new DefaultSchemaClient(node.regionCode)
         const registryNames = await getRegistryNames(node, client)
         if (registryNames.length === 0) {
-            await vscode.window.showInformationMessage(
+            void vscode.window.showInformationMessage(
                 localize('AWS.schemas.search.no_registries', 'No Schema Registries')
             )
 

--- a/packages/core/src/shared/awsContextCommands.ts
+++ b/packages/core/src/shared/awsContextCommands.ts
@@ -135,7 +135,7 @@ export class AwsContextCommands {
             credentialTypeId: resp.name,
         }
 
-        await vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize(
                 'AWS.message.prompt.credentials.definition.done',
                 'Created {0} credentials profile: {1}',

--- a/packages/core/src/shared/cloudformation/activation.ts
+++ b/packages/core/src/shared/cloudformation/activation.ts
@@ -29,7 +29,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         extensionContext.subscriptions.push(registry)
         setTemplateRegistryInGlobals(registry)
     } catch (e) {
-        await vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize(
                 'AWS.codelens.failToInitialize',
                 'Failed to activate template registry. {0}} will not appear on SAM template files.',

--- a/packages/core/src/shared/extensionStartup.ts
+++ b/packages/core/src/shared/extensionStartup.ts
@@ -24,7 +24,7 @@ export async function showQuickStartWebview(context: vscode.ExtensionContext): P
         const view = await createQuickStartWebview(context)
         view.reveal()
     } catch {
-        await vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize('AWS.command.quickStart.error', 'Error while loading Quick Start page')
         )
     }

--- a/packages/core/src/shared/extensions/ssh.ts
+++ b/packages/core/src/shared/extensions/ssh.ts
@@ -64,7 +64,7 @@ exit !$?
             })
 
             if (!result.stdout.includes(runningMessage) && !result.stderr) {
-                await vscode.window.showInformationMessage(
+                void vscode.window.showInformationMessage(
                     localize('AWS.ssh.ssh-agent.start', 'The SSH agent has been started.')
                 )
             }

--- a/packages/core/src/shared/sam/activation.ts
+++ b/packages/core/src/shared/sam/activation.ts
@@ -180,7 +180,7 @@ async function activateCodeLensRegistry(context: ExtContext) {
         ])
         await registry.rebuild()
     } catch (e) {
-        await vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize(
                 'AWS.codelens.failToInitializeCode',
                 'Failed to activate Lambda handler {0}',
@@ -199,7 +199,7 @@ async function samDebugConfigCmd() {
     const activeEditor = vscode.window.activeTextEditor
     if (!activeEditor) {
         getLogger().error(`aws.addSamDebugConfig was called without an active text editor`)
-        await vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize('AWS.pickDebugHandler.noEditor', 'Toolkit could not find an active editor')
         )
 
@@ -209,7 +209,7 @@ async function samDebugConfigCmd() {
     const provider = supportedLanguages[document.languageId]
     if (!provider) {
         getLogger().error(`aws.addSamDebugConfig called on a document with an invalid language: ${document.languageId}`)
-        await vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize(
                 'AWS.pickDebugHandler.invalidLanguage',
                 'Toolkit cannot detect handlers in language: {0}',

--- a/packages/core/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/packages/core/src/shared/sam/debugger/csharpSamDebug.ts
@@ -80,7 +80,7 @@ export async function invokeCsharpLambda(ctx: ExtContext, config: SamLaunchReque
 
     if (!config.noDebug) {
         if (config.architecture === 'arm64') {
-            await vscode.window.showWarningMessage(
+            void vscode.window.showWarningMessage(
                 localize(
                     'AWS.sam.noArm.dotnet.debug',
                     'The vsdbg debugger does not currently support the arm64 architecture. Function will run locally without debug.'

--- a/plugins/eslint-plugin-aws-toolkits/index.ts
+++ b/plugins/eslint-plugin-aws-toolkits/index.ts
@@ -4,9 +4,11 @@
  */
 
 import NoOnlyInTests from './lib/rules/no-only-in-tests'
+import NoAwaitOnVscodeMsg from './lib/rules/no-await-on-vscode-msg'
 
 const rules = {
     'no-only-in-tests': NoOnlyInTests,
+    'no-await-on-vscode-msg': NoAwaitOnVscodeMsg,
 }
 
 export { rules }

--- a/plugins/eslint-plugin-aws-toolkits/lib/rules/no-await-on-vscode-msg.ts
+++ b/plugins/eslint-plugin-aws-toolkits/lib/rules/no-await-on-vscode-msg.ts
@@ -1,0 +1,89 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Showing vscode notifications is an async process. If we await on a notification, then we are
+ * telling VSCode that we need a response from the user to continue the codepath. Not all
+ * notifications require user input, so a user may ignore one indefinitely, blocking the codepath.
+ * Awaiting without assigning or otherwise using the response could keep code blocked and cause subtle issues.
+ */
+
+import { ESLintUtils } from '@typescript-eslint/utils'
+import { AST_NODE_TYPES } from '@typescript-eslint/types'
+import { Node, Identifier } from '@typescript-eslint/types/dist/generated/ast-spec'
+import { Rule } from 'eslint'
+
+export const errMsg =
+    'cannot await on vscode window messages unless the response is assigned; use `void`, assign to a response variable, or add a .then callback'
+
+const notificationFuncNames = ['showInformationMessage', 'showWarningMessage', 'showErrorMessage']
+
+function isVariableAssignment(node: Node) {
+    while (node.parent) {
+        if (node.parent.type === AST_NODE_TYPES.VariableDeclarator) {
+            return true // we are assigning the response, i.e. its being used.
+        } else if (node.parent.type === AST_NODE_TYPES.ConditionalExpression) {
+            node = node.parent
+        } else {
+            return false
+        }
+    }
+    return false
+}
+
+export default ESLintUtils.RuleCreator.withoutDocs({
+    meta: {
+        docs: {
+            description: 'disallow awaiting on vscode notifications if the response is unused',
+            recommended: 'error',
+        },
+        messages: {
+            errMsg,
+        },
+        type: 'problem',
+        fixable: 'code',
+        schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+        return {
+            AwaitExpression(node) {
+                if (isVariableAssignment(node)) {
+                    // we are assigning the response, i.e. its being used.
+                    return
+                }
+
+                if (node.parent?.type === AST_NODE_TYPES.IfStatement) {
+                    return // we are in an if statement, so we are probably expecting a response
+                }
+
+                if (node.argument.type !== AST_NODE_TYPES.CallExpression) {
+                    return
+                }
+
+                const expr = node.argument.callee
+                let property
+                if (expr.type === AST_NODE_TYPES.MemberExpression) {
+                    property = expr.property as Identifier
+                } else if (expr.type === AST_NODE_TYPES.Identifier) {
+                    property = expr as Identifier
+                } else {
+                    return
+                }
+
+                if (property.name === 'then') {
+                    return // we are using the response in a callback, but waiting on it.
+                }
+
+                if (notificationFuncNames.includes(property.name)) {
+                    return context.report({
+                        node,
+                        messageId: 'errMsg',
+                    })
+                }
+            },
+        }
+    },
+}) as unknown as Rule.RuleModule

--- a/plugins/eslint-plugin-aws-toolkits/lib/rules/no-only-in-tests.ts
+++ b/plugins/eslint-plugin-aws-toolkits/lib/rules/no-only-in-tests.ts
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * .only() can be important during testing to test a specific feature/unit test.
+ * This rule prevents us from accidentially committing this to the public repo.
+ */
+
 import { ESLintUtils } from '@typescript-eslint/utils'
 import { AST_NODE_TYPES } from '@typescript-eslint/types'
 import { CallExpression, Identifier, MemberExpression } from '@typescript-eslint/types/dist/generated/ast-spec'

--- a/plugins/eslint-plugin-aws-toolkits/test/rules/no-await-on-vscode-msg.test.ts
+++ b/plugins/eslint-plugin-aws-toolkits/test/rules/no-await-on-vscode-msg.test.ts
@@ -1,0 +1,79 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { rules } from '../../index'
+import { errMsg } from '../../lib/rules/no-await-on-vscode-msg'
+import { getRuleTester } from '../testUtil'
+
+getRuleTester().run('no-await-on-vscode-msg', rules['no-await-on-vscode-msg'], {
+    valid: [
+        "vscode.window.showInformationMessage('Hey there!')",
+        "vscode.window.showWarningMessage('Hey there!')",
+        "vscode.window.showErrorMessage('Hey there!')",
+
+        "void vscode.window.showInformationMessage('Hey there!')",
+        "void vscode.window.showWarningMessage('Hey there!')",
+        "void vscode.window.showErrorMessage('Hey there!')",
+
+        "async function test() { const response = await vscode.window.showInformationMessage('Hey there!') }",
+        "async function test() { const response = await vscode.window.showWarningMessage('Hey there!') }",
+        "async function test() { const response = await vscode.window.showErrorMessage('Hey there!') }",
+
+        "showInformationMessage('Hey there!')",
+        "showWarningMessage('Hey there!')",
+        "showErrorMessage('Hey there!')",
+
+        "vscode.window.showInformationMessage('Hey there!').then(r => console.log(r))",
+        "vscode.window.showWarningMessage('Hey there!').then(r => console.log(r))",
+        "vscode.window.showErrorMessage('Hey there!').then(r => console.log(r))",
+
+        "async function test() { await vscode.window.showInformationMessage('Hey there!').then(r => console.log(r)) }",
+        "async function test() { await vscode.window.showWarningMessage('Hey there!').then(r => console.log(r)) }",
+        "async function test() { await vscode.window.showErrorMessage('Hey there!').then(r => console.log(r)) }",
+
+        "async function test() { const resp = isSomething() ? doSomething() : await vscode.window.showInformationMessage('Hey there!')}",
+        "async function test() { const resp = isSomething() ? doSomething() : isOtherThing() ? doOtherThing() : await vscode.window.showInformationMessage('Hey there!')}",
+
+        "async function test() { if(await vscode.window.showInformationMessage('Hey there!')) { console.log('ok') } }",
+    ],
+
+    invalid: [
+        {
+            code: "async function test() { await vscode.window.showInformationMessage('Hey there!') }",
+            errors: [errMsg],
+        },
+        {
+            code: "async function test() { await vscode.window.showWarningMessage('Hey there!') }",
+            errors: [errMsg],
+        },
+        {
+            code: "async function test() { await vscode.window.showErrorMessage('Hey there!') }",
+            errors: [errMsg],
+        },
+
+        {
+            code: "async function test() { isSomething() ? doSomething() : await vscode.window.showInformationMessage('Hey there!')}",
+            errors: [errMsg],
+        },
+        {
+            code: "async function test() { isSomething() ? doSomething() : isOtherThing() ? doOtherThing() : await vscode.window.showInformationMessage('Hey there!')}",
+            errors: [errMsg],
+        },
+
+        // Devs shouldn't use these as function names; we assume them to be referring to vscode.window...
+        {
+            code: "async function test() { await showInformationMessage('Hey there!') }",
+            errors: [errMsg],
+        },
+        {
+            code: "async function test() { await showWarningMessage('Hey there!') }",
+            errors: [errMsg],
+        },
+        {
+            code: "async function test() { await showErrorMessage('Hey there!') }",
+            errors: [errMsg],
+        },
+    ],
+})

--- a/plugins/eslint-plugin-aws-toolkits/test/testUtil.ts
+++ b/plugins/eslint-plugin-aws-toolkits/test/testUtil.ts
@@ -8,7 +8,7 @@ import { RuleTester } from 'eslint'
 export function getRuleTester() {
     return new RuleTester({
         // TODO: For tests that need to access TS types, we will need to pass a parser:
-        // parser: "@typescript-eslint/parser",
+        // parser: require.resolve('@typescript-eslint/parser'),
         parserOptions: {
             project: './tsconfig.json',
             tsconfigRootDir: __dirname,


### PR DESCRIPTION
- add new lint rule with test suite.
- fix cases found by the lint rule.

This lint rule would have prevented the bug that was fixed in #4833

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
