### PR TITLE
telemetry: mark file scans as passive

### DIFF
--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -288,7 +288,10 @@ export async function emitCodeScanTelemetry(editor: vscode.TextEditor, codeScanT
         )
         codeScanTelemetryEntry.codewhispererCodeScanProjectBytes = projectSize
     }
-    telemetry.codewhisperer_securityScan.emit(codeScanTelemetryEntry)
+    telemetry.codewhisperer_securityScan.emit({
+        ...codeScanTelemetryEntry,
+        passive: codeScanTelemetryEntry.codewhispererCodeScanScope === CodeAnalysisScope.FILE,
+    })
 }
 
 export function errorPromptHelper(error: Error, scope: CodeAnalysisScope) {

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -193,6 +193,10 @@ describe('startSecurityScan', function () {
         assert.ok(securityScanRenderSpy.calledOnce)
         const warnings = getTestWindow().shownMessages.filter(m => m.severity === SeverityLevel.Warning)
         assert.strictEqual(warnings.length, 0)
+        assertTelemetry('codewhisperer_securityScan', {
+            codewhispererCodeScanScope: 'FILE',
+            passive: true,
+        })
     })
 
     it('Should stop security scan for project scans when confirmed', async function () {
@@ -287,6 +291,8 @@ describe('startSecurityScan', function () {
             codewhispererLanguage: 'yaml',
             codewhispererCodeScanTotalIssues: 1,
             codewhispererCodeScanIssuesWithFixes: 0,
+            codewhispererCodeScanScope: 'PROJECT',
+            passive: false,
         } as CodewhispererSecurityScan)
     })
 


### PR DESCRIPTION
## Problem

File scan metrics should be passive

## Solution

Set `passive` to true if current scope is `FILE`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
