### PR TITLE
fix(amazonq): Listitems inside markdown shows shows typewriter wrapper spans as text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,27 +3607,27 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.7.1.tgz",
-            "integrity": "sha512-IfsXvq1VOdINCyNHgcyf9MdoikIIONCGAOwoysIk++7NbNHFcpMIWPtSEVdvv6Z/vZRF2Op2ZjhTNVWa/PiMuA==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.8.0.tgz",
+            "integrity": "sha512-UHzY7xRsVxO4p9R+tf+3RTk6hBWW8sD3gIW5Q0G9oWVcEKEIBx067hwkkmtffzppIaQDdU0ckSKcPH5Mtk5qqQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",
-                "marked": "^7.0.3",
+                "marked": "^12.0.2",
                 "prismjs": "1.29.0",
                 "sanitize-html": "^2.12.1",
                 "unescape-html": "^1.1.0"
             }
         },
         "node_modules/@aws/mynah-ui/node_modules/marked": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-7.0.5.tgz",
-            "integrity": "sha512-lwNAFTfXgqpt/XvK17a/8wY9/q6fcSPZT1aP6QW0u74VwaJF/Z9KbRcX23sWE4tODM+AolJNcUtErTkgOeFP/Q==",
+            "version": "12.0.2",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+            "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
             "bin": {
                 "marked": "bin/marked.js"
             },
             "engines": {
-                "node": ">= 16"
+                "node": ">= 18"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -19612,7 +19612,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.7.1",
+                "@aws/mynah-ui": "^4.8.0",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/shared-ini-file-loader": "^2.2.8",

--- a/packages/amazonq/.changes/next-release/Bug Fix-c2be4698-9cf5-4e3f-9411-8a8aff3c07fb.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-c2be4698-9cf5-4e3f-9411-8a8aff3c07fb.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Typewriter animator parts showing up in code fields inside listitems"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4049,7 +4049,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.7.1",
+        "@aws/mynah-ui": "^4.8.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/shared-ini-file-loader": "^2.2.8",


### PR DESCRIPTION
## Problem
Code fields inside listitems for the markdowns are showing parts of the typewriter animator wrapper spans.
<img width="486" alt="image" src="https://github.com/aws/mynah-ui/assets/116281103/196efe48-e0be-46c8-8bea-320a3e714294">

## Solution
Updated markdown parser structure and added a skip also to the code fields inside the list items through [`mynah-ui v4.8.0`](https://github.com/aws/mynah-ui/releases/tag/v4.8.0)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
