### PR TITLE
fix(amazonq): reduce api calls for file scans

### DIFF
--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -232,13 +232,17 @@ export const codeFileScanJobTimeoutSeconds = 60 //1 minute
 
 export const projectSizeCalculateTimeoutSeconds = 10
 
-export const codeScanJobPollingIntervalSeconds = 1
+export const codeScanJobPollingIntervalSeconds = 5
+
+export const fileScanPollingDelaySeconds = 10
+
+export const projectScanPollingDelaySeconds = 30
 
 export const artifactTypeSource = 'SourceCode'
 
 export const codeScanFindingsSchema = 'codescan/findings/1.0'
 
-export const autoScanDebounceDelaySeconds = 2
+export const autoScanDebounceDelaySeconds = 5
 
 export const codewhispererDiagnosticSourceLabel = 'Amazon Q '
 

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -121,6 +121,7 @@ export class CodeScansState {
     onDidChangeState = this.#onDidChangeState.event
 
     private exceedsMonthlyQuota = false
+    private latestScanTime: number | undefined = undefined
 
     static #instance: CodeScansState
     static get instance() {
@@ -157,6 +158,14 @@ export class CodeScansState {
 
     isMonthlyQuotaExceeded() {
         return this.exceedsMonthlyQuota
+    }
+
+    setLatestScanTime(time: number) {
+        this.latestScanTime = time
+    }
+
+    getLatestScanTime() {
+        return this.latestScanTime
     }
 }
 

--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -12,21 +12,18 @@ import { CodeAnalysisScope, codewhispererDiagnosticSourceLabel } from '../models
 interface SecurityScanRender {
     securityDiagnosticCollection: vscode.DiagnosticCollection | undefined
     initialized: boolean
-    lastUpdated: number
 }
 
 export const securityScanRender: SecurityScanRender = {
     securityDiagnosticCollection: undefined,
     initialized: false,
-    lastUpdated: 0,
 }
 
 export function initSecurityScanRender(
     securityRecommendationList: AggregatedCodeScanIssue[],
     context: vscode.ExtensionContext,
     editor: vscode.TextEditor,
-    scope: CodeAnalysisScope,
-    codeScanStartTime: number
+    scope: CodeAnalysisScope
 ) {
     securityScanRender.initialized = false
     if (scope === CodeAnalysisScope.FILE) {
@@ -39,7 +36,6 @@ export function initSecurityScanRender(
         updateSecurityIssueHoverAndCodeActions(securityRecommendation)
     })
     securityScanRender.initialized = true
-    securityScanRender.lastUpdated = codeScanStartTime
 }
 
 function updateSecurityIssueHoverAndCodeActions(securityRecommendation: AggregatedCodeScanIssue) {

--- a/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
+++ b/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
@@ -88,6 +88,7 @@ describe('CodeWhisperer security scan', async function () {
     returns artifactMap, projectPath and codeScanName
     */
     async function securityJobSetup(editor: vscode.TextEditor) {
+        const codeScanStartTime = performance.now()
         const zipUtil = new ZipUtil()
         const uri = editor.document.uri
 
@@ -106,6 +107,7 @@ describe('CodeWhisperer security scan', async function () {
             artifactMap: artifactMap,
             projectPath: projectPath,
             codeScanName: codeScanName,
+            codeScanStartTime: codeScanStartTime,
         }
     }
 
@@ -130,7 +132,12 @@ describe('CodeWhisperer security scan', async function () {
             scope,
             securityJobSetupResult.codeScanName
         )
-        const jobStatus = await pollScanJobStatus(client, scanJob.jobId, scope)
+        const jobStatus = await pollScanJobStatus(
+            client,
+            scanJob.jobId,
+            scope,
+            securityJobSetupResult.codeScanStartTime
+        )
         const securityRecommendationCollection = await listScanResults(
             client,
             scanJob.jobId,
@@ -165,7 +172,12 @@ describe('CodeWhisperer security scan', async function () {
         )
 
         //get job status and result
-        const jobStatus = await pollScanJobStatus(client, scanJob.jobId, scope)
+        const jobStatus = await pollScanJobStatus(
+            client,
+            scanJob.jobId,
+            scope,
+            securityJobSetupResult.codeScanStartTime
+        )
         const securityRecommendationCollection = await listScanResults(
             client,
             scanJob.jobId,


### PR DESCRIPTION
## Problem

Optimize and reduce the number of API calls for file scans

## Solution

- Increase debounce delay from 2 to 5 seconds.
- Increase polling frequency from 1 to 5 seconds.
- Add a polling delay of 10 seconds (file scans) or 20 seconds (project scans).
- Cancel (stop polling) previous scan if a new scan starts.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
