### PR TITLE
refactor: create helper to identify remote workspaces

### DIFF
--- a/packages/core/src/codecatalyst/commands.ts
+++ b/packages/core/src/codecatalyst/commands.ts
@@ -26,7 +26,7 @@ import { CreateDevEnvironmentRequest, UpdateDevEnvironmentRequest } from 'aws-sd
 import { Auth } from '../auth/auth'
 import { SsoConnection } from '../auth/connection'
 import { getShowManageConnections } from '../auth/ui/vue/show'
-import { isInDevEnv } from '../shared/vscode/env'
+import { isInDevEnv, isRemoteWorkspace } from '../shared/vscode/env'
 
 /** "List CodeCatalyst Commands" command. */
 export async function listCommands(): Promise<void> {
@@ -231,7 +231,7 @@ export class CodeCatalystCommands {
     }
 
     public createDevEnv(): Promise<void> {
-        if (vscode.env.remoteName === 'ssh-remote' && isInDevEnv()) {
+        if (isRemoteWorkspace() && isInDevEnv()) {
             throw new RemoteContextError()
         }
         return this.withClient(showCreateDevEnv, globals.context, CodeCatalystCommands.declared)
@@ -280,7 +280,7 @@ export class CodeCatalystCommands {
         targetPath?: string,
         connection?: { startUrl: string; region: string }
     ): Promise<void> {
-        if (vscode.env.remoteName === 'ssh-remote' && isInDevEnv()) {
+        if (isRemoteWorkspace() && isInDevEnv()) {
             throw new RemoteContextError()
         }
 

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -41,6 +41,7 @@ import { SecurityIssueCodeActionProvider } from '../service/securityIssueCodeAct
 import { SsoAccessTokenProvider } from '../../auth/sso/ssoAccessTokenProvider'
 import { SystemUtilities } from '../../shared/systemUtilities'
 import { ToolkitError } from '../../shared/errors'
+import { isRemoteWorkspace } from '../../shared/vscode/env'
 
 export const toggleCodeSuggestions = Commands.declare(
     { id: 'aws.amazonq.toggleCodeSuggestion', compositeKey: { 1: 'source' } },
@@ -301,7 +302,7 @@ export const fetchFeatureConfigsCmd = Commands.declare(
 export const installAmazonQExtension = Commands.declare(
     { id: 'aws.toolkit.installAmazonQExtension', logging: true },
     () => async () => {
-        if (vscode.env.remoteName === 'ssh-remote') {
+        if (isRemoteWorkspace()) {
             /**
              * due to a bug in https://github.com/microsoft/vscode/pull/206381/files#diff-efa08c29460835c0ffa740d751c34078033fd6cb6c7b031500fb31f524655de2R360
              * installExtension will fail on remote environments when the amazon q extension is already installed locally.

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -8,7 +8,7 @@ import { env, Memento, version } from 'vscode'
 import { getLogger } from '../logger'
 import { fromExtensionManifest, migrateSetting, Settings } from '../settings'
 import { shared } from '../utilities/functionUtils'
-import { isInDevEnv, extensionVersion, isAutomation } from '../vscode/env'
+import { isInDevEnv, extensionVersion, isAutomation, isRemoteWorkspace } from '../vscode/env'
 import { addTypeName } from '../utilities/typeConstructors'
 import globals, { isWeb } from '../extensionGlobals'
 import { mapMetadata } from './telemetryLogger'
@@ -154,7 +154,7 @@ export function getComputeEnvType(): EnvType {
         return 'codecatalyst'
     } else if (isSageMaker()) {
         return 'sagemaker'
-    } else if (env.remoteName === 'ssh-remote' && !isInDevEnv()) {
+    } else if (isRemoteWorkspace() && !isInDevEnv()) {
         return 'ec2'
     } else if (env.remoteName) {
         return 'wsl'

--- a/packages/core/src/shared/vscode/env.ts
+++ b/packages/core/src/shared/vscode/env.ts
@@ -92,6 +92,10 @@ export function isInDevEnv(): boolean {
     return !!getCodeCatalystDevEnvId()
 }
 
+export function isRemoteWorkspace(): boolean {
+    return vscode.env.remoteName === 'ssh-remote'
+}
+
 export function getCodeCatalystProjectName(): string | undefined {
     return process.env['__DEV_ENVIRONMENT_PROJECT_NAME']
 }


### PR DESCRIPTION
## Problem
- We are constantly making the same remote workspace check

## Solution
- Extract it

I'm probably going to have to add it in an up and coming PR, might as well extract it ahead of time

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
