### PR TITLE
feat(auth): request necessary scopes only

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -380,14 +380,24 @@ export class Auth implements AuthService, ConnectionManager {
         await this.validateConnection(connection.id, profile)
     }
 
-    public async updateConnection(connection: Pick<SsoConnection, 'id'>, profile: SsoProfile): Promise<SsoConnection>
-    public async updateConnection(connection: Pick<Connection, 'id'>, profile: Profile): Promise<Connection> {
+    public async updateConnection(
+        connection: Pick<SsoConnection, 'id'>,
+        profile: SsoProfile,
+        invalidate?: boolean
+    ): Promise<SsoConnection>
+    public async updateConnection(
+        connection: Pick<Connection, 'id'>,
+        profile: Profile,
+        invalidate?: boolean
+    ): Promise<Connection> {
         getLogger().info(`auth: Updating connection ${connection.id}`)
         if (profile.type === 'iam') {
             throw new Error('Updating IAM connections is not supported')
         }
 
-        await this.invalidateConnection(connection.id, { skipGlobalLogout: true })
+        if (invalidate ?? true) {
+            await this.invalidateConnection(connection.id, { skipGlobalLogout: true })
+        }
 
         const newProfile = await this.store.updateProfile(connection.id, profile)
         const updatedConn = this.getSsoConnection(connection.id, newProfile as StoredProfile<SsoProfile>)

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -561,8 +561,8 @@ export class Auth implements AuthService, ConnectionManager {
         }
 
         return runCheck().catch(async err => {
+            await this.handleSsoTokenError(id, err) // may throw without setting state to invalid - this is intended.
             await this.updateConnectionState(id, 'invalid')
-            return this.handleSsoTokenError(id, err)
         })
     }
 

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -92,8 +92,6 @@ interface AuthService {
     /**
      * Replaces the profile for a connection with a new one.
      *
-     * This will invalidate the connection, potentially requiring a re-authentication.
-     *
      * **IAM connections are not implemented**
      */
     updateConnection(connection: Pick<Connection, 'id'>, profile: Profile): Promise<Connection>
@@ -395,7 +393,7 @@ export class Auth implements AuthService, ConnectionManager {
             throw new Error('Updating IAM connections is not supported')
         }
 
-        if (invalidate ?? true) {
+        if (invalidate ?? false) {
             await this.invalidateConnection(connection.id, { skipGlobalLogout: true })
         }
 

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -164,9 +164,10 @@ export class Auth implements AuthService, ConnectionManager {
         }
     }
 
-    public async reauthenticate({ id }: Pick<SsoConnection, 'id'>): Promise<SsoConnection>
-    public async reauthenticate({ id }: Pick<IamConnection, 'id'>): Promise<IamConnection>
-    public async reauthenticate({ id }: Pick<Connection, 'id'>): Promise<Connection> {
+    public async reauthenticate({ id }: Pick<SsoConnection, 'id'>, invalidate?: boolean): Promise<SsoConnection>
+    public async reauthenticate({ id }: Pick<IamConnection, 'id'>, invalidate?: boolean): Promise<IamConnection>
+    public async reauthenticate({ id }: Pick<Connection, 'id'>, invalidate?: boolean): Promise<Connection> {
+        const shouldInvalidate = invalidate ?? true
         const profile = this.store.getProfileOrThrow(id)
         if (profile.type === 'sso') {
             const provider = this.getSsoTokenProvider(id, profile)
@@ -175,13 +176,13 @@ export class Auth implements AuthService, ConnectionManager {
             // so we need to set it here.
             await telemetry.aws_loginWithBrowser.run(async span => {
                 span.record({ isReAuth: true, credentialStartUrl: profile.startUrl })
-                await this.authenticate(id, () => provider.createToken())
+                await this.authenticate(id, () => provider.createToken(), shouldInvalidate)
             })
 
             return this.getSsoConnection(id, profile)
         } else {
             const provider = await this.getCredentialsProvider(id, profile)
-            await this.authenticate(id, () => this.createCachedCredentials(provider))
+            await this.authenticate(id, () => this.createCachedCredentials(provider), shouldInvalidate)
 
             return this.getIamConnection(id, profile)
         }
@@ -559,7 +560,10 @@ export class Auth implements AuthService, ConnectionManager {
             }
         }
 
-        return runCheck().catch(err => this.handleSsoTokenError(id, err))
+        return runCheck().catch(async err => {
+            await this.updateConnectionState(id, 'invalid')
+            return this.handleSsoTokenError(id, err)
+        })
     }
 
     private async handleSsoTokenError(id: Connection['id'], err: unknown) {
@@ -567,7 +571,6 @@ export class Auth implements AuthService, ConnectionManager {
 
         this.#validationErrors.set(id, UnknownError.cast(err))
         getLogger().info(`auth: Handling validation error of connection: ${id}`)
-        return this.updateConnectionState(id, 'invalid')
     }
 
     private async getConnectionFromStoreEntry([id, profile]: readonly [Connection['id'], StoredProfile<Profile>]) {
@@ -704,7 +707,8 @@ export class Auth implements AuthService, ConnectionManager {
     }
 
     private readonly authenticate = keyedDebounce(this._authenticate.bind(this))
-    private async _authenticate<T>(id: Connection['id'], callback: () => Promise<T>): Promise<T> {
+    private async _authenticate<T>(id: Connection['id'], callback: () => Promise<T>, invalidate?: boolean): Promise<T> {
+        const originalState = this.getConnectionState({ id }) ?? 'unauthenticated'
         await this.updateConnectionState(id, 'authenticating')
 
         try {
@@ -714,6 +718,7 @@ export class Auth implements AuthService, ConnectionManager {
             return result
         } catch (err) {
             await this.handleSsoTokenError(id, err)
+            await this.updateConnectionState(id, invalidate ? 'invalid' : originalState)
             throw err
         }
     }

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -267,7 +267,17 @@ export class SecondaryAuth<T extends Connection = Connection> {
 }
 
 /**
- * This should exist in connection.ts or utils.ts, but due to circular dependencies, it must go here.
+ * Used to add scopes to a connection, usually when re-using a connection across extensions.
+ * It does not invalidate or otherwise change the state of the connection, but it does
+ * trigger listeners for connection updates.
+ *
+ * How connections and scopes currently work for both this quickpick and the common Login page:
+ * - Don't request AWS scopes if we are signing into Amazon Q
+ * - Request AWS scopes for explorer sign in. Request AWS + CodeCatalyst scopes for CC sign in.
+ * - Request scope difference if re-using a connection. Cancelling or otherwise failing to get the new scopes does NOT invalidate the connection.
+ * - Adding scopes updates the connection profile, but does not change its state.
+ *
+ * Note: This should exist in connection.ts or utils.ts, but due to circular dependencies, it must go here.
  */
 export async function addScopes(conn: SsoConnection, extraScopes: string[], auth = Auth.instance) {
     const oldScopes = conn.scopes ?? []

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -285,7 +285,7 @@ export async function addScopes(conn: SsoConnection, extraScopes: string[], auth
     const updatedConn = await updateConnectionScopes(newScopes)
 
     try {
-        return await auth.reauthenticate(updatedConn)
+        return await auth.reauthenticate(updatedConn, false)
     } catch (e) {
         // We updated the connection scopes pre-emptively, but if there is some issue (e.g. user cancels,
         // InvalidGrantException, etc), then we need to revert to the old connection scopes. Otherwise,

--- a/packages/core/src/auth/utils.ts
+++ b/packages/core/src/auth/utils.ts
@@ -102,7 +102,11 @@ export async function promptAndUseConnection(...[auth, type]: Parameters<typeof 
         // HACK: We assume that if we are toolkit we want AWS account scopes.
         // Although, Q shouldn't enter this codepath anyways.
         if (!isAmazonQ() && isSsoConnection(conn) && !hasScopes(conn, scopesSsoAccountAccess)) {
-            conn = await addScopes(conn, scopesSsoAccountAccess, { invalidate: false })
+            try {
+                conn = await addScopes(conn, scopesSsoAccountAccess)
+            } catch (e: any) {
+                throw new ToolkitError(`Failed to use connection${conn.label ? `: ${conn.label}` : '.'}`, e)
+            }
         }
 
         await auth.useConnection(conn)

--- a/packages/core/src/auth/utils.ts
+++ b/packages/core/src/auth/utils.ts
@@ -92,6 +92,10 @@ export async function promptForConnection(auth: Auth, type?: 'iam' | 'iam-only' 
     return resp
 }
 
+/**
+ * Creates the 'Switch Connection' quickpick for the Toolkit.
+ * See {@link addScopes} for details about how scopes are requested for new and existing connections.
+ */
 export async function promptAndUseConnection(...[auth, type]: Parameters<typeof promptForConnection>) {
     return telemetry.aws_setCredentials.run(async span => {
         let conn = await promptForConnection(auth, type)
@@ -100,7 +104,8 @@ export async function promptAndUseConnection(...[auth, type]: Parameters<typeof 
         }
 
         // HACK: We assume that if we are toolkit we want AWS account scopes.
-        // Although, Q shouldn't enter this codepath anyways.
+        // TODO: Although, Q shouldn't enter this codepath anyways.
+        // We should deprecate any codepath in Q that may enter this.
         if (!isAmazonQ() && isSsoConnection(conn) && !hasScopes(conn, scopesSsoAccountAccess)) {
             try {
                 conn = await addScopes(conn, scopesSsoAccountAccess)

--- a/packages/core/src/codecatalyst/auth.ts
+++ b/packages/core/src/codecatalyst/auth.ts
@@ -356,7 +356,8 @@ export class CodeCatalystAuthenticationProvider {
             await this.promptOnboarding()
         }
 
-        return this.secondaryAuth.useNewConnection(conn)
+        await this.secondaryAuth.useNewConnection(conn)
+        return conn
     }
 
     /**

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -20,7 +20,6 @@ import {
     isIamConnection,
     isSsoConnection,
     isBuilderIdConnection,
-    scopesSsoAccountAccess,
     scopesCodeWhispererChat,
     scopesFeatureDev,
     scopesGumby,
@@ -36,7 +35,7 @@ import { showReauthenticateMessage } from '../../shared/utilities/messages'
 import { showAmazonQWalkthroughOnce } from '../../amazonq/onboardingPage/walkthrough'
 
 /** Backwards compatibility for connections w pre-chat scopes */
-export const codeWhispererCoreScopes = [...scopesSsoAccountAccess, ...scopesCodeWhispererCore]
+export const codeWhispererCoreScopes = [...scopesCodeWhispererCore]
 export const codeWhispererChatScopes = [...codeWhispererCoreScopes, ...scopesCodeWhispererChat]
 export const amazonQScopes = [...codeWhispererChatScopes, ...scopesGumby, ...scopesFeatureDev]
 

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -154,13 +154,6 @@ describe('Auth', function () {
             assert.deepStrictEqual(updated.scopes, updatedProfile.scopes)
         })
 
-        it('invalidates the connection', async function () {
-            const conn = await auth.createConnection(ssoProfile)
-            const updated = await auth.updateConnection(conn, updatedProfile)
-
-            assert.strictEqual(auth.getConnectionState(updated), 'invalid')
-        })
-
         it('fires an event when updating', async function () {
             const conn = await auth.createConnection(ssoProfile)
             await auth.updateConnection(conn, updatedProfile)

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -154,6 +154,14 @@ describe('Auth', function () {
             assert.deepStrictEqual(updated.scopes, updatedProfile.scopes)
         })
 
+        it('does not change the connection state', async function () {
+            const conn = await auth.createConnection(ssoProfile)
+            const originalState = auth.getConnectionState(conn)
+            const updated = await auth.updateConnection(conn, updatedProfile)
+
+            assert.strictEqual(auth.getConnectionState(updated), originalState)
+        })
+
         it('fires an event when updating', async function () {
             const conn = await auth.createConnection(ssoProfile)
             await auth.updateConnection(conn, updatedProfile)


### PR DESCRIPTION
Applies to both IdC and BuilderID, Amazon Q and Toolkit.

- Don't request AWS scopes if we are signing into Amazon Q
- Request AWS scopes for explorer sign in. Request AWS + CodeCatalyst scopes for CC sign in.
- Request scope difference if re-using a connection. Cancelling or otherwise failing to get the new scopes does NOT invalidate the connection.
  - Updating a connection profile now no longer invalidates the connection. I couldn't find a use for it anymore.
- Works via login page AND quickpick menu

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
