### PR TITLE
feat(dev): autofill login starturl setting

### DIFF
--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -30,6 +30,7 @@ import { telemetry } from '../../../shared/telemetry'
 import { AuthSources } from '../util'
 import { AuthEnabledFeatures, AuthError, AuthFlowState, AuthUiClick, TelemetryMetadata, userCancelled } from './types'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
+import { DevSettings } from '../../../shared/settings'
 
 export abstract class CommonAuthWebview extends VueWebview {
     private metricMetadata: TelemetryMetadata = {}
@@ -290,5 +291,9 @@ export abstract class CommonAuthWebview extends VueWebview {
         }
 
         return authEnabledFeatures.join(',')
+    }
+
+    getDefaultStartUrl() {
+        return DevSettings.instance.get('autofillStartUrl', '')
     }
 }

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -330,6 +330,7 @@ export default defineComponent({
         }
     },
     async created() {
+        this.startUrl = await this.getDefaultStartUrl()
         await this.emitUpdate('created')
     },
 
@@ -499,6 +500,9 @@ export default defineComponent({
             }
 
             this.$forceUpdate()
+        },
+        async getDefaultStartUrl() {
+            return await client.getDefaultStartUrl()
         },
     },
 })

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -729,6 +729,7 @@ const devSettings = {
     ssoCacheDirectory: String,
     enableIamPolicyChecksFeature: Boolean,
     pkceAuth: Boolean,
+    autofillStartUrl: String,
 }
 type ResolvedDevSettings = FromDescriptor<typeof devSettings>
 type AwsDevSetting = keyof ResolvedDevSettings


### PR DESCRIPTION
New dev setting to autofill the start url:

```
"aws.dev.autofillStartUrl": "<url>"
```

Should probably be integrated into the login page for all users somehow, but that requires some UX thought. Here is a quick fix for devs.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
