### PR TITLE
fix(amazonq): fix codeSelection incorrect if user has no selection

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-12271e0b-126f-4112-936d-a94ad0566aee.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-12271e0b-126f-4112-936d-a94ad0566aee.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix bug when Amazon Q chat sends code selection while user has no selection"
+}

--- a/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
+++ b/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
@@ -57,7 +57,7 @@ export class FocusAreaContextExtractor {
             extendedCodeBlock: this.getRangeText(editor.document, extendedCodeBlockRange),
             codeBlock: codeBlock,
             selectionInsideExtendedCodeBlock: this.getSelectionInsideExtendedCodeBlock(
-                importantRange as Selection,
+                editor.selection,
                 extendedCodeBlockRange
             ),
             names:


### PR DESCRIPTION
## Problem
Ask Q to write a unit test of a function, Q does not know how to do it. It hallucinates the function.( It does not know which class I am generating against). See internal TT P128119238. 



## Solution
Let the cursorState.range be undefined if user do not have a selection. The function `getSelectionInsideExtendedCodeBlock` is supposed to take the original selection as input, not the importantRange ( which is current line of cursor)

![Screenshot 2024-05-02 at 3 28 08 PM](https://github.com/aws/aws-toolkit-vscode/assets/97199248/f20c54a3-9765-4886-913f-b04c535fd646)



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
