### PR TITLE
fix(amazonq): Update cross file context config

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-5ccb4f03-68ca-4582-93a8-6c6a40397f14.json
+++ b/packages/amazonq/.changes/next-release/Feature-5ccb4f03-68ca-4582-93a8-6c6a40397f14.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Update cross file context config for Q inline suggestion"
+}

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -588,9 +588,9 @@ export const codeFixAppliedFailedMessage = 'Failed to apply suggested code fix.'
 export const runSecurityScanButtonTitle = 'Run security scan'
 
 export const crossFileContextConfig = {
-    numberOfChunkToFetch: 60,
-    topK: 3,
-    numberOfLinesEachChunk: 10,
+    numberOfChunkToFetch: 200,
+    topK: 10,
+    numberOfLinesEachChunk: 50,
 }
 
 export const utgConfig = {

--- a/packages/core/src/test/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/crossFileContextUtil.test.ts
@@ -38,19 +38,30 @@ describe('crossFileContextUtil', function () {
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
         })
 
-        describe('should fetch 3 chunks and each chunk should contains 10 lines', function () {
+        describe('should fetch 10 chunks and each chunk should contains 50 lines', function () {
             async function assertCorrectCodeChunk() {
-                await openATextEditorWithText(sampleFileOf60Lines, 'CrossFile.java', tempFolder, { preview: false })
+                await openATextEditorWithText(sampleFileOf60Lines.repeat(10), 'CrossFile.java', tempFolder, {
+                    preview: false,
+                })
                 const myCurrentEditor = await openATextEditorWithText('', 'TargetFile.java', tempFolder, {
                     preview: false,
                 })
                 const actual = await crossFile.fetchSupplementalContextForSrc(myCurrentEditor, fakeCancellationToken)
                 assert.ok(actual)
-                assert.ok(actual.supplementalContextItems.length === 3)
+                assert.ok(actual.supplementalContextItems.length === crossFileContextConfig.topK)
 
-                assert.strictEqual(actual.supplementalContextItems[0].content.split('\n').length, 10)
-                assert.strictEqual(actual.supplementalContextItems[1].content.split('\n').length, 10)
-                assert.strictEqual(actual.supplementalContextItems[2].content.split('\n').length, 10)
+                assert.strictEqual(
+                    actual.supplementalContextItems[0].content.split('\n').length,
+                    crossFileContextConfig.numberOfLinesEachChunk
+                )
+                assert.strictEqual(
+                    actual.supplementalContextItems[1].content.split('\n').length,
+                    crossFileContextConfig.numberOfLinesEachChunk
+                )
+                assert.strictEqual(
+                    actual.supplementalContextItems[2].content.split('\n').length,
+                    crossFileContextConfig.numberOfLinesEachChunk
+                )
             }
 
             it('control group', async function () {
@@ -267,12 +278,12 @@ describe('crossFileContextUtil', function () {
             assert.strictEqual(chunks[1].content, 'line_6\nline_7')
         })
 
-        it('codewhisperer crossfile config should use 10 lines', async function () {
+        it('codewhisperer crossfile config should use 50 lines', async function () {
             const filePath = path.join(tempFolder, 'file.txt')
             await toFile(sampleFileOf60Lines, filePath)
 
             const chunks = await crossFile.splitFileToChunks(filePath, crossFileContextConfig.numberOfLinesEachChunk)
-            assert.strictEqual(chunks.length, 6)
+            assert.strictEqual(chunks.length, 2)
         })
     })
 })


### PR DESCRIPTION
## Problem

1) number of input chunks for BM25 retrieval needs to be changed from 60 to 200,
2) the chunk size is changed from 10 lines to 50 lines, which means totally 200x 50 lines of cross-file code will be considered in the BM25 retrieval.
3) number of chunks returned from plugin to server for prompting increased from 3 to 10.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
