### PR TITLE
fix(ci): prerelease automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,10 @@ jobs:
         outputs:
             feature: ${{ steps.build.outputs.feature }}
             tagname: ${{ steps.build.outputs.tagname }}
-            version: ${{ steps.build.outputs.version }}
-            changes: ${{ steps.build.outputs.changes }}
+            toolkit_version: ${{ steps.build.outputs.toolkit_version }}
+            amazonq_version: ${{ steps.build.outputs.amazonq_version }}
+            toolkit_changes: ${{ steps.build.outputs.toolkit_changes }}
+            amazonq_changes: ${{ steps.build.outputs.amazonq_changes }}
         steps:
             - uses: actions/checkout@v4
               with:
@@ -65,31 +67,34 @@ jobs:
                   write_package_info() {
                       PKG_NAME=$1
                       PKG_DISPLAY_NAME=$(grep -m 1 displayName packages/${PKG_NAME}/package.json | grep -o '[a-zA-z][^\"]\+' | tail -n1)
-                      echo "version=$(grep -m 1 version packages/${PKG_NAME}/package.json | grep -o '[0-9][^\"]\+' | sed 's/-SNAPSHOT//')" >> $GITHUB_OUTPUT
+                      echo "${PKG_NAME}_version=$(grep -m 1 version packages/${PKG_NAME}/package.json | grep -o '[0-9][^\"]\+' | sed 's/-SNAPSHOT//')" >> $GITHUB_OUTPUT
                       echo "${PKG_NAME}_changes<<EOF" >> $GITHUB_OUTPUT
                       # Add extension display name to the topmost changelog section.
                       cat packages/${PKG_NAME}/CHANGELOG.md | perl -ne 'BEGIN{$/="\n\n"} print; exit if $. == 2' | sed -e "1 s/## /## ${PKG_DISPLAY_NAME} - /" >> $GITHUB_OUTPUT
+                      echo 'EOF' >> $GITHUB_OUTPUT
                   }
                   echo "feature=$FEAT_NAME" >> $GITHUB_OUTPUT
                   echo "tagname=$TAG_NAME" >> $GITHUB_OUTPUT
                   write_package_info toolkit
                   write_package_info amazonq
-                  echo 'EOF' >> $GITHUB_OUTPUT
 
     publish:
         needs: [package]
         runs-on: ubuntu-latest
         env:
+            #
             # For `gh`.
+            #
             GH_REPO: ${{ github.repository }}
-            # For `gh`.
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             FEAT_NAME: ${{ needs.package.outputs.feature }}
             TAG_NAME: ${{ needs.package.outputs.tagname }}
-            AWS_TOOLKIT_VERSION: ${{ needs.package.outputs.version }}
+            AWS_TOOLKIT_VERSION: ${{ needs.package.outputs.toolkit_version }}
+            AMAZON_Q_VERSION: ${{ needs.package.outputs.amazonq_version }}
+            #
             # Used in release_notes.md
+            #
             BRANCH: ${{ github.ref_name }}
-            # Used in release_notes.md
             AWS_TOOLKIT_CHANGES: ${{ needs.package.outputs.toolkit_changes }}
             AMAZON_Q_CHANGES: ${{ needs.package.outputs.amazonq_changes }}
         permissions:
@@ -103,7 +108,7 @@ jobs:
               # "prerelease" (main branch) or "pre-<feature>"
               if: "env.TAG_NAME == 'prerelease' || startsWith(env.TAG_NAME, 'pre-')"
               run: |
-                  echo "SUBJECT=AWS Toolkit ${AWS_TOOLKIT_VERSION}: ${FEAT_NAME:-${TAG_NAME}}" >> $GITHUB_ENV
+                  echo "SUBJECT=AWS IDE Extensions: ${FEAT_NAME:-${TAG_NAME}}" >> $GITHUB_ENV
                   gh release delete "$TAG_NAME" --cleanup-tag --yes || true
                   # git push origin :"$TAG_NAME" || true
             - name: Publish Prerelease

--- a/.github/workflows/release_notes.md
+++ b/.github/workflows/release_notes.md
@@ -1,9 +1,11 @@
-_This is an **unsupported preview build** of the `${BRANCH}` branch of AWS Toolkit._
+This is an **unsupported preview build** of the `${BRANCH}` branch of AWS IDE Extensions for VSCode.
 
 # Install
 
-1. Download the vsix file from "Assets" below.
-2. In VSCode, run `Extensions: Install from VSIX...` and choose the vsix file.
+1. Download the vsix file(s) from "Assets" below.
+    - Amazon Q $AMAZON_Q_VERSION is provided by `amazon-q-vscode….vsix`
+    - AWS Toolkit $AWS_TOOLKIT_VERSION is provided by `aws-toolkit-vscode….vsix`
+2. Run `Extensions: Install from VSIX...` from the VSCode [command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) and choose the vsix file(s).
 
 # Changes
 
@@ -13,5 +15,5 @@ ${AMAZON_Q_CHANGES}
 
 ## Previous changes
 
--   For Toolkit, see [CHANGELOG.md](/packages/toolkit/CHANGELOG.md)
--   For Amazon Q, see [CHANGELOG.md](/packages/amazonq/CHANGELOG.md)
+-   [AWS Toolkit changelog](/packages/toolkit/CHANGELOG.md)
+-   [Amazon Q changelog](/packages/amazonq/CHANGELOG.md)


### PR DESCRIPTION
Problem:
- prerelease description only mentions Toolkit, not Q
- changelogs not shown in prereleases

Solution:
- update script
- Example: https://github.com/justinmk3/aws-toolkit-vscode/releases/tag/pre-smurf

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
