### PR TITLE
auth: remove pkce feature flag and use device code on remote

### DIFF
--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -37,8 +37,8 @@ import OidcClientPKCE from './oidcclientpkce'
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 import { randomUUID, randomBytes, createHash } from 'crypto'
 import { UriHandler } from '../../shared/vscode/uriHandler'
-import { DevSettings } from '../../shared/settings'
 import { localize } from '../../shared/utilities/vsCodeUtils'
+import { isRemoteWorkspace } from '../../shared/vscode/env'
 
 export const authenticationPath = 'sso/authenticated'
 
@@ -250,7 +250,7 @@ export abstract class SsoAccessTokenProvider {
         cache = getCache(),
         oidc: OidcClient = OidcClient.create(profile.region)
     ) {
-        if (!DevSettings.instance.get('pkceAuth', false)) {
+        if (isRemoteWorkspace()) {
             return new DeviceFlowAuthorization(profile, cache, oidc)
         }
         return new AuthFlowAuthorization(profile, cache, OidcClientV2.create(profile.region))

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -728,7 +728,6 @@ const devSettings = {
     codewhispererService: Record(String, String),
     ssoCacheDirectory: String,
     enableIamPolicyChecksFeature: Boolean,
-    pkceAuth: Boolean,
     autofillStartUrl: String,
 }
 type ResolvedDevSettings = FromDescriptor<typeof devSettings>


### PR DESCRIPTION
_Still pending final decision on what we will do before releasing_

## Problem
- auth server ports are hard to forward (and unforward) making the device code a better option for now when running in a remote workspace

## Solution
- remove the feature flag and use device code authorization when in a remote workspace

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
