### PR TITLE
fix: update session state config when modifying root folder

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-06dc9320-3b6d-43d9-b811-c910852fdc2b.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-06dc9320-3b6d-43d9-b811-c910852fdc2b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "modifying the root folder for /dev now modifies it"
+}

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -623,7 +623,7 @@ export class FeatureDevController {
         }
 
         if (uri && uri instanceof vscode.Uri) {
-            session.config.workspaceRoots = [uri.fsPath]
+            session.updateWorkspaceRoot(uri.fsPath)
             this.messenger.sendAnswer({
                 message: `Changed source root to: ${uri.fsPath}`,
                 type: 'answer',

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -88,6 +88,11 @@ export class Session {
         )
     }
 
+    updateWorkspaceRoot(workspaceRootFolder: string) {
+        this.config.workspaceRoots = [workspaceRootFolder]
+        this._state && this._state.updateWorkspaceRoot && this._state.updateWorkspaceRoot(workspaceRootFolder)
+    }
+
     private getSessionStateConfig(): Omit<SessionStateConfig, 'uploadId'> {
         return {
             workspaceRoots: this.config.workspaceRoots,

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -55,6 +55,11 @@ export class PrepareRefinementState implements Omit<SessionState, 'uploadId'> {
     constructor(private config: Omit<SessionStateConfig, 'uploadId'>, public approach: string, public tabID: string) {
         this.tokenSource = new vscode.CancellationTokenSource()
     }
+
+    updateWorkspaceRoot(workspaceRoot: string) {
+        this.config.workspaceRoots = [workspaceRoot]
+    }
+
     async interact(action: SessionStateAction): Promise<SessionStateInteraction> {
         const uploadId = await telemetry.amazonq_createUpload.run(async span => {
             span.record({
@@ -452,6 +457,11 @@ export class PrepareCodeGenState implements SessionState {
         this.uploadId = config.uploadId
         this.conversationId = config.conversationId
     }
+
+    updateWorkspaceRoot(workspaceRoot: string) {
+        this.config.workspaceRoots = [workspaceRoot]
+    }
+
     async interact(action: SessionStateAction): Promise<SessionStateInteraction> {
         action.messenger.sendAnswer({
             message: 'Uploading code ...',

--- a/packages/core/src/amazonqFeatureDev/types.ts
+++ b/packages/core/src/amazonqFeatureDev/types.ts
@@ -50,6 +50,7 @@ export interface SessionState {
     readonly tokenSource: CancellationTokenSource
     readonly tabID: string
     interact(action: SessionStateAction): Promise<SessionStateInteraction>
+    updateWorkspaceRoot?: (workspaceRoot: string) => void
 }
 
 export interface SessionStateConfig {


### PR DESCRIPTION
## Problem

When the repo is larger that 200MB amazonqFeatureDev doesn't allow the customer to upload the repo and it prompts the customer to select a folder that could be used for the plan. This modification was not updating accordingly the config of the session state so it kept using the same root.

## Solution

Update the config of the state on the fly and the session config to have the root folder correctly selected.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
