### PR TITLE
fix(amazonq): ensure summary.md + icons saved, populate job history sooner, fix minor styling issues

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-58e09665-68a7-477e-b4a6-708cc77d7c54.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-58e09665-68a7-477e-b4a6-708cc77d7c54.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Code Transformation: make jobId visible in job history tab at start of job and allow summary.md + icons to be saved when accepting changes\""
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-58e09665-68a7-477e-b4a6-708cc77d7c54.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-58e09665-68a7-477e-b4a6-708cc77d7c54.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q Code Transformation: make jobId visible in job history tab at start of job and allow summary.md + icons to be saved when accepting changes\""
+	"description": "Amazon Q Code Transformation: make jobId visible in job history tab at start of job and allow summary.md + icons to be saved when accepting changes"
 }

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -258,24 +258,19 @@
             ],
             "view/title": [
                 {
-                    "command": "aws.amazonq.startTransformationInHub",
+                    "command": "aws.amazonq.stopTransformationInHub",
                     "when": "view == aws.amazonq.transformationHub",
                     "group": "navigation@1"
                 },
                 {
-                    "command": "aws.amazonq.stopTransformationInHub",
+                    "command": "aws.amazonq.showPlanProgressInHub",
                     "when": "view == aws.amazonq.transformationHub",
                     "group": "navigation@2"
                 },
                 {
-                    "command": "aws.amazonq.showPlanProgressInHub",
-                    "when": "view == aws.amazonq.transformationHub",
-                    "group": "navigation@3"
-                },
-                {
                     "command": "aws.amazonq.showHistoryInHub",
                     "when": "view == aws.amazonq.transformationHub",
-                    "group": "navigation@4"
+                    "group": "navigation@3"
                 },
                 {
                     "command": "aws.amazonq.transformationHub.summary.reveal",
@@ -600,12 +595,6 @@
                 "title": "Open Developer Menu",
                 "category": "Amazon Q (Developer)",
                 "enablement": "aws.isDevMode"
-            },
-            {
-                "command": "aws.amazonq.startTransformationInHub",
-                "title": "Start Transformation",
-                "icon": "$(play)",
-                "enablement": "gumby.isTransformAvailable"
             },
             {
                 "command": "aws.amazonq.stopTransformationInHub",

--- a/packages/core/resources/css/amazonqTransformationHub.css
+++ b/packages/core/resources/css/amazonqTransformationHub.css
@@ -1,0 +1,105 @@
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+body {
+    margin: 0;
+    padding: 0 1em;
+    height: 100vh;
+}
+
+.wrapper {
+    height: 100%;
+    display: flex;
+}
+
+.spinner {
+    display: inline-block;
+    animation: spin 1s infinite;
+}
+
+.column--container,
+.substep-container {
+    display: flex;
+    flex-direction: row;
+}
+
+.column {
+    flex-grow: 1;
+}
+
+.substep-container p {
+    margin: 0.5em 0;
+}
+
+.step,
+.simple-step {
+    padding: 0.5em 0 0.5em 0;
+    margin: 0;
+}
+
+.step {
+    padding-left: 20px;
+}
+
+.step:hover,
+.step.active {
+    color: var(--vscode-editor-selectionForeground, inherit);
+    background-color: var(--vscode-editor-selectionBackground, aliceblue);
+}
+
+#stepdetails {
+    width: 40%;
+    padding: 0 20px;
+    border-left: solid rgba(230, 230, 230, 0.5);
+    min-height: 100vh;
+    display: block;
+}
+
+#progress {
+    width: 60%;
+}
+
+.status-PENDING {
+    color: grey;
+}
+
+.status-COMPLETED {
+    color: green;
+}
+
+.status-FAILED {
+    color: red;
+}
+
+.substep {
+    display: none;
+}
+
+.substep-icon {
+    padding: 0 1em;
+}
+
+.visible {
+    display: block;
+}
+
+.center {
+    position: absolute;
+    top: 50%;
+    transform: translate(0, -50%);
+}
+
+.center-flex {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#step-duration {
+    color: grey;
+}

--- a/packages/core/src/amazonq/webview/ui/tabs/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/generator.ts
@@ -28,7 +28,7 @@ export class TabDataGenerator {
         ['unknown', 'Ask a question or enter "/" for quick actions'],
         ['cwc', 'Ask a question or enter "/" for quick actions'],
         ['featuredev', 'Briefly describe a task or issue'],
-        ['gumby', 'Chat is disabled during Code Transformation.'],
+        ['gumby', 'Open a new tab to chat with Q'],
     ])
 
     private tabWelcomeMessage: Map<TabType, string> = new Map([

--- a/packages/core/src/amazonqGumby/activation.ts
+++ b/packages/core/src/amazonqGumby/activation.ts
@@ -55,11 +55,11 @@ export async function activate(context: ExtContext) {
             }),
 
             Commands.register('aws.amazonq.showHistoryInHub', async () => {
-                transformationHubViewProvider.updateContent('job history')
+                await transformationHubViewProvider.updateContent('job history')
             }),
 
             Commands.register('aws.amazonq.showPlanProgressInHub', async (startTime: number) => {
-                transformationHubViewProvider.updateContent('plan progress', startTime)
+                await transformationHubViewProvider.updateContent('plan progress', startTime)
             }),
 
             Commands.register('aws.amazonq.showTransformationPlanInHub', async () => {

--- a/packages/core/src/amazonqGumby/activation.ts
+++ b/packages/core/src/amazonqGumby/activation.ts
@@ -55,7 +55,7 @@ export async function activate(context: ExtContext) {
             }),
 
             Commands.register('aws.amazonq.showHistoryInHub', async () => {
-                transformationHubViewProvider.updateContent('job history', 0) // 0 is dummy value for startTime - not used
+                transformationHubViewProvider.updateContent('job history')
             }),
 
             Commands.register('aws.amazonq.showPlanProgressInHub', async (startTime: number) => {

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -319,7 +319,7 @@ export class GumbyController {
     private async processHumanChatMessage(data: { message: string; tabID: string }) {
         this.messenger.sendUserPrompt(data.message, data.tabID)
         this.messenger.sendChatInputEnabled(data.tabID, false)
-        this.messenger.sendUpdatePlaceholder(data.tabID, 'Chat is disabled during Code Transformation.')
+        this.messenger.sendUpdatePlaceholder(data.tabID, 'Open a new tab to chat with Q')
 
         const session = this.sessionStorage.getSession()
         switch (session.conversationState) {

--- a/packages/core/src/amazonqGumby/telemetry/codeTransformTelemetry.ts
+++ b/packages/core/src/amazonqGumby/telemetry/codeTransformTelemetry.ts
@@ -89,4 +89,4 @@ export const javapOutputToTelemetryValue = (javapCommandLineOutput: string) => {
     }
 }
 
-export const calculateTotalLatency = (startTime: number, endTime: number = Date.now()): number => endTime - startTime
+export const calculateTotalLatency = (startTime: number): number => Date.now() - startTime

--- a/packages/core/src/amazonqGumby/telemetry/codeTransformTelemetryState.ts
+++ b/packages/core/src/amazonqGumby/telemetry/codeTransformTelemetryState.ts
@@ -8,7 +8,6 @@ import { randomUUID } from '../../common/crypto'
 interface ICodeTransformTelemetryState {
     sessionId: string
     sessionStartTime: number
-    resultStatus: string
 }
 
 export class CodeTransformTelemetryState {
@@ -18,22 +17,17 @@ export class CodeTransformTelemetryState {
         this.mainState = {
             sessionId: randomUUID(),
             sessionStartTime: Date.now(),
-            resultStatus: '',
         }
     }
 
     public getSessionId = () => this.mainState.sessionId
     public getStartTime = () => this.mainState.sessionStartTime
-    public getResultStatus = () => this.mainState.resultStatus
 
     public setSessionId = () => {
         this.mainState.sessionId = randomUUID()
     }
     public setStartTime = () => {
         this.mainState.sessionStartTime = Date.now()
-    }
-    public setResultStatus = (newValue: string) => {
-        this.mainState.resultStatus = newValue
     }
 
     static #instance: CodeTransformTelemetryState

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -12,13 +12,13 @@ import * as CodeWhispererConstants from '../models/constants'
 import {
     transformByQState,
     StepProgress,
-    TransformByQReviewStatus,
     JDKVersion,
-    sessionPlanProgress,
+    jobPlanProgress,
+    sessionJobHistory,
     FolderInfo,
     TransformationCandidateProject,
 } from '../models/model'
-import { convertToTimeString, convertDateToTimestamp, encodeHTML } from '../../shared/utilities/textUtilities'
+import { convertToTimeString, convertDateToTimestamp } from '../../shared/utilities/textUtilities'
 import {
     getTransformationPlan,
     pollTransformationJob,
@@ -51,8 +51,6 @@ import { JavaHomeNotSetError } from '../../amazonqGumby/errors'
 import { ChatSessionManager } from '../../amazonqGumby/chat/storages/chatSession'
 import { getDependenciesFolderInfo, writeLogs } from '../service/transformByQ/transformFileHandler'
 import { sleep } from '../../shared/utilities/timeoutUtils'
-
-let sessionJobHistory: { timestamp: string; module: string; status: string; duration: string; id: string }[] = []
 
 export async function processTransformFormInput(
     pathToProject: string,
@@ -129,21 +127,26 @@ export async function compileProject() {
     }
 }
 
+export async function startInterval() {
+    const intervalId = setInterval(() => {
+        void vscode.commands.executeCommand(
+            'aws.amazonq.showPlanProgressInHub',
+            CodeTransformTelemetryState.instance.getStartTime()
+        )
+        updateJobHistory()
+    }, CodeWhispererConstants.transformationJobPollingIntervalSeconds * 1000)
+    transformByQState.setIntervalId(intervalId)
+}
+
 export async function startTransformByQ() {
-    let intervalId = undefined
     // Set the default state variables for our store and the UI
     await setTransformationToRunningState()
 
     try {
-        // Set web view UI to poll for progress
-        intervalId = setInterval(() => {
-            void vscode.commands.executeCommand(
-                'aws.amazonq.showPlanProgressInHub',
-                CodeTransformTelemetryState.instance.getStartTime()
-            )
-        }, CodeWhispererConstants.transformationJobPollingIntervalSeconds * 1000)
+        // Set webview UI to poll for progress
+        await startInterval()
 
-        // step 1: CreateCodeUploadUrl and upload code
+        // step 1: CreateUploadUrl and upload code
         const uploadId = await preTransformationUploadCode()
 
         // step 2: StartJob and store the returned jobId in TransformByQState
@@ -161,7 +164,7 @@ export async function startTransformByQ() {
         await transformationJobErrorHandler(error)
     } finally {
         await postTransformationJob()
-        await cleanupTransformationJob(intervalId)
+        await cleanupTransformationJob()
     }
 }
 
@@ -195,6 +198,7 @@ export async function startTransformationJob(uploadId: string) {
     let jobId = ''
     try {
         jobId = await startJob(uploadId)
+        getLogger().info(`CodeTransformation: jobId: ${jobId}`)
     } catch (error) {
         getLogger().error(`CodeTransformation: ${CodeWhispererConstants.failedToStartJobNotification}`, error)
         if ((error as Error).message.includes('too many active running jobs')) {
@@ -210,7 +214,6 @@ export async function startTransformationJob(uploadId: string) {
         }
         throw new Error('Start job failed')
     }
-    transformByQState.setJobId(encodeHTML(jobId))
 
     await sleep(2000) // sleep before polling job to prevent ThrottlingException
     throwIfCancelled()
@@ -245,7 +248,7 @@ export async function pollTransformationStatusUntilPlanReady(jobId: string) {
         transformByQState.setPlanFilePath(planFilePath)
         await vscode.commands.executeCommand('setContext', 'gumby.isPlanAvailable', true)
     }
-    sessionPlanProgress['generatePlan'] = StepProgress.Succeeded
+    jobPlanProgress['generatePlan'] = StepProgress.Succeeded
     throwIfCancelled()
 }
 
@@ -266,23 +269,17 @@ export async function pollTransformationStatusUntilComplete(jobId: string) {
 export async function finalizeTransformationJob(status: string) {
     if (!(status === 'COMPLETED' || status === 'PARTIALLY_COMPLETED')) {
         getLogger().error(`CodeTransformation: ${CodeWhispererConstants.failedToCompleteJobNotification}`)
-        sessionPlanProgress['transformCode'] = StepProgress.Failed
+        jobPlanProgress['transformCode'] = StepProgress.Failed
         transformByQState.setJobFailureErrorNotification(CodeWhispererConstants.failedToCompleteJobNotification)
         transformByQState.setJobFailureErrorChatMessage(CodeWhispererConstants.failedToCompleteJobChatMessage)
         throw new Error('Job was not successful nor partially successful')
     }
-
     transformByQState.setToSucceeded()
     if (status === 'PARTIALLY_COMPLETED') {
         transformByQState.setToPartiallySucceeded()
-        CodeTransformTelemetryState.instance.setResultStatus('JobPartiallySucceeded')
-    } else {
-        CodeTransformTelemetryState.instance.setResultStatus('JobCompletedSuccessfully')
     }
-
     await vscode.commands.executeCommand('aws.amazonq.transformationHub.reviewChanges.reveal')
-
-    sessionPlanProgress['transformCode'] = StepProgress.Succeeded
+    jobPlanProgress['transformCode'] = StepProgress.Succeeded
 }
 
 export async function getValidCandidateProjects(): Promise<TransformationCandidateProject[]> {
@@ -294,11 +291,14 @@ export async function setTransformationToRunningState() {
     await setContextVariables()
     await vscode.commands.executeCommand('aws.amazonq.transformationHub.reviewChanges.reset')
     transformByQState.setToRunning()
-    sessionPlanProgress['startJob'] = StepProgress.Pending
-    sessionPlanProgress['buildCode'] = StepProgress.Pending
-    sessionPlanProgress['generatePlan'] = StepProgress.Pending
-    sessionPlanProgress['transformCode'] = StepProgress.Pending
+    jobPlanProgress['startJob'] = StepProgress.Pending
+    jobPlanProgress['buildCode'] = StepProgress.Pending
+    jobPlanProgress['generatePlan'] = StepProgress.Pending
+    jobPlanProgress['transformCode'] = StepProgress.Pending
     transformByQState.resetPlanSteps()
+    transformByQState.resetSessionJobHistory()
+    transformByQState.setJobId('') // so that details for last job are not overwritten when running one job after another
+    transformByQState.setPolledJobStatus('') // so that previous job's status does not display at very beginning of this job
 
     CodeTransformTelemetryState.instance.setStartTime()
 
@@ -321,24 +321,21 @@ export async function setTransformationToRunningState() {
     })
 
     await vscode.commands.executeCommand('workbench.view.extension.aws-codewhisperer-transformation-hub')
-    await vscode.commands.executeCommand(
-        'aws.amazonq.showPlanProgressInHub',
-        CodeTransformTelemetryState.instance.getStartTime()
-    )
 }
 
 export async function postTransformationJob() {
-    if (sessionPlanProgress['startJob'] !== StepProgress.Succeeded) {
-        sessionPlanProgress['startJob'] = StepProgress.Failed
+    await updateJobHistory()
+    if (jobPlanProgress['startJob'] !== StepProgress.Succeeded) {
+        jobPlanProgress['startJob'] = StepProgress.Failed
     }
-    if (sessionPlanProgress['buildCode'] !== StepProgress.Succeeded) {
-        sessionPlanProgress['buildCode'] = StepProgress.Failed
+    if (jobPlanProgress['buildCode'] !== StepProgress.Succeeded) {
+        jobPlanProgress['buildCode'] = StepProgress.Failed
     }
-    if (sessionPlanProgress['generatePlan'] !== StepProgress.Succeeded) {
-        sessionPlanProgress['generatePlan'] = StepProgress.Failed
+    if (jobPlanProgress['generatePlan'] !== StepProgress.Succeeded) {
+        jobPlanProgress['generatePlan'] = StepProgress.Failed
     }
-    if (sessionPlanProgress['transformCode'] !== StepProgress.Succeeded) {
-        sessionPlanProgress['transformCode'] = StepProgress.Failed
+    if (jobPlanProgress['transformCode'] !== StepProgress.Succeeded) {
+        jobPlanProgress['transformCode'] = StepProgress.Failed
     }
 
     let chatMessage = transformByQState.getJobFailureErrorChatMessage()
@@ -352,7 +349,7 @@ export async function postTransformationJob() {
         .getChatControllers()
         ?.transformationFinished.fire({ message: chatMessage, tabID: ChatSessionManager.Instance.getSession().tabID })
     const durationInMs = calculateTotalLatency(CodeTransformTelemetryState.instance.getStartTime())
-    const resultStatusMessage = CodeTransformTelemetryState.instance.getResultStatus()
+    const resultStatusMessage = transformByQState.getStatus()
 
     const versionInfo = await getVersionData()
     const mavenVersionInfoMessage = `${versionInfo[0]} (${transformByQState.getMavenName()})`
@@ -365,18 +362,9 @@ export async function postTransformationJob() {
         codeTransformRunTimeLatency: durationInMs,
         codeTransformLocalMavenVersion: mavenVersionInfoMessage,
         codeTransformLocalJavaVersion: javaVersionInfoMessage,
-        result: resultStatusMessage === 'JobCompletedSuccessfully' ? MetadataResult.Pass : MetadataResult.Fail,
+        result: resultStatusMessage === 'Succeeded' ? MetadataResult.Pass : MetadataResult.Fail,
         reason: resultStatusMessage,
     })
-
-    sessionJobHistory = processHistory(
-        sessionJobHistory,
-        convertDateToTimestamp(new Date(CodeTransformTelemetryState.instance.getStartTime())),
-        transformByQState.getProjectName(),
-        transformByQState.getStatus(),
-        convertToTimeString(durationInMs),
-        transformByQState.getJobId()
-    )
 
     if (transformByQState.isSucceeded()) {
         void vscode.window.showInformationMessage(CodeWhispererConstants.jobCompletedNotification)
@@ -402,9 +390,10 @@ export async function transformationJobErrorHandler(error: any) {
     if (!transformByQState.isCancelled()) {
         // means some other error occurred; cancellation already handled by now with stopTransformByQ
         transformByQState.setToFailed()
-        CodeTransformTelemetryState.instance.setResultStatus('JobFailed')
+        transformByQState.setPolledJobStatus('FAILED')
         // jobFailureErrorNotification should always be defined here
-        let displayedErrorMessage = transformByQState.getJobFailureErrorNotification() ?? 'Job failed'
+        let displayedErrorMessage =
+            transformByQState.getJobFailureErrorNotification() ?? CodeWhispererConstants.failedToCompleteJobNotification
         if (transformByQState.getJobFailureMetadata() !== '') {
             displayedErrorMessage += ` ${transformByQState.getJobFailureMetadata()}`
             transformByQState.setJobFailureErrorChatMessage(
@@ -424,8 +413,8 @@ export async function transformationJobErrorHandler(error: any) {
     getLogger().error(`CodeTransformation: ${error.message}`)
 }
 
-export async function cleanupTransformationJob(intervalId: NodeJS.Timeout | undefined) {
-    clearInterval(intervalId)
+export async function cleanupTransformationJob() {
+    clearInterval(transformByQState.getIntervalId())
     transformByQState.setJobDefaults()
     await vscode.commands.executeCommand('setContext', 'gumby.isStopButtonAvailable', false)
     await vscode.commands.executeCommand(
@@ -434,26 +423,20 @@ export async function cleanupTransformationJob(intervalId: NodeJS.Timeout | unde
     )
 }
 
-export function processHistory(
-    sessionJobHistory: { timestamp: string; module: string; status: string; duration: string; id: string }[],
-    startTime: string,
-    module: string,
-    status: string,
-    duration: string,
-    id: string
-) {
-    sessionJobHistory = [] // reset job history; only storing the last run for now
-    const copyState = { timestamp: startTime, module: module, status: status, duration: duration, id: id }
-    sessionJobHistory.push(copyState)
+export async function updateJobHistory() {
+    if (transformByQState.getJobId() !== '') {
+        sessionJobHistory[transformByQState.getJobId()] = {
+            startTime: convertDateToTimestamp(new Date(CodeTransformTelemetryState.instance.getStartTime())),
+            projectName: transformByQState.getProjectName(),
+            status: transformByQState.getPolledJobStatus(),
+            duration: convertToTimeString(calculateTotalLatency(CodeTransformTelemetryState.instance.getStartTime())),
+        }
+    }
     return sessionJobHistory
 }
 
 export function getJobHistory() {
     return sessionJobHistory
-}
-
-export function getPlanProgress() {
-    return sessionPlanProgress
 }
 
 export async function stopTransformByQ(
@@ -463,7 +446,7 @@ export async function stopTransformByQ(
     if (transformByQState.isRunning()) {
         getLogger().info('CodeTransformation: User requested to stop transformation. Stopping transformation.')
         transformByQState.setToCancelled()
-        CodeTransformTelemetryState.instance.setResultStatus('JobCancelled')
+        transformByQState.setPolledJobStatus('CANCELLED')
         await vscode.commands.executeCommand('setContext', 'gumby.isStopButtonAvailable', false)
         try {
             await stopJob(jobId)
@@ -502,6 +485,4 @@ async function setContextVariables() {
     await vscode.commands.executeCommand('setContext', 'gumby.isStopButtonAvailable', true)
     await vscode.commands.executeCommand('setContext', 'gumby.isPlanAvailable', false)
     await vscode.commands.executeCommand('setContext', 'gumby.isSummaryAvailable', false)
-    await vscode.commands.executeCommand('setContext', 'gumby.reviewState', TransformByQReviewStatus.NotStarted)
-    await vscode.commands.executeCommand('setContext', 'gumby.transformationProposalReviewInProgress', false)
 }

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -14,17 +14,17 @@ import {
     StepProgress,
     JDKVersion,
     jobPlanProgress,
-    sessionJobHistory,
     FolderInfo,
     TransformationCandidateProject,
 } from '../models/model'
-import { convertToTimeString, convertDateToTimestamp } from '../../shared/utilities/textUtilities'
+import { convertDateToTimestamp } from '../../shared/utilities/textUtilities'
 import {
     getTransformationPlan,
     pollTransformationJob,
     startJob,
     stopJob,
     throwIfCancelled,
+    updateJobHistory,
     uploadPayload,
     zipCode,
 } from '../service/transformByQ/transformApiHandler'
@@ -426,22 +426,6 @@ export async function cleanupTransformationJob() {
         'aws.amazonq.showPlanProgressInHub',
         CodeTransformTelemetryState.instance.getStartTime()
     )
-}
-
-export async function updateJobHistory() {
-    if (transformByQState.getJobId() !== '') {
-        sessionJobHistory[transformByQState.getJobId()] = {
-            startTime: transformByQState.getStartTime(),
-            projectName: transformByQState.getProjectName(),
-            status: transformByQState.getPolledJobStatus(),
-            duration: convertToTimeString(calculateTotalLatency(CodeTransformTelemetryState.instance.getStartTime())),
-        }
-    }
-    return sessionJobHistory
-}
-
-export function getJobHistory() {
-    return sessionJobHistory
 }
 
 export async function stopTransformByQ(

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -226,8 +226,12 @@ export async function pollTransformationStatusUntilPlanReady(jobId: string) {
         await pollTransformationJob(jobId, CodeWhispererConstants.validStatesForPlanGenerated)
     } catch (error) {
         getLogger().error(`CodeTransformation: ${CodeWhispererConstants.failedToCompleteJobNotification}`, error)
-        transformByQState.setJobFailureErrorNotification(CodeWhispererConstants.failedToCompleteJobNotification)
-        transformByQState.setJobFailureErrorChatMessage(CodeWhispererConstants.failedToCompleteJobChatMessage)
+        if (!transformByQState.getJobFailureErrorNotification()) {
+            transformByQState.setJobFailureErrorNotification(CodeWhispererConstants.failedToCompleteJobNotification)
+        }
+        if (!transformByQState.getJobFailureErrorChatMessage()) {
+            transformByQState.setJobFailureErrorChatMessage(CodeWhispererConstants.failedToCompleteJobChatMessage)
+        }
         throw new Error('Poll job failed')
     }
     let plan = undefined
@@ -258,8 +262,12 @@ export async function pollTransformationStatusUntilComplete(jobId: string) {
         status = await pollTransformationJob(jobId, CodeWhispererConstants.validStatesForCheckingDownloadUrl)
     } catch (error) {
         getLogger().error(`CodeTransformation: ${CodeWhispererConstants.failedToCompleteJobNotification}`, error)
-        transformByQState.setJobFailureErrorNotification(CodeWhispererConstants.failedToCompleteJobNotification)
-        transformByQState.setJobFailureErrorChatMessage(CodeWhispererConstants.failedToCompleteJobChatMessage)
+        if (!transformByQState.getJobFailureErrorNotification()) {
+            transformByQState.setJobFailureErrorNotification(CodeWhispererConstants.failedToCompleteJobNotification)
+        }
+        if (!transformByQState.getJobFailureErrorChatMessage()) {
+            transformByQState.setJobFailureErrorChatMessage(CodeWhispererConstants.failedToCompleteJobChatMessage)
+        }
         throw new Error('Poll job failed')
     }
 

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -127,13 +127,13 @@ export async function compileProject() {
     }
 }
 
-export async function startInterval() {
-    const intervalId = setInterval(async () => {
-        await vscode.commands.executeCommand(
+export function startInterval() {
+    const intervalId = setInterval(() => {
+        void vscode.commands.executeCommand(
             'aws.amazonq.showPlanProgressInHub',
             CodeTransformTelemetryState.instance.getStartTime()
         )
-        await updateJobHistory()
+        updateJobHistory()
     }, CodeWhispererConstants.transformationJobPollingIntervalSeconds * 1000)
     transformByQState.setIntervalId(intervalId)
 }
@@ -144,7 +144,7 @@ export async function startTransformByQ() {
 
     try {
         // Set webview UI to poll for progress
-        await startInterval()
+        startInterval()
 
         // step 1: CreateUploadUrl and upload code
         const uploadId = await preTransformationUploadCode()
@@ -327,7 +327,7 @@ export async function setTransformationToRunningState() {
 }
 
 export async function postTransformationJob() {
-    await updateJobHistory()
+    updateJobHistory()
     if (jobPlanProgress['startJob'] !== StepProgress.Succeeded) {
         jobPlanProgress['startJob'] = StepProgress.Failed
     }

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -301,6 +301,9 @@ export async function setTransformationToRunningState() {
     transformByQState.setPolledJobStatus('') // so that previous job's status does not display at very beginning of this job
 
     CodeTransformTelemetryState.instance.setStartTime()
+    transformByQState.setStartTime(
+        convertDateToTimestamp(new Date(CodeTransformTelemetryState.instance.getStartTime()))
+    )
 
     const projectPath = transformByQState.getProjectPath()
     let projectId = telemetryUndefined
@@ -408,6 +411,8 @@ export async function transformationJobErrorHandler(error: any) {
                 }
             })
     } else {
+        transformByQState.setToCancelled()
+        transformByQState.setPolledJobStatus('CANCELLED')
         transformByQState.setJobFailureErrorChatMessage(CodeWhispererConstants.jobCancelledChatMessage)
     }
     getLogger().error(`CodeTransformation: ${error.message}`)
@@ -426,7 +431,7 @@ export async function cleanupTransformationJob() {
 export async function updateJobHistory() {
     if (transformByQState.getJobId() !== '') {
         sessionJobHistory[transformByQState.getJobId()] = {
-            startTime: convertDateToTimestamp(new Date(CodeTransformTelemetryState.instance.getStartTime())),
+            startTime: transformByQState.getStartTime(),
             projectName: transformByQState.getProjectName(),
             status: transformByQState.getPolledJobStatus(),
             duration: convertToTimeString(calculateTotalLatency(CodeTransformTelemetryState.instance.getStartTime())),

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -128,12 +128,12 @@ export async function compileProject() {
 }
 
 export async function startInterval() {
-    const intervalId = setInterval(() => {
-        void vscode.commands.executeCommand(
+    const intervalId = setInterval(async () => {
+        await vscode.commands.executeCommand(
             'aws.amazonq.showPlanProgressInHub',
             CodeTransformTelemetryState.instance.getStartTime()
         )
-        updateJobHistory()
+        await updateJobHistory()
     }, CodeWhispererConstants.transformationJobPollingIntervalSeconds * 1000)
     transformByQState.setIntervalId(intervalId)
 }

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -372,6 +372,37 @@ export const amazonQFeedbackKey = 'Amazon Q'
 
 export const amazonQFeedbackText = 'Submit feedback'
 
+export const waitingForJobStartStepMessage = 'Waiting for job to start'
+
+export const buildCodeStepMessage = 'Build uploaded code in secure build environment'
+
+export const generatePlanStepMessage = 'Generate transformation plan'
+
+export const transformStepMessage = 'Transform your code to Java 17 using transformation plan'
+
+export const filesUploadedMessage =
+    'Files have been uploaded to Amazon Q, transformation job has been accepted and is preparing to start.'
+
+export const planningMessage = 'Amazon Q is analyzing your code in order to generate a transformation plan.'
+
+export const transformingMessage = 'Amazon Q is transforming your code. Details will appear soon.'
+
+export const stoppingJobMessage = 'Stopping the transformation...'
+
+export const buildingCodeMessage =
+    'Amazon Q is building your code using Java JAVA_VERSION_HERE in a secure build environment.'
+
+export const scanningProjectMessage =
+    'Amazon Q is scanning the project files and getting ready to start the job. To start the job, Amazon Q needs to upload the project artifacts. Once that is done, Amazon Q can start the transformation job. The estimated time for this operation ranges from a few seconds to several minutes.'
+
+export const failedStepMessage = 'The step failed, fetching additional details...'
+
+export const jobCompletedMessage = 'The transformation completed.'
+
+export const noOngoingJobMessage = 'No ongoing job.'
+
+export const nothingToShowMessage = 'Nothing to show'
+
 export const jobStartedChatMessage =
     "I'm starting to transform your code. It can take 10 to 30 minutes to upgrade your code, depending on the size of your project. To monitor progress, go to the Transformation Hub."
 
@@ -542,27 +573,19 @@ export const planHeaderMessage = 'Planned transformation changes'
 export const planDisclaimerMessage =
     'Amazon Q will use the proposed changes as guidance during the transformation. The final code updates might differ from this plan.'
 
-export const linesOfCodeMessage = 'Lines of code in your application'
-
-export const dependenciesToBeReplacedMessage = 'Dependencies to be replaced'
-
-export const deprecatedCodeToBeReplacedMessage = 'Deprecated code instances to be replaced'
-
-export const filesToBeChangedMessage = 'Files to be changed'
-
-export const dependencyNameColumn = 'Dependency'
-
-export const actionColumn = 'Action'
-
-export const currentVersionColumn = 'Current version'
-
-export const targetVersionColumn = 'Target version'
-
-export const relativePathColumn = 'File'
-
-export const apiNameColumn = 'Deprecated code'
-
-export const numChangedFilesColumn = 'Files to be changed'
+export const formattedStringMap = new Map([
+    ['linesOfCode', 'Lines of code in your application'],
+    ['plannedDependencyChanges', 'Dependencies to be replaced'],
+    ['plannedDeprecatedApiChanges', 'Deprecated code instances to be replaced'],
+    ['plannedFileChanges', 'Files to be changed'],
+    ['dependencyName', 'Dependency'],
+    ['action', 'Action'],
+    ['currentVersion', 'Current version'],
+    ['targetVersion', 'Target version'],
+    ['relativePath', 'File'],
+    ['apiFullyQualifiedName', 'Deprecated code'],
+    ['numChangedFiles', 'Files to be changed'],
+])
 
 // end of QCT Strings
 

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -339,6 +339,8 @@ export class TransformByQState {
     private projectName: string = ''
     private projectPath: string = ''
 
+    private startTime: string = ''
+
     private jobId: string = ''
 
     private sourceJDKVersion: JDKVersion | undefined = undefined
@@ -405,6 +407,10 @@ export class TransformByQState {
 
     public getProjectPath() {
         return this.projectPath
+    }
+
+    public getStartTime() {
+        return this.startTime
     }
 
     public getJobId() {
@@ -521,6 +527,10 @@ export class TransformByQState {
 
     public setProjectPath(path: string) {
         this.projectPath = path
+    }
+
+    public setStartTime(time: string) {
+        this.startTime = time
     }
 
     public setJobId(id: string) {

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -317,7 +317,7 @@ export enum DropdownStep {
     STEP_2 = 2,
 }
 
-export const sessionPlanProgress: {
+export const jobPlanProgress: {
     startJob: StepProgress
     buildCode: StepProgress
     generatePlan: StepProgress
@@ -328,6 +328,10 @@ export const sessionPlanProgress: {
     generatePlan: StepProgress.NotStarted,
     transformCode: StepProgress.NotStarted,
 }
+
+export let sessionJobHistory: {
+    [jobId: string]: { startTime: string; projectName: string; status: string; duration: string }
+} = {}
 
 export class TransformByQState {
     private transformByQState: TransformByQStatus = TransformByQStatus.NotStarted
@@ -368,6 +372,8 @@ export class TransformByQState {
     private dependencyFolderInfo: FolderInfo | undefined = undefined
 
     private planSteps: TransformationSteps | undefined = undefined
+
+    private intervalId: NodeJS.Timeout | undefined = undefined
 
     public isNotStarted() {
         return this.transformByQState === TransformByQStatus.NotStarted
@@ -477,6 +483,10 @@ export class TransformByQState {
         return this.planSteps
     }
 
+    public getIntervalId() {
+        return this.intervalId
+    }
+
     public appendToErrorLog(message: string) {
         this.errorLog += `${message}\n\n`
     }
@@ -577,6 +587,10 @@ export class TransformByQState {
         this.dependencyFolderInfo = folderInfo
     }
 
+    public setIntervalId(id: NodeJS.Timeout | undefined) {
+        this.intervalId = id
+    }
+
     public setPlanSteps(steps: TransformationSteps) {
         this.planSteps = steps
     }
@@ -585,34 +599,18 @@ export class TransformByQState {
         this.planSteps = undefined
     }
 
-    public getPrefixTextForButton() {
-        switch (this.transformByQState) {
-            case TransformByQStatus.NotStarted:
-                return 'Run'
-            case TransformByQStatus.Cancelled:
-                return 'Stopping'
-            default:
-                return 'Stop'
-        }
-    }
-
-    public getIconForButton() {
-        switch (this.transformByQState) {
-            case TransformByQStatus.NotStarted:
-                return getIcon('vscode-play')
-            default:
-                return getIcon('vscode-stop-circle')
-        }
+    public resetSessionJobHistory() {
+        sessionJobHistory = {}
     }
 
     public setJobDefaults() {
-        this.setToNotStarted() // so that the "Transform by Q" button resets
-        this.polledJobStatus = '' // reset polled job status too
+        this.setToNotStarted()
         this.jobFailureErrorNotification = undefined
         this.jobFailureErrorChatMessage = undefined
         this.jobFailureMetadata = ''
         this.payloadFilePath = ''
         this.errorLog = ''
+        this.intervalId = undefined
     }
 }
 

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -207,7 +207,7 @@ export async function uploadPayload(payloadFileName: string) {
         throw new Error('S3 upload failed')
     }
     transformByQState.setJobId(encodeHTML(response.uploadId))
-    await updateJobHistory()
+    updateJobHistory()
     return response.uploadId
 }
 

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -56,7 +56,7 @@ export function throwIfCancelled() {
     }
 }
 
-export async function updateJobHistory() {
+export function updateJobHistory() {
     if (transformByQState.getJobId() !== '') {
         sessionJobHistory[transformByQState.getJobId()] = {
             startTime: transformByQState.getStartTime(),

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -11,7 +11,7 @@ import * as crypto from 'crypto'
 import * as CodeWhispererConstants from '../../models/constants'
 import {
     FolderInfo,
-    sessionPlanProgress,
+    jobPlanProgress,
     StepProgress,
     transformByQState,
     TransformByQStoppedError,
@@ -31,6 +31,8 @@ import { ZipExceedsSizeLimitError } from '../../../amazonqGumby/errors'
 import { writeLogs } from './transformFileHandler'
 import { AuthUtil } from '../../util/authUtil'
 import { ChatSessionManager } from '../../../amazonqGumby/chat/storages/chatSession'
+import { encodeHTML } from '../../../shared/utilities/textUtilities'
+import { updateJobHistory } from '../../commands/startTransformByQ'
 
 export function getSha256(buffer: Buffer) {
     const hasher = crypto.createHash('sha256')
@@ -192,6 +194,8 @@ export async function uploadPayload(payloadFileName: string) {
         getLogger().error(`CodeTransformation: UploadArtifactToS3 error: = ${errorMessage}`)
         throw new Error('S3 upload failed')
     }
+    transformByQState.setJobId(encodeHTML(response.uploadId))
+    await updateJobHistory()
     return response.uploadId
 }
 
@@ -424,32 +428,7 @@ export function getTransformationIcon(name: string) {
 }
 
 export function getFormattedString(s: string) {
-    switch (s) {
-        case 'linesOfCode':
-            return CodeWhispererConstants.linesOfCodeMessage
-        case 'plannedDependencyChanges':
-            return CodeWhispererConstants.dependenciesToBeReplacedMessage
-        case 'plannedDeprecatedApiChanges':
-            return CodeWhispererConstants.deprecatedCodeToBeReplacedMessage
-        case 'plannedFileChanges':
-            return CodeWhispererConstants.filesToBeChangedMessage
-        case 'dependencyName':
-            return CodeWhispererConstants.dependencyNameColumn
-        case 'action':
-            return CodeWhispererConstants.actionColumn
-        case 'currentVersion':
-            return CodeWhispererConstants.currentVersionColumn
-        case 'targetVersion':
-            return CodeWhispererConstants.targetVersionColumn
-        case 'relativePath':
-            return CodeWhispererConstants.relativePathColumn
-        case 'apiFullyQualifiedName':
-            return CodeWhispererConstants.apiNameColumn
-        case 'numChangedFiles':
-            return CodeWhispererConstants.numChangedFilesColumn
-        default:
-            return s
-    }
+    return CodeWhispererConstants.formattedStringMap.get(s) ?? s
 }
 
 export function addTableMarkdown(plan: string, stepId: string, tableMapping: { [key: string]: string }) {
@@ -543,13 +522,13 @@ export async function getTransformationPlan(jobId: string) {
 
         const arrowIcon = getTransformationIcon('upArrow')
 
-        let plan = `<style>table {border: 1px solid #424750;}</style>\n\n<a id="top"></a><br><p style="font-size: 24px; color: white;"><img src="${logoIcon}" style="margin-right: 15px; vertical-align: middle;"></img><b>${CodeWhispererConstants.planTitle}</b></p><br>`
+        let plan = `<style>table {border: 1px solid #424750;}</style>\n\n<a id="top"></a><br><p style="font-size: 24px;"><img src="${logoIcon}" style="margin-right: 15px; vertical-align: middle;"></img><b>${CodeWhispererConstants.planTitle}</b></p><br>`
         plan += `<div style="display: flex;"><div style="flex: 1; border: 1px solid #424750; border-radius: 8px; padding: 10px;"><p>${
             CodeWhispererConstants.planIntroductionMessage
         }</p></div>${getJobStatisticsHtml(jobStatistics)}</div>`
-        plan += `<div style="margin-top: 32px; border: 1px solid #424750; border-radius: 8px; padding: 10px;"><p style="font-size: 18px; color: white; margin-bottom: 4px;"><b>${CodeWhispererConstants.planHeaderMessage}</b></p><i>${CodeWhispererConstants.planDisclaimerMessage} <a href="https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/code-transformation.html">Read more.</a></i><br><br>`
+        plan += `<div style="margin-top: 32px; border: 1px solid #424750; border-radius: 8px; padding: 10px;"><p style="font-size: 18px; margin-bottom: 4px;"><b>${CodeWhispererConstants.planHeaderMessage}</b></p><i>${CodeWhispererConstants.planDisclaimerMessage} <a href="https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/code-transformation.html">Read more.</a></i><br><br>`
         response.transformationPlan.transformationSteps.slice(1).forEach(step => {
-            plan += `<div style="border: 1px solid #424750; border-radius: 8px; padding: 20px;"><div style="display:flex; justify-content:space-between; align-items:center;"><p style="font-size: 16px; color: white; margin-bottom: 4px;">${step.name}</p><a href="#top">Scroll to top <img src="${arrowIcon}" style="vertical-align: middle"></a></div><p>${step.description}</p>`
+            plan += `<div style="border: 1px solid #424750; border-radius: 8px; padding: 20px;"><div style="display:flex; justify-content:space-between; align-items:center;"><p style="font-size: 16px; margin-bottom: 4px;">${step.name}</p><a href="#top">Scroll to top <img src="${arrowIcon}" style="vertical-align: middle"></a></div><p>${step.description}</p>`
             plan = addTableMarkdown(plan, step.id, tableMapping)
             plan += `</div><br>`
         })
@@ -635,10 +614,10 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
             status = response.transformationJob.status!
             // must be series of ifs, not else ifs
             if (CodeWhispererConstants.validStatesForJobStarted.includes(status)) {
-                sessionPlanProgress['startJob'] = StepProgress.Succeeded
+                jobPlanProgress['startJob'] = StepProgress.Succeeded
             }
             if (CodeWhispererConstants.validStatesForBuildSucceeded.includes(status)) {
-                sessionPlanProgress['buildCode'] = StepProgress.Succeeded
+                jobPlanProgress['buildCode'] = StepProgress.Succeeded
             }
             // emit metric when job status changes
             if (status !== transformByQState.getPolledJobStatus()) {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
@@ -156,6 +156,9 @@ export async function prepareProjectDependencies(dependenciesFolder: FolderInfo)
         copyProjectDependencies(dependenciesFolder)
     } catch (err) {
         // continue in case of errors
+        getLogger().info(
+            `CodeTransformation: Maven copy-dependencies failed, but transformation will continue and may succeed`
+        )
     }
 
     try {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
@@ -38,7 +38,7 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
                 this._view!.webview.html = this.showJobHistory()
             } else {
                 if (transformByQState.getIntervalId() === undefined && transformByQState.isRunning()) {
-                    await startInterval()
+                    startInterval()
                 }
                 await this.showPlanProgress(startTime)
                     .then(jobPlanProgress => {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
@@ -5,8 +5,8 @@
 
 import * as vscode from 'vscode'
 import globals from '../../../shared/extensionGlobals'
-import { getJobHistory, getPlanProgress } from '../../commands/startTransformByQ'
-import { StepProgress, transformByQState } from '../../models/model'
+import * as CodeWhispererConstants from '../../models/constants'
+import { StepProgress, jobPlanProgress, sessionJobHistory, transformByQState } from '../../models/model'
 import { convertToTimeString } from '../../../shared/utilities/textUtilities'
 import { getLogger } from '../../../shared/logger'
 import { getTransformationSteps } from './transformApiHandler'
@@ -15,6 +15,8 @@ import {
     ProgressUpdates,
     TransformationStatus,
 } from '../../../codewhisperer/client/codewhispereruserclient'
+import { startInterval } from '../../commands/startTransformByQ'
+import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/codeTransformTelemetryState'
 
 export class TransformationHubViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'aws.amazonq.transformationHub'
@@ -24,15 +26,23 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
     constructor() {}
     static #instance: TransformationHubViewProvider
 
-    public updateContent(button: 'job history' | 'plan progress', startTime: number) {
+    public async updateContent(
+        button: 'job history' | 'plan progress',
+        startTime: number = CodeTransformTelemetryState.instance.getStartTime()
+    ) {
         this.lastClickedButton = button
         if (this._view) {
             if (this.lastClickedButton === 'job history') {
+                clearInterval(transformByQState.getIntervalId())
+                transformByQState.setIntervalId(undefined)
                 this._view!.webview.html = this.showJobHistory()
             } else {
-                this.showPlanProgress(startTime)
-                    .then(planProgress => {
-                        this._view!.webview.html = planProgress
+                if (transformByQState.getIntervalId() === undefined && transformByQState.isRunning()) {
+                    await startInterval()
+                }
+                await this.showPlanProgress(startTime)
+                    .then(jobPlanProgress => {
+                        this._view!.webview.html = jobPlanProgress
                     })
                     .catch(e => {
                         getLogger().error('showPlanProgress failed: %s', (e as Error).message)
@@ -61,8 +71,8 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
             this._view!.webview.html = this.showJobHistory()
         } else {
             this.showPlanProgress(Date.now())
-                .then(planProgress => {
-                    this._view!.webview.html = planProgress
+                .then(jobPlanProgress => {
+                    this._view!.webview.html = jobPlanProgress
                 })
                 .catch(e => {
                     getLogger().error('showPlanProgress failed: %s', (e as Error).message)
@@ -71,7 +81,6 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
     }
 
     private showJobHistory(): string {
-        const history = getJobHistory()
         return `<!DOCTYPE html>
             <html lang="en">
             <head>
@@ -84,35 +93,35 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
             </head>
             <body>
             <p><b>Job Status</b></p>
-            ${history.length === 0 ? '<p>Nothing to show</p>' : this.getTableMarkup(history)}
+            ${
+                Object.keys(sessionJobHistory).length === 0
+                    ? `<p>${CodeWhispererConstants.nothingToShowMessage}</p>`
+                    : this.getTableMarkup(sessionJobHistory[transformByQState.getJobId()])
+            }
             </body>
             </html>`
     }
 
-    private getTableMarkup(
-        history: { timestamp: string; module: string; status: string; duration: string; id: string }[]
-    ) {
+    private getTableMarkup(job: { startTime: string; projectName: string; status: string; duration: string }) {
         return `
             <table border="1" style="border-collapse:collapse">
                 <thead>
                     <tr>
                         <th>Date</th>
-                        <th>Module</th>
+                        <th>Project</th>
                         <th>Status</th>
                         <th>Duration</th>
                         <th>Id</th>
                     </tr>
                 </thead>
                 <tbody>
-                    ${history.map(
-                        job => `<tr>
-                        <td>${job.timestamp}</td>
-                        <td>${job.module}</td>
-                        <td>${job.status}</td>
-                        <td>${job.duration}</td>
-                        <td>${job.id}</td>
-                    </tr>`
-                    )}
+                <tr>
+                    <td>${job.startTime}</td>
+                    <td>${job.projectName}</td>
+                    <td>${job.status}</td>
+                    <td>${job.duration}</td>
+                    <td>${transformByQState.getJobId()}</td>
+                </tr>
                 </tbody>
             </table>
         `
@@ -251,43 +260,46 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
             case 'CREATED':
             case 'ACCEPTED':
             case 'STARTED':
-                return 'Files have been uploaded to Amazon Q, transformation job has been accepted and is preparing to start.'
+                return CodeWhispererConstants.filesUploadedMessage
             case 'PREPARING':
             case 'PREPARED':
-                return `Amazon Q is building your code using Java ${transformByQState.getSourceJDKVersion()} in a secure build environment.`
+                return CodeWhispererConstants.buildingCodeMessage.replace(
+                    'JAVA_VERSION_HERE',
+                    transformByQState.getSourceJDKVersion() ?? ''
+                )
             case 'PLANNING':
             case 'PLANNED':
-                return 'Amazon Q is analyzing your code in order to generate a transformation plan.'
+                return CodeWhispererConstants.planningMessage
             case 'TRANSFORMING':
             case 'TRANSFORMED':
             case 'COMPLETED':
             case 'PARTIALLY_COMPLETED':
-                return 'Amazon Q is transforming your code. Details will appear soon.'
+                return CodeWhispererConstants.transformingMessage
             case 'STOPPING':
             case 'STOPPED':
-                return 'Stopping the job...'
+                return CodeWhispererConstants.stoppingJobMessage
             case 'FAILED':
             case 'REJECTED':
-                return 'The step failed, fetching additional details...'
+                return CodeWhispererConstants.failedStepMessage
             default:
                 if (transformByQState.isCancelled()) {
-                    return 'Stopping the job...'
+                    return CodeWhispererConstants.stoppingJobMessage
                 } else if (transformByQState.isFailed()) {
-                    return 'The step failed, fetching additional details...'
+                    return CodeWhispererConstants.failedStepMessage
                 } else if (transformByQState.isRunning()) {
-                    return `Amazon Q is scanning the project files and getting ready to start the job. 
-                    To start the job, Amazon Q needs to upload the project artifacts. Once that's done, Q can start the transformation job. 
-                    The estimated time for this operation ranges from a few seconds to several minutes.`
+                    return CodeWhispererConstants.scanningProjectMessage
                 } else if (transformByQState.isPartiallySucceeded() || transformByQState.isSucceeded()) {
-                    return 'Job completed' // this should never have too be shown since substeps will block the generic details. Added for completeness.
+                    return CodeWhispererConstants.jobCompletedMessage // this should never have to be shown since substeps will block the generic details, added for completeness
                 } else {
-                    return 'No ongoing job.'
+                    return CodeWhispererConstants.noOngoingJobMessage
                 }
         }
     }
 
     public async showPlanProgress(startTime: number): Promise<string> {
-        const planProgress = getPlanProgress()
+        const styleSheet = this._view?.webview.asWebviewUri(
+            vscode.Uri.joinPath(this._extensionUri, 'resources', 'css', 'amazonqTransformationHub.css')
+        )
         const simpleStep = (icon: string, text: string, isActive: boolean) => {
             return isActive
                 ? `<p class="simple-step active">${icon} ${text}</p>`
@@ -295,55 +307,55 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
         }
 
         let planSteps = transformByQState.getPlanSteps()
-        if (planProgress['generatePlan'] === StepProgress.Succeeded && transformByQState.isRunning()) {
+        if (jobPlanProgress['generatePlan'] === StepProgress.Succeeded && transformByQState.isRunning()) {
             planSteps = await getTransformationSteps(transformByQState.getJobId())
             transformByQState.setPlanSteps(planSteps)
         }
         let progressHtml
         // for each step that has succeeded, increment activeStepId by 1
         let activeStepId = [
-            planProgress.startJob,
-            planProgress.buildCode,
-            planProgress.generatePlan,
-            planProgress.transformCode,
+            jobPlanProgress.startJob,
+            jobPlanProgress.buildCode,
+            jobPlanProgress.generatePlan,
+            jobPlanProgress.transformCode,
         ]
             .map(it => (it === StepProgress.Succeeded ? 1 : 0) as number)
             .reduce((prev, current) => prev + current)
         // When we receive plan step details, we want those to be active -> increment activeStepId
         activeStepId += planSteps === undefined || planSteps.length === 0 ? 0 : 1
 
-        if (planProgress['transformCode'] !== StepProgress.NotStarted) {
+        if (jobPlanProgress['transformCode'] !== StepProgress.NotStarted) {
             const waitingMarkup = simpleStep(
-                this.getProgressIconMarkup(planProgress['startJob']),
-                'Waiting for job to start',
+                this.getProgressIconMarkup(jobPlanProgress['startJob']),
+                CodeWhispererConstants.waitingForJobStartStepMessage,
                 activeStepId === 0
             )
             const buildMarkup =
                 activeStepId >= 1
                     ? simpleStep(
-                          this.getProgressIconMarkup(planProgress['buildCode']),
-                          'Build uploaded code in secure build environment',
+                          this.getProgressIconMarkup(jobPlanProgress['buildCode']),
+                          CodeWhispererConstants.buildCodeStepMessage,
                           activeStepId === 1
                       )
                     : ''
             const planMarkup =
                 activeStepId >= 2
                     ? simpleStep(
-                          this.getProgressIconMarkup(planProgress['generatePlan']),
-                          'Generate transformation plan',
+                          this.getProgressIconMarkup(jobPlanProgress['generatePlan']),
+                          CodeWhispererConstants.generatePlanStepMessage,
                           activeStepId === 2
                       )
                     : ''
             const transformMarkup =
                 activeStepId >= 3
                     ? simpleStep(
-                          this.getProgressIconMarkup(planProgress['transformCode']),
-                          'Transform your code to Java 17 using transformation plan',
+                          this.getProgressIconMarkup(jobPlanProgress['transformCode']),
+                          CodeWhispererConstants.transformStepMessage,
                           activeStepId === 3
                       )
                     : ''
 
-            const isTransformFailed = planProgress['transformCode'] === StepProgress.Failed
+            const isTransformFailed = jobPlanProgress['transformCode'] === StepProgress.Failed
             const progress = this.getTransformationStepProgressMarkup(planSteps, isTransformFailed)
             const latestGenericStepDetails = this.getLatestGenericStepDetails(transformByQState.getPolledJobStatus())
             progressHtml = `
@@ -378,111 +390,8 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
             <html lang="en">
             
             <head>
-            <title>Transformation Hub</title>
-            <style>
-                @keyframes spin {
-                    0% {
-                        transform: rotate(0deg);
-                    }
-                    100% {
-                        transform: rotate(360deg);
-                    }
-                }
-                body {
-                    margin: 0;
-                    padding: 0 1em;
-                    height: 100vh;
-                }
-
-                .wrapper {
-                    height: 100%;
-                    display: flex;
-                }
-
-                .spinner {
-                    display: inline-block;
-                    animation: spin 1s infinite;
-                }
-
-                .column--container, .substep-container {
-                    display: flex;
-                    flex-direction: row;
-                }
-
-                .column {
-                    flex-grow: 1;
-                }
-
-                .substep-container  p {
-                    margin: .5em 0;
-                }
-
-                .step, .simple-step {
-                    padding: .5em 0 .5em 0;
-                    margin: 0;
-                }
-
-                .step {
-                    padding-left: 20px;
-                }
-
-                .step:hover, .active {
-                    background-color: aliceblue;
-                    background-color: var(button.hoverBackground);
-                }
-
-                #stepdetails {
-                    width: 40%;
-                    padding: 0 20px;
-                    border-left: solid rgba(229,229,229, .5);
-                    min-height: 100vh;
-                    display: block;
-                }
-
-                #progress {
-                    width: 60%;
-                }
-
-                .status-PENDING {
-                    color: grey;
-                }
-
-                .status-COMPLETED {
-                    color: green;
-                }
-
-                .status-FAILED {
-                    color: red;
-                }
-
-                .substep {
-                    display: none;
-                }
-
-                .substep-icon {
-                    padding: 0 1em;
-                }
-
-                .visible {
-                    display: block;
-                }
-
-                .center {
-                    position: absolute;
-                    top: 50%;
-                    transform: translate(0, -50%);
-                }
-
-                .center-flex {
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                }
-
-                #step-duration {
-                    color: rgba(59, 59, 59, .75);
-                }
-            </style>
+                <title>Transformation Hub</title>
+                <link href="${styleSheet}" rel="stylesheet">
             </head>
             <body>
             <div class="wrapper">

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -97,6 +97,11 @@ export class AddedChangeNode extends ProposedChangeNode {
     }
 
     override saveFile(): void {
+        // create parent directory before copying files (ex. for the summary/ and assets/ folders)
+        const parentDir = path.dirname(this.pathToWorkspaceFile)
+        if (!fs.existsSync(parentDir)) {
+            fs.mkdirSync(parentDir, { recursive: true })
+        }
         fs.copyFileSync(this.pathToTmpFile, this.pathToWorkspaceFile)
     }
 }
@@ -265,10 +270,13 @@ export class ProposedTransformationExplorer {
             await vscode.commands.executeCommand('setContext', 'gumby.transformationProposalReviewInProgress', false)
             await vscode.commands.executeCommand('setContext', 'gumby.reviewState', TransformByQReviewStatus.NotStarted)
 
-            // delete result archive after changes cleared
-            // Summary is under ResultArchiveFilePath
-            fs.rmSync(transformByQState.getResultArchiveFilePath(), { recursive: true, force: true })
-            fs.rmSync(transformByQState.getProjectCopyFilePath(), { recursive: true, force: true })
+            // delete result archive after changes cleared; summary is under ResultArchiveFilePath
+            if (fs.existsSync(transformByQState.getResultArchiveFilePath())) {
+                fs.rmSync(transformByQState.getResultArchiveFilePath(), { recursive: true, force: true })
+            }
+            if (fs.existsSync(transformByQState.getProjectCopyFilePath())) {
+                fs.rmSync(transformByQState.getProjectCopyFilePath(), { recursive: true, force: true })
+            }
 
             diffModel.clearChanges()
             transformByQState.setSummaryFilePath('')

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -435,7 +435,7 @@ export class ProposedTransformationExplorer {
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.acceptChanges', async () => {
             diffModel.saveChanges()
             telemetry.ui_click.emit({ elementId: 'transformationHub_acceptChanges' })
-            await vscode.window.showInformationMessage(CodeWhispererConstants.changesAppliedNotification)
+            void vscode.window.showInformationMessage(CodeWhispererConstants.changesAppliedNotification)
             transformByQState.getChatControllers()?.transformationFinished.fire({
                 message: CodeWhispererConstants.changesAppliedChatMessage,
                 tabID: ChatSessionManager.Instance.getSession().tabID,

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -165,15 +165,18 @@ describe('transformByQ', function () {
 
     it(`WHEN update job history called THEN returns details of last run job`, async function () {
         transformByQState.setJobId('abc-123')
-        const actual = startTransformByQ.updateJobHistory()
-        const expected = [
-            {
-                startTime: '01/01/23, 12:00 AM',
-                projectName: 'my-module',
-                status: 'Succeeded',
-                duration: '20 sec',
+        transformByQState.setProjectName('test-project')
+        transformByQState.setPolledJobStatus('COMPLETED')
+        transformByQState.setStartTime('05/03/24, 11:35 AM')
+        const actual = await startTransformByQ.updateJobHistory()
+        const expected = {
+            'abc-123': {
+                duration: '0 sec',
+                projectName: 'test-project',
+                startTime: '05/03/24, 11:35 AM',
+                status: 'COMPLETED',
             },
-        ]
+        }
         assert.deepStrictEqual(actual, expected)
     })
 

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -169,7 +169,7 @@ describe('transformByQ', function () {
         transformByQState.setProjectName('test-project')
         transformByQState.setPolledJobStatus('COMPLETED')
         transformByQState.setStartTime('05/03/24, 11:35 AM')
-        const actual = await updateJobHistory()
+        const actual = updateJobHistory()
         const expected = {
             'abc-123': {
                 duration: '0 sec',

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs-extra'
 import * as sinon from 'sinon'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { transformByQState, TransformByQStoppedError } from '../../../codewhisperer/models/model'
-import * as startTransformByQ from '../../../codewhisperer/commands/startTransformByQ'
+import { stopTransformByQ } from '../../../codewhisperer/commands/startTransformByQ'
 import { HttpResponse } from 'aws-sdk'
 import * as codeWhisperer from '../../../codewhisperer/client/codewhisperer'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
@@ -27,6 +27,7 @@ import {
     pollTransformationJob,
     getHeadersObj,
     throwIfCancelled,
+    updateJobHistory,
     zipCode,
     getTableMapping,
 } from '../../../codewhisperer/service/transformByQ/transformApiHandler'
@@ -78,7 +79,7 @@ describe('transformByQ', function () {
 
     it('WHEN job is stopped THEN status is updated to cancelled', async function () {
         transformByQState.setToRunning()
-        await startTransformByQ.stopTransformByQ('abc-123')
+        await stopTransformByQ('abc-123')
         assert.strictEqual(transformByQState.getStatus(), 'Cancelled')
     })
 
@@ -168,7 +169,7 @@ describe('transformByQ', function () {
         transformByQState.setProjectName('test-project')
         transformByQState.setPolledJobStatus('COMPLETED')
         transformByQState.setStartTime('05/03/24, 11:35 AM')
-        const actual = await startTransformByQ.updateJobHistory()
+        const actual = await updateJobHistory()
         const expected = {
             'abc-123': {
                 duration: '0 sec',


### PR DESCRIPTION
## Problem

Several minor issues from GA launch: summary.md + icons not actually being saved when users accept changes, job history info not shown until the job terminates, and issues with white text / blue highlighting / grey text in transformation plan not visible with certain background colors.

## Solution

Since the summary.md and icons are in their own new directories, ensure those are created before saving the files. Populate the job history tab once job ID is available and allow users to switch back and forth between plan progress and job history throughout the transformation. Use default text color which will adjust by background, make blue highlighting look better for dark backgrounds, use a lighter grey font color.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
