### PR TITLE
fix: buildUri should be extension specific

### DIFF
--- a/packages/core/src/shared/vscode/uriHandler.ts
+++ b/packages/core/src/shared/vscode/uriHandler.ts
@@ -10,6 +10,7 @@ import * as nls from 'vscode-nls'
 import { showViewLogsMessage } from '../utilities/messages'
 import { URL, URLSearchParams } from 'whatwg-url'
 import { VSCODE_EXTENSION_ID } from '../extensions'
+import { isAmazonQ } from '../extensionUtilities'
 
 const localize = nls.loadMessageBundle()
 
@@ -100,7 +101,8 @@ export class UriHandler implements vscode.UriHandler {
     }
 
     static buildUri(path: string) {
-        return vscode.Uri.parse(`vscode://${VSCODE_EXTENSION_ID.awstoolkit}/${path}`)
+        const extensionId = isAmazonQ() ? VSCODE_EXTENSION_ID.amazonq : VSCODE_EXTENSION_ID.awstoolkit
+        return vscode.Uri.parse(`vscode://${extensionId}/${path}`)
     }
 }
 


### PR DESCRIPTION
## Problem
- buildUri only grabs the extension id for the aws toolkit. This means if you only have the q extension installed you get prompted to install the aws toolkit when a uri is registered

## Solution
- build the uri depending on the extension you are in

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
