### PR TITLE
fix(build): invalid resource paths on Windows

### DIFF
--- a/packages/core/scripts/build/generateIcons.ts
+++ b/packages/core/scripts/build/generateIcons.ts
@@ -112,7 +112,7 @@ async function generate(mappings: Record<string, number | undefined> = {}) {
         template: 'css',
         templateClassName: 'icon',
         descent: 200, // Icons were negatively offset on the y-axes, this fixes it
-        templateFontPath: path.relative(stylesheetsDir, fontsDir),
+        templateFontPath: path.relative(stylesheetsDir, fontsDir).replace(/\\/g, '/'),
         glyphTransformFn: obj => {
             const filePath = (obj as { path?: string }).path
 

--- a/packages/webpack.vue.config.js
+++ b/packages/webpack.vue.config.js
@@ -32,7 +32,7 @@ const createVueBundleName = file => {
  */
 const createVueEntries = (targetPattern = 'index.ts') => {
     return glob
-        .sync(path.resolve(currentDir, 'src', '**', 'vue', '**', targetPattern))
+        .sync(path.resolve(currentDir, 'src', '**', 'vue', '**', targetPattern).replace(/\\/g, '/'))
         .map(f => ({ name: createVueBundleName(f), path: f }))
         .reduce((a, b) => ((a[b.name] = b.path), a), {})
 }


### PR DESCRIPTION
## Problem
Development on `Windows` for `aws-toolkit-vscode` is not working because inaccurate path

## Solution
glob.sync requires posix style path. The code changes updates path.resolve to replace \\ to / from Windows to posix style.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
