### PR TITLE
fix(amazonq): update icons for Auth on Login Page

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -90,6 +90,7 @@
                             :itemId="LoginOption.EXISTING_LOGINS + index"
                             :itemText="existingLogin.text"
                             :itemTitle="existingLogin.title"
+                            :itemType="existingLogin.type"
                             class="selectable-item bottomMargin"
                         ></SelectableItem>
                     </div>
@@ -103,6 +104,7 @@
                     :itemId="LoginOption.BUILDER_ID"
                     :itemText="'No AWS account required'"
                     :itemTitle="'Use For Free'"
+                    :itemType="LoginOption.BUILDER_ID"
                     class="selectable-item bottomMargin"
                 ></SelectableItem>
                 <SelectableItem
@@ -112,6 +114,7 @@
                     :itemId="LoginOption.ENTERPRISE_SSO"
                     :itemText="''"
                     :itemTitle="'Use with Pro license'"
+                    :itemType="LoginOption.ENTERPRISE_SSO"
                     class="selectable-item bottomMargin"
                 ></SelectableItem>
                 <SelectableItem
@@ -121,6 +124,7 @@
                     :itemId="LoginOption.ENTERPRISE_SSO"
                     :itemText="'Sign in to AWS with single sign-on'"
                     :itemTitle="'Workforce'"
+                    :itemType="LoginOption.ENTERPRISE_SSO"
                     class="selectable-item bottomMargin"
                 ></SelectableItem>
                 <SelectableItem
@@ -130,6 +134,7 @@
                     :itemId="LoginOption.IAM_CREDENTIAL"
                     :itemText="'Store keys for use with AWS CLI tools'"
                     :itemTitle="'IAM Credentials'"
+                    :itemtype="LoginOption.IAM_CREDENTIAL"
                     class="selectable-item bottomMargin"
                 ></SelectableItem>
                 <button
@@ -296,6 +301,7 @@ interface ExistingLogin {
     text: string
     title: string
     connectionId: string
+    type: number
 }
 
 export default defineComponent({
@@ -468,7 +474,7 @@ export default defineComponent({
         },
         async emitUpdate(cause?: string) {},
         async updateExistingConnections() {
-            // fetch existing connections of aws toolkit in Amazon Q
+            // fetch existing connections of AWS toolkit in Amazon Q
             // or fetch existing connections of Amazon Q in AWS Toolkit
             // to reuse connections in AWS Toolkit & Amazon Q
             const sharedConnections = await client.fetchConnections()
@@ -480,6 +486,7 @@ export default defineComponent({
                         ? 'AWS Builder ID'
                         : `IAM Identity Center ${connection.startUrl}`,
                     connectionId: connection.id,
+                    type: isBuilderId(connection.startUrl) ? LoginOption.BUILDER_ID : LoginOption.ENTERPRISE_SSO,
                 })
             })
             // fetch existing connections of itself

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -8,7 +8,7 @@
     >
         <div class="icon">
             <svg
-                v-if="itemTitle == 'Use For Free'"
+                v-if="itemType === LoginOption.BUILDER_ID"
                 width="16"
                 height="16"
                 viewBox="0 0 16 16"
@@ -23,7 +23,7 @@
                 />
             </svg>
             <svg
-                v-if="itemTitle == 'Workforce' || itemTitle == 'Use with Pro license'"
+                v-if="itemType === LoginOption.ENTERPRISE_SSO"
                 width="16"
                 height="16"
                 viewBox="0 0 16 16"
@@ -38,7 +38,7 @@
                 />
             </svg>
             <svg
-                v-if="itemTitle == 'IAM Credentials'"
+                v-if="itemType === LoginOption.IAM_CREDENTIAL"
                 width="16"
                 height="16"
                 viewBox="0 0 16 16"
@@ -70,6 +70,7 @@ export default defineComponent({
         itemId: Number,
         itemText: String,
         itemTitle: String,
+        itemType: Number,
         isSelected: Boolean,
         isHovering: Boolean,
     },


### PR DESCRIPTION
## Problem
Icons are not displayed on for existing connections.

## Solution
- Use `type` to render icons 

<img width="276" alt="Screenshot 2024-05-06 at 6 53 22 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/371007/a4583b8d-b62e-45ab-a7fe-af3b872c4e7f">


## Notes
- Discuss a better way to differentiate between SSO and IAM Login in Frontend.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
