### PR TITLE
fix(csharpSamDebug): remove debug mode for arm64

### DIFF
--- a/packages/core/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/packages/core/src/shared/sam/debugger/csharpSamDebug.ts
@@ -77,9 +77,10 @@ export async function invokeCsharpLambda(ctx: ExtContext, config: SamLaunchReque
     config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([waitForDebuggerMessages.DOTNET])
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = waitForPort
+    const platformArchitecture = os.arch()
 
     if (!config.noDebug) {
-        if (config.architecture === 'arm64') {
+        if ([config.architecture, platformArchitecture].includes('arm64')) {
             void vscode.window.showWarningMessage(
                 localize(
                     'AWS.sam.noArm.dotnet.debug',


### PR DESCRIPTION
## Problem
When `sam local` is invoked for `cSharp`, the invocation gets blocked when trying to attach a debugger. `vsdbg` is not supported for `arm64` architecture. 

## Solution
Disable `debug` mode for cases when the template architecture is `arm64` or the developer is using `arm64` architecture machines, for eg - Apple M1/M2/M3 chips.

<img width="1000" alt="Screenshot 2024-05-05 at 11 22 45 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/371007/4e99e9bf-92b6-4abb-a3a4-6a34ec5d577f">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
