### PR TITLE
placeholder changelog item

### DIFF
--- a/packages/toolkit/.changes/next-release/Test-5ceb1b76-ac6d-4c7d-9da7-8f90db51270f.json
+++ b/packages/toolkit/.changes/next-release/Test-5ceb1b76-ac6d-4c7d-9da7-8f90db51270f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Release",
+	"description": "No user-facing changes"
+}


### PR DESCRIPTION
We just need something so the CHANGELOG.md does not look weird and has no items for the Toolkit release.

We will want a better mechanism for this in the future.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
