### PR TITLE
feat: add a conversationId as an info log to ease customer feedback

### DIFF
--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -300,6 +300,8 @@ export class FeatureDevController {
     private async onApproachGeneration(session: Session, message: string, tabID: string) {
         await session.preloader(message)
 
+        getLogger().info(`Q - Dev Chat conversation id: ${session.conversationId}`)
+
         this.messenger.sendAnswer({
             type: 'answer',
             tabID,
@@ -345,6 +347,8 @@ export class FeatureDevController {
      * Handle a regular incoming message when a user is in the code generation phase
      */
     private async onCodeGeneration(session: Session, message: string, tabID: string) {
+        getLogger().info(`Q - Dev chat conversation id: ${session.conversationId}`)
+
         // lock the UI/show loading bubbles
         this.messenger.sendAsyncEventProgress(
             tabID,


### PR DESCRIPTION
## Problem

Searching for the conversationId in logs could be cumbersome for some customers. This aims to make it a little bit easier.

## Solution

Add an info level log with the conversation id in approach and code generation, including their iterations for easy conversation Id finding.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
