### PR TITLE
fix(featureDev): 'Code changes summary' component when only 1 file was updated

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
@@ -155,7 +155,7 @@ export class Connector {
         if (this.onChatAnswerReceived !== undefined) {
             const actions = getActions([...messageData.filePaths, ...messageData.deletedFiles])
             const answer: ChatItem = {
-                type: ChatItemType.CODE_RESULT,
+                type: ChatItemType.ANSWER,
                 relatedContent: undefined,
                 followUp: undefined,
                 canBeVoted: true,
@@ -163,6 +163,7 @@ export class Connector {
                 // TODO get the backend to store a message id in addition to conversationID
                 messageId: messageData.messageID ?? messageData.triggerID ?? messageData.conversationID,
                 fileList: {
+                    rootFolderTitle: 'Changes',
                     filePaths: messageData.filePaths.map((f: DiffTreeFileInfo) => f.zipFilePath),
                     deletedFiles: messageData.deletedFiles.map((f: DiffTreeFileInfo) => f.zipFilePath),
                     actions,

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -232,8 +232,9 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
         },
         onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => {
             const updateWith: Partial<ChatItem> = {
-                type: ChatItemType.CODE_RESULT,
+                type: ChatItemType.ANSWER,
                 fileList: {
+                    rootFolderTitle: 'Changes',
                     filePaths: filePaths.map(i => i.relativePath),
                     deletedFiles: deletedFiles.map(i => i.relativePath),
                     details: getDetails(filePaths),


### PR DESCRIPTION
## Problem

'Code changes summary' component when only 1 file is generated looks wrong. More info: [slack thread](https://amzn-aws.slack.com/archives/C02C9T4C1BQ/p1714147457229129)

The issue was fixed in 4.7.0 mynah-ui release

## Solution


Adding `rootFolderTitle` to fixes the issue when displaying one file in 'Code changes summary' component 


`CODE_RESULT` is changed because it is going to be deprecated soon.

Tested:

Yes, manually

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
