### PR TITLE
fix(build): "npm run package" fails on Windows

### DIFF
--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -155,7 +155,7 @@ function main() {
         fs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, undefined, '    '))
         child_process.execFileSync('vsce', ['package', '--ignoreFile', '../.vscodeignore.packages'], {
             stdio: 'inherit',
-            shell: process.platform === 'win32',
+            shell: process.platform === 'win32',  // For vsce.cmd on Windows.
         })
 
         console.log(`VSIX Version: ${packageJson.version}`)

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -155,6 +155,7 @@ function main() {
         fs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, undefined, '    '))
         child_process.execFileSync('vsce', ['package', '--ignoreFile', '../.vscodeignore.packages'], {
             stdio: 'inherit',
+            shell: process.platform === 'win32',
         })
 
         console.log(`VSIX Version: ${packageJson.version}`)


### PR DESCRIPTION
Use shell for execFileSync during extension packaging on Windows OS

## Problem

A recent node update has introduced an issue with spawnSync (execFileSync) on Windows. An issue has been filed for this here https://github.com/nodejs/node/issues/52554.

This is affecting the packageExtension step for Windows OS on the latest Node versions (Node v20.12.2), giving the following error: 
```
> ts-node ./scripts/build/handlePackageJson

<ref *1> Error: spawnSync vsce ENOENT
    at Object.spawnSync (node:internal/child_process:1124:20)
    at spawnSync (node:child_process:876:24)
    at Object.execFileSync (node:child_process:919:15)
    at main (C:\Users\rbbarad\Desktop\vscode-toolkit\aws-toolkit-vscode-staging\scripts\package.ts:156:23)
    at Object.<anonymous> (C:\Users\rbbarad\Desktop\vscode-toolkit\aws-toolkit-vscode-staging\scripts\package.ts:181:1)
    at Module._compile (node:internal/modules/cjs/loader:1369:14)
    at Module.m._compile (C:\Users\rbbarad\Desktop\vscode-toolkit\aws-toolkit-vscode-staging\node_modules\ts-node\src\index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
    at Object.require.extensions.<computed> [as .ts] (C:\Users\rbbarad\Desktop\vscode-toolkit\aws-toolkit-vscode-staging\node_modules\ts-node\src\index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1206:32) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawnSync vsce',
  path: 'vsce',
  spawnargs: [ 'package', '--ignoreFile', '../.vscodeignore.packages' ],
  error: [Circular *1],
  status: null,
  signal: null,
  output: null,
  pid: 0,
  stdout: null,
  stderr: null
}
```
## Solution

This PR fixes the issue by using a shell to run execFileSync when on Windows OS. This is because `vsce` is a `.cmd` file which needs a shell to run. 

## Testing
- Ran `npm install`, `npm run compile`, `npm run package` locally. confirmed packaging was successful

## Related Issue(s), If Filed
- https://github.com/aws/aws-toolkit-azure-devops/pull/552
- https://github.com/nodejs/node/issues/52554

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
