### PR TITLE
feat(amazonq): multi-root workspace support

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-98fc029d-ac6f-43c6-b168-fb37bb077c14.json
+++ b/packages/amazonq/.changes/next-release/Feature-98fc029d-ac6f-43c6-b168-fb37bb077c14.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Security Scan: Scans can now be run without an open editor"
+}

--- a/packages/amazonq/.changes/next-release/Feature-b7c62308-5e6e-4aeb-9dc8-ec8a5137dfb7.json
+++ b/packages/amazonq/.changes/next-release/Feature-b7c62308-5e6e-4aeb-9dc8-ec8a5137dfb7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Security Scan: Multi-root workspace support"
+}

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -33,7 +33,6 @@ import { FeatureConfigProvider } from '../service/featureConfigProvider'
 import { TelemetryHelper } from '../util/telemetryHelper'
 import { Auth, AwsConnection } from '../../auth'
 import { once } from '../../shared/utilities/functionUtils'
-import { isTextEditor } from '../../shared/utilities/editorUtilities'
 import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
 import { removeDiagnostic } from '../service/diagnosticsProvider'
 import { SecurityIssueHoverProvider } from '../service/securityIssueHoverProvider'
@@ -117,26 +116,16 @@ export const showSecurityScan = Commands.declare(
             if (AuthUtil.instance.isConnectionExpired()) {
                 await AuthUtil.instance.notifyReauthenticate()
             }
-            const editor = vscode.window.activeTextEditor
-            if (editor && isTextEditor(editor)) {
-                if (codeScanState.isNotStarted()) {
-                    // User intends to start as "Start Security Scan" is shown in the explorer tree
-                    codeScanState.setToRunning()
-                    void startSecurityScanWithProgress(
-                        securityPanelViewProvider,
-                        editor,
-                        client,
-                        context.extensionContext
-                    )
-                } else if (codeScanState.isRunning()) {
-                    // User intends to stop as "Stop Security Scan" is shown in the explorer tree
-                    // Cancel only when the code scan state is "Running"
-                    await confirmStopSecurityScan()
-                }
-                vsCodeState.isFreeTierLimitReached = false
-            } else {
-                void vscode.window.showInformationMessage('Open a valid file to scan.')
+            if (codeScanState.isNotStarted()) {
+                // User intends to start as "Start Security Scan" is shown in the explorer tree
+                codeScanState.setToRunning()
+                void startSecurityScanWithProgress(securityPanelViewProvider, client, context.extensionContext)
+            } else if (codeScanState.isRunning()) {
+                // User intends to stop as "Stop Security Scan" is shown in the explorer tree
+                // Cancel only when the code scan state is "Running"
+                await confirmStopSecurityScan()
             }
+            vsCodeState.isFreeTierLimitReached = false
         }
 )
 

--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -22,11 +22,11 @@ export const securityScanRender: SecurityScanRender = {
 export function initSecurityScanRender(
     securityRecommendationList: AggregatedCodeScanIssue[],
     context: vscode.ExtensionContext,
-    editor: vscode.TextEditor,
+    editor: vscode.TextEditor | undefined,
     scope: CodeAnalysisScope
 ) {
     securityScanRender.initialized = false
-    if (scope === CodeAnalysisScope.FILE) {
+    if (scope === CodeAnalysisScope.FILE && editor) {
         securityScanRender.securityDiagnosticCollection?.delete(editor.document.uri)
     } else if (scope === CodeAnalysisScope.PROJECT) {
         securityScanRender.securityDiagnosticCollection?.clear()

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -29,7 +29,7 @@ export async function listScanResults(
     client: DefaultCodeWhispererClient,
     jobId: string,
     codeScanFindingsSchema: string,
-    projectPath: string,
+    projectPaths: string[],
     scope: CodeWhispererConstants.CodeAnalysisScope
 ) {
     const logger = getLoggerForScope(scope)
@@ -51,30 +51,32 @@ export async function listScanResults(
         mapToAggregatedList(codeScanIssueMap, issue)
     })
     codeScanIssueMap.forEach((issues, key) => {
-        const filePath = path.join(projectPath, '..', key)
-        if (existsSync(filePath) && statSync(filePath).isFile()) {
-            const aggregatedCodeScanIssue: AggregatedCodeScanIssue = {
-                filePath: filePath,
-                issues: issues.map(issue => {
-                    return {
-                        startLine: issue.startLine - 1 >= 0 ? issue.startLine - 1 : 0,
-                        endLine: issue.endLine,
-                        comment: `${issue.title.trim()}: ${issue.description.text.trim()}`,
-                        title: issue.title,
-                        description: issue.description,
-                        detectorId: issue.detectorId,
-                        detectorName: issue.detectorName,
-                        findingId: issue.findingId,
-                        ruleId: issue.ruleId,
-                        relatedVulnerabilities: issue.relatedVulnerabilities,
-                        severity: issue.severity,
-                        recommendation: issue.remediation.recommendation,
-                        suggestedFixes: issue.remediation.suggestedFixes,
-                    }
-                }),
+        projectPaths.forEach(projectPath => {
+            const filePath = path.join(projectPath, '..', key)
+            if (existsSync(filePath) && statSync(filePath).isFile()) {
+                const aggregatedCodeScanIssue: AggregatedCodeScanIssue = {
+                    filePath: filePath,
+                    issues: issues.map(issue => {
+                        return {
+                            startLine: issue.startLine - 1 >= 0 ? issue.startLine - 1 : 0,
+                            endLine: issue.endLine,
+                            comment: `${issue.title.trim()}: ${issue.description.text.trim()}`,
+                            title: issue.title,
+                            description: issue.description,
+                            detectorId: issue.detectorId,
+                            detectorName: issue.detectorName,
+                            findingId: issue.findingId,
+                            ruleId: issue.ruleId,
+                            relatedVulnerabilities: issue.relatedVulnerabilities,
+                            severity: issue.severity,
+                            recommendation: issue.remediation.recommendation,
+                            suggestedFixes: issue.remediation.suggestedFixes,
+                        }
+                    }),
+                }
+                aggregatedCodeScanIssueList.push(aggregatedCodeScanIssue)
             }
-            aggregatedCodeScanIssueList.push(aggregatedCodeScanIssue)
-        }
+        })
     })
     return aggregatedCodeScanIssueList
 }

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -14,6 +14,7 @@ import { collectFiles } from '../../amazonqFeatureDev/util/files'
 import { getLoggerForScope } from '../service/securityScanHandler'
 import { runtimeLanguageContext } from './runtimeLanguageContext'
 import { CodewhispererLanguage } from '../../shared/telemetry/telemetry.gen'
+import { CurrentWsFolders } from '../../amazonqFeatureDev/types'
 
 export interface ZipMetadata {
     rootDir: string
@@ -53,21 +54,12 @@ export class ZipUtil {
         return CodeWhispererConstants.projectScanPayloadSizeLimitBytes
     }
 
-    public getProjectName(uri: vscode.Uri) {
-        const projectPath = this.getProjectPath(uri)
-        return path.basename(projectPath)
-    }
-
-    public getProjectPath(uri: vscode.Uri) {
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
-        if (workspaceFolder === undefined) {
-            return this.getBaseDirPath(uri)
+    public getProjectPaths() {
+        const workspaceFolders = vscode.workspace.workspaceFolders
+        if (!workspaceFolders || workspaceFolders.length === 0) {
+            throw Error('No workspace folders found')
         }
-        return workspaceFolder.uri.fsPath
-    }
-
-    protected getBaseDirPath(uri: vscode.Uri) {
-        return path.dirname(uri.fsPath)
+        return workspaceFolders.map(folder => folder.uri.fsPath)
     }
 
     protected async getTextContent(uri: vscode.Uri) {
@@ -93,12 +85,22 @@ export class ZipUtil {
         return willReachLimit
     }
 
-    protected async zipFile(uri: vscode.Uri) {
+    protected async zipFile(uri: vscode.Uri | undefined) {
+        if (!uri) {
+            throw Error('Uri is undefined')
+        }
         const zip = new admZip()
 
         const content = await this.getTextContent(uri)
 
-        zip.addFile(this.getZipPath(uri), Buffer.from(content, 'utf-8'))
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
+        if (!workspaceFolder) {
+            throw Error('No workspace folder found')
+        }
+        const projectName = workspaceFolder.name
+        const relativePath = vscode.workspace.asRelativePath(uri)
+        const zipEntryPath = this.getZipEntryPath(projectName, relativePath)
+        zip.addFile(zipEntryPath, Buffer.from(content, 'utf-8'))
 
         this._pickedSourceFiles.add(uri.fsPath)
         this._totalSize += (await fsCommon.stat(uri.fsPath)).size
@@ -113,16 +115,19 @@ export class ZipUtil {
         return zipFilePath
     }
 
-    protected async zipProject(uri: vscode.Uri) {
+    protected getZipEntryPath(projectName: string, relativePath: string) {
+        // Workspaces with multiple folders have the folder names as the root folder,
+        // but workspaces with only a single folder don't. So prepend the workspace folder name
+        // if it is not present.
+        return relativePath.split('/').shift() === projectName ? relativePath : path.join(projectName, relativePath)
+    }
+
+    protected async zipProject() {
         const zip = new admZip()
 
-        const projectPath = this.getProjectPath(uri)
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
-        if (!workspaceFolder) {
-            throw Error('No workspace folder found')
-        }
+        const projectPaths = this.getProjectPaths()
 
-        const files = await collectFiles([projectPath], [workspaceFolder])
+        const files = await collectFiles(projectPaths, vscode.workspace.workspaceFolders as CurrentWsFolders)
         const languageCount = new Map<CodewhispererLanguage, number>()
         for (const file of files) {
             const isFileOpenAndDirty = this.isFileOpenAndDirty(file.fileUri)
@@ -151,10 +156,12 @@ export class ZipUtil {
                 }
             }
 
+            const zipEntryPath = this.getZipEntryPath(file.workspaceFolder.name, file.zipFilePath)
+
             if (isFileOpenAndDirty) {
-                zip.addFile(this.getZipPath(file.fileUri), Buffer.from(fileContent, 'utf-8'))
+                zip.addFile(zipEntryPath, Buffer.from(fileContent, 'utf-8'))
             } else {
-                zip.addLocalFile(file.fileUri.fsPath, path.dirname(this.getZipPath(file.fileUri)))
+                zip.addLocalFile(file.fileUri.fsPath, path.dirname(zipEntryPath))
             }
         }
 
@@ -171,12 +178,6 @@ export class ZipUtil {
         return vscode.workspace.textDocuments.some(document => document.uri.fsPath === uri.fsPath && document.isDirty)
     }
 
-    protected getZipPath(uri: vscode.Uri) {
-        const projectName = this.getProjectName(uri)
-        const relativePath = vscode.workspace.asRelativePath(uri)
-        return path.join(projectName, relativePath)
-    }
-
     protected getZipDirPath(): string {
         if (this._zipDir === '') {
             this._zipDir = path.join(
@@ -187,14 +188,17 @@ export class ZipUtil {
         return this._zipDir
     }
 
-    public async generateZip(uri: vscode.Uri, scope: CodeWhispererConstants.CodeAnalysisScope): Promise<ZipMetadata> {
+    public async generateZip(
+        uri: vscode.Uri | undefined,
+        scope: CodeWhispererConstants.CodeAnalysisScope
+    ): Promise<ZipMetadata> {
         try {
             const zipDirPath = this.getZipDirPath()
             let zipFilePath: string
             if (scope === CodeWhispererConstants.CodeAnalysisScope.FILE) {
                 zipFilePath = await this.zipFile(uri)
             } else if (scope === CodeWhispererConstants.CodeAnalysisScope.PROJECT) {
-                zipFilePath = await this.zipProject(uri)
+                zipFilePath = await this.zipProject()
             } else {
                 throw new ToolkitError(`Unknown code analysis scope: ${scope}`)
             }

--- a/packages/core/src/shared/filesystemUtilities.ts
+++ b/packages/core/src/shared/filesystemUtilities.ts
@@ -19,12 +19,7 @@ export const tempDirPath = path.join(
     'aws-toolkit-vscode'
 )
 
-export async function getDirSize(
-    dirPath: string,
-    startTime: number,
-    duration: number,
-    fileExt: string
-): Promise<number> {
+export async function getDirSize(dirPath: string, startTime: number, duration: number): Promise<number> {
     if (performance.now() - startTime > duration) {
         getLogger().warn('getDirSize: exceeds time limit')
         return 0
@@ -38,9 +33,9 @@ export async function getDirSize(
             return 0
         }
         if (type === vscode.FileType.Directory) {
-            return getDirSize(filePath, startTime, duration, fileExt)
+            return getDirSize(filePath, startTime, duration)
         }
-        if (type === vscode.FileType.File && fileName.endsWith(fileExt)) {
+        if (type === vscode.FileType.File) {
             // TODO: This is SLOW on Cloud9.
             const stat = await fsCommon.stat(filePath)
             return stat.size

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -51,7 +51,6 @@ import { waitUntil } from '../../../shared/utilities/timeoutUtils'
 import { listCodeWhispererCommands } from '../../../codewhisperer/ui/statusBarMenu'
 import { CodeScansState, CodeSuggestionsState } from '../../../codewhisperer/models/model'
 import { cwQuickPickSource } from '../../../codewhisperer/commands/types'
-import { isTextEditor } from '../../../shared/utilities/editorUtilities'
 import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
 import { focusAmazonQPanel } from '../../../codewhispererChat/commands/registerCommands'
 import * as diagnosticsProvider from '../../../codewhisperer/service/diagnosticsProvider'
@@ -218,16 +217,6 @@ describe('CodeWhisperer-basicCommands', function () {
 
             await targetCommand.execute(placeholder, cwQuickPickSource)
             assert.ok(spy.called)
-        })
-
-        it('shows information message if there is no active text editor', async function () {
-            targetCommand = testCommand(showSecurityScan, mockExtContext, mockSecurityPanelViewProvider, mockClient)
-
-            sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
-
-            assert.ok(!vscode.window.activeTextEditor || !isTextEditor(vscode.window.activeTextEditor))
-            await targetCommand.execute(placeholder, cwQuickPickSource)
-            assert.strictEqual(getTestWindow().shownMessages[0].message, 'Open a valid file to scan.')
         })
 
         it('includes the "source" in the command execution metric', async function () {

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -49,7 +49,7 @@ import {
 } from '../../../codewhisperer/ui/codeWhispererNodes'
 import { waitUntil } from '../../../shared/utilities/timeoutUtils'
 import { listCodeWhispererCommands } from '../../../codewhisperer/ui/statusBarMenu'
-import { CodeScansState, CodeSuggestionsState } from '../../../codewhisperer/models/model'
+import { CodeScansState, CodeSuggestionsState, codeScanState } from '../../../codewhisperer/models/model'
 import { cwQuickPickSource } from '../../../codewhisperer/commands/types'
 import { refreshStatusBar } from '../../../codewhisperer/service/inlineCompletionService'
 import { focusAmazonQPanel } from '../../../codewhispererChat/commands/registerCommands'
@@ -207,6 +207,7 @@ describe('CodeWhisperer-basicCommands', function () {
         afterEach(function () {
             targetCommand?.dispose()
             sinon.restore()
+            codeScanState.setToNotStarted()
         })
 
         it('prompts user to reauthenticate if connection is expired', async function () {

--- a/packages/core/src/test/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/core/src/test/codewhisperer/service/securityScanHandler.test.ts
@@ -81,7 +81,7 @@ describe('securityScanHandler', function () {
                 mockClient,
                 'jobId',
                 'codeScanFindingsSchema',
-                'projectPath',
+                ['projectPath'],
                 CodeAnalysisScope.PROJECT
             )
 
@@ -102,7 +102,7 @@ describe('securityScanHandler', function () {
                 mockClient,
                 'jobId',
                 'codeScanFindingsSchema',
-                'projectPath',
+                ['projectPath'],
                 CodeAnalysisScope.PROJECT
             )
 

--- a/packages/core/src/test/codewhisperer/util/zipUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/zipUtil.test.ts
@@ -18,17 +18,10 @@ describe('zipUtil', function () {
     const appRoot = join(workspaceFolder, 'java11-plain-maven-sam-app')
     const appCodePath = join(appRoot, 'HelloWorldFunction', 'src', 'main', 'java', 'helloworld', 'App.java')
 
-    describe('getProjectName', function () {
-        it('Should return the correct project name', function () {
+    describe('getProjectPaths', function () {
+        it('Should return the correct project paths', function () {
             const zipUtil = new ZipUtil()
-            assert.strictEqual(zipUtil.getProjectName(vscode.Uri.file(appCodePath)), 'workspaceFolder')
-        })
-    })
-
-    describe('getProjectPath', function () {
-        it('Should return the correct project path', function () {
-            const zipUtil = new ZipUtil()
-            assert.strictEqual(zipUtil.getProjectPath(vscode.Uri.file(appCodePath)), workspaceFolder)
+            assert.deepStrictEqual(zipUtil.getProjectPaths(), [workspaceFolder])
         })
     })
 

--- a/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
+++ b/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
@@ -92,7 +92,7 @@ describe('CodeWhisperer security scan', async function () {
         const zipUtil = new ZipUtil()
         const uri = editor.document.uri
 
-        const projectPath = zipUtil.getProjectPath(editor.document.uri)
+        const projectPaths = zipUtil.getProjectPaths()
         const scope = CodeWhispererConstants.CodeAnalysisScope.PROJECT
         const zipMetadata = await zipUtil.generateZip(uri, scope)
         const codeScanName = randomUUID()
@@ -105,7 +105,7 @@ describe('CodeWhisperer security scan', async function () {
         }
         return {
             artifactMap: artifactMap,
-            projectPath: projectPath,
+            projectPaths: projectPaths,
             codeScanName: codeScanName,
             codeScanStartTime: codeScanStartTime,
         }
@@ -120,7 +120,7 @@ describe('CodeWhisperer security scan', async function () {
         //run security scan
         const securityJobSetupResult = await securityJobSetup(editor)
         const artifactMap = securityJobSetupResult.artifactMap
-        const projectPath = securityJobSetupResult.projectPath
+        const projectPaths = securityJobSetupResult.projectPaths
 
         const scope = CodeWhispererConstants.CodeAnalysisScope.PROJECT
 
@@ -142,7 +142,7 @@ describe('CodeWhisperer security scan', async function () {
             client,
             scanJob.jobId,
             CodeWhispererConstants.codeScanFindingsSchema,
-            projectPath,
+            projectPaths,
             scope
         )
 
@@ -162,7 +162,7 @@ describe('CodeWhisperer security scan', async function () {
         //run security scan
         const securityJobSetupResult = await securityJobSetup(editor)
         const artifactMap = securityJobSetupResult.artifactMap
-        const projectPath = securityJobSetupResult.projectPath
+        const projectPaths = securityJobSetupResult.projectPaths
         const scanJob = await createScanJob(
             client,
             artifactMap,
@@ -182,7 +182,7 @@ describe('CodeWhisperer security scan', async function () {
             client,
             scanJob.jobId,
             CodeWhispererConstants.codeScanFindingsSchema,
-            projectPath,
+            projectPaths,
             scope
         )
 


### PR DESCRIPTION
## Problem

Security scans don't work for multi-root workspaces.

## Solution

- Gather all open workspace folders for security scan payload instead of from the active file
- Since we no longer require the active file, remove the requirement of having a file open to run scans

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
