### PR TITLE
Fix bug where messages to chat got lost.

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-99765db0-02f5-421b-8188-f85f020f4763.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-99765db0-02f5-421b-8188-f85f020f4763.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Code Transform: Show additional status messages to align with experience when JAVA_HOME set incorrectly."
+}

--- a/packages/core/src/amazonq/webview/ui/apps/gumbyChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/gumbyChatConnector.ts
@@ -166,7 +166,7 @@ export class Connector {
             action: action.id,
             formSelectedValues: action.formItemValues,
             tabType: 'gumby',
-            tabId: tabId,
+            tabID: tabId,
         })
     }
 

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -214,18 +214,18 @@ export class GumbyController {
                 await this.initiateTransformationOnProject(message)
                 break
             case ButtonActions.CANCEL_TRANSFORMATION_FORM:
-                this.messenger.sendJobFinishedMessage(message.tabId, CodeWhispererConstants.jobCancelledChatMessage)
+                this.messenger.sendJobFinishedMessage(message.tabID, CodeWhispererConstants.jobCancelledChatMessage)
                 break
             case ButtonActions.VIEW_TRANSFORMATION_HUB:
                 await vscode.commands.executeCommand(GumbyCommands.FOCUS_TRANSFORMATION_HUB)
-                this.messenger.sendJobSubmittedMessage(message.tabId)
+                this.messenger.sendJobSubmittedMessage(message.tabID)
                 break
             case ButtonActions.STOP_TRANSFORMATION_JOB:
                 await stopTransformByQ(transformByQState.getJobId(), CancelActionPositions.Chat)
                 break
             case ButtonActions.CONFIRM_START_TRANSFORMATION_FLOW:
                 this.messenger.sendCommandMessage({ ...message, command: GumbyCommands.CLEAR_CHAT })
-                await this.transformInitiated({ ...message, tabID: message.tabId })
+                await this.transformInitiated(message)
                 break
         }
     }
@@ -243,10 +243,10 @@ export class GumbyController {
         const fromJDKVersion: JDKVersion = message.formSelectedValues['GumbyTransformJdkFromForm']
 
         const projectName = path.basename(pathToProject)
-        this.messenger.sendProjectSelectionMessage(projectName, fromJDKVersion, toJDKVersion, message.tabId)
+        this.messenger.sendProjectSelectionMessage(projectName, fromJDKVersion, toJDKVersion, message.tabID)
 
         if (fromJDKVersion === JDKVersion.UNSUPPORTED) {
-            this.messenger.sendRetryableErrorResponse('unsupported-source-jdk-version', message.tabId)
+            this.messenger.sendRetryableErrorResponse('unsupported-source-jdk-version', message.tabID)
             return
         }
 
@@ -299,9 +299,9 @@ export class GumbyController {
         } catch (err: any) {
             if (err instanceof JavaHomeNotSetError) {
                 this.sessionStorage.getSession().conversationState = ConversationState.PROMPT_JAVA_HOME
-                this.messenger.sendStaticTextResponse('java-home-not-set', message.tabId)
-                this.messenger.sendChatInputEnabled(message.tabId, true)
-                this.messenger.sendUpdatePlaceholder(message.tabId, 'Enter the path to your Java installation.')
+                this.messenger.sendStaticTextResponse('java-home-not-set', message.tabID)
+                this.messenger.sendChatInputEnabled(message.tabID, true)
+                this.messenger.sendUpdatePlaceholder(message.tabID, 'Enter the path to your Java installation.')
                 return
             }
             throw err

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -329,7 +329,7 @@ export class Messenger {
     }
 
     public sendCommandMessage(message: any) {
-        this.dispatcher.sendCommandMessage(new SendCommandMessage(message.command, message.tabId, message.eventId))
+        this.dispatcher.sendCommandMessage(new SendCommandMessage(message.command, message.tabID, message.eventId))
     }
 
     public sendJobFinishedMessage(tabID: string, message: string = '') {


### PR DESCRIPTION
## Problem
Messages get lost in the code path where customers do not need to provide a JAVA_HOME.
This leads to missing chat bubbles for 
1. Building your project
2. I was able to build your project
3. I am starting to transform your code

## Solution
Issue was due to typo when translating  `tabId` to `tabID`.
Search in the code shows that `tabID` is 10x more common than `tabId` so aligning Q Code Transform to this format.
After aligning the usages the missing messages are shown again and are animated where required.

### Before fix
1.  When JAVA_HOME set correctly from the start, then `I'm building your project ...` text does not show
<img width="1305" alt="Screenshot 2024-05-07 at 18 20 52" src="https://github.com/aws/aws-toolkit-vscode/assets/9272897/3cf8acd3-204d-4889-84df-e21c5453e8af">

2. When job completes, then nothing indicates it completed in the chat.
<img width="1272" alt="Screenshot 2024-05-07 at 18 25 36" src="https://github.com/aws/aws-toolkit-vscode/assets/9272897/772fe2a7-f06b-4259-b48a-e1f807aab62d">

### After fix
<img width="1792" alt="Screenshot 2024-05-07 at 20 05 17" src="https://github.com/aws/aws-toolkit-vscode/assets/9272897/6e1623e9-e56c-4245-b3bd-58351501c88f">
<img width="1792" alt="Screenshot 2024-05-07 at 20 10 04" src="https://github.com/aws/aws-toolkit-vscode/assets/9272897/e2c1012f-2bbd-45ea-92ff-cf12b109c64d">



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
