### PR TITLE
fix(amazonq): chat may hang in ts/js files

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-1a8a24b4-8845-4955-84a5-895eaed1194e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-1a8a24b4-8845-4955-84a5-895eaed1194e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Prevent Q chat hang in js/ts files by disable FQN"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-1a8a24b4-8845-4955-84a5-895eaed1194e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-1a8a24b4-8845-4955-84a5-895eaed1194e.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Prevent Q chat hang in js/ts files by disable FQN"
+	"description": "Prevent Q chat from hanging in Js/Ts files by temporarily disable FQN"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-1a8a24b4-8845-4955-84a5-895eaed1194e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-1a8a24b4-8845-4955-84a5-895eaed1194e.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Prevent Q chat from hanging in Js/Ts files by temporarily disable FQN"
+	"description": "Q chat may stop responding after processing Javascript/Typescript code"
 }

--- a/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
+++ b/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Java, Python, TypeScript } from '@aws/fully-qualified-names'
+import { Java, Python } from '@aws/fully-qualified-names'
 import { extractContextFromJavaImports } from './javaImportReader'
 
 export async function readImports(text: string, languageId: string): Promise<string[]> {

--- a/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
+++ b/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Java, Python, TypeScript, Tsx } from '@aws/fully-qualified-names'
+import { Java, Python, TypeScript } from '@aws/fully-qualified-names'
 import { extractContextFromJavaImports } from './javaImportReader'
 
 export async function readImports(text: string, languageId: string): Promise<string[]> {
@@ -15,14 +15,16 @@ export async function readImports(text: string, languageId: string): Promise<str
         case 'javascript':
         case 'javascriptreact':
         case 'typescriptreact':
-            names = await Tsx.findNames(text)
-            break
+            // Disable Tsx.findNames because promise Tsx.findNames
+            // may not resolve and can cause chat to hang
+            //names = await Tsx.findNames(text)
+            return []
         case 'python':
             names = await Python.findNames(text)
             break
         case 'typescript':
-            names = await TypeScript.findNames(text)
-            break
+            //names = await TypeScript.findNames(text)
+            return []
     }
     if (names.fullyQualified === undefined) {
         return []

--- a/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
+++ b/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
@@ -5,7 +5,7 @@
 
 import { TextEditor, Selection, TextDocument, Range } from 'vscode'
 
-import { Extent, Java, Python, Tsx, TypeScript, Location } from '@aws/fully-qualified-names'
+import { Extent, Java, Python, Location } from '@aws/fully-qualified-names'
 import { FocusAreaContext, FullyQualifiedName } from './model'
 
 const focusAreaCharLimit = 9_000
@@ -235,13 +235,17 @@ export class FocusAreaContextExtractor {
             case 'javascript':
             case 'javascriptreact':
             case 'typescriptreact':
-                names = await Tsx.findNamesWithInExtent(fileText, extent)
+                // Disable Tsx.findNamesWithInExtent because promise Tsx.findNamesWithInExtent
+                // may not resolve and can cause chat to hang
+                //names = await Tsx.findNamesWithInExtent(fileText, extent)
+                names = undefined
                 break
             case 'python':
                 names = await Python.findNamesWithInExtent(fileText, extent)
                 break
             case 'typescript':
-                names = await TypeScript.findNamesWithInExtent(fileText, extent)
+                //names = await TypeScript.findNamesWithInExtent(fileText, extent)
+                names = undefined
                 break
         }
 


### PR DESCRIPTION
## Problem
Q chat will hang when the current opened file is ts/js and the syntax of the ts/js file is broken. See https://github.com/aws/aws-toolkit-vscode/pull/4876/files

- https://github.com/aws/aws-toolkit-vscode/issues/4935
- https://github.com/aws/aws-toolkit-vscode/issues/4810

## Solution

Temporarily disable FQN extraction in Ts/Js files. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
