### PR TITLE
Revert "fix(amazonq): update cross file context config"

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-f01dcb01-94da-48a5-a986-e2c323622411.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-f01dcb01-94da-48a5-a986-e2c323622411.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Completion may fail unexpected if user opened many tabs"
+}

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -611,9 +611,9 @@ export const codeFixAppliedFailedMessage = 'Failed to apply suggested code fix.'
 export const runSecurityScanButtonTitle = 'Run security scan'
 
 export const crossFileContextConfig = {
-    numberOfChunkToFetch: 200,
-    topK: 10,
-    numberOfLinesEachChunk: 50,
+    numberOfChunkToFetch: 60,
+    topK: 3,
+    numberOfLinesEachChunk: 10,
 }
 
 export const utgConfig = {

--- a/packages/core/src/test/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/crossFileContextUtil.test.ts
@@ -38,30 +38,19 @@ describe('crossFileContextUtil', function () {
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
         })
 
-        describe('should fetch 10 chunks and each chunk should contains 50 lines', function () {
+        describe('should fetch 3 chunks and each chunk should contains 10 lines', function () {
             async function assertCorrectCodeChunk() {
-                await openATextEditorWithText(sampleFileOf60Lines.repeat(10), 'CrossFile.java', tempFolder, {
-                    preview: false,
-                })
+                await openATextEditorWithText(sampleFileOf60Lines, 'CrossFile.java', tempFolder, { preview: false })
                 const myCurrentEditor = await openATextEditorWithText('', 'TargetFile.java', tempFolder, {
                     preview: false,
                 })
                 const actual = await crossFile.fetchSupplementalContextForSrc(myCurrentEditor, fakeCancellationToken)
                 assert.ok(actual)
-                assert.ok(actual.supplementalContextItems.length === crossFileContextConfig.topK)
+                assert.ok(actual.supplementalContextItems.length === 3)
 
-                assert.strictEqual(
-                    actual.supplementalContextItems[0].content.split('\n').length,
-                    crossFileContextConfig.numberOfLinesEachChunk
-                )
-                assert.strictEqual(
-                    actual.supplementalContextItems[1].content.split('\n').length,
-                    crossFileContextConfig.numberOfLinesEachChunk
-                )
-                assert.strictEqual(
-                    actual.supplementalContextItems[2].content.split('\n').length,
-                    crossFileContextConfig.numberOfLinesEachChunk
-                )
+                assert.strictEqual(actual.supplementalContextItems[0].content.split('\n').length, 10)
+                assert.strictEqual(actual.supplementalContextItems[1].content.split('\n').length, 10)
+                assert.strictEqual(actual.supplementalContextItems[2].content.split('\n').length, 10)
             }
 
             it('control group', async function () {
@@ -278,12 +267,12 @@ describe('crossFileContextUtil', function () {
             assert.strictEqual(chunks[1].content, 'line_6\nline_7')
         })
 
-        it('codewhisperer crossfile config should use 50 lines', async function () {
+        it('codewhisperer crossfile config should use 10 lines', async function () {
             const filePath = path.join(tempFolder, 'file.txt')
             await toFile(sampleFileOf60Lines, filePath)
 
             const chunks = await crossFile.splitFileToChunks(filePath, crossFileContextConfig.numberOfLinesEachChunk)
-            assert.strictEqual(chunks.length, 2)
+            assert.strictEqual(chunks.length, 6)
         })
     })
 })


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/pull/4922 may make completion fail if user opened too many tabs. The service side changes are not ready in prod yet.


## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
