### PR TITLE
feat(auth): navigate login page with keyboard

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-13e24999-a2c9-4636-9ca8-d79b2ae78ca6.json
+++ b/packages/amazonq/.changes/next-release/Feature-13e24999-a2c9-4636-9ca8-d79b2ae78ca6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "UX: Added keyboard navigation to login screen."
+}

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -241,16 +241,27 @@
                 id="profileName"
                 name="profileName"
                 v-model="profileName"
+                @keydown.enter="handleContinueClick()"
             />
             <div class="title">Access Key</div>
-            <input class="iamInput bottomMargin" type="text" id="accessKey" name="accessKey" v-model="accessKey" />
+            <input
+                class="iamInput bottomMargin"
+                type="text"
+                id="accessKey"
+                name="accessKey"
+                v-model="accessKey"
+                @keydown.enter="handleContinueClick()"
+            />
             <div class="title">Secret Key</div>
-            <input class="iamInput bottomMargin" type="text" id="secretKey" name="secretKey" v-model="secretKey" />
-            <button
-                class="continue-button"
-                :disabled="profileName.length <= 0 || accessKey.length <= 0 || secretKey.length <= 0"
-                v-on:click="handleContinueClick()"
-            >
+            <input
+                class="iamInput bottomMargin"
+                type="text"
+                id="secretKey"
+                name="secretKey"
+                v-model="secretKey"
+                @keydown.enter="handleContinueClick()"
+            />
+            <button class="continue-button" :disabled="shouldDisableIamContinue()" v-on:click="handleContinueClick()">
                 Continue
             </button>
         </template>
@@ -415,6 +426,7 @@ export default defineComponent({
                     }
                 } else if (this.selectedLoginOption === LoginOption.IAM_CREDENTIAL) {
                     this.stage = 'AWS_PROFILE'
+                    this.$nextTick(() => document.getElementById('profileName')!.focus())
                 }
             } else if (this.stage === 'SSO_FORM') {
                 if (this.shouldDisableSsoContinue()) {
@@ -429,6 +441,9 @@ export default defineComponent({
                     this.stage = 'CONNECTED'
                 }
             } else if (this.stage === 'AWS_PROFILE') {
+                if (this.shouldDisableIamContinue()) {
+                    return
+                }
                 this.stage = 'AUTHENTICATING'
                 const error = await client.startIamCredentialSetup(this.profileName, this.accessKey, this.secretKey)
                 if (error) {
@@ -525,6 +540,9 @@ export default defineComponent({
         },
         shouldDisableSsoContinue() {
             return this.startUrl.length == 0 || this.startUrlError.length > 0 || !this.selectedRegion
+        },
+        shouldDisableIamContinue() {
+            return this.profileName.length <= 0 || this.accessKey.length <= 0 || this.secretKey.length <= 0
         },
     },
 })

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -1,8 +1,10 @@
 <template>
     <div
         class="item-container-base"
+        tabindex="0"
         :class="{ selected: isSelected, hovering: isHovering }"
         @click="toggleSelection"
+        @keydown.enter="toggleSelection"
         @mouseover="isHovering = true"
         @mouseout="isHovering = false"
     >

--- a/packages/toolkit/.changes/next-release/Feature-2ac7c80a-b285-47a8-a512-7d10fd78d5ac.json
+++ b/packages/toolkit/.changes/next-release/Feature-2ac7c80a-b285-47a8-a512-7d10fd78d5ac.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "UX: Added keyboard navigation to login screen."
+}


### PR DESCRIPTION
- Use tab/shift+tab to navigate the login.
- Press enter on start url field to shortcut continue (if the form is valid).
- Press enter on any of the IAM credential fields to continue (if the form is valid).
- Autofocus the start url field.
- Autofocus IAM profile name field.

https://github.com/aws/aws-toolkit-vscode/assets/149123719/4eb2fa77-55a1-4dba-bcac-7a03b7cf763a


TODO:
- Should we allow enter key to act as the continue button for selecting the auth options as well?

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
