### PR TITLE
web: get Amazon Q debug mode running

### DIFF
--- a/packages/amazonq/.vscode/launch.json
+++ b/packages/amazonq/.vscode/launch.json
@@ -24,6 +24,27 @@
             "outFiles": ["${workspaceFolder}/dist/**/*.js", "${workspaceFolder}/../core/dist/**/*.js"],
             "preLaunchTask": "watch",
             "postDebugTask": "terminate"
+        },
+        {
+            /** Handles the entire process of building and running the toolkit extension in the browser. **/
+            "name": "Extension (Web)",
+            "type": "chrome",
+            "request": "attach",
+            "port": 9222,
+            /**
+            To get an understanding why we need the following:
+              - comment out the following
+              - set a breakpoint in VS Code that gets triggerd on extension startup
+            Now in the Chrome Developer Tools menu, the extension will load slower and open up random files.
+            I think this is due to source maps for irrelevant code being attempted to be resolved and slowing execution.
+
+            What this is doing is ignoring certain modules that match the following paths, it matches the path of
+            a file in `Developer Tools` > `Sources`.
+            I was inspired by this: https://github.com/microsoft/vscode-test-web/blob/897bca4907a87a6bc564efc242ce6794e5da3232/.vscode/launch.json#L28
+            **/
+            "resolveSourceMapLocations": ["!**/node_modules/**", "!**/vs/**", "!**/extensions/**"],
+            "preLaunchTask": "webRun",
+            "postDebugTask": "webRunTerminate"
         }
     ]
 }

--- a/packages/amazonq/.vscode/tasks.json
+++ b/packages/amazonq/.vscode/tasks.json
@@ -54,6 +54,79 @@
                 "close": true
             }
         },
+        // ---------- Start: Web Mode Tasks ----------
+        {
+            "label": "webRun",
+            "type": "npm",
+            "script": "webRun",
+            "detail": "Runs VS Code in the Chrome browser with our toolkit installed",
+            "isBackground": true,
+            "dependsOn": ["webWatch"],
+            /**
+            We only need this problem matcher to signal when this task is completed.
+            Since this task starts a web server it does not terminate and we need to use
+            problemMatcher.background.endsPattern to read the CLI and know when this task
+            can signal it is done.
+
+            The rest of the data in problemMatcher is required by VS Code to be "valid",
+            but not important for what we need.
+
+            Doc: https://code.visualstudio.com/Docs/editor/tasks#_defining-a-problem-matcher
+            **/
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "this section irrelevant but it must exist to work",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^@vscode/test-web",
+                    "endsPattern": "^Listening on"
+                }
+            }
+        },
+        {
+            "label": "webWatch",
+            "type": "npm",
+            "script": "webWatch",
+            "detail": "Webpacks our toolkit code (with --watch) in preparation to be run in the browser",
+            "isBackground": true,
+            // Since `webpack --watch` never terminates (but finishes packaging at some point),
+            // VS Code uses this to parse the CLI output to pattern match something that indicates it is done
+            "problemMatcher": "$ts-webpack-watch",
+            "dependsOn": ["webCoreModuleWatch"]
+        },
+        {
+            "label": "webCoreModuleWatch",
+            "type": "shell",
+            "command": "npm run compileDev -- --watch",
+            "detail": "Webpacks our toolkit code as a module in preparation to be webpacked by the toolkit package",
+            "isBackground": true,
+            // Since `webpack --watch` never terminates (but finishes packaging at some point),
+            // VS Code uses this to parse the CLI output to pattern match something that indicates it is done
+            "problemMatcher": "$ts-webpack-watch",
+            "dependsOn": ["copyPackageJson"],
+            "options": {
+                "cwd": "../core"
+            }
+        },
+        /**
+        After we stop debugging our browser, we also want to stop the web server.
+        When this task is ran it will stop the web server.
+
+        From: https://stackoverflow.com/a/60330174
+        **/
+        {
+            "label": "webRunTerminate",
+            "command": "echo ${input:webRunTerminate}",
+            "type": "shell",
+            "dependsOn": ["restorePackageJson"]
+        },
+        // ---------- End: Web Mode Tasks ----------
         {
             "type": "npm",
             "script": "lint",
@@ -89,6 +162,12 @@
             "type": "command",
             "command": "workbench.action.tasks.terminate",
             "args": "terminateAll"
+        },
+        {
+            "id": "webRunTerminate",
+            "type": "command",
+            "command": "workbench.action.tasks.terminate",
+            "args": "webRun"
         }
     ]
 }

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -42,6 +42,7 @@
         "onView:aws.codeWhisperer.securityPanel"
     ],
     "main": "./dist/src/extension",
+    "browser": "./dist/src/extensionWeb",
     "scripts": {
         "vscode:prepublish": "npm run clean && npm run buildScripts && webpack --mode production",
         "buildScripts": "npm run generateNonCodeFiles && npm run copyFiles && npm run syncPackageJson",
@@ -55,6 +56,8 @@
         "formatfix": "prettier --ignore-path ../../.prettierignore --write src scripts",
         "lint": "echo 'Nothing to lint yet!'",
         "watch": "npm run clean && npm run buildScripts -- --vueHr && tsc -watch -p ./",
+        "webRun": "npx @vscode/test-web --open-devtools --browserOption=--disable-web-security --waitForDebugger=9222 --extensionDevelopmentPath=. .",
+        "webWatch": "npm run clean && npm run buildScripts && webpack --mode development --watch",
         "serve": "webpack serve --config-name mainServe --mode development",
         "newChange": "ts-node ../../scripts/newChange.ts",
         "createRelease": "ts-node ../../scripts/createRelease.ts"

--- a/packages/amazonq/src/extensionWeb.ts
+++ b/packages/amazonq/src/extensionWeb.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ExtensionContext } from 'vscode'
+import { activate as activateWeb, deactivate as deactivateWeb } from 'aws-core-vscode/web'
+
+export async function activate(context: ExtensionContext) {
+    return activateWeb(context)
+}
+
+export async function deactivate() {
+    await deactivateWeb()
+}

--- a/packages/amazonq/webpack.config.js
+++ b/packages/amazonq/webpack.config.js
@@ -4,7 +4,7 @@
  */
 
 const baseConfigFactory = require('../webpack.base.config')
-const baseVueConfigFactory = require('../webpack.vue.config')
+const baseWebConfigsFactory = require('../webpack.web.config')
 
 module.exports = (env, argv) => {
     const config = {
@@ -14,14 +14,12 @@ module.exports = (env, argv) => {
         },
     }
 
-    const vue = baseVueConfigFactory(env, argv)
-    const vueConfig = {
-        ...vue.config,
+    const webConfig = {
+        ...baseWebConfigsFactory(env, argv),
         entry: {
-            ...vue.createVueEntries(),
-            //'src/amazonq/webview/ui/amazonq-ui': './src/amazonq/webview/ui/main.ts',
+            'src/extensionWeb': './src/extensionWeb.ts',
         },
     }
 
-    return [config, vueConfig]
+    return [config, webConfig]
 }

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -35,10 +35,11 @@ import { AuthSSOServer } from './server'
 import { CancellationError, sleep } from '../../shared/utilities/timeoutUtils'
 import OidcClientPKCE from './oidcclientpkce'
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
-import { randomUUID, randomBytes, createHash } from 'crypto'
+import { randomBytes, createHash } from 'crypto'
 import { UriHandler } from '../../shared/vscode/uriHandler'
 import { DevSettings } from '../../shared/settings'
 import { localize } from '../../shared/utilities/vsCodeUtils'
+import { randomUUID } from '../../common/crypto'
 
 export const authenticationPath = 'sso/authenticated'
 

--- a/packages/toolkit/.vscode/tasks.json
+++ b/packages/toolkit/.vscode/tasks.json
@@ -92,6 +92,7 @@
             },
             "dependsOn": ["restorePackageJson"]
         },
+        // ---------- Start: Web Mode Tasks ----------
         {
             "label": "webRun",
             "type": "npm",
@@ -163,6 +164,7 @@
             "type": "shell",
             "dependsOn": ["restorePackageJson"]
         },
+        // ---------- End: Web Mode Tasks ----------
         {
             "type": "npm",
             "script": "lint",

--- a/packages/toolkit/webpack.config.js
+++ b/packages/toolkit/webpack.config.js
@@ -5,7 +5,6 @@
 
 const path = require('path')
 const currentDir = process.cwd()
-const { merge } = require('webpack-merge')
 
 const baseConfigFactory = require('../webpack.base.config')
 const baseWebConfigsFactory = require('../webpack.web.config')


### PR DESCRIPTION
Amazon Q is not fully working in web, but this gets the Debug setup working so we can start developing

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
