### PR TITLE
feat(amazonq): add commands to command palette

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-c669b6ba-84ae-4255-aa13-c1dd7b66e7ab.json
+++ b/packages/amazonq/.changes/next-release/Feature-c669b6ba-84ae-4255-aa13-c1dd7b66e7ab.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Add additional commands for Amazon Q."
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -218,15 +218,7 @@
         "menus": {
             "commandPalette": [
                 {
-                    "command": "aws.amazonq.signout",
-                    "when": "false"
-                },
-                {
                     "command": "aws.amazonq.reconnect",
-                    "when": "false"
-                },
-                {
-                    "command": "aws.amazonq.openReferencePanel",
                     "when": "false"
                 },
                 {
@@ -365,42 +357,50 @@
             {
                 "command": "aws.amazonq.explainCode",
                 "title": "%AWS.command.amazonq.explainCode%",
-                "category": "%AWS.amazonq.title%"
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.security.scan",
                 "title": "%AWS.command.amazonq.security.scan%",
-                "category": "%AWS.amazonq.title%"
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.refactorCode",
                 "title": "%AWS.command.amazonq.refactorCode%",
-                "category": "%AWS.amazonq.title%"
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.fixCode",
                 "title": "%AWS.command.amazonq.fixCode%",
-                "category": "%AWS.amazonq.title%"
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.optimizeCode",
                 "title": "%AWS.command.amazonq.optimizeCode%",
-                "category": "%AWS.amazonq.title%"
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.sendToPrompt",
                 "title": "%AWS.command.amazonq.sendToPrompt%",
-                "category": "%AWS.amazonq.title%"
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.reconnect",
                 "title": "%AWS.command.codewhisperer.reconnect%",
-                "category": "%AWS.amazonq.title%"
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.openReferencePanel",
                 "title": "%AWS.command.codewhisperer.openReferencePanel%",
-                "category": "%AWS.amazonq.title%"
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.transformationHub.reviewChanges.acceptChanges",
@@ -455,7 +455,8 @@
             {
                 "command": "aws.amazonq.invokeInlineCompletion",
                 "title": "%AWS.command.codewhisperer.title%",
-                "category": "%AWS.amazonq.title%"
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.configure",
@@ -474,6 +475,12 @@
                 "title": "%AWS.command.codewhisperer.signout%",
                 "category": "%AWS.amazonq.title%",
                 "icon": "$(debug-disconnect)"
+            },
+            {
+                "command": "aws.amazonq.signout",
+                "title": "%AWS.command.codewhisperer.signout%",
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.learnMore",
@@ -501,6 +508,30 @@
                 "command": "aws.amazonq.showHistoryInHub",
                 "title": "Show Job Status",
                 "icon": "$(history)"
+            },
+            {
+                "command": "aws.amazonq.selectCustomization",
+                "title": "%AWS.codewhisperer.customization.notification.new_customizations.select%",
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
+            },
+            {
+                "command": "aws.amazonq.gettingStarted",
+                "title": "Try inline suggestion examples",
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
+            },
+            {
+                "command": "aws.amazonq.toggleCodeSuggestion",
+                "title": "%AWS.amazonq.toggleCodeSuggestion%",
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
+            },
+            {
+                "command": "aws.codeWhisperer.toggleCodeScan",
+                "title": "%AWS.amazonq.toggleCodeScan%",
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             }
         ],
         "keybindings": [

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -254,5 +254,7 @@
     "AWS.amazonq.chat": "Chat",
     "AWS.amazonq.login": "Login",
     "AWS.amazonq.learnMore": "Learn More About Amazon Q",
-    "AWS.amazonq.codewhisperer.title": "Amazon Q"
+    "AWS.amazonq.codewhisperer.title": "Amazon Q",
+    "AWS.amazonq.toggleCodeSuggestion": "Toggle Auto-Suggestions",
+    "AWS.amazonq.toggleCodeScan": "Toggle Auto-Scans"
 }

--- a/packages/core/src/codecatalyst/commands.ts
+++ b/packages/core/src/codecatalyst/commands.ts
@@ -26,6 +26,7 @@ import { CreateDevEnvironmentRequest, UpdateDevEnvironmentRequest } from 'aws-sd
 import { Auth } from '../auth/auth'
 import { SsoConnection } from '../auth/connection'
 import { isInDevEnv, isRemoteWorkspace } from '../shared/vscode/env'
+import { commandPalette } from '../codewhisperer/commands/types'
 
 /** "List CodeCatalyst Commands" command. */
 export async function listCommands(): Promise<void> {
@@ -303,7 +304,7 @@ export class CodeCatalystCommands {
         // need to be careful of mapping explosion so this granular data would either need
         // to be flattened or we restrict the names to a pre-determined set
         if (id === undefined) {
-            telemetry.record({ source: 'CommandPalette' })
+            telemetry.record({ source: commandPalette })
         }
 
         if (connection !== undefined) {

--- a/packages/core/src/codewhisperer/commands/types.ts
+++ b/packages/core/src/codewhisperer/commands/types.ts
@@ -16,6 +16,8 @@ export const amazonQChatSource = 'amazonQChat'
 export const firstStartUpSource = ExtStartUpSources.firstStartUp
 /** Indicates a CodeWhisperer command was executed as a result of selecting an ellipses menu item */
 export const cwEllipsesMenu = 'ellipsesMenu'
+/** Indicates a CodeWhisperer command was executed from the command palette */
+export const commandPalette = 'commandPalette'
 
 /**
  * Indicates what caused the CodeWhisperer command to be executed, since a command can be executed from different "sources"
@@ -32,3 +34,4 @@ export type CodeWhispererSource =
     | typeof amazonQChatSource
     | typeof firstStartUpSource
     | typeof cwEllipsesMenu
+    | typeof commandPalette

--- a/packages/core/src/codewhispererChat/commands/registerCommands.ts
+++ b/packages/core/src/codewhispererChat/commands/registerCommands.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { commandPalette } from '../../codewhisperer/commands/types'
 import { CodeScanIssue } from '../../codewhisperer/models/model'
 import { Commands, VsCodeCommandArg, placeholder } from '../../shared/vscode/commands2'
 import { ChatControllerMessagePublishers } from '../controllers/chat/controller'
@@ -106,7 +107,7 @@ export type CodeScanIssueCommandType = 'aws.amazonq.explainIssue'
 
 export type EditorContextCommandType = EditorContextBaseCommandType | CodeScanIssueCommandType
 
-export type EditorContextCommandTriggerType = 'contextMenu' | 'keybinding' | 'commandPalette' | 'click'
+export type EditorContextCommandTriggerType = 'contextMenu' | 'keybinding' | typeof commandPalette | 'click'
 
 export interface EditorContextCommandBase {
     type: EditorContextBaseCommandType

--- a/packages/core/src/shared/vscode/commands2.ts
+++ b/packages/core/src/shared/vscode/commands2.ts
@@ -520,7 +520,9 @@ function handleBadCompositeKey(data: { id: string; args: any[]; compositeKey: Co
     Object.entries(compositeKey).forEach(([index, field]) => {
         const indexAsInt = parseInt(index)
         const arg = args[indexAsInt]
-        if (field === 'source' && typeof arg !== 'string') {
+        if (field === 'source' && arg === undefined) {
+            args[indexAsInt] = 'vscodeUI'
+        } else if (field === 'source' && typeof arg !== 'string') {
             /**
              * This case happens when either the caller sets the wrong args themselves through
              * vscode.commands.executeCommand OR if through a VS Code UI component like the ellipsis menu

--- a/packages/core/src/test/shared/vscode/runCommand.test.ts
+++ b/packages/core/src/test/shared/vscode/runCommand.test.ts
@@ -9,7 +9,7 @@ import * as sinon from 'sinon'
 import assert from 'assert'
 import { ToolkitError } from '../../../shared/errors'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
-import { Commands, defaultTelemetryThrottleMs, unsetSource } from '../../../shared/vscode/commands2'
+import { Commands, defaultTelemetryThrottleMs } from '../../../shared/vscode/commands2'
 import { assertTelemetry, installFakeClock } from '../../testUtil'
 import { getTestWindow } from '../../shared/vscode/window'
 
@@ -168,7 +168,7 @@ describe('runCommand', function () {
                     passive: true,
                     command: command.id,
                     result: 'Succeeded',
-                    source: unsetSource,
+                    source: 'vscodeUI',
                 })
             })
         })


### PR DESCRIPTION
## Problem
Add commands in Command Palette for Amazon Q to improve feature discoverability

## Solution
Commands Added
- Amazon Q: Open Chat Panel
- Amazon Q: Open Code Reference Log
- Amazon Q: Select Customizations
- Amazon Q: Toggle Auto-Scans
- Amazon Q: Toggle Auto-Suggestions
- Amazon Q: Try inline suggestion example
- Amazon Q: Sign Out

TODO:
- [X] ~~Discuss `FromCommandPalette` pattern. -- Discussed offline, this is the right approach. Going forward use the same prefix and add `.commandPalette` as suffix.~~
- [X] Discuss `telemetry`/`metrics`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
