### PR TITLE
fix: copyPackageJson script development mode

### DIFF
--- a/packages/toolkit/.vscode/tasks.json
+++ b/packages/toolkit/.vscode/tasks.json
@@ -57,9 +57,8 @@
         },
         {
             "label": "copyPackageJson",
-            "type": "npm",
-            "script": "copyPackageJson",
-            "problemMatcher": [],
+            "type": "shell",
+            "command": "npm run copyPackageJson -- --development",
             "isBackground": false,
             "group": {
                 "kind": "build",

--- a/packages/toolkit/scripts/build/handlePackageJson.ts
+++ b/packages/toolkit/scripts/build/handlePackageJson.ts
@@ -11,22 +11,26 @@
  * extension when required (e.g. debugging, packaging).
  *
  * TODO: Find a better way to do this, hopefully remove the need for this in the core library.
+ *
+ * Args:
+ *   --restore : reverts the package json changes to the original state
+ *   --development: performs actions that should only be done during development and not production
  */
 
 import * as fs from 'fs-extra'
 
 function main() {
-    fixNullExtensionIssue()
+    const args = process.argv.slice(2)
+    const restoreMode = args.includes('--restore')
+
+    if (args.includes('--development')) {
+        /** When we actually package the extension the null extension does not occur, so we will skip this hack */
+        fixNullExtensionIssue(restoreMode)
+    }
 
     const packageJsonFile = './package.json'
     const backupJsonFile = `${packageJsonFile}.handlePackageJson.bk`
     const coreLibPackageJsonFile = '../core/package.json'
-    let restoreMode = false
-
-    const args = process.argv.slice(2)
-    if (args.includes('--restore')) {
-        restoreMode = true
-    }
 
     if (restoreMode) {
         try {
@@ -67,15 +71,9 @@ function main() {
  *
  * Github Issue: https://github.com/aws/aws-toolkit-vscode/issues/4658
  */
-function fixNullExtensionIssue() {
+function fixNullExtensionIssue(restoreMode: boolean) {
     const corePackageJsonFile = '../core/package.json'
     const backupJsonFile = `${corePackageJsonFile}.core.bk`
-    let restoreMode = false
-
-    const args = process.argv.slice(2)
-    if (args.includes('--restore')) {
-        restoreMode = true
-    }
 
     if (restoreMode) {
         try {


### PR DESCRIPTION
## Problem:

With the recent addition for the null extension fix in debug mode, we ran the hack during actual packaging of the AWS Toolkit extension. This hack caused the vsix to not work

## Solution:

Only run the hack during development. We did this by adding a flag to the handlePackageJson script to do the hack if the '--development' flag is given.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
