### PR TITLE
fix(auth): re-use existing connections if provided manually

### DIFF
--- a/packages/core/src/codecatalyst/auth.ts
+++ b/packages/core/src/codecatalyst/auth.ts
@@ -383,7 +383,7 @@ export class CodeCatalystAuthenticationProvider {
             await this.isConnectionOnboarded(conn, true)
         } else {
             getLogger().info(`auth: re-use(new scope) to connection from existing connection id ${connId}`)
-            const newConn = await this.secondaryAuth.addScopes(conn, scopesCodeCatalyst)
+            const newConn = await this.secondaryAuth.addScopes(conn, defaultScopes)
             await this.secondaryAuth.useNewConnection(newConn)
             await this.isConnectionOnboarded(newConn, true)
         }

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -59,6 +59,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
     }
 
     async useConnection(connectionId: string, auto: boolean): Promise<AuthError | undefined> {
+        getLogger().debug(`called useConnection() with connectionId: '${connectionId}', auto: '${auto}'`)
         return this.ssoSetup(
             'useConnection',
             async () => {
@@ -140,6 +141,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
     }
 
     async startBuilderIdSetup(): Promise<AuthError | undefined> {
+        getLogger().debug(`called startBuilderIdSetup()`)
         return await this.ssoSetup('startCodeWhispererBuilderIdSetup', async () => {
             this.storeMetricMetadata({
                 credentialSourceId: 'awsId',
@@ -153,6 +155,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
     }
 
     async startEnterpriseSetup(startUrl: string, region: string): Promise<AuthError | undefined> {
+        getLogger().debug(`called useConnection() with startUrl: '${startUrl}', region: '${region}'`)
         return await this.ssoSetup('startCodeWhispererEnterpriseSetup', async () => {
             this.storeMetricMetadata({
                 credentialStartUrl: startUrl,

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -275,7 +275,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import SelectableItem from './selectableItem.vue'
-import { LoginOption } from './types'
+import { LoginOption, AuthError } from './types'
 import { CommonAuthWebview } from './backend'
 import { WebviewClientFactory } from '../../../webviews/client'
 import { Region } from '../../../shared/regions/endpoints'
@@ -325,6 +325,10 @@ interface ExistingLogin {
     title: string
     connectionId: string
     type: number
+
+    // used internally
+    startUrl: string
+    region: string
 }
 
 export default defineComponent({
@@ -355,7 +359,6 @@ export default defineComponent({
             profileName: '',
             accessKey: '',
             secretKey: '',
-            existingConnectionStartUrls: [] as string[],
         }
     },
     async created() {
@@ -439,7 +442,17 @@ export default defineComponent({
                     return
                 }
                 this.stage = 'AUTHENTICATING'
-                const error = await client.startEnterpriseSetup(this.startUrl, this.selectedRegion, this.app)
+
+                // First check if the user tried submitting a connection that was already displayed as existing.
+                const existingConn = this.existingLogins.find(conn => conn.startUrl === this.startUrl)
+
+                let error: AuthError | undefined
+                if (existingConn !== undefined) {
+                    error = await client.useConnection(existingConn.connectionId, false)
+                } else {
+                    error = await client.startEnterpriseSetup(this.startUrl, this.selectedRegion, this.app)
+                }
+
                 if (error) {
                     this.stage = 'START'
                     void client.errorNotification(error)
@@ -476,7 +489,14 @@ export default defineComponent({
             if (this.startUrl && !validateSsoUrlFormat(this.startUrl)) {
                 this.startUrlError =
                     'URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start'
-            } else if (this.startUrl && this.existingConnectionStartUrls.includes(this.startUrl)) {
+            } else if (
+                this.startUrl &&
+                this.existingLogins.some(conn => conn.startUrl === this.startUrl && conn.region !== this.selectedRegion)
+            ) {
+                // Here, the user provided a startUrl that is already displayed as an existing option (in the previous screen).
+                // If the selectedRegion differs from the region in the existing connection, then we can display this error.
+                // Otherwise, we would have skipped this codepath and we will just re-use the existing connection since it is the same
+                // as what the user provided.
                 this.startUrlError =
                     'A connection for this start URL already exists. Sign out before creating a new one.'
             } else {
@@ -487,6 +507,7 @@ export default defineComponent({
             }
         },
         handleRegionInput(event: any) {
+            this.handleUrlInput() // startUrl validity depends on region, see handleUriInput() for details
             void client.storeMetricMetadata({
                 region: event.target.value,
             })
@@ -518,18 +539,14 @@ export default defineComponent({
                         : `IAM Identity Center ${connection.startUrl}`,
                     connectionId: connection.id,
                     type: isBuilderId(connection.startUrl) ? LoginOption.BUILDER_ID : LoginOption.ENTERPRISE_SSO,
+                    startUrl: connection.startUrl,
+                    region: connection.ssoRegion,
                 })
-            })
-            // fetch existing connections of itself
-            const connections = await client.listConnections()
-            connections.forEach(connection => {
-                if ('startUrl' in connection) {
-                    this.existingConnectionStartUrls.push(connection.startUrl)
-                }
             })
 
             // If Amazon Q has no connections while Toolkit has connections
             // Auto connect Q using toolkit connection.
+            const connections = await client.listConnections()
             if (connections.length === 0 && sharedConnections && sharedConnections.length > 0) {
                 const conn = await client.findUsableConnection(sharedConnections)
                 if (conn) {

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -194,5 +194,6 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
 
     async quitLoginScreen() {
         await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', false)
+        await this.showResourceExplorer()
     }
 }

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -36,6 +36,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
     }
 
     async startEnterpriseSetup(startUrl: string, region: string): Promise<AuthError | undefined> {
+        getLogger().debug(`called useConnection() with startUrl: '${startUrl}', region: '${region}'`)
         const metadata: TelemetryMetadata = {
             credentialSourceId: 'iamIdentityCenter',
             credentialStartUrl: startUrl,
@@ -75,6 +76,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
         accessKey: string,
         secretKey: string
     ): Promise<AuthError | undefined> {
+        getLogger().debug(`called startIamCredentialSetup()`)
         // See submitData() in manageCredentials.vue
         const runAuth = async () => {
             const data = { aws_access_key_id: accessKey, aws_secret_access_key: secretKey }
@@ -104,6 +106,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
     }
 
     async startBuilderIdSetup(): Promise<AuthError | undefined> {
+        getLogger().debug(`called startBuilderIdSetup()`)
         return this.ssoSetup('startCodeCatalystBuilderIdSetup', async () => {
             this.storeMetricMetadata({ credentialSourceId: 'awsId', authEnabledFeatures: 'codecatalyst' })
 
@@ -139,6 +142,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
      * Re-use connection that is pushed from Amazon Q to Toolkit.
      */
     async useConnection(connectionId: string, auto: boolean): Promise<AuthError | undefined> {
+        getLogger().debug(`called useConnection() with connectionId: '${connectionId}', auto: '${auto}'`)
         return this.ssoSetup('useConnection', async () => {
             let conn = await Auth.instance.getConnection({ id: connectionId })
             if (conn === undefined || conn.type !== 'sso') {


### PR DESCRIPTION
- If the user enters start url and region of an already existing connection that was displayed, we will just proceed with re-using that connection.
- If the user enters start url but region differs from what exists, we will display the error.

Other misc fixes:
- fix(toolkit): return to explorer if login page is exited
- fix(codecatalyst): use default scopes (includes aws account scopes) for sign in
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
