### PR TITLE
fix(amazonq): tf scans mapped to wrong language

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-7d44c921-beb1-42c5-9a6c-35efc4994d4d.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-7d44c921-beb1-42c5-9a6c-35efc4994d4d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Security Scan: Fixes an issue where scans fail for projects with Terraform files"
+}

--- a/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -181,17 +181,6 @@ export class RuntimeLanguageContext {
     }
 
     /**
-     *
-     * @param fileExtension File extension i.e. py, js, java
-     * @returns The corresponding {@link CodewhispererLanguage} of the file extension
-     */
-    public getLanguageFromFileExtension(fileExtension: string): CodewhispererLanguage | undefined {
-        return [...this.supportedLanguageExtensionMap.entries()].find(
-            ([, extension]) => extension === fileExtension
-        )?.[0]
-    }
-
-    /**
      * Mapping the field ProgrammingLanguage of codewhisperer generateRecommendationRequest | listRecommendationRequest to
      * its Codewhisperer runtime language e.g. jsx -> typescript, typescript -> typescript
      * @param request : cwspr generateRecommendationRequest | ListRecommendationRequest

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -152,10 +152,12 @@ export class ZipUtil {
                 this._totalSize += fileSize
                 this._totalLines += fileContent.split(ZipConstants.newlineRegex).length
 
-                const language = runtimeLanguageContext.getLanguageFromFileExtension(
+                const document = await vscode.workspace.openTextDocument(file.fileUri)
+                const { language } = runtimeLanguageContext.getLanguageContext(
+                    document.languageId,
                     path.extname(file.fileUri.fsPath).slice(1)
                 )
-                if (language) {
+                if (language && language !== 'plaintext') {
                     languageCount.set(language, (languageCount.get(language) || 0) + 1)
                 }
             }


### PR DESCRIPTION
## Problem

Projects with terraform files fail with `Improperly formed request` error. This is happening due to `tf` incorrectly mapped to `hcl`.

## Solution

The reverse map lookup function `getLanguageFromFileExtension` is unreliable because there could be duplicate values. Use `getLanguageContext` instead.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
