### PR TITLE
fix(featureDev): use max repo size from featuredev constants

### DIFF
--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -12,7 +12,7 @@ import { getLogger } from '../../shared/logger'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { VirtualFileSystem } from '../../shared/virtualFilesystem'
 import { VirtualMemoryFile } from '../../shared/virtualMemoryFile'
-import { featureDevScheme } from '../constants'
+import { featureDevScheme, maxRepoSizeBytes } from '../constants'
 import { IllegalStateTransition, UserMessageNotFoundError } from '../errors'
 import {
     CurrentWsFolders,
@@ -380,7 +380,8 @@ export class MockCodeGenState implements SessionState {
             const files = await collectFiles(
                 this.config.workspaceFolders.map(f => path.join(f.uri.fsPath, './mock-data')),
                 this.config.workspaceFolders,
-                false
+                false,
+                maxRepoSizeBytes
             )
             const newFileContents = files.map(f => ({
                 zipFilePath: f.zipFilePath,

--- a/packages/core/src/amazonqFeatureDev/util/files.ts
+++ b/packages/core/src/amazonqFeatureDev/util/files.ts
@@ -16,6 +16,7 @@ import { CurrentWsFolders } from '../types'
 import { ToolkitError } from '../../shared/errors'
 import { AmazonqCreateUpload, Metric } from '../../shared/telemetry/telemetry'
 import { TelemetryHelper } from './telemetryHelper'
+import { maxRepoSizeBytes } from '../constants'
 
 const getSha256 = (file: Buffer) => createHash('sha256').update(file).digest('base64')
 
@@ -29,7 +30,7 @@ export async function prepareRepoData(
     span: Metric<AmazonqCreateUpload>
 ) {
     try {
-        const files = await collectFiles(repoRootPaths, workspaceFolders, true)
+        const files = await collectFiles(repoRootPaths, workspaceFolders, true, maxRepoSizeBytes)
         const zip = new AdmZip()
 
         let totalBytes = 0


### PR DESCRIPTION
Problem: using default maxSize in util function that used by multiple team can make bugs in the future
Solution: use featureDev constants and override the default one, since they're now matching the limits will not be affected

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
