### PR TITLE
feat: add conversation id on error messages in amazonqFeatureDev

### DIFF
--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -194,7 +194,7 @@ export class FeatureDevController {
     // TODO add type
     private async processUserChatMessage(message: any) {
         if (message.message === undefined) {
-            this.messenger.sendErrorMessage('chatMessage should be set', message.tabID, 0, undefined)
+            this.messenger.sendErrorMessage('chatMessage should be set', message.tabID, 0, undefined, undefined)
             return
         }
 
@@ -232,7 +232,13 @@ export class FeatureDevController {
             }
         } catch (err: any) {
             if (err instanceof ContentLengthError) {
-                this.messenger.sendErrorMessage(err.message, message.tabID, this.retriesRemaining(session))
+                this.messenger.sendErrorMessage(
+                    err.message,
+                    message.tabID,
+                    this.retriesRemaining(session),
+                    undefined,
+                    session?.conversationIdUnsafe
+                )
                 this.messenger.sendAnswer({
                     type: 'system-prompt',
                     tabID: message.tabID,
@@ -247,7 +253,13 @@ export class FeatureDevController {
             } else if (err instanceof MonthlyConversationLimitError) {
                 this.messenger.sendMonthlyLimitError(message.tabID)
             } else if (err instanceof PlanIterationLimitError) {
-                this.messenger.sendErrorMessage(err.message, message.tabID, this.retriesRemaining(session))
+                this.messenger.sendErrorMessage(
+                    err.message,
+                    message.tabID,
+                    this.retriesRemaining(session),
+                    undefined,
+                    session?.conversationIdUnsafe
+                )
                 this.messenger.sendAnswer({
                     type: 'system-prompt',
                     tabID: message.tabID,
@@ -265,7 +277,13 @@ export class FeatureDevController {
                     ],
                 })
             } else if (err instanceof CodeIterationLimitError) {
-                this.messenger.sendErrorMessage(err.message, message.tabID, this.retriesRemaining(session))
+                this.messenger.sendErrorMessage(
+                    err.message,
+                    message.tabID,
+                    this.retriesRemaining(session),
+                    undefined,
+                    session?.conversationIdUnsafe
+                )
                 this.messenger.sendAnswer({
                     type: 'system-prompt',
                     tabID: message.tabID,
@@ -286,7 +304,8 @@ export class FeatureDevController {
                     errorMessage,
                     message.tabID,
                     this.retriesRemaining(session),
-                    session?.state.phase
+                    session?.state.phase,
+                    session?.conversationIdUnsafe
                 )
             }
 
@@ -447,7 +466,8 @@ export class FeatureDevController {
                 errorMessage,
                 message.tabID,
                 this.retriesRemaining(session),
-                session?.state.phase
+                session?.state.phase,
+                session?.conversationIdUnsafe
             )
         }
     }
@@ -502,7 +522,8 @@ export class FeatureDevController {
                 createUserFacingErrorMessage(`Failed to insert code changes: ${err.message}`),
                 message.tabID,
                 this.retriesRemaining(session),
-                session?.state.phase
+                session?.state.phase,
+                session?.conversationIdUnsafe
             )
         }
     }
@@ -546,7 +567,8 @@ export class FeatureDevController {
                 createUserFacingErrorMessage(`Failed to retry request: ${err.message}`),
                 message.tabID,
                 this.retriesRemaining(session),
-                session?.state.phase
+                session?.state.phase,
+                session?.conversationIdUnsafe
             )
         } finally {
             // Finish processing the event
@@ -730,7 +752,8 @@ export class FeatureDevController {
                 createUserFacingErrorMessage(err.message),
                 message.tabID,
                 this.retriesRemaining(session),
-                session?.state.phase
+                session?.state.phase,
+                session?.conversationIdUnsafe
             )
         }
     }

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -55,12 +55,20 @@ export class Messenger {
         this.sendUpdatePlaceholder(tabID, 'Chat input is disabled')
     }
 
-    public sendErrorMessage(errorMessage: string, tabID: string, retries: number, phase?: SessionStatePhase) {
+    public sendErrorMessage(
+        errorMessage: string,
+        tabID: string,
+        retries: number,
+        phase?: SessionStatePhase,
+        conversationId?: string
+    ) {
+        const conversationIdText = conversationId ? `\n\nConversation ID: **${conversationId}**` : ''
+
         if (retries === 0) {
             this.dispatcher.sendErrorMessage(
                 new ErrorMessage(
                     `Sorry, we're unable to provide a response at this time. Please try again later or share feedback with our team to help us troubleshoot.`,
-                    errorMessage,
+                    errorMessage + conversationIdText,
                     tabID
                 )
             )
@@ -84,7 +92,7 @@ export class Messenger {
                 this.dispatcher.sendErrorMessage(
                     new ErrorMessage(
                         `Sorry, we're experiencing an issue on our side. Would you like to try again?`,
-                        errorMessage,
+                        errorMessage + conversationIdText,
                         tabID
                     )
                 )
@@ -93,7 +101,7 @@ export class Messenger {
                 this.dispatcher.sendErrorMessage(
                     new ErrorMessage(
                         `Sorry, we're experiencing an issue on our side. Would you like to try again?`,
-                        errorMessage,
+                        errorMessage + conversationIdText,
                         tabID
                     )
                 )
@@ -103,7 +111,7 @@ export class Messenger {
                 this.dispatcher.sendErrorMessage(
                     new ErrorMessage(
                         `Sorry, we encountered a problem when processing your request.`,
-                        errorMessage,
+                        errorMessage + conversationIdText,
                         tabID
                     )
                 )

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -234,6 +234,11 @@ export class Session {
         return this._conversationId
     }
 
+    // Used for cases where it is not needed to have conversationId
+    get conversationIdUnsafe() {
+        return this._conversationId
+    }
+
     get latestMessage() {
         return this._latestMessage
     }


### PR DESCRIPTION
## Problem

Even with the conversation id in the info logs, it could be cumbersome for a customer to get it. From UX feedback it was proposed to add the conversation on the error messages to be more specific and direct, and make the sharing of the conversation Id to customer support more convenient.

## Solution

if the session has a conversation id, error messages will show the id with an accompanying text.

How the message will look:

![Screenshot 2024-05-15 at 14 35 26](https://github.com/aws/aws-toolkit-vscode/assets/143631912/8e68c117-57d0-463a-9409-2849afe5e722)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


