### PR TITLE
devEnv: Fix Dev Env timeout + logs

### DIFF
--- a/packages/core/src/auth/activation.ts
+++ b/packages/core/src/auth/activation.ts
@@ -11,8 +11,8 @@ import { getLogger } from '../shared/logger'
 import { ExtensionUse, initAuthCommands } from './utils'
 import { isCloud9 } from '../shared/extensionUtilities'
 import { isInDevEnv } from '../shared/vscode/env'
-import { registerCommands, getShowManageConnections } from './ui/vue/show'
 import { isWeb } from '../shared/extensionGlobals'
+import { getShowManageConnections, registerCommands } from '../login/command'
 
 export async function initialize(
     extensionContext: vscode.ExtensionContext,

--- a/packages/core/src/codecatalyst/activation.ts
+++ b/packages/core/src/codecatalyst/activation.ts
@@ -12,7 +12,7 @@ import { CodeCatalystCommands } from './commands'
 import { GitExtension } from '../shared/extensions/git'
 import { CodeCatalystAuthenticationProvider } from './auth'
 import { registerDevfileWatcher, updateDevfileCommand } from './devfile'
-import { DevEnvClient, DevEnvActivity } from '../shared/clients/devenvClient'
+import { DevEnvClient } from '../shared/clients/devenvClient'
 import { watchRestartingDevEnvs } from './reconnect'
 import { ToolkitPromptSettings } from '../shared/settings'
 import { dontShow } from '../shared/localizedText'
@@ -22,7 +22,7 @@ import { createClient, getCodeCatalystConfig } from '../shared/clients/codecatal
 import { isDevenvVscode } from './utils'
 import { codeCatalystConnectCommand, getThisDevEnv } from './model'
 import { getLogger } from '../shared/logger/logger'
-import { InactivityMessage, shouldTrackUserActivity } from './devEnv'
+import { DevEnvActivityStarter } from './devEnv'
 import { learnMoreCommand, onboardCommand, reauth } from './explorer'
 import { getShowManageConnections } from '../login/command'
 
@@ -123,17 +123,10 @@ export async function activate(ctx: ExtContext): Promise<void> {
                 }
             })
         }
-
-        const maxInactivityMinutes = thisDevenv.summary.inactivityTimeoutMinutes
-        const devEnvClient = thisDevenv.devenvClient
-        const devEnvActivity = await DevEnvActivity.instanceIfActivityTrackingEnabled(devEnvClient)
-        if (shouldTrackUserActivity(maxInactivityMinutes) && devEnvActivity) {
-            const inactivityMessage = new InactivityMessage()
-            await inactivityMessage.setupMessage(maxInactivityMinutes, devEnvActivity)
-
-            ctx.extensionContext.subscriptions.push(inactivityMessage, devEnvActivity)
-        }
     }
+
+    // This must always be called on activation
+    DevEnvActivityStarter.register(authProvider)
 }
 
 async function showReadmeFileOnFirstLoad(workspaceState: vscode.ExtensionContext['workspaceState']): Promise<void> {

--- a/packages/core/src/codecatalyst/activation.ts
+++ b/packages/core/src/codecatalyst/activation.ts
@@ -23,8 +23,8 @@ import { isDevenvVscode } from './utils'
 import { codeCatalystConnectCommand, getThisDevEnv } from './model'
 import { getLogger } from '../shared/logger/logger'
 import { InactivityMessage, shouldTrackUserActivity } from './devEnv'
-import { getShowManageConnections } from '../auth/ui/vue/show'
 import { learnMoreCommand, onboardCommand, reauth } from './explorer'
+import { getShowManageConnections } from '../login/command'
 
 const localize = nls.loadMessageBundle()
 

--- a/packages/core/src/codecatalyst/commands.ts
+++ b/packages/core/src/codecatalyst/commands.ts
@@ -25,8 +25,8 @@ import { AccountStatus } from '../shared/telemetry/telemetryClient'
 import { CreateDevEnvironmentRequest, UpdateDevEnvironmentRequest } from 'aws-sdk/clients/codecatalyst'
 import { Auth } from '../auth/auth'
 import { SsoConnection } from '../auth/connection'
-import { getShowManageConnections } from '../auth/ui/vue/show'
 import { isInDevEnv, isRemoteWorkspace } from '../shared/vscode/env'
+import { getShowManageConnections } from '../login/command'
 
 /** "List CodeCatalyst Commands" command. */
 export async function listCommands(): Promise<void> {

--- a/packages/core/src/codecatalyst/explorer.ts
+++ b/packages/core/src/codecatalyst/explorer.ts
@@ -16,7 +16,7 @@ import * as codecatalyst from './model'
 import { getLogger } from '../shared/logger'
 import { Connection } from '../auth/connection'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
-import { getShowManageConnections } from '../auth/ui/vue/show'
+import { getShowManageConnections } from '../login/command'
 
 export const learnMoreCommand = Commands.declare('aws.learnMore', () => async (docsUrl: vscode.Uri) => {
     return openUrl(docsUrl)

--- a/packages/core/src/login/command.ts
+++ b/packages/core/src/login/command.ts
@@ -1,0 +1,54 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import vscode from 'vscode'
+import { Commands, RegisteredCommand, VsCodeCommandArg, placeholder } from '../shared/vscode/commands2'
+import { ServiceItemId, isServiceItemId } from '../auth/ui/vue/types'
+import { authCommands } from '../auth/utils'
+import { showCodeWhispererConnectionPrompt } from '../codewhisperer/util/showSsoPrompt'
+import { AuthSource, AuthSources } from './webview/util'
+import { isCloud9 } from '../shared/extensionUtilities'
+import { isWeb } from '../shared/extensionGlobals'
+import { CommonAuthWebview } from './webview/vue/backend'
+
+let showManageConnections: RegisteredCommand<any> | undefined
+export function getShowManageConnections(): RegisteredCommand<any> {
+    if (!showManageConnections) {
+        throw new Error('showManageConnections not registered')
+    }
+    return showManageConnections
+}
+
+export function registerCommands(context: vscode.ExtensionContext, prefix: string) {
+    showManageConnections = Commands.register(
+        { id: `aws.${prefix}.auth.manageConnections`, compositeKey: { 1: 'source' } },
+        async (_: VsCodeCommandArg, source: AuthSource, serviceToShow?: ServiceItemId) => {
+            if (_ !== placeholder) {
+                source = AuthSources.vscodeComponent
+            }
+
+            // The auth webview page does not make sense to use in C9,
+            // so show the auth quick pick instead.
+            if (isCloud9('any') || isWeb()) {
+                if (source.toLowerCase().includes('codewhisperer')) {
+                    // Show CW specific quick pick for CW connections
+                    return showCodeWhispererConnectionPrompt()
+                }
+                return authCommands().addConnection.execute()
+            }
+
+            if (!isServiceItemId(serviceToShow)) {
+                serviceToShow = undefined
+            }
+
+            // TODO: hack
+            if (prefix === 'toolkit') {
+                CommonAuthWebview.authSource = source
+                await vscode.commands.executeCommand('aws.explorer.setLoginService', serviceToShow)
+                await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', true)
+                await vscode.commands.executeCommand('aws.toolkit.AmazonCommonAuth.focus')
+            }
+        }
+    )
+}

--- a/packages/core/src/shared/clients/devenvClient.ts
+++ b/packages/core/src/shared/clients/devenvClient.ts
@@ -146,9 +146,10 @@ export class DevEnvActivity implements vscode.Disposable {
     ): Promise<DevEnvActivity | undefined> {
         try {
             await client.getActivity()
+            getLogger().debug('codecatalyst: DevEnvActivity: Activity API is enabled')
         } catch (e) {
             const error = e instanceof HTTPError ? e.response.body : e
-            getLogger().error(`DevEnvActivity: Activity API failed:%s`, error)
+            getLogger().error(`codecatalyst: DevEnvActivity: Activity API failed:%s`, error)
             return undefined
         }
 
@@ -163,6 +164,7 @@ export class DevEnvActivity implements vscode.Disposable {
     /** Send activity timestamp to the Dev Env */
     async sendActivityUpdate(timestamp: number = Date.now()): Promise<number> {
         await this.client.updateActivity()
+        getLogger().debug(`codecatalyst: DevEnvActivity: heartbeat sent at ${timestamp}`)
         this.lastLocalActivity = timestamp
         this.activityUpdatedEmitter.fire(timestamp)
         return timestamp

--- a/packages/core/src/shared/clients/devenvClient.ts
+++ b/packages/core/src/shared/clients/devenvClient.ts
@@ -134,6 +134,7 @@ export class DevEnvActivity implements vscode.Disposable {
     /** The last known activity timestamp, but there could be a newer one on the server. */
     private lastLocalActivity: number | undefined
     private extensionUserActivity: ExtensionUserActivity
+    private static _defaultExtensionUserActivity: ExtensionUserActivity | undefined
 
     static readonly activityUpdateDelay = 10_000
 
@@ -157,8 +158,13 @@ export class DevEnvActivity implements vscode.Disposable {
     }
 
     private constructor(private readonly client: DevEnvClient, extensionUserActivity?: ExtensionUserActivity) {
-        this.extensionUserActivity =
-            extensionUserActivity ?? new ExtensionUserActivity(DevEnvActivity.activityUpdateDelay)
+        this.extensionUserActivity = extensionUserActivity ?? this.defaultExtensionUserActivity
+    }
+
+    private get defaultExtensionUserActivity(): ExtensionUserActivity {
+        return (DevEnvActivity._defaultExtensionUserActivity ??= new ExtensionUserActivity(
+            DevEnvActivity.activityUpdateDelay
+        ))
     }
 
     /** Send activity timestamp to the Dev Env */
@@ -192,20 +198,21 @@ export class DevEnvActivity implements vscode.Disposable {
 
     /** Runs the given callback when the activity is updated */
     onActivityUpdate(callback: (timestamp: number) => any) {
-        this.updateActivityOnIdeActivity()
         this.activityUpdatedEmitter.event(callback)
-    }
-
-    /** Stops sending activity timestamps to the dev env on user ide activity. */
-    stopUpdatingActivityOnIdeActivity() {
-        this.ideActivityListener?.dispose()
-        this.ideActivityListener = undefined
     }
 
     /**
      * Sends an activity timestamp to Dev Env when there is user activity, throttled to once every {@link DevEnvActivity.activityUpdateDelay}.
      */
-    private updateActivityOnIdeActivity() {
+    setUpdateActivityOnIdeActivity(doUpdate: boolean) {
+        this.ideActivityListener?.dispose()
+        this.ideActivityListener = undefined
+
+        if (!doUpdate) {
+            // Stop updating the activity heartbeat
+            return
+        }
+
         if (this.ideActivityListener) {
             return
         }
@@ -216,7 +223,7 @@ export class DevEnvActivity implements vscode.Disposable {
     }
 
     dispose() {
-        this.stopUpdatingActivityOnIdeActivity()
+        this.setUpdateActivityOnIdeActivity(false)
     }
 }
 

--- a/packages/core/src/test/shared/clients/devenvClient.test.ts
+++ b/packages/core/src/test/shared/clients/devenvClient.test.ts
@@ -77,6 +77,7 @@ describe('DevEnvActivity', function () {
 
         it('when vscode user activity event is emitted', async () => {
             assert.strictEqual(activitySubscriber.callCount, 0)
+            devEnvActivity.setUpdateActivityOnIdeActivity(true)
             await triggerUserActivityEvent({})
             assert.strictEqual(activitySubscriber.callCount, 1)
         })


### PR DESCRIPTION
## Problem:

We only tried to start the activity heartbeat on extension startup. So if
that failed due to something like an invalid connection, the heartbeat mechanism
would not start

## Solution:

- Try and start the heartbeat mechanism when the CC connection changes as well.
But if it is already running then we just skip it.
- Also added better logs to help debug this issue. The user should see `codecatalyst: DevEnvActivity: heartbeat sent at ...` in the logs, which indicates we called the Dev Env `/activity` api

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
