### PR TITLE
fix(auth): use startUrl for cache key

### DIFF
--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -39,7 +39,7 @@ import { toSnakeCase } from '../../shared/utilities/textUtilities'
 export class OidcClient {
     public constructor(private readonly client: SSOOIDC, private readonly clock: { Date: typeof Date }) {}
 
-    public async registerClient(request: RegisterClientRequest, flow?: AuthenticationFlow) {
+    public async registerClient(request: RegisterClientRequest, startUrl: string, flow?: AuthenticationFlow) {
         const response = await this.client.registerClient(request)
         assertHasProps(response, 'clientId', 'clientSecret', 'clientSecretExpiresAt')
 
@@ -48,6 +48,7 @@ export class OidcClient {
             clientId: response.clientId,
             clientSecret: response.clientSecret,
             expiresAt: new this.clock.Date(response.clientSecretExpiresAt * 1000),
+            startUrl,
             ...(flow ? { flow } : {}),
         }
     }

--- a/packages/core/src/auth/sso/model.ts
+++ b/packages/core/src/auth/sso/model.ts
@@ -64,6 +64,11 @@ export interface ClientRegistration {
     readonly expiresAt: Date
 
     /**
+     * The start URL used to create this registration.
+     */
+    readonly startUrl: string
+
+    /**
      * Scope of the client registration. Applies to all tokens created using this registration.
      */
     readonly scopes?: string[]

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -203,7 +203,7 @@ export abstract class SsoAccessTokenProvider {
     }
 
     protected get registrationCacheKey() {
-        return { region: this.profile.region, scopes: this.profile.scopes }
+        return { startUrl: this.profile.startUrl, region: this.profile.region, scopes: this.profile.scopes }
     }
 
     /**
@@ -349,11 +349,14 @@ export class DeviceFlowAuthorization extends SsoAccessTokenProvider {
 
     override async registerClient(): Promise<ClientRegistration> {
         const companyName = getIdeProperties().company
-        return this.oidc.registerClient({
-            clientName: isCloud9() ? `${companyName} Cloud9` : `${companyName} IDE Extensions for VSCode`,
-            clientType: clientRegistrationType,
-            scopes: this.profile.scopes,
-        })
+        return this.oidc.registerClient(
+            {
+                clientName: isCloud9() ? `${companyName} Cloud9` : `${companyName} IDE Extensions for VSCode`,
+                clientType: clientRegistrationType,
+                scopes: this.profile.scopes,
+            },
+            this.profile.startUrl
+        )
     }
 
     override async authorize(
@@ -425,6 +428,7 @@ class AuthFlowAuthorization extends SsoAccessTokenProvider {
                 redirectUris: ['http://127.0.0.1/oauth/callback'],
                 issuerUrl: this.profile.startUrl,
             },
+            this.profile.startUrl,
             'auth code'
         )
     }

--- a/packages/core/src/test/credentials/sso/cache.test.ts
+++ b/packages/core/src/test/credentials/sso/cache.test.ts
@@ -20,6 +20,7 @@ describe('SSO Cache', function () {
         clientId: 'dummyId',
         clientSecret: 'dummySecret',
         expiresAt: new Date(Date.now() + hourInMs),
+        startUrl,
     }
 
     const validToken = {
@@ -43,7 +44,7 @@ describe('SSO Cache', function () {
         })
 
         it('caches based off region', async function () {
-            await cache.save({ region }, validRegistration)
+            await cache.save({ startUrl, region }, validRegistration)
 
             const cachedPath = path.join(testDir, `aws-toolkit-vscode-client-id-${region}.json`)
             const contents = await fs.readFile(cachedPath, 'utf-8')
@@ -53,7 +54,7 @@ describe('SSO Cache', function () {
                 expiresAt: validRegistration.expiresAt.toISOString(),
             })
 
-            assert.deepStrictEqual(await cache.load({ region }), validRegistration)
+            assert.deepStrictEqual(await cache.load({ startUrl, region }), validRegistration)
         })
     })
 

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -54,6 +54,7 @@ describe('SsoAccessTokenProvider', function () {
             clientId: 'dummyClientId',
             clientSecret: 'dummyClientSecret',
             expiresAt: new clock.Date(clock.Date.now() + timeDelta),
+            startUrl,
             ...extras,
         }
     }
@@ -100,11 +101,11 @@ describe('SsoAccessTokenProvider', function () {
         it('removes cached tokens and registrations', async function () {
             const validToken = createToken(hourInMs)
             await cache.token.save(startUrl, { region, startUrl, token: validToken })
-            await cache.registration.save({ region }, createRegistration(hourInMs))
+            await cache.registration.save({ startUrl, region }, createRegistration(hourInMs))
             await sut.invalidate()
 
             assert.strictEqual(await cache.token.load(startUrl), undefined)
-            assert.strictEqual(await cache.registration.load({ region }), undefined)
+            assert.strictEqual(await cache.registration.load({ startUrl, region }), undefined)
         })
     })
 
@@ -220,7 +221,7 @@ describe('SsoAccessTokenProvider', function () {
             assert.deepStrictEqual(await sut.createToken(), { ...token, identity: startUrl })
             const cachedToken = await cache.token.load(startUrl).then(a => a?.token)
             assert.deepStrictEqual(cachedToken, token)
-            assert.deepStrictEqual(await cache.registration.load({ region }), registration)
+            assert.deepStrictEqual(await cache.registration.load({ startUrl, region }), registration)
             assertTelemetry('aws_loginWithBrowser', {
                 result: 'Succeeded',
                 isReAuth: undefined,
@@ -274,14 +275,15 @@ describe('SsoAccessTokenProvider', function () {
          * Saves an expired client registration to the cache.
          */
         async function saveExpiredRegistrationToCache(): Promise<{
-            key: { region: string; scopes: string[] }
+            key: { startUrl: string; region: string; scopes: string[] }
             registration: ClientRegistration
         }> {
-            const key = { region, scopes: [] }
+            const key = { startUrl, region, scopes: [] }
             const registration = {
                 clientId: 'myExpiredClientId',
                 clientSecret: 'myExpiredClientSecret',
                 expiresAt: new clock.Date(clock.Date.now() - 1), // expired date
+                startUrl: key.startUrl,
             }
             await cache.registration.save(key, registration)
             return { key, registration }
@@ -321,7 +323,7 @@ describe('SsoAccessTokenProvider', function () {
                 oidcClient.startDeviceAuthorization.rejects(exception)
 
                 await assert.rejects(sut.createToken(), exception)
-                assert.strictEqual(await cache.registration.load({ region }), undefined)
+                assert.strictEqual(await cache.registration.load({ startUrl, region }), undefined)
             })
 
             it('removes the client registration cache on client faults (token step)', async function () {
@@ -335,7 +337,7 @@ describe('SsoAccessTokenProvider', function () {
                 stubOpen()
 
                 await assert.rejects(sut.createToken(), exception)
-                assert.strictEqual(await cache.registration.load({ region }), undefined)
+                assert.strictEqual(await cache.registration.load({ startUrl, region }), undefined)
                 assertTelemetry('aws_loginWithBrowser', {
                     result: 'Failed',
                     isReAuth: undefined,
@@ -351,7 +353,7 @@ describe('SsoAccessTokenProvider', function () {
                 oidcClient.startDeviceAuthorization.rejects(exception)
 
                 await assert.rejects(sut.createToken(), exception)
-                assert.deepStrictEqual(await cache.registration.load({ region }), registration)
+                assert.deepStrictEqual(await cache.registration.load({ startUrl, region }), registration)
             })
         })
 
@@ -375,9 +377,9 @@ describe('SsoAccessTokenProvider', function () {
             it('saves the client registration even when cancelled', async function () {
                 stubOpen(false)
                 const registration = createRegistration(hourInMs)
-                await cache.registration.save({ region }, registration)
+                await cache.registration.save({ startUrl, region }, registration)
                 await assert.rejects(sut.createToken(), ToolkitError)
-                const cached = await cache.registration.load({ region })
+                const cached = await cache.registration.load({ startUrl, region })
                 assert.deepStrictEqual(cached, registration)
             })
 


### PR DESCRIPTION
- Also adds startUrl to the registration file.

Problem: We only index client registrations files on region, scopes. IdC and builder ID are not distinguishable at the region + scopes level. This means that we can cache to the same registration file if the user tries IdC or builder Id. Now that we have moved to a new auth flow we no longer control opening the start URL, it is provided by the registration. If the registration is shared between IdC and builder ID, whatever one is accessed first will have its start URL saved to the cache.

Solution: Add start url to the hash key. This will prevent IdC and buidler ID logins matching to the same registration and routing to the same start url.

Steps to reproduce without this:
1. Try to log into builder ID or IdC
2. Don't fully sign in, cancel and return.
3. Try to sign in with the other.
4. The start URL will be for sign in method in step 1, not the one from step 3.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
