### PR TITLE
fix(/dev): logic to allow customer to modify root source folder

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-7034adfe-fc09-44d2-8328-d908ab99f1ac.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-7034adfe-fc09-44d2-8328-d908ab99f1ac.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fixes an issue where the /dev chat wouldn't let customers modify the source folder when exceeding the size limit"
+}

--- a/packages/core/src/amazonqFeatureDev/util/files.ts
+++ b/packages/core/src/amazonqFeatureDev/util/files.ts
@@ -16,6 +16,7 @@ import { CurrentWsFolders } from '../types'
 import { ToolkitError } from '../../shared/errors'
 import { AmazonqCreateUpload, Metric } from '../../shared/telemetry/telemetry'
 import { TelemetryHelper } from './telemetryHelper'
+import { maxRepoSizeBytes } from '../constants'
 
 const getSha256 = (file: Buffer) => createHash('sha256').update(file).digest('base64')
 
@@ -29,7 +30,7 @@ export async function prepareRepoData(
     span: Metric<AmazonqCreateUpload>
 ) {
     try {
-        const files = await collectFiles(repoRootPaths, workspaceFolders, true)
+        const files = await collectFiles(repoRootPaths, workspaceFolders, true, maxRepoSizeBytes)
         const zip = new AdmZip()
 
         let totalBytes = 0
@@ -55,8 +56,8 @@ export async function prepareRepoData(
         }
     } catch (error) {
         getLogger().debug(`featureDev: Failed to prepare repo: ${error}`)
-        if (error instanceof ContentLengthError) {
-            throw error
+        if (error instanceof ToolkitError && error.code === 'ContentLengthError') {
+            throw new ContentLengthError()
         }
         throw new PrepareRepoFailedError()
     }

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -16,6 +16,7 @@ import { getGlobDirExcludedPatterns } from '../fs/watchedFiles'
 import { sanitizeFilename } from './textUtilities'
 import { GitIgnoreAcceptor } from '@gerhobbelt/gitignore-parser'
 import * as parser from '@gerhobbelt/gitignore-parser'
+import { fsCommon } from '../../srcShared/fs'
 
 type GitIgnoreRelativeAcceptor = {
     folderPath: string
@@ -351,7 +352,7 @@ export async function collectFiles(
                 continue
             }
 
-            const fileStat = await vscode.workspace.fs.stat(file)
+            const fileStat = await fsCommon.stat(file)
             if (totalSizeBytes + fileStat.size > maxSize) {
                 throw new ToolkitError(
                     'The project you have selected for source code is too large to use as context. Please select a different folder to use',


### PR DESCRIPTION
## Problem

A recent refactor (https://github.com/aws/aws-toolkit-vscode/pull/4924) moved `collectFiles` to a shared file but also updated the logic to throw another error that the `/dev` controller was not expecting. This effectively broke the feature that allows customer to modify root source folder when the folder exceeds 200MB

## Solution

- Updated the if-else logic to check for the correct error
- Added a unit test to make it clearer that `/dev` controller expects the error to be specific to avoid breaking the logic.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
