### PR TITLE
telemetry(amazonq): modifySourceFolder event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3284,9 +3284,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.205",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.205.tgz",
-            "integrity": "sha512-PTfUswOmp8WXWhB2ib+PzoQ5g5Ti1xH8OQS/zSEwWYrCsd1DaTlFlVKkaSF+8g8AoSK2hRseuWQE/33HR3ipcg==",
+            "version": "1.0.208",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.208.tgz",
+            "integrity": "sha512-X5wQXcr48+uiDFBv3MKtMuO0beD7+o2aIDTF/AG0Mkfr4k2i2foa1QsCOHyQa4wXrdfqJ/bjXZPlaxw5qiQGUA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -19004,7 +19004,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
-                "@aws-toolkits/telemetry": "^1.0.205",
+                "@aws-toolkits/telemetry": "^1.0.208",
                 "@aws/fully-qualified-names": "^2.1.4",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3984,7 +3984,7 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws-toolkits/telemetry": "^1.0.205",
+        "@aws-toolkits/telemetry": "^1.0.208",
         "@aws/fully-qualified-names": "^2.1.4",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",

--- a/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -184,6 +184,7 @@ describe('Controller', () => {
         }
 
         it('fails if selected folder is not under a workspace folder', async () => {
+            sinon.stub(controllerSetup.sessionStorage, 'getSession').resolves(session)
             sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(undefined)
             const messengerSpy = sinon.spy(controllerSetup.messenger, 'sendAnswer')
             await modifyDefaultSourceFolder('../../')


### PR DESCRIPTION
## Problem

There is no current metric tracking the usage of this UI feature form /dev which allows customer to modify root source folder. This will hopefully help us calculate any impact if this feature gets broken in the future or also have an insight of the usage.

## Solution

send the modifySourceFolder when customer clicks the button to do so on the chat.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
