### PR TITLE
auth: do not use URI Handler in Auth PKCE flow

### DIFF
--- a/packages/core/src/auth/activation.ts
+++ b/packages/core/src/auth/activation.ts
@@ -12,15 +12,12 @@ import { ExtensionUse, initAuthCommands } from './utils'
 import { isCloud9 } from '../shared/extensionUtilities'
 import { isInDevEnv } from '../shared/vscode/env'
 import { registerCommands, getShowManageConnections } from './ui/vue/show'
-import { UriHandler } from '../shared/vscode/uriHandler'
-import { authenticationPath } from './sso/ssoAccessTokenProvider'
 import { isWeb } from '../shared/extensionGlobals'
 
 export async function initialize(
     extensionContext: vscode.ExtensionContext,
     loginManager: LoginManager,
-    contextPrefix: string,
-    uriHandler?: UriHandler
+    contextPrefix: string
 ): Promise<void> {
     Auth.instance.onDidChangeActiveConnection(async conn => {
         // This logic needs to be moved to `Auth.useConnection` to correctly record `passive`
@@ -37,11 +34,6 @@ export async function initialize(
     extensionContext.subscriptions.push(getShowManageConnections())
 
     await showManageConnectionsOnStartup()
-
-    uriHandler?.onPath(`/${authenticationPath}`, () => {
-        // TODO emit telemetry
-        getLogger().info('authenticated')
-    })
 }
 
 /**

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -40,7 +40,6 @@ import { AuthSSOServer } from './server'
 import { CancellationError, sleep } from '../../shared/utilities/timeoutUtils'
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 import { randomBytes, createHash } from 'crypto'
-import { UriHandler } from '../../shared/vscode/uriHandler'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { randomUUID } from '../../common/crypto'
 import { isRemoteWorkspace } from '../../shared/vscode/env'
@@ -437,7 +436,7 @@ class AuthFlowAuthorization extends SsoAccessTokenProvider {
         registration: ClientRegistration
     ): Promise<{ token: SsoToken; registration: ClientRegistration; region: string; startUrl: string }> {
         const state = randomUUID()
-        const authServer = new AuthSSOServer(state, UriHandler.buildUri(authenticationPath).toString())
+        const authServer = new AuthSSOServer(state)
 
         try {
             await authServer.start()

--- a/packages/core/src/extensionShared.ts
+++ b/packages/core/src/extensionShared.ts
@@ -140,7 +140,7 @@ export async function activateShared(
     )
 
     // auth
-    await initializeAuth(context, globals.loginManager, contextPrefix, globals.uriHandler)
+    await initializeAuth(context, globals.loginManager, contextPrefix)
     await initializeAwsCredentialsStatusBarItem(globals.awsContext, context)
 
     const extContext: ExtContext = {

--- a/packages/core/src/test/credentials/sso/server.test.ts
+++ b/packages/core/src/test/credentials/sso/server.test.ts
@@ -24,7 +24,7 @@ describe('AuthSSOServer', function () {
     let server: AuthSSOServer
 
     beforeEach(async function () {
-        server = new AuthSSOServer(state, 'vscode://foo')
+        server = new AuthSSOServer(state)
         await server.start()
     })
 


### PR DESCRIPTION
## Problem:

When users finish accepting scopes in the browser, they are brought to a custom "success" page. Additionally we use the URI Handler to then redirect them back to the IDE.

The issue is that the user is being redirected from the local server address which includes a port number. Since this port number is dynamic there will always be an "allow" prompt in the browser, instead of seamlessly taking them back to the IDE.

## Solution:

For now we will disable the URI Handler redirect and add it back in if the vscode:// uri becomes allowed to use as a redirect URI instead

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
