### PR TITLE
fix(codecatalyst): don't display onboard node when using existing connection

### DIFF
--- a/packages/core/src/codecatalyst/auth.ts
+++ b/packages/core/src/codecatalyst/auth.ts
@@ -84,6 +84,7 @@ export class CodeCatalystAuthenticationProvider {
         this.onDidChangeActiveConnection(async () => {
             if (this.activeConnection) {
                 await this.setScopeExpired(this.activeConnection, false)
+                await this.isConnectionOnboarded(this.activeConnection, true)
             }
             await setCodeCatalystConnectedContext(this.isConnectionValid())
             this.onDidChangeEmitter.fire()
@@ -91,6 +92,9 @@ export class CodeCatalystAuthenticationProvider {
 
         this.onAccessDeniedException(async (showReauthPrompt: boolean) => {
             await this.accessDeniedExceptionHandler(showReauthPrompt)
+            if (this.activeConnection) {
+                await this.isConnectionOnboarded(this.activeConnection, true)
+            }
             this.onDidChangeEmitter.fire()
         })
 

--- a/packages/toolkit/.changes/next-release/Bug Fix-b9005bc6-20e0-48f3-a67a-ab23ee2cf62c.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-b9005bc6-20e0-48f3-a67a-ab23ee2cf62c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeCatalyst: No longer display a prompt to 'Onboard' if re-using an existing connection from Amazon Q and it is already onboarded."
+}


### PR DESCRIPTION
## Problem
There is some race condition that will display an onboarding node when re-using a connection from amazon Q, even if the connection is already onboarded. This occurs even if we updating the onboarded state after adding a new connection.

## Solution
Update the onboarded state in the connection change callback directly. This should fire before updating the tree nodes, eliminating the race condition.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
