### PR TITLE
fix(amazonq): prevent auto-scan if connection expired

### DIFF
--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -314,7 +314,7 @@ export async function activate(context: ExtContext): Promise<void> {
         if (
             CodeScansState.instance.isScansEnabled() &&
             !CodeScansState.instance.isMonthlyQuotaExceeded() &&
-            auth.isConnected() &&
+            auth.isConnectionValid() &&
             !auth.isBuilderIdInUse() &&
             editor &&
             securityScanLanguageContext.isLanguageSupported(editor.document.languageId) &&
@@ -335,7 +335,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 if (
                     CodeScansState.instance.isScansEnabled() &&
                     !CodeScansState.instance.isMonthlyQuotaExceeded() &&
-                    auth.isConnected() &&
+                    auth.isConnectionValid() &&
                     !auth.isBuilderIdInUse() &&
                     editor &&
                     securityScanLanguageContext.isLanguageSupported(editor.document.languageId)
@@ -366,7 +366,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 if (
                     CodeScansState.instance.isScansEnabled() &&
                     !CodeScansState.instance.isMonthlyQuotaExceeded() &&
-                    auth.isConnected() &&
+                    auth.isConnectionValid() &&
                     !auth.isBuilderIdInUse() &&
                     editor &&
                     event.document === editor.document &&
@@ -390,7 +390,7 @@ export async function activate(context: ExtContext): Promise<void> {
             if (
                 isScansEnabled &&
                 !CodeScansState.instance.isMonthlyQuotaExceeded() &&
-                auth.isConnected() &&
+                auth.isConnectionValid() &&
                 !auth.isBuilderIdInUse() &&
                 editor &&
                 securityScanLanguageContext.isLanguageSupported(editor.document.languageId) &&


### PR DESCRIPTION
## Problem

Auto-scans are triggered even if auth connection is expired.

## Solution

Use `isConnectionValid()` instead of `isConnected()`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
