### PR TITLE
chore: remove cn and cloud9 items from q contributes

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -75,11 +75,6 @@
         "configuration": {
             "type": "object",
             "title": "%AWS.amazonq.productName%",
-            "cloud9": {
-                "cn": {
-                    "title": "%AWS.amazonq.productName.cn%"
-                }
-            },
             "properties": {
                 "amazonQ.telemetry": {
                     "type": "boolean",
@@ -155,13 +150,13 @@
                     "type": "webview",
                     "id": "aws.amazonq.AmazonCommonAuth",
                     "name": "%AWS.amazonq.login%",
-                    "when": "!isCloud9 && !aws.isSageMaker && aws.amazonq.showLoginView"
+                    "when": "!aws.isSageMaker && aws.amazonq.showLoginView"
                 },
                 {
                     "type": "webview",
                     "id": "aws.AmazonQChatView",
                     "name": "%AWS.amazonq.chat%",
-                    "when": "!isCloud9 && !aws.isSageMaker && !aws.amazonq.showLoginView"
+                    "when": "!aws.isSageMaker && !aws.amazonq.showLoginView"
                 },
                 {
                     "id": "aws.AmazonQNeverShowBadge",
@@ -252,7 +247,7 @@
                 },
                 {
                     "command": "amazonq.dev.openMenu",
-                    "when": "aws.isDevMode || isCloud9"
+                    "when": "aws.isDevMode"
                 },
                 {
                     "command": "aws.amazonq.learnMore",
@@ -412,45 +407,24 @@
                 "command": "aws.amazonq.login",
                 "title": "%AWS.command.login%",
                 "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "title": "%AWS.command.login.cn%",
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                },
                 "enablement": "false"
             },
             {
                 "command": "aws.amazonq.credentials.profile.create",
                 "title": "%AWS.command.credentials.profile.create%",
                 "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                },
                 "enablement": "false"
             },
             {
                 "command": "aws.amazonq.credentials.edit",
                 "title": "%AWS.command.credentials.edit%",
                 "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                },
                 "enablement": "false"
             },
             {
                 "command": "aws.amazonq.logout",
                 "title": "%AWS.command.logout%",
                 "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                },
                 "enablement": "false"
             },
             {
@@ -504,8 +478,7 @@
             {
                 "command": "aws.amazonq.auth.signout",
                 "title": "%AWS.command.auth.signout%",
-                "category": "%AWS.amazonq.title%",
-                "enablement": "!isCloud9"
+                "category": "%AWS.amazonq.title%"
             },
             {
                 "command": "aws.amazonq.auth.help",
@@ -516,24 +489,14 @@
             {
                 "command": "aws.amazonq.createIssueOnGitHub",
                 "title": "%AWS.command.createIssueOnGitHub%",
-                "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                }
+                "category": "%AWS.amazonq.title%"
             },
             {
                 "command": "aws.amazonq.submitFeedback",
                 "title": "%AWS.command.submitFeedback%",
                 "enablement": "!aws.isWebExtHost",
                 "category": "%AWS.amazonq.title%",
-                "icon": "$(comment)",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                }
+                "icon": "$(comment)"
             },
             {
                 "command": "aws.amazonq.viewLogs",
@@ -543,12 +506,7 @@
             {
                 "command": "aws.amazonq.github",
                 "title": "%AWS.command.github%",
-                "category": "%AWS.amazonq.title%",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                }
+                "category": "%AWS.amazonq.title%"
             },
             {
                 "command": "aws.amazonq.aboutExtension",
@@ -564,23 +522,13 @@
                 "command": "aws.amazonq.configure",
                 "title": "%AWS.command.codewhisperer.configure%",
                 "category": "%AWS.amazonq.title%",
-                "icon": "$(gear)",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.title.cn%"
-                    }
-                }
+                "icon": "$(gear)"
             },
             {
                 "command": "aws.amazonq.introduction",
                 "title": "%AWS.command.codewhisperer.introduction%",
                 "category": "%AWS.amazonq.title%",
-                "icon": "$(question)",
-                "cloud9": {
-                    "cn": {
-                        "category": "%AWS.amazonq.productName.cn%"
-                    }
-                }
+                "icon": "$(question)"
             },
             {
                 "command": "aws.amazonq.signout",
@@ -657,13 +605,13 @@
                 "command": "aws.amazonq.invokeInlineCompletion",
                 "key": "alt+c",
                 "mac": "alt+c",
-                "when": "editorTextFocus && aws.codewhisperer.connected || isCloud9 && editorTextFocus"
+                "when": "editorTextFocus && aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.rejectCodeSuggestion",
                 "key": "escape",
                 "mac": "escape",
-                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected || isCloud9 && suggestWidgetVisible && !editorReadonly"
+                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected"
             },
             {
                 "command": "aws.amazonq.dismissTutorial",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -4,7 +4,6 @@
     "AWS.productName": "AWS Toolkit",
     "AWS.productName.cn": "Amazon Toolkit",
     "AWS.amazonq.productName": "Amazon Q",
-    "AWS.amazonq.productName.cn": "Amazon Q",
     "AWS.codecatalyst.submenu.title": "Manage CodeCatalyst",
     "AWS.configuration.profileDescription": "The name of the credential profile to obtain credentials from.",
     "AWS.configuration.description.lambda.recentlyUploaded": "Recently selected Lambda upload targets.",


### PR DESCRIPTION
- Should fix nls warnings.
- Amazon Q is not supported in cloud9 at this time.
- No need for cn translations, there is nothing to change about it for Amazon Q.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
