### PR TITLE
fix: add missing amazon q china region title

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -251,6 +251,7 @@
     "AWS.codewhisperer.customization.notification.new_customizations.select": "Select Customization",
     "AWS.codewhisperer.customization.notification.new_customizations.learn_more": "Learn More",
     "AWS.amazonq.title": "Amazon Q",
+    "AWS.amazonq.title.cn": "Amazon Q",
     "AWS.amazonq.chat": "Chat",
     "AWS.amazonq.login": "Login",
     "AWS.amazonq.learnMore": "Learn More About Amazon Q",


### PR DESCRIPTION
We were seeing errors in a dev env in the `Remote - SSH` log output saying that this was missing.

<img width="2120" alt="Screenshot 2024-05-15 at 3 25 18 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/118216176/967588e5-15c9-4e81-9cc0-6274b90cb94d">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
