### PR TITLE
codecatalyst: fix invalid SSO profile in Dev Env

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -654,7 +654,7 @@ export class Auth implements AuthService, ConnectionManager {
 
         return startUrl === builderIdStartUrl
             ? [identifier, createBuilderIdProfile(scopesCodeCatalyst)]
-            : [identifier, createSsoProfile(region, startUrl, scopesCodeCatalyst)]
+            : [identifier, createSsoProfile(startUrl, region, scopesCodeCatalyst)]
     }
 
     private getSsoTokenProvider(id: Connection['id'], profile: StoredProfile<SsoProfile>) {


### PR DESCRIPTION
## Problem:

When a Dev Env is spun up, the AWS Toolkit extension automatically creates an SSO profile in the Dev Env using the the sso session metadata in the ~/.aws/config file.

In the scenario the ~/.aws/config file contained the session for a non-builder id session (IdC),  the SSO profile created would be incorrect due to the startUrl and Region being reversed with eachother when the SSO profile was created.

This led to an invalid SSO profile, so any attempts to reauthenticate would fail.

## Solution:

correctly create the SSO profile by swapping the args in the method call.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
