### PR TITLE
fix(auth): allow flow to continue if users copy url

### DIFF
--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -19,7 +19,6 @@ import {
     builderIdStartUrl,
     openSsoPortalLink,
     isDeprecatedAuth,
-    openSsoUrl,
 } from './model'
 import { getCache } from './cache'
 import { hasProps, hasStringProps, RequiredProps, selectFrom } from '../../shared/utilities/tsUtils'
@@ -436,7 +435,7 @@ class AuthFlowAuthorization extends SsoAccessTokenProvider {
         registration: ClientRegistration
     ): Promise<{ token: SsoToken; registration: ClientRegistration; region: string; startUrl: string }> {
         const state = randomUUID()
-        const authServer = new AuthSSOServer(state)
+        const authServer = AuthSSOServer.init(state)
 
         try {
             await authServer.start()
@@ -457,9 +456,7 @@ class AuthFlowAuthorization extends SsoAccessTokenProvider {
                     codeChallengeMethod: 'S256',
                 })
 
-                if (!(await openSsoUrl(vscode.Uri.parse(location)))) {
-                    throw new CancellationError('user')
-                }
+                await vscode.env.openExternal(vscode.Uri.parse(location))
 
                 const authorizationCode = await authServer.waitForAuthorization()
                 if (authorizationCode.isErr()) {

--- a/packages/core/src/login/webview/commonAuthViewProvider.ts
+++ b/packages/core/src/login/webview/commonAuthViewProvider.ts
@@ -104,6 +104,7 @@ export class CommonAuthViewProvider implements WebviewViewProvider {
                     this.webView!.server.storeMetricMetadata({ isReAuth: false })
                 }
                 this.webView!.server.emitAuthMetric()
+                this.webView!.server.cancelAuthFlow()
 
                 // Set after emitting. If users use side bar to return to login, this source is correct
                 // for the next iteration. Otherwise, other sources will be set accordingly by whatever

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -31,6 +31,7 @@ import { AuthSources } from '../util'
 import { AuthEnabledFeatures, AuthError, AuthFlowState, AuthUiClick, TelemetryMetadata, userCancelled } from './types'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { DevSettings } from '../../../shared/settings'
+import { AuthSSOServer } from '../../../auth/sso/server'
 
 export abstract class CommonAuthWebview extends VueWebview {
     private metricMetadata: TelemetryMetadata = {}
@@ -295,5 +296,9 @@ export abstract class CommonAuthWebview extends VueWebview {
 
     getDefaultStartUrl() {
         return DevSettings.instance.get('autofillStartUrl', '')
+    }
+
+    cancelAuthFlow() {
+        AuthSSOServer.lastInstance?.cancelCurrentFlow()
     }
 }

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -514,6 +514,8 @@ export default defineComponent({
             void client.emitUiClick('auth_regionSelection')
         },
         async handleCancelButton() {
+            void client.cancelAuthFlow()
+
             await client.storeMetricMetadata({ isReAuth: false, result: 'Cancelled' })
             void client.emitAuthMetric()
             void client.emitUiClick('auth_cancelButton')

--- a/packages/core/src/test/credentials/sso/server.test.ts
+++ b/packages/core/src/test/credentials/sso/server.test.ts
@@ -13,7 +13,8 @@ import {
 } from '../../../auth/sso/server'
 import request from '../../../common/request'
 import { URLSearchParams } from 'url'
-import { ToolkitError } from '../../../shared/errors'
+import { isUserCancelledError, ToolkitError } from '../../../shared/errors'
+import { sleep } from '../../../shared/utilities/timeoutUtils'
 
 describe('AuthSSOServer', function () {
     const code = 'zfhgaiufgsbdfigsdfg'
@@ -24,7 +25,7 @@ describe('AuthSSOServer', function () {
     let server: AuthSSOServer
 
     beforeEach(async function () {
-        server = new AuthSSOServer(state)
+        server = AuthSSOServer.init(state)
         await server.start()
     })
 
@@ -121,5 +122,22 @@ describe('AuthSSOServer', function () {
             return
         }
         assert.fail('Expected address 127.0.0.1')
+    })
+
+    it('can be cancelled while waiting for auth', async function () {
+        const promise = server.waitForAuthorization().catch(e => {
+            return e
+        })
+        server.cancelCurrentFlow()
+
+        const err = await promise
+        assert.ok(isUserCancelledError(err), 'CancellationError not thrown.')
+    })
+
+    it('initializes and closes instances', async function () {
+        const newServer = AuthSSOServer.init('1234')
+        assert.equal(AuthSSOServer.lastInstance, newServer)
+        await sleep(100)
+        assert.ok(server.closed)
     })
 })

--- a/packages/core/src/test/credentials/sso/server.test.ts
+++ b/packages/core/src/test/credentials/sso/server.test.ts
@@ -131,7 +131,7 @@ describe('AuthSSOServer', function () {
         server.cancelCurrentFlow()
 
         const err = await promise
-        assert.ok(isUserCancelledError(err), 'CancellationError not thrown.')
+        assert.ok(isUserCancelledError(err.inner), 'CancellationError not thrown.')
     })
 
     it('initializes and closes instances', async function () {


### PR DESCRIPTION
### Problem
Clicking anything other than 'open' in the VSC redirect url modal for the auth page would result in cancelling the auth attempt.

### Solution
Do not expect a specific response from the url modal. Allow the auth flow to continue even if the user hits 'Cancel' or 'Copy'. To cancel the auth flow, the user should click 'Cancel' in the login ui OR leave the login ui.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
