### PR TITLE
fix(amazonq): update refresh status bar command

### DIFF
--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -90,7 +90,7 @@ export const toggleCodeScans = Commands.declare(
                     : CodeWhispererConstants.autoScansConfig.deactivated,
             })
 
-            await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
+            await vscode.commands.executeCommand('aws.amazonq.refreshStatusBar')
         })
     }
 )


### PR DESCRIPTION
## Problem

Wrong command is used or missed during merge

## Solution

Replace `aws.codeWhisperer.refreshStatusBar` with `aws.amazonq.refreshStatusBar`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
