### PR TITLE
fix(amazonq): Autofocus to prompt field when Q panel is open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3335,9 +3335,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.8.0.tgz",
-            "integrity": "sha512-UHzY7xRsVxO4p9R+tf+3RTk6hBWW8sD3gIW5Q0G9oWVcEKEIBx067hwkkmtffzppIaQDdU0ckSKcPH5Mtk5qqQ==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.0.tgz",
+            "integrity": "sha512-XlvtQ89km6NI9EwJ0DRTbFv6hvs+0vW/gdsmwoD6fBJLSl8kfiRUCteUjTDsnfVMMqtfx+7FnmHo5p6+xbG0gg==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",
@@ -18954,7 +18954,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.8.0",
+                "@aws/mynah-ui": "^4.9.0",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-7c590127-172d-4803-8810-37745c4d516a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-7c590127-172d-4803-8810-37745c4d516a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Inside chat body, if there is a code block inside a list item it shows <br/> tags"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-86b9e6a2-2d86-4be5-b362-93eb5f96568f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-86b9e6a2-2d86-4be5-b362-93eb5f96568f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Prompt input field in Q Chat tabs doesn't stop after it reaches to the given maxLength"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-86b9e6a2-2d86-4be5-b362-93eb5f96568f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-86b9e6a2-2d86-4be5-b362-93eb5f96568f.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q Chat: Prompt input field in Q Chat tabs doesn't stop after it reaches to the given maxLength"
+	"description": "Amazon Q Chat: Prompt input field allows additional input beyond the character limit"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-b8c7f55f-2986-48a9-91e7-cf143faf51fc.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b8c7f55f-2986-48a9-91e7-cf143faf51fc.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: When window gets focus, even though the autoFocus property is set to true, input field doesn't get focus"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-b8c7f55f-2986-48a9-91e7-cf143faf51fc.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b8c7f55f-2986-48a9-91e7-cf143faf51fc.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q Chat: When window gets focus, even though the autoFocus property is set to true, input field doesn't get focus"
+	"description": "Amazon Q Chat: Prompt input field not getting focus when chat window opens"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4054,7 +4054,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.8.0",
+        "@aws/mynah-ui": "^4.9.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
This PR includes fixes for Q Chat panel related problems: Autofocus to prompt input field, unexpected `<br/>` tags inside code blocks, prompt input field maxLength is not working and middle mouse clicks to links are not behaving as expected.

## Problem(s)
- When Q panel opens, it doesn't autofocus to prompt input field
- Inside chat body, if there is a code block inside a list item it shows `<br/>` tags
- Prompt input field in Q Chat tabs doesn't stop after it reaches to the given maxLength
- Links are not behaving as expected for middle mouse clicks inside a chat item.

## Solution(s)
- Added autofocus to prompt field when the panel opens or there is a new tab.
- Removed break generation for list items (which is the supposed way from markedjs and github's own markdown styling)
- Prompt input `maxLength` value was used incorrectly, it was using the function declaration instead of the return value of the function. It is corrected.
- As we do for the clicks, we also mapped the middle clicks (`auxclick`) to the same handler functions.

Related `mynah-ui` changes:
[Autofocus](https://github.com/aws/mynah-ui/pull/48)
[Rest of the fixes](https://github.com/aws/mynah-ui/pull/49)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
