### PR TITLE
fix(auth): enforce 5 scopes when reauthing amazon q

### DIFF
--- a/packages/core/src/amazonq/auth/controller.ts
+++ b/packages/core/src/amazonq/auth/controller.ts
@@ -31,6 +31,6 @@ export class AuthController {
     }
 
     private handleReAuth() {
-        void reconnect.execute(placeholder, amazonQChatSource, true)
+        void reconnect.execute(placeholder, amazonQChatSource)
     }
 }

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -139,13 +139,7 @@ export const selectCustomizationPrompt = Commands.declare(
 
 export const reconnect = Commands.declare(
     { id: 'aws.amazonq.reconnect', compositeKey: { 1: 'source' } },
-    () =>
-        async (_: VsCodeCommandArg, source: CodeWhispererSource, addMissingScopes: boolean = false) => {
-            if (typeof addMissingScopes !== 'boolean') {
-                addMissingScopes = false
-            }
-            await AuthUtil.instance.reauthenticate(addMissingScopes)
-        }
+    () => async (_: VsCodeCommandArg, source: CodeWhispererSource) => await AuthUtil.instance.reauthenticate()
 )
 
 /** @deprecated in favor of the `Add Connection` page */

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -324,23 +324,16 @@ export class AuthUtil {
         AuthUtil.logIfChanged(logStr)
     }
 
-    public async reauthenticate(addMissingScopes: boolean = false) {
+    public async reauthenticate() {
         try {
             if (this.conn?.type !== 'sso') {
                 return
             }
 
-            // Edge Case: With the addition of Amazon Q/Chat scopes we may need to add
-            // the new scopes to existing pre-chat connections.
-            if (addMissingScopes) {
-                if (
-                    (isBuilderIdConnection(this.conn) || isIdcSsoConnection(this.conn)) &&
-                    !isValidAmazonQConnection(this.conn)
-                ) {
-                    const conn = await this.secondaryAuth.addScopes(this.conn, amazonQScopes)
-                    await this.secondaryAuth.useNewConnection(conn)
-                    return
-                }
+            if (!isValidAmazonQConnection(this.conn)) {
+                const conn = await this.secondaryAuth.addScopes(this.conn, amazonQScopes)
+                await this.secondaryAuth.useNewConnection(conn)
+                return
             }
 
             await this.auth.reauthenticate(this.conn)

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -194,7 +194,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                     isReAuth: true,
                     ...this.getMetadataForExistingConn(),
                 })
-                await AuthUtil.instance.reauthenticate(true)
+                await AuthUtil.instance.reauthenticate()
             })
         } finally {
             this.isReauthenticating = false

--- a/packages/core/src/test/codewhisperer/util/authUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/authUtil.test.ts
@@ -143,38 +143,41 @@ describe('AuthUtil', async function () {
         assert.strictEqual(auth.getConnectionState(conn), 'valid')
     })
 
-    it('reauthenticate does NOT add missing CodeWhisperer scopes if not required to', async function () {
-        const conn = await auth.createConnection(createBuilderIdProfile({ scopes: codeWhispererCoreScopes }))
+    it('reauthenticates SSO connection that already has all scopes', async function () {
+        const conn = await auth.createInvalidSsoConnection(createBuilderIdProfile({ scopes: amazonQScopes }))
         await auth.useConnection(conn)
 
         await authUtil.reauthenticate()
 
         assert.strictEqual(authUtil.conn?.type, 'sso')
-        assert.deepStrictEqual(authUtil.conn?.scopes, codeWhispererCoreScopes)
+        assert.deepStrictEqual(authUtil.conn?.scopes, amazonQScopes)
+        assert.strictEqual(auth.getConnectionState(conn), 'valid')
     })
 
     it('reauthenticate adds missing Builder ID scopes when explicitly required', async function () {
-        const conn = await auth.createConnection(createBuilderIdProfile({ scopes: codeWhispererCoreScopes }))
+        const conn = await auth.createInvalidSsoConnection(createBuilderIdProfile({ scopes: codeWhispererCoreScopes }))
         await auth.useConnection(conn)
 
         // method under test
-        await authUtil.reauthenticate(true)
+        await authUtil.reauthenticate()
 
         assert.strictEqual(authUtil.conn?.type, 'sso')
         assert.deepStrictEqual(authUtil.conn?.scopes, amazonQScopes)
+        assert.strictEqual(auth.getConnectionState(conn), 'valid')
     })
 
     it('reauthenticate adds missing Amazon Q IdC scopes when explicitly required', async function () {
-        const conn = await auth.createConnection(
+        const conn = await auth.createInvalidSsoConnection(
             createSsoProfile({ startUrl: enterpriseSsoStartUrl, scopes: codeWhispererCoreScopes })
         )
         await auth.useConnection(conn)
 
         // method under test
-        await authUtil.reauthenticate(true)
+        await authUtil.reauthenticate()
 
         assert.strictEqual(authUtil.conn?.type, 'sso')
         assert.deepStrictEqual(authUtil.conn?.scopes, amazonQScopes)
+        assert.strictEqual(auth.getConnectionState(conn), 'valid')
     })
 
     it('CodeWhisperer uses fallback connection when switching to an unsupported connection', async function () {

--- a/packages/core/src/test/codewhisperer/util/authUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/util/authUtil.test.ts
@@ -143,10 +143,11 @@ describe('AuthUtil', async function () {
         assert.strictEqual(auth.getConnectionState(conn), 'valid')
     })
 
-    it('reauthenticates SSO connection that already has all scopes', async function () {
+    it('reauthenticates Builder ID connection that already has all scopes', async function () {
         const conn = await auth.createInvalidSsoConnection(createBuilderIdProfile({ scopes: amazonQScopes }))
         await auth.useConnection(conn)
 
+        // method under test
         await authUtil.reauthenticate()
 
         assert.strictEqual(authUtil.conn?.type, 'sso')
@@ -154,7 +155,21 @@ describe('AuthUtil', async function () {
         assert.strictEqual(auth.getConnectionState(conn), 'valid')
     })
 
-    it('reauthenticate adds missing Builder ID scopes when explicitly required', async function () {
+    it('reauthenticates IdC connection that already has all scopes', async function () {
+        const conn = await auth.createInvalidSsoConnection(
+            createSsoProfile({ startUrl: enterpriseSsoStartUrl, scopes: codeWhispererCoreScopes })
+        )
+        await auth.useConnection(conn)
+
+        // method under test
+        await authUtil.reauthenticate()
+
+        assert.strictEqual(authUtil.conn?.type, 'sso')
+        assert.deepStrictEqual(authUtil.conn?.scopes, amazonQScopes)
+        assert.strictEqual(auth.getConnectionState(conn), 'valid')
+    })
+
+    it('reauthenticate adds missing Builder ID scopes', async function () {
         const conn = await auth.createInvalidSsoConnection(createBuilderIdProfile({ scopes: codeWhispererCoreScopes }))
         await auth.useConnection(conn)
 
@@ -166,7 +181,7 @@ describe('AuthUtil', async function () {
         assert.strictEqual(auth.getConnectionState(conn), 'valid')
     })
 
-    it('reauthenticate adds missing Amazon Q IdC scopes when explicitly required', async function () {
+    it('reauthenticate adds missing Amazon Q IdC scopes', async function () {
         const conn = await auth.createInvalidSsoConnection(
             createSsoProfile({ startUrl: enterpriseSsoStartUrl, scopes: codeWhispererCoreScopes })
         )


### PR DESCRIPTION
Problem: Users can keep an old 3 scope connection if they continue to reauth with the notification once auth expires.

Solution: Any call to the amazon q's reauth function enforces 5 scopes, which will fix the reauth notification.

- Does NOT update the case where user reauths an amazon q connection via toolkit quickpick. That is more difficult.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
