### PR TITLE
fix(auth): enforce 5 scopes for using existing connections in amazon q

### DIFF
--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -3,13 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode'
-import {
-    scopesCodeWhispererChat,
-    AwsConnection,
-    Connection,
-    isSsoConnection,
-    SsoConnection,
-} from '../../../../auth/connection'
+import { AwsConnection, Connection, isSsoConnection, SsoConnection, hasScopes } from '../../../../auth/connection'
 import { AuthUtil, amazonQScopes } from '../../../../codewhisperer/util/authUtil'
 import { CommonAuthWebview } from '../backend'
 import { awsIdSignIn } from '../../../../codewhisperer/util/showSsoPrompt'
@@ -85,7 +79,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                                     })
                                 }
                                 let newConn: SsoConnection
-                                if (conn.scopes?.includes(scopesCodeWhispererChat[0])) {
+                                if (hasScopes(conn.scopes ?? [], amazonQScopes)) {
                                     getLogger().info(
                                         `auth: re-use connection from existing connection id ${connectionId}`
                                     )


### PR DESCRIPTION
Problem: Users with 3 scopes can import their connection in amazon q (it is not autoconnected, it must be selected manually in the login ui). This creates edge cases and creates non-unformity for connection users. Q features may behave in unexpected ways.

Solution: Instead of checking for just 1 Q scope, check for all 5. Importing a connection was intended to add missing scopes anyways.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
