### PR TITLE
fix(amazonq): update filter condition to remove diagnostic

### DIFF
--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -128,12 +128,13 @@ export function removeDiagnostic(uri: vscode.Uri, issue: CodeScanIssue) {
     const currentSecurityDiagnostics = securityScanRender.securityDiagnosticCollection?.get(uri)
     if (currentSecurityDiagnostics) {
         const newSecurityDiagnostics = currentSecurityDiagnostics.filter(diagnostic => {
-            return (
+            return !(
                 typeof diagnostic.code !== 'string' &&
                 typeof diagnostic.code !== 'number' &&
-                diagnostic.code?.value !== issue.detectorId &&
-                diagnostic.message !== issue.title &&
-                diagnostic.range !== new vscode.Range(issue.startLine, 0, issue.endLine, 0)
+                diagnostic.code?.value === issue.detectorId &&
+                diagnostic.message === issue.title &&
+                diagnostic.range.start.line === issue.startLine &&
+                diagnostic.range.end.line === issue.endLine
             )
         })
         securityScanRender.securityDiagnosticCollection?.set(uri, newSecurityDiagnostics)


### PR DESCRIPTION
## Problem

Diagnostics are being incorrectly removed if there are multiple of the same type in the same file.

## Solution

Update filter condition to remove diagnostic.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
