### PR TITLE
fix(amazonq): duplicate diagnostics from other sources

### DIFF
--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -53,7 +53,9 @@ export function updateSecurityDiagnosticCollection(securityRecommendation: Aggre
     const filePath = securityRecommendation.filePath
     const uri = vscode.Uri.file(filePath)
     const securityDiagnosticCollection = createSecurityDiagnosticCollection()
-    const securityDiagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(uri)
+    const securityDiagnostics: vscode.Diagnostic[] = vscode.languages
+        .getDiagnostics(uri)
+        .filter(diagnostic => diagnostic.source === codewhispererDiagnosticSourceLabel)
     securityRecommendation.issues.forEach(securityIssue => {
         securityDiagnostics.push(createSecurityDiagnostic(securityIssue))
     })


### PR DESCRIPTION
## Problem

Diagnostics from other sources are being duplicated

## Solution

Only update diagnostics from Amazon Q

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
