### PR TITLE
fix(amazonq): duplicate findings for multi-folder workspaces

### DIFF
--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -59,7 +59,7 @@ export async function listScanResults(
     })
     codeScanIssueMap.forEach((issues, key) => {
         projectPaths.forEach(projectPath => {
-            const filePath = path.join(projectPath, '..', key)
+            const filePath = path.join(projectPath, key.split('/').slice(1).join('/'))
             if (existsSync(filePath) && statSync(filePath).isFile()) {
                 const aggregatedCodeScanIssue: AggregatedCodeScanIssue = {
                     filePath: filePath,


### PR DESCRIPTION
## Problem

Finding sometimes get duplicated for multi-folder workspaces if two folders have the same parent folder.

## Solution

Drop the first part of the key instead of using `..` in the path.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
