### PR TITLE
Revert "fix(codecatalyst): don't display onboard node when using existing connection (#4988)

### DIFF
--- a/packages/core/src/codecatalyst/auth.ts
+++ b/packages/core/src/codecatalyst/auth.ts
@@ -84,7 +84,6 @@ export class CodeCatalystAuthenticationProvider {
         this.onDidChangeActiveConnection(async () => {
             if (this.activeConnection) {
                 await this.setScopeExpired(this.activeConnection, false)
-                await this.isConnectionOnboarded(this.activeConnection, true)
             }
             await setCodeCatalystConnectedContext(this.isConnectionValid())
             this.onDidChangeEmitter.fire()
@@ -92,9 +91,6 @@ export class CodeCatalystAuthenticationProvider {
 
         this.onAccessDeniedException(async (showReauthPrompt: boolean) => {
             await this.accessDeniedExceptionHandler(showReauthPrompt)
-            if (this.activeConnection) {
-                await this.isConnectionOnboarded(this.activeConnection, true)
-            }
             this.onDidChangeEmitter.fire()
         })
 


### PR DESCRIPTION
This reverts commit 974b1881e25171d80ebe3b8beaedd0f65be60245.

It is causing a large number of API calls to the codecatalyst service due to a circular dependency issue.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
