### PR TITLE
fix(telemetry): use awsRegion instead of region, update guess function

### DIFF
--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -80,7 +80,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                                         credentialSourceId:
                                             conn.startUrl === builderIdStartUrl ? 'awsId' : 'iamIdentityCenter',
                                         credentialStartUrl: conn.startUrl,
-                                        region: conn.ssoRegion,
+                                        awsRegion: conn.ssoRegion,
                                         authEnabledFeatures: this.getAuthEnabledFeatures(conn),
                                     })
                                 }
@@ -123,7 +123,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                                 if (!auto) {
                                     this.storeMetricMetadata({
                                         credentialStartUrl: conn.startUrl,
-                                        region: conn.ssoRegion,
+                                        awsRegion: conn.ssoRegion,
                                         authEnabledFeatures: this.getAuthEnabledFeatures(newConn),
                                     })
                                 }
@@ -159,7 +159,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
         return await this.ssoSetup('startCodeWhispererEnterpriseSetup', async () => {
             this.storeMetricMetadata({
                 credentialStartUrl: startUrl,
-                region,
+                awsRegion: region,
                 credentialSourceId: 'iamIdentityCenter',
                 authEnabledFeatures: 'codewhisperer',
                 isReAuth: false,

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -421,7 +421,7 @@ export default defineComponent({
                 } else if (this.selectedLoginOption === LoginOption.ENTERPRISE_SSO) {
                     this.stage = 'SSO_FORM'
                     this.$nextTick(() => document.getElementById('startUrl')!.focus())
-                    await client.storeMetricMetadata({ region: this.selectedRegion })
+                    await client.storeMetricMetadata({ awsRegion: this.selectedRegion })
                 } else if (this.selectedLoginOption >= LoginOption.EXISTING_LOGINS) {
                     this.stage = 'AUTHENTICATING'
                     const selectedConnection =
@@ -509,7 +509,7 @@ export default defineComponent({
         handleRegionInput(event: any) {
             this.handleUrlInput() // startUrl validity depends on region, see handleUriInput() for details
             void client.storeMetricMetadata({
-                region: event.target.value,
+                awsRegion: event.target.value,
             })
             void client.emitUiClick('auth_regionSelection')
         },

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -40,7 +40,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
         const metadata: TelemetryMetadata = {
             credentialSourceId: 'iamIdentityCenter',
             credentialStartUrl: startUrl,
-            region,
+            awsRegion: region,
         }
 
         if (this.isCodeCatalystLogin) {

--- a/packages/core/src/shared/telemetry/telemetryService.ts
+++ b/packages/core/src/shared/telemetry/telemetryService.ts
@@ -275,7 +275,8 @@ export class DefaultTelemetryService {
             commonMetadata.push({ Key: computeRegionKey, Value: this.computeRegion })
         }
         if (!event?.Metadata?.some((m: any) => m?.Key === regionKey)) {
-            commonMetadata.push({ Key: regionKey, Value: globals.regionProvider.guessDefaultRegion() })
+            const guessedRegion = globals.regionProvider.guessDefaultRegion()
+            commonMetadata.push({ Key: regionKey, Value: guessedRegion ?? AccountStatus.NotSet })
         }
 
         if (event.Metadata) {

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -363,7 +363,7 @@
             "description": "Comma-delimited list of scopes that user has."
         },
         {
-            "name": "region",
+            "name": "awsRegion",
             "type": "string",
             "description": "An AWS region."
         }
@@ -1249,7 +1249,7 @@
                     "required": false
                 },
                 {
-                    "type": "region",
+                    "type": "awsRegion",
                     "required": false
                 },
                 {

--- a/packages/core/src/shared/ui/common/regionSubmenu.ts
+++ b/packages/core/src/shared/ui/common/regionSubmenu.ts
@@ -28,7 +28,7 @@ export class RegionSubmenu<T> extends Prompter<RegionSubmenuResponse<T>> {
         private readonly dataOptions?: ExtendedQuickPickOptions<T>,
         private readonly regionOptions?: ExtendedQuickPickOptions<T>,
         private readonly separatorLabel: string = 'Items',
-        private currentRegion = globals.regionProvider.guessDefaultRegion()
+        private currentRegion = globals.regionProvider.guessDefaultRegion() ?? globals.regionProvider.defaultRegionId
     ) {
         super()
     }


### PR DESCRIPTION
Problem: Some telemetry (auth_addConnection) is using a 'region' field instead of the built in 'awsRegion' field. This provides misleading results in telemetry, since 'awsRegion' is guessed based on toolkit usage.

Solution: Remove 'region' field and just use 'awsRegion'. Also, updating the 'awsRegion' guess function to account for amazon Q.

- Remove checking tree nodes from the region guess function, since it was unused functionality.
- If a region can't be determined, return undefined. It is up to the caller to define the default instead now.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
