### PR TITLE
auth: use minimal CW scopes with Q, but expire connection

### DIFF
--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -248,6 +248,19 @@ export class AuthUtil {
         return this.secondaryAuth.useNewConnection(conn)
     }
 
+    /**
+     * HACK: Use the connection, but then mark it as expired.
+     * We currently only need this to handle an edge case with the transition
+     * from the old to new standalone extension. This should eventually be removed.
+     */
+    public async useConnectionButExpire(conn: Connection) {
+        await this.secondaryAuth.useNewConnection(conn)
+        if (conn.type !== 'sso') {
+            return
+        }
+        await this.auth.updateConnection(conn, conn, true)
+    }
+
     public static get instance() {
         if (this.#instance !== undefined) {
             return this.#instance
@@ -424,10 +437,14 @@ export class AuthUtil {
     }
 
     /**
-     * From the given connections, returns a connection that works with Amazon Q.
+     * From the given connections, returns a connection that has some connection to Q.
+     *
+     * HACK: There is an edge case where we want to connect to the connection that only has
+     *       the old CW scopes, but not all Q scopes. So this function at the bare minimum returns
+     *       a connection if it has some CW scopes.
      */
-    findUsableQConnection(connections: AwsConnection[]): AwsConnection | undefined {
-        const hasQScopes = (c: AwsConnection) => amazonQScopes.every(s => c.scopes?.includes(s))
+    findMinimalQConnection(connections: AwsConnection[]): AwsConnection | undefined {
+        const hasQScopes = (c: AwsConnection) => codeWhispererCoreScopes.every(s => c.scopes?.includes(s))
         const score = (c: AwsConnection) => Number(hasQScopes(c)) * 10 + Number(c.state === 'valid')
         connections.sort(function (a, b) {
             return score(b) - score(a)

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -9,6 +9,7 @@ import {
     Connection,
     isSsoConnection,
     SsoConnection,
+    hasScopes,
 } from '../../../../auth/connection'
 import { AuthUtil, amazonQScopes } from '../../../../codewhisperer/util/authUtil'
 import { CommonAuthWebview } from '../backend'
@@ -55,7 +56,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
      * @returns Amazon Q connection, or undefined if none of the given connections have scopes required for Amazon Q.
      */
     findUsableConnection(connections: AwsConnection[]): AwsConnection | undefined {
-        return AuthUtil.instance.findUsableQConnection(connections)
+        return AuthUtil.instance.findMinimalQConnection(connections)
     }
 
     async useConnection(connectionId: string, auto: boolean): Promise<AuthError | undefined> {
@@ -90,7 +91,18 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                                         `auth: re-use connection from existing connection id ${connectionId}`
                                     )
                                     newConn = await Auth.instance.createConnectionFromApi(conn)
-                                    await AuthUtil.instance.secondaryAuth.useNewConnection(newConn)
+
+                                    // HACK: This if statement should eventually be removed when we assume users have added all Q scopes (reauthed).
+                                    //
+                                    // In this case we have a connection that has the CW scopes, but not all Amazon Q scopes
+                                    // We will use this connection but mark it as expired hoping that the user will reauth,
+                                    // and as a result add all Amazon Q scopes.
+                                    if (!hasScopes(conn.scopes, amazonQScopes)) {
+                                        await AuthUtil.instance.useConnectionButExpire(newConn)
+                                    } else {
+                                        // Once we remove the above 'if' statement, this is all that needs to actually be called
+                                        await AuthUtil.instance.secondaryAuth.useNewConnection(newConn)
+                                    }
                                 } else {
                                     getLogger().info(
                                         `auth: re-use(new scope) to connection from existing connection id ${connectionId}`

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -279,6 +279,7 @@ import { LoginOption, AuthError } from './types'
 import { CommonAuthWebview } from './backend'
 import { WebviewClientFactory } from '../../../webviews/client'
 import { Region } from '../../../shared/regions/endpoints'
+import { SsoConnection } from '../../../auth/connection'
 
 const client = WebviewClientFactory.create<CommonAuthWebview>()
 
@@ -546,10 +547,9 @@ export default defineComponent({
                 })
             })
 
-            // If Amazon Q has no connections while Toolkit has connections
-            // Auto connect Q using toolkit connection.
-            const connections = await client.listConnections()
-            if (connections.length === 0 && sharedConnections && sharedConnections.length > 0) {
+            // If Toolkit has usable connections, instead auto connect Q using toolkit connection.
+            // Keep in mind that a "usable" connection is one with at least the CW core scopes (inline, ...)
+            if (sharedConnections && sharedConnections.length > 0) {
                 const conn = await client.findUsableConnection(sharedConnections)
                 if (conn) {
                     await client.useConnection(conn.id, true)

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -33,4 +33,10 @@ describe('tech debt', function () {
             'with node16+, we can now use AbortController to cancel Node things (child processes, HTTP requests, etc.)'
         )
     })
+
+    it('remove missing Amazon Q scopes edge case handling', async function () {
+        const now = Date.now()
+        const cutoffDate = Date.parse('2024-06-30')
+        assert.ok(now <= cutoffDate, 'Remove the edge case code from the commit that this test is a part of.')
+    })
 })


### PR DESCRIPTION
### Problem:

In AWS Toolkit 2.19 we only added the 3 CW scopes for BiD, but now with Amazon Q there are an additional 2 scopes (gumby/weaverbird).

The issue is that connections made with 2.19 did not seamlessly transition in to the new standalone Q extension. Instead users needed to know to go to the Q login webview and select their existing BiD connection and have it reauthed to work with Q.

Instead of the above behavior, if the user has the 3 scope connection, we want to auto connect to this connection but then mark it as expired so that the status bar icon for Q tells the user they need to reauth (yellow background and reauth icon).

### Repro Steps of current state (before this change):
- Delete all connection cache from AWS + Amazon Q extensions first
- Download AWS Toolkit 2.19 (this only adds the 3 scopes)
- Connect to CW with BiD
- Install the latest Amazon Q

Note how the old connection is not automatically transitioned over, the status bar shows the 'X' as there is no connection. But if you open the Q login webview it will show BiD, then you can select that and things will work again.

### Solution:

This commit changes the code to detect a 3 scope CW connection, then use it for Q but mark it as expired.

So what will happen is that if you follow the repro steps above, but instead launch Amazon Q with this change, once you open the Q webview it will auto connect to the old connection but show it as expired in the status bar.

### Things that still need to be addressed:

- The logic to check + use the 3 scope connection only triggers when the Amazon Q panel/webview is opened. Until it is opened nothing happens, and the user is not made aware to reauth in the status bar icon. A better solution is to move this logic to the backend code so we can trigger it without the need to open the webview. Or does it make sense to auto open the Q webview if we detect they only have the 3 scopes instead of 5

- If the status bar is shown as expired, then none of Q chat will work BUT the user will still be able to type messages in that (please verify this). Though it will say they need to reauth once they send the message. Do we want this behavior or to show the reauth page?

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
