### PR TITLE
fix(amazonq): reverse map file extension to language

### DIFF
--- a/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -43,11 +43,11 @@ export class RuntimeLanguageContext {
     >
 
     /**
-     * A map storing CodeWhisperer supported programming language with key: vscLanguageId and value: language extension
-     * Key: vscLanguageId
-     * Value: language extension
+     * A map storing CodeWhisperer supported programming language with key: language extension and value: vscLanguageId
+     * Key: language extension
+     * Value: vscLanguageId
      */
-    private supportedLanguageExtensionMap: ConstantMap<CodewhispererLanguage, string>
+    private supportedLanguageExtensionMap: ConstantMap<string, CodewhispererLanguage>
 
     constructor() {
         this.supportedLanguageMap = createConstantMap<
@@ -88,29 +88,29 @@ export class RuntimeLanguageContext {
             yml: 'yaml',
             yaml: 'yaml',
         })
-        this.supportedLanguageExtensionMap = createConstantMap<CodewhispererLanguage, string>({
+        this.supportedLanguageExtensionMap = createConstantMap<string, CodewhispererLanguage>({
             c: 'c',
             cpp: 'cpp',
-            csharp: 'cs',
+            cs: 'csharp',
             go: 'go',
             hcl: 'tf',
             java: 'java',
-            javascript: 'js',
+            js: 'javascript',
             json: 'json',
             jsonc: 'json',
             jsx: 'jsx',
-            kotlin: 'kt',
-            plaintext: 'txt',
+            kt: 'kotlin',
+            txt: 'plaintext',
             php: 'php',
-            python: 'py',
-            ruby: 'rb',
-            rust: 'rs',
+            py: 'python',
+            rb: 'ruby',
+            rs: 'rust',
             scala: 'scala',
-            shell: 'sh',
+            sh: 'shell',
             sql: 'sql',
             tf: 'tf',
             tsx: 'tsx',
-            typescript: 'ts',
+            ts: 'typescript',
             yaml: 'yaml',
             yml: 'yaml',
         })
@@ -154,7 +154,9 @@ export class RuntimeLanguageContext {
      * @returns corresponding language extension if any, otherwise undefined
      */
     public getLanguageExtensionForNotebook(languageId?: string): string | undefined {
-        return this.supportedLanguageExtensionMap.get(this.normalizeLanguage(languageId)) ?? undefined
+        return [...this.supportedLanguageExtensionMap.entries()].find(
+            ([, language]) => language === this.normalizeLanguage(languageId)
+        )?.[0]
     }
 
     /**
@@ -223,8 +225,16 @@ export class RuntimeLanguageContext {
      * @returns  true if the fileformat is supported by CodeWhisperer otherwise false
      */
     public isFileFormatSupported(fileFormat: string): boolean {
-        const fileformat = this.supportedLanguageExtensionMap.get(fileFormat)
-        return fileformat !== undefined && this.supportedLanguageExtensionMap.get(fileformat) !== 'txt'
+        const language = this.supportedLanguageExtensionMap.get(fileFormat)
+        return language !== undefined && language !== 'plaintext'
+    }
+
+    /**
+     * @param fileExtension: extension of the selected file
+     * @returns corresponding vscode language id if any, otherwise undefined
+     */
+    public getLanguageFromFileExtension(fileExtension: string) {
+        return this.supportedLanguageExtensionMap.get(fileExtension)
     }
 }
 

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -158,17 +158,10 @@ export class ZipUtil {
                 this._totalSize += fileSize
                 this._totalLines += fileContent.split(ZipConstants.newlineRegex).length
 
-                try {
-                    const document = await vscode.workspace.openTextDocument(file.fileUri)
-                    const { language } = runtimeLanguageContext.getLanguageContext(
-                        document.languageId,
-                        path.extname(file.fileUri.fsPath).slice(1)
-                    )
-                    if (language && language !== 'plaintext') {
-                        languageCount.set(language, (languageCount.get(language) || 0) + 1)
-                    }
-                } catch (e) {
-                    getLogger().error(e as Error)
+                const fileExtension = path.extname(file.fileUri.fsPath).slice(1)
+                const language = runtimeLanguageContext.getLanguageFromFileExtension(fileExtension)
+                if (language && language !== 'plaintext') {
+                    languageCount.set(language, (languageCount.get(language) || 0) + 1)
                 }
             }
 


### PR DESCRIPTION
## Problem

Project scans are slow when calling `vscode.workspace.openTextDocument` on large projects.

## Solution

Inverse the file extension map for faster lookup of file extension to language, to avoid calling `vscode.workspace.openTextDocument`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
