### PR TITLE
Amazon Q 3 scopes to 5 scopes migration

### DIFF
--- a/packages/amazonq/src/auth/util.ts
+++ b/packages/amazonq/src/auth/util.ts
@@ -64,5 +64,5 @@ async function getAutoConnectableConnection(): Promise<AwsConnection | undefined
         return undefined
     }
 
-    return AuthUtil.instance.findUsableQConnection(await listConnections())
+    return AuthUtil.instance.findMinimalQConnection(await listConnections())
 }

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -42,6 +42,7 @@ import { SystemUtilities } from '../../shared/systemUtilities'
 import { ToolkitError } from '../../shared/errors'
 import { isRemoteWorkspace } from '../../shared/vscode/env'
 import { hasScopes } from '../../auth/connection'
+import globals from '../../shared/extensionGlobals'
 
 export const toggleCodeSuggestions = Commands.declare(
     { id: 'aws.amazonq.toggleCodeSuggestion', compositeKey: { 1: 'source' } },
@@ -273,7 +274,7 @@ export const notifyNewCustomizationsCmd = Commands.declare(
 
 function focusQAfterDelay() {
     // this command won't work without a small delay after install
-    setTimeout(() => {
+    globals.clock.setTimeout(() => {
         void focusAmazonQPanel.execute(placeholder, 'startDelay')
     }, 1000)
 }
@@ -461,7 +462,7 @@ const registerToolkitApiCallbackOnce = once(async () => {
         // If the user has an old 3 scope Amazon Q connection, we will use it and expire it to
         // bring the user to the new 5 scope connection. The code for this lives in the webview,
         // so we will force show the webview if we have a connection that fits this criteria.
-        if (!AuthUtil.instance.isConnected()) {
+        if ('listConnections' in _toolkitApi && !AuthUtil.instance.isConnected()) {
             const conn = AuthUtil.instance.findMinimalQConnection(await _toolkitApi.listConnections())
             if (conn !== undefined && !hasScopes(conn.scopes!, amazonQScopes)) {
                 focusQAfterDelay()

--- a/packages/core/src/codewhisperer/service/inlineCompletionService.ts
+++ b/packages/core/src/codewhisperer/service/inlineCompletionService.ts
@@ -248,6 +248,7 @@ export class CodeWhispererStatusBar {
             }
             case 'notConnected':
                 statusBar.text = codicon` ${getIcon('vscode-chrome-close')} ${title}`
+                statusBar.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
                 break
         }
 

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -248,6 +248,19 @@ export class AuthUtil {
         return this.secondaryAuth.useNewConnection(conn)
     }
 
+    /**
+     * HACK: Use the connection, but then mark it as expired.
+     * We currently only need this to handle an edge case with the transition
+     * from the old to new standalone extension. This should eventually be removed.
+     */
+    public async useConnectionButExpire(conn: Connection) {
+        await this.secondaryAuth.useNewConnection(conn)
+        if (conn.type !== 'sso') {
+            return
+        }
+        await this.auth.updateConnection(conn, conn, true)
+    }
+
     public static get instance() {
         if (this.#instance !== undefined) {
             return this.#instance
@@ -424,10 +437,14 @@ export class AuthUtil {
     }
 
     /**
-     * From the given connections, returns a connection that works with Amazon Q.
+     * From the given connections, returns a connection that has some connection to Q.
+     *
+     * HACK: There is an edge case where we want to connect to the connection that only has
+     *       the old CW scopes, but not all Q scopes. So this function at the bare minimum returns
+     *       a connection if it has some CW scopes.
      */
-    findUsableQConnection(connections: AwsConnection[]): AwsConnection | undefined {
-        const hasQScopes = (c: AwsConnection) => amazonQScopes.every(s => c.scopes?.includes(s))
+    findMinimalQConnection(connections: AwsConnection[]): AwsConnection | undefined {
+        const hasQScopes = (c: AwsConnection) => codeWhispererCoreScopes.every(s => c.scopes?.includes(s))
         const score = (c: AwsConnection) => Number(hasQScopes(c)) * 10 + Number(c.state === 'valid')
         connections.sort(function (a, b) {
             return score(b) - score(a)

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -258,7 +258,8 @@ export class AuthUtil {
         if (conn.type !== 'sso') {
             return
         }
-        await this.auth.updateConnection(conn, conn, true)
+        await this.auth.expireConnection(conn)
+        await this.notifyReauthenticate()
     }
 
     public static get instance() {

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -4,12 +4,12 @@
  */
 import * as vscode from 'vscode'
 import {
-    scopesCodeWhispererChat,
     AwsConnection,
     Connection,
     isSsoConnection,
     SsoConnection,
     hasScopes,
+    scopesCodeWhispererCore,
 } from '../../../../auth/connection'
 import { AuthUtil, amazonQScopes } from '../../../../codewhisperer/util/authUtil'
 import { CommonAuthWebview } from '../backend'
@@ -86,7 +86,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                                     })
                                 }
                                 let newConn: SsoConnection
-                                if (conn.scopes?.includes(scopesCodeWhispererChat[0])) {
+                                if (conn.scopes && hasScopes(conn.scopes, scopesCodeWhispererCore)) {
                                     getLogger().info(
                                         `auth: re-use connection from existing connection id ${connectionId}`
                                     )

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -9,6 +9,7 @@ import {
     Connection,
     isSsoConnection,
     SsoConnection,
+    hasScopes,
 } from '../../../../auth/connection'
 import { AuthUtil, amazonQScopes } from '../../../../codewhisperer/util/authUtil'
 import { CommonAuthWebview } from '../backend'
@@ -55,7 +56,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
      * @returns Amazon Q connection, or undefined if none of the given connections have scopes required for Amazon Q.
      */
     findUsableConnection(connections: AwsConnection[]): AwsConnection | undefined {
-        return AuthUtil.instance.findUsableQConnection(connections)
+        return AuthUtil.instance.findMinimalQConnection(connections)
     }
 
     async useConnection(connectionId: string, auto: boolean): Promise<AuthError | undefined> {
@@ -90,7 +91,18 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                                         `auth: re-use connection from existing connection id ${connectionId}`
                                     )
                                     newConn = await Auth.instance.createConnectionFromApi(conn)
-                                    await AuthUtil.instance.secondaryAuth.useNewConnection(newConn)
+
+                                    // HACK: This if statement should eventually be removed when we assume users have added all Q scopes (reauthed).
+                                    //
+                                    // In this case we have a connection that has the CW scopes, but not all Amazon Q scopes
+                                    // We will use this connection but mark it as expired hoping that the user will reauth,
+                                    // and as a result add all Amazon Q scopes.
+                                    if (!hasScopes(conn.scopes, amazonQScopes)) {
+                                        await AuthUtil.instance.useConnectionButExpire(newConn)
+                                    } else {
+                                        // Once we remove the above 'if' statement, this is all that needs to actually be called
+                                        await AuthUtil.instance.secondaryAuth.useNewConnection(newConn)
+                                    }
                                 } else {
                                     getLogger().info(
                                         `auth: re-use(new scope) to connection from existing connection id ${connectionId}`

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -279,6 +279,7 @@ import { LoginOption, AuthError } from './types'
 import { CommonAuthWebview } from './backend'
 import { WebviewClientFactory } from '../../../webviews/client'
 import { Region } from '../../../shared/regions/endpoints'
+import { SsoConnection } from '../../../auth/connection'
 
 const client = WebviewClientFactory.create<CommonAuthWebview>()
 
@@ -546,10 +547,9 @@ export default defineComponent({
                 })
             })
 
-            // If Amazon Q has no connections while Toolkit has connections
-            // Auto connect Q using toolkit connection.
-            const connections = await client.listConnections()
-            if (connections.length === 0 && sharedConnections && sharedConnections.length > 0) {
+            // If Toolkit has usable connections, instead auto connect Q using toolkit connection.
+            // Keep in mind that a "usable" connection is one with at least the CW core scopes (inline, ...)
+            if (sharedConnections && sharedConnections.length > 0) {
                 const conn = await client.findUsableConnection(sharedConnections)
                 if (conn) {
                     await client.useConnection(conn.id, true)

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -279,7 +279,6 @@ import { LoginOption, AuthError } from './types'
 import { CommonAuthWebview } from './backend'
 import { WebviewClientFactory } from '../../../webviews/client'
 import { Region } from '../../../shared/regions/endpoints'
-import { SsoConnection } from '../../../auth/connection'
 
 const client = WebviewClientFactory.create<CommonAuthWebview>()
 

--- a/packages/core/src/login/webview/vue/reauthenticate.vue
+++ b/packages/core/src/login/webview/vue/reauthenticate.vue
@@ -68,7 +68,16 @@ and the final results are retrieved by the frontend. For this Component to updat
                 <button id="signout" v-on:click="signout">Sign Out</button>
             </template>
             <template v-else-if="state === 'REAUTHENTICATING'">
-                <div>Re-authentication in progress</div>
+                <div>
+                    <div>Re-authentication in progress</div>
+                    <button
+                        id="cancel"
+                        style="color: #6f6f6f; background-color: var(--vscode-input-background)"
+                        v-on:click="cancel"
+                    >
+                        Cancel
+                    </button>
+                </div>
             </template>
         </div>
     </div>
@@ -129,6 +138,10 @@ export default defineComponent({
         async signout() {
             client.emitUiClick('auth_signout')
             await client.signout()
+        },
+        async cancel() {
+            void client.emitUiClick('auth_reauthCancelButton')
+            await client.cancelAuthFlow()
         },
     },
 })
@@ -198,6 +211,18 @@ button#signout {
     border: none;
     background: none;
     user-select: none;
+}
+
+button#cancel {
+    background-color: var(--vscode-button-background);
+    color: white;
+    border-radius: 3px;
+    border: none;
+    padding: 0.3rem;
+    width: 80%;
+    font-weight: bold;
+    margin-top: 15px;
+    cursor: pointer;
 }
 
 #title {

--- a/packages/core/src/login/webview/vue/types.ts
+++ b/packages/core/src/login/webview/vue/types.ts
@@ -48,6 +48,7 @@ export enum LoginOption {
 export type AuthUiClick =
     | 'auth_backButton'
     | 'auth_cancelButton'
+    | 'auth_reauthCancelButton'
     | 'auth_continueButton'
     | 'auth_idcOption'
     | 'auth_builderIdOption'

--- a/packages/core/src/test/codewhisperer/service/inlineCompletionService.test.ts
+++ b/packages/core/src/test/codewhisperer/service/inlineCompletionService.test.ts
@@ -220,7 +220,7 @@ describe('codewhisperer status bar', function () {
         const actualStatusBar = statusBar.getStatusBar()
         assert.strictEqual(actualStatusBar.text, '$(chrome-close) Amazon Q')
         assert.strictEqual(actualStatusBar.command, listCodeWhispererCommandsId)
-        assert.deepStrictEqual(actualStatusBar.backgroundColor, undefined)
+        assert.deepStrictEqual(actualStatusBar.backgroundColor, new vscode.ThemeColor('statusBarItem.errorBackground'))
     })
 
     it('shows correct status bar when auth is connected', async function () {

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -33,4 +33,10 @@ describe('tech debt', function () {
             'with node16+, we can now use AbortController to cancel Node things (child processes, HTTP requests, etc.)'
         )
     })
+
+    it('remove missing Amazon Q scopes edge case handling', async function () {
+        const now = Date.now()
+        const cutoffDate = Date.parse('2024-06-30')
+        assert.ok(now <= cutoffDate, 'Remove the edge case code from the commit that this test is a part of.')
+    })
 })


### PR DESCRIPTION
Continuation of https://github.com/aws/aws-toolkit-vscode/pull/5026

Changes:
- Force the flow by focusing the amazon Q panel specifically for users with a 3 scope connection.
- Additional commit to turn the status bar item red when not connected.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
