### PR TITLE
test(amazonq): increase test coverage

### DIFF
--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -279,7 +279,7 @@ export function showSecurityScanResults(
     }
     if (scope === CodeWhispererConstants.CodeAnalysisScope.PROJECT) {
         populateCodeScanLogStream(zipMetadata.scannedFiles)
-        showScanCompletedNotification(totalIssues, zipMetadata.scannedFiles, false)
+        showScanCompletedNotification(totalIssues, zipMetadata.scannedFiles)
     }
 }
 
@@ -331,20 +331,13 @@ export async function confirmStopSecurityScan() {
     }
 }
 
-function showScanCompletedNotification(total: number, scannedFiles: Set<string>, isProjectTruncated: boolean) {
+function showScanCompletedNotification(total: number, scannedFiles: Set<string>) {
     const totalFiles = `${scannedFiles.size} ${scannedFiles.size === 1 ? 'file' : 'files'}`
     const totalIssues = `${total} ${total === 1 ? 'issue was' : 'issues were'}`
-    const fileSizeLimitReached = isProjectTruncated ? 'File size limit reached.' : ''
     const learnMore = 'Learn More'
     const items = [CodeWhispererConstants.showScannedFilesMessage]
-    if (isProjectTruncated) {
-        items.push(learnMore)
-    }
     void vscode.window
-        .showInformationMessage(
-            `Security scan completed for ${totalFiles}. ${totalIssues} found. ${fileSizeLimitReached}`,
-            ...items
-        )
+        .showInformationMessage(`Security scan completed for ${totalFiles}. ${totalIssues} found.`, ...items)
         .then(value => {
             if (value === CodeWhispererConstants.showScannedFilesMessage) {
                 const [, codeScanOutpuChan] = getLogOutputChan()

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -17,6 +17,7 @@ import {
     selectCustomizationPrompt,
     reconnect,
     signoutCodeWhisperer,
+    toggleCodeScans,
 } from '../../../codewhisperer/commands/basicCommands'
 import { FakeMemento, FakeExtensionContext } from '../../fakeExtensionContext'
 import { testCommand } from '../../shared/vscode/testUtils'
@@ -186,6 +187,98 @@ describe('CodeWhisperer-basicCommands', function () {
 
         it('includes the "source" in the command execution metric', async function () {
             targetCommand = testCommand(toggleCodeSuggestions, codeSuggestionsState)
+            await targetCommand.execute(placeholder, cwQuickPickSource)
+            assertTelemetry('vscode_executeCommand', { source: cwQuickPickSource, command: targetCommand.id })
+        })
+    })
+
+    describe('toggleCodeScans', function () {
+        class TestCodeScansState extends CodeScansState {
+            public constructor(initialState?: boolean) {
+                super(new FakeMemento(), initialState)
+            }
+        }
+
+        let codeScansState: CodeScansState
+
+        beforeEach(async function () {
+            await resetCodeWhispererGlobalVariables()
+            codeScansState = new TestCodeScansState()
+        })
+
+        it('has auto scans enabled by default', async function () {
+            targetCommand = testCommand(toggleCodeScans, codeScansState)
+            assert.strictEqual(codeScansState.isScansEnabled(), true)
+        })
+
+        it('toggles states as expected', async function () {
+            targetCommand = testCommand(toggleCodeScans, codeScansState)
+            assert.strictEqual(codeScansState.isScansEnabled(), true)
+            await targetCommand.execute(placeholder, cwQuickPickSource)
+            assert.strictEqual(codeScansState.isScansEnabled(), false)
+            await targetCommand.execute(placeholder, cwQuickPickSource)
+            assert.strictEqual(codeScansState.isScansEnabled(), true)
+            await targetCommand.execute(placeholder, cwQuickPickSource)
+            assert.strictEqual(codeScansState.isScansEnabled(), false)
+        })
+
+        it('setScansEnabled() works as expected', async function () {
+            // initially true
+            assert.strictEqual(codeScansState.isScansEnabled(), true)
+
+            await codeScansState.setScansEnabled(false)
+            assert.strictEqual(codeScansState.isScansEnabled(), false)
+
+            // set new state to current state
+            await codeScansState.setScansEnabled(false)
+            assert.strictEqual(codeScansState.isScansEnabled(), false)
+
+            // set to opposite state
+            await codeScansState.setScansEnabled(true)
+            assert.strictEqual(codeScansState.isScansEnabled(), true)
+        })
+
+        it('triggers event listener when toggled', async function () {
+            const eventListener = sinon.stub()
+            codeScansState.onDidChangeState(() => {
+                eventListener()
+            })
+            assert.strictEqual(eventListener.callCount, 0)
+
+            targetCommand = testCommand(toggleCodeScans, codeScansState)
+            await targetCommand.execute(placeholder, cwQuickPickSource)
+
+            await waitUntil(async () => eventListener.callCount === 1, { timeout: 1000, interval: 1 })
+            assert.strictEqual(eventListener.callCount, 1)
+        })
+
+        it('emits aws_modifySetting event on user toggling autoScans - deactivate', async function () {
+            targetCommand = testCommand(toggleCodeScans, codeScansState)
+            await targetCommand.execute(placeholder, cwQuickPickSource)
+
+            assert.strictEqual(codeScansState.isScansEnabled(), false)
+            assertTelemetryCurried('aws_modifySetting')({
+                settingId: CodeWhispererConstants.autoScansConfig.settingId,
+                settingState: CodeWhispererConstants.autoScansConfig.deactivated,
+            })
+        })
+
+        it('emits aws_modifySetting event on user toggling autoScans -- activate', async function () {
+            codeScansState = new TestCodeScansState(false)
+            assert.strictEqual(codeScansState.isScansEnabled(), false)
+
+            targetCommand = testCommand(toggleCodeScans, codeScansState)
+            await targetCommand.execute(placeholder, cwQuickPickSource)
+
+            assert.strictEqual(codeScansState.isScansEnabled(), true)
+            assertTelemetryCurried('aws_modifySetting')({
+                settingId: CodeWhispererConstants.autoScansConfig.settingId,
+                settingState: CodeWhispererConstants.autoScansConfig.activated,
+            })
+        })
+
+        it('includes the "source" in the command execution metric', async function () {
+            targetCommand = testCommand(toggleCodeScans, codeScansState)
             await targetCommand.execute(placeholder, cwQuickPickSource)
             assertTelemetry('vscode_executeCommand', { source: cwQuickPickSource, command: targetCommand.id })
         })

--- a/packages/core/src/test/codewhisperer/service/securityIssueCodeActionProvider.test.ts
+++ b/packages/core/src/test/codewhisperer/service/securityIssueCodeActionProvider.test.ts
@@ -62,4 +62,24 @@ describe('securityIssueCodeActionProvider', () => {
         assert.strictEqual(actual[1].title, 'Amazon Q: Explain "issue 1"')
         assert.strictEqual(actual[1].kind, vscode.CodeActionKind.QuickFix)
     })
+
+    it('should skip issues not in the current file', () => {
+        securityIssueCodeActionProvider.issues = [
+            {
+                filePath: 'some/path',
+                issues: [createCodeScanIssue({ title: 'issue 1' })],
+            },
+            {
+                filePath: mockDocument.fileName,
+                issues: [createCodeScanIssue({ title: 'issue 2' })],
+            },
+        ]
+        const range = new vscode.Range(0, 0, 0, 0)
+        const actual = securityIssueCodeActionProvider.provideCodeActions(mockDocument, range, context, token.token)
+
+        assert.strictEqual(actual.length, 3)
+        assert.strictEqual(actual[0].title, 'Amazon Q: Fix "issue 2"')
+        assert.strictEqual(actual[1].title, 'Amazon Q: View details for "issue 2"')
+        assert.strictEqual(actual[2].title, 'Amazon Q: Explain "issue 2"')
+    })
 })

--- a/packages/core/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
+++ b/packages/core/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
@@ -113,4 +113,108 @@ describe('securityIssueHoverProvider', () => {
         const actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(2, 0), token.token)
         assert.strictEqual(actual.contents.length, 0)
     })
+
+    it('should skip issues not in the current file', () => {
+        securityIssueHoverProvider.issues = [
+            {
+                filePath: 'some/path',
+                issues: [createCodeScanIssue()],
+            },
+            {
+                filePath: mockDocument.fileName,
+                issues: [createCodeScanIssue()],
+            },
+        ]
+        const actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(0, 0), token.token)
+        assert.strictEqual(actual.contents.length, 1)
+    })
+
+    it('should not show severity badge if undefined', () => {
+        const issues = [createCodeScanIssue({ severity: undefined, suggestedFixes: [] })]
+        securityIssueHoverProvider.issues = [
+            {
+                filePath: mockDocument.fileName,
+                issues,
+            },
+        ]
+        const actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(0, 0), token.token)
+        assert.strictEqual(actual.contents.length, 1)
+        assert.strictEqual(
+            (actual.contents[0] as vscode.MarkdownString).value,
+            '## title \n' +
+                'recommendationText\n\n' +
+                `[$(eye) View Details](command:aws.amazonq.openSecurityIssuePanel?${encodeURIComponent(
+                    JSON.stringify([issues[0], mockDocument.fileName])
+                )} 'Open "Amazon Q Security Issue"')\n` +
+                ` | [$(comment) Explain](command:aws.amazonq.explainIssue?${encodeURIComponent(
+                    JSON.stringify([issues[0]])
+                )} 'Explain with Amazon Q')\n`
+        )
+    })
+
+    it('should handle fixes with consecutive lines removed', () => {
+        const issues = [
+            createCodeScanIssue({
+                suggestedFixes: [
+                    {
+                        code: '@@ -1,1 +1,1 @@\nfirst line\n-second line\n-third line\n+fourth line\nfifth line',
+                        description: 'fix',
+                    },
+                ],
+            }),
+        ]
+        securityIssueHoverProvider.issues = [
+            {
+                filePath: mockDocument.fileName,
+                issues,
+            },
+        ]
+        const actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(0, 0), token.token)
+        assert.strictEqual(actual.contents.length, 1)
+        assert.strictEqual(
+            (actual.contents[0] as vscode.MarkdownString).value,
+            '## title ![High](severity-high.svg)\n' +
+                'fix\n\n' +
+                `[$(eye) View Details](command:aws.amazonq.openSecurityIssuePanel?${encodeURIComponent(
+                    JSON.stringify([issues[0], mockDocument.fileName])
+                )} 'Open "Amazon Q Security Issue"')\n` +
+                ` | [$(comment) Explain](command:aws.amazonq.explainIssue?${encodeURIComponent(
+                    JSON.stringify([issues[0]])
+                )} 'Explain with Amazon Q')\n` +
+                ` | [$(wrench) Fix](command:aws.amazonq.applySecurityFix?${encodeURIComponent(
+                    JSON.stringify([issues[0], mockDocument.fileName, 'hover'])
+                )} 'Fix with Amazon Q')\n` +
+                '### Suggested Fix Preview\n\n' +
+                '<span class="codicon codicon-none" style="background-color:var(--vscode-editorMarkerNavigationInfo-headerBackground);">\n\n' +
+                '```undefined\n' +
+                '@@ -1,1 +1,1 @@  \n' +
+                '```\n\n' +
+                '</span>\n' +
+                '<br />\n' +
+                '<span class="codicon codicon-none" style="background-color:var(--vscode-diffEditor-unchangedCodeBackground);">\n\n' +
+                '```language\n' +
+                'first line       \n' +
+                '```\n\n' +
+                '</span>\n' +
+                '<br />\n' +
+                '<span class="codicon codicon-none" style="background-color:var(--vscode-diffEditor-removedTextBackground);">\n\n' +
+                '```diff\n' +
+                '-second line     \n' +
+                '-third line      \n' +
+                '```\n\n' +
+                '</span>\n' +
+                '<br />\n' +
+                '<span class="codicon codicon-none" style="background-color:var(--vscode-diffEditor-insertedTextBackground);">\n\n' +
+                '```diff\n' +
+                '+fourth line     \n' +
+                '```\n\n' +
+                '</span>\n' +
+                '<br />\n' +
+                '<span class="codicon codicon-none" style="background-color:var(--vscode-diffEditor-unchangedCodeBackground);">\n\n' +
+                '```language\n' +
+                'fifth line       \n' +
+                '```\n\n' +
+                '</span>\n\n'
+        )
+    })
 })


### PR DESCRIPTION
## Problem

There are uncovered lines for security scans.

## Solution

Add tests to increase coverage for security scans.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
