### PR TITLE
telemetry(Amazon Q Code Transform): move metric earlier in transformation flow

### DIFF
--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -38,14 +38,18 @@ import {
 } from '../../errors'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
 import MessengerUtils, { ButtonActions, GumbyCommands } from './messenger/messengerUtils'
-import { CancelActionPositions } from '../../telemetry/codeTransformTelemetry'
+import { CancelActionPositions, JDKToTelemetryValue, telemetryUndefined } from '../../telemetry/codeTransformTelemetry'
 import { openUrl } from '../../../shared/utilities/vsCodeUtils'
-import { telemetry } from '../../../shared/telemetry/telemetry'
+import {
+    telemetry,
+    CodeTransformJavaTargetVersionsAllowed,
+    CodeTransformJavaSourceVersionsAllowed,
+} from '../../../shared/telemetry/telemetry'
 import { MetadataResult } from '../../../shared/telemetry/telemetryClient'
 import { CodeTransformTelemetryState } from '../../telemetry/codeTransformTelemetryState'
 import { getAuthType } from '../../../codewhisperer/service/transformByQ/transformApiHandler'
 import DependencyVersions from '../../models/dependencies'
-
+import { getStringHash } from '../../../shared/utilities/textUtilities'
 // These events can be interactions within the chat,
 // or elsewhere in the IDE
 export interface ChatControllerEventEmitters {
@@ -306,6 +310,18 @@ export class GumbyController {
             )
         }
 
+        const projectPath = transformByQState.getProjectPath()
+        telemetry.codeTransform_jobStartedCompleteFromPopupDialog.emit({
+            codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+            codeTransformJavaSourceVersionsAllowed: JDKToTelemetryValue(
+                transformByQState.getSourceJDKVersion()!
+            ) as CodeTransformJavaSourceVersionsAllowed,
+            codeTransformJavaTargetVersionsAllowed: JDKToTelemetryValue(
+                transformByQState.getTargetJDKVersion()
+            ) as CodeTransformJavaTargetVersionsAllowed,
+            codeTransformProjectId: projectPath === undefined ? telemetryUndefined : getStringHash(projectPath),
+            result: MetadataResult.Pass,
+        })
         try {
             this.sessionStorage.getSession().conversationState = ConversationState.COMPILING
             this.messenger.sendCompilationInProgress(message.tabID)

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -18,7 +18,7 @@ import {
     TransformationCandidateProject,
     ZipManifest,
 } from '../models/model'
-import { convertDateToTimestamp, getStringHash } from '../../shared/utilities/textUtilities'
+import { convertDateToTimestamp } from '../../shared/utilities/textUtilities'
 import {
     createZipManifest,
     downloadHilResultArchive,
@@ -41,19 +41,9 @@ import {
     prepareProjectDependencies,
     runMavenDependencyUpdateCommands,
 } from '../service/transformByQ/transformMavenHandler'
-import {
-    CodeTransformCancelSrcComponents,
-    CodeTransformJavaSourceVersionsAllowed,
-    CodeTransformJavaTargetVersionsAllowed,
-    telemetry,
-} from '../../shared/telemetry/telemetry'
+import { CodeTransformCancelSrcComponents, telemetry } from '../../shared/telemetry/telemetry'
 import { CodeTransformTelemetryState } from '../../amazonqGumby/telemetry/codeTransformTelemetryState'
-import {
-    CancelActionPositions,
-    JDKToTelemetryValue,
-    calculateTotalLatency,
-    telemetryUndefined,
-} from '../../amazonqGumby/telemetry/codeTransformTelemetry'
+import { CancelActionPositions, calculateTotalLatency } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
 import { MetadataResult } from '../../shared/telemetry/telemetryClient'
 import { submitFeedback } from '../../feedback/vue/submitFeedback'
 import { placeholder } from '../../shared/vscode/commands2'
@@ -589,24 +579,6 @@ export async function setTransformationToRunningState() {
     transformByQState.setStartTime(
         convertDateToTimestamp(new Date(CodeTransformTelemetryState.instance.getStartTime()))
     )
-
-    const projectPath = transformByQState.getProjectPath()
-    let projectId = telemetryUndefined
-    if (projectPath !== undefined) {
-        projectId = getStringHash(projectPath)
-    }
-
-    telemetry.codeTransform_jobStartedCompleteFromPopupDialog.emit({
-        codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-        codeTransformJavaSourceVersionsAllowed: JDKToTelemetryValue(
-            transformByQState.getSourceJDKVersion()!
-        ) as CodeTransformJavaSourceVersionsAllowed,
-        codeTransformJavaTargetVersionsAllowed: JDKToTelemetryValue(
-            transformByQState.getTargetJDKVersion()
-        ) as CodeTransformJavaTargetVersionsAllowed,
-        codeTransformProjectId: projectId,
-        result: MetadataResult.Pass,
-    })
 
     await vscode.commands.executeCommand('workbench.view.extension.aws-codewhisperer-transformation-hub')
 }


### PR DESCRIPTION
## Problem
`jobStartedCompleteFromPopupDialog` telemetry was supposed to signify one of the first events happening in the transform flow:

```
A validated job was started but we have not yet compiled using Maven.
```

However currently its emitted after `mvn clean install`, this is wrong. 

## Solution
Move the `jobStartedCompleteFromPopupDialog` telemetry after the `prevalidation` is finished but before the `mvn clean install`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
