### PR TITLE
Reset sessionId when new project transformation is triggered.

### DIFF
--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -209,7 +209,7 @@ export class GumbyController {
                     this.messenger.sendCompilationInProgress(message.tabID)
                     return
             }
-
+            CodeTransformTelemetryState.instance.setSessionId()
             this.messenger.sendTransformationIntroduction(message.tabID)
 
             // start /transform chat flow


### PR DESCRIPTION
## Problem
SessionId remains the same for different transformation jobs while it should reset for different transformation jobs.

## Solution

Call the preExisting `setSessionId()` which recalculates the hash before the introduction for Q Code Transform is written to chat. (this method was never called before, or its invocations must have been mistakenly removed)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
