### PR TITLE
Amazon Q Code Transform: Stop verifying project on plugin activation.

### DIFF
--- a/packages/core/src/amazonqGumby/activation.ts
+++ b/packages/core/src/amazonqGumby/activation.ts
@@ -14,7 +14,6 @@ import { CodeTransformTelemetryState } from './telemetry/codeTransformTelemetryS
 import { telemetry } from '../shared/telemetry/telemetry'
 import { CancelActionPositions } from './telemetry/codeTransformTelemetry'
 import { AuthUtil } from '../codewhisperer/util/authUtil'
-import { validateAndLogProjectDetails } from '../codewhisperer/service/transformByQ/transformProjectValidationHandler'
 
 export async function activate(context: ExtContext) {
     void vscode.commands.executeCommand('setContext', 'gumby.wasQCodeTransformationUsed', false)
@@ -71,7 +70,5 @@ export async function activate(context: ExtContext) {
 
             workspaceChangeEvent
         )
-
-        await validateAndLogProjectDetails()
     }
 }

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -38,9 +38,9 @@ import {
 } from '../../errors'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
 import MessengerUtils, { ButtonActions, GumbyCommands } from './messenger/messengerUtils'
-import { CancelActionPositions } from '../../telemetry/codeTransformTelemetry'
+import { CancelActionPositions, JDKToTelemetryValue } from '../../telemetry/codeTransformTelemetry'
 import { openUrl } from '../../../shared/utilities/vsCodeUtils'
-import { telemetry } from '../../../shared/telemetry/telemetry'
+import { telemetry, CodeTransformJavaSourceVersionsAllowed } from '../../../shared/telemetry/telemetry'
 import { MetadataResult } from '../../../shared/telemetry/telemetryClient'
 import { CodeTransformTelemetryState } from '../../telemetry/codeTransformTelemetryState'
 import { getAuthType } from '../../../codewhisperer/service/transformByQ/transformApiHandler'
@@ -225,8 +225,16 @@ export class GumbyController {
     }
 
     private async validateProjectsWithReplyOnError(message: any): Promise<TransformationCandidateProject[]> {
+        let telemetryJavaVersion = JDKToTelemetryValue(JDKVersion.UNSUPPORTED) as CodeTransformJavaSourceVersionsAllowed
+        let errorCode = undefined
         try {
-            return await getValidCandidateProjects()
+            const validProjects = await getValidCandidateProjects()
+            if (validProjects.length > 0) {
+                // validProjects[0].JDKVersion will be undefined if javap errors out or no .class files found, so call it UNSUPPORTED
+                const javaVersion = validProjects[0].JDKVersion ?? JDKVersion.UNSUPPORTED
+                telemetryJavaVersion = JDKToTelemetryValue(javaVersion) as CodeTransformJavaSourceVersionsAllowed
+            }
+            return validProjects
         } catch (err: any) {
             if (err instanceof NoJavaProjectsFoundError) {
                 this.messenger.sendUnrecoverableErrorResponse('no-java-project-found', message.tabID)
@@ -235,6 +243,16 @@ export class GumbyController {
             } else {
                 this.messenger.sendUnrecoverableErrorResponse('no-project-found', message.tabID)
             }
+            errorCode = err.code
+        } finally {
+            // New projectDetails metric should always be fired whether the project was valid or invalid
+            telemetry.codeTransform_projectDetails.emit({
+                passive: true,
+                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                codeTransformLocalJavaVersion: telemetryJavaVersion,
+                result: errorCode ? MetadataResult.Fail : MetadataResult.Pass,
+                reason: errorCode,
+            })
         }
         return []
     }

--- a/packages/core/src/codewhisperer/service/transformByQ/transformProjectValidationHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformProjectValidationHandler.ts
@@ -7,12 +7,9 @@ import { getLogger } from '../../../shared/logger'
 import * as CodeWhispererConstants from '../../models/constants'
 import * as vscode from 'vscode'
 import { spawnSync } from 'child_process' // Consider using ChildProcess once we finalize all spawnSync calls
-import { CodeTransformJavaSourceVersionsAllowed, telemetry } from '../../../shared/telemetry/telemetry'
+import { telemetry } from '../../../shared/telemetry/telemetry'
 import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/codeTransformTelemetryState'
-import {
-    javapOutputToTelemetryValue,
-    JDKToTelemetryValue,
-} from '../../../amazonqGumby/telemetry/codeTransformTelemetry'
+import { javapOutputToTelemetryValue } from '../../../amazonqGumby/telemetry/codeTransformTelemetry'
 import { MetadataResult } from '../../../shared/telemetry/telemetryClient'
 import {
     NoJavaProjectsFoundError,
@@ -20,31 +17,6 @@ import {
     NoOpenProjectsError,
 } from '../../../amazonqGumby/errors'
 import { checkBuildSystem } from './transformFileHandler'
-
-// log project details silently
-export async function validateAndLogProjectDetails() {
-    let telemetryJavaVersion = JDKToTelemetryValue(JDKVersion.UNSUPPORTED) as CodeTransformJavaSourceVersionsAllowed
-    let errorCode = undefined
-    try {
-        const openProjects = await getOpenProjects()
-        const validProjects = await validateOpenProjects(openProjects, true)
-        if (validProjects.length > 0) {
-            // validProjects[0].JDKVersion will be undefined if javap errors out or no .class files found, so call it UNSUPPORTED
-            const javaVersion = validProjects[0].JDKVersion ?? JDKVersion.UNSUPPORTED
-            telemetryJavaVersion = JDKToTelemetryValue(javaVersion) as CodeTransformJavaSourceVersionsAllowed
-        }
-    } catch (err: any) {
-        errorCode = err.code
-    } finally {
-        telemetry.codeTransform_projectDetails.emit({
-            passive: true,
-            codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-            codeTransformLocalJavaVersion: telemetryJavaVersion,
-            result: errorCode ? MetadataResult.Fail : MetadataResult.Pass,
-            reason: errorCode,
-        })
-    }
-}
 
 export async function getOpenProjects(): Promise<TransformationCandidateProject[]> {
     const folders = vscode.workspace.workspaceFolders


### PR DESCRIPTION
## Problem
The `codeTransform_ProjectDetails` metric was calculated and emitted on plugin activation no matter if user used Q Code Transform or not. This has the following issues:

1. Minor slowdown when starting vscode (some scanning of project is done)
2. Telemetry for `codeTransform_ProjectDetails` differs from IntelliJ leading to metric being useless.
3. Duplicate code
4. As part of the scanning of the project we also emit `codeTransform_isDoubleClickedToTriggerInvalidProject` which (as name suggests only should be emitted on transform started)

## Solution

This removes the project validation call from the activation so it's only calculated after customer actually starts the transform process. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
