### PR TITLE
refactor(ux): add css variables for font-sizes

### DIFF
--- a/packages/core/src/login/webview/vue/base.css
+++ b/packages/core/src/login/webview/vue/base.css
@@ -1,0 +1,8 @@
+:root {
+    /* Font-sizes */
+    --font-size-sm: calc(0.75 * var(--font-size-base));
+    --font-size-base: var(--vscode-font-size);
+    --font-size-md: calc(1.25 * var(--font-size-base));
+    --font-size-lg: calc(1.5 * var(--font-size-base));
+    --font-size-xl: calc(1.75 * var(--font-size-base));
+}

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -574,6 +574,8 @@ export default defineComponent({
 </script>
 
 <style>
+@import './base.css';
+
 .selectable-item {
     margin-bottom: 10px;
     margin-top: 10px;
@@ -590,7 +592,7 @@ export default defineComponent({
     color: #c6c6c6;
     margin-bottom: 5px;
     margin-top: 5px;
-    font-size: 10px;
+    font-size: var(--font-size-sm);
     font-weight: 500;
 }
 .vscode-light .hint {
@@ -611,31 +613,32 @@ export default defineComponent({
 }
 
 .header {
-    font-size: 12px;
+    font-size: var(--font-size-base);
     font-weight: bold;
 }
-.header.vscode-dark {
+
+.vscode-dark .header {
     color: white;
 }
-.header.vscode-light {
+.vscode-light .header {
     color: black;
 }
 
 .title {
     margin-bottom: 3px;
     margin-top: 3px;
-    font-size: 11px;
+    font-size: var(--font-size-base);
     font-weight: 500;
 }
-.title.vscode-dark {
+.vscode-dark .title {
     color: white;
 }
-.title.vscode-light {
+.vscode-light .title {
     color: black;
 }
 
 .subHeader {
-    font-size: 10px;
+    font-size: var(--font-size-sm);
 }
 .continue-button {
     background-color: var(--vscode-button-background);
@@ -648,6 +651,7 @@ export default defineComponent({
     margin-bottom: 3px;
     margin-top: 3px;
     cursor: pointer;
+    font-size: var(--font-size-base);
 }
 .back-button {
     background: none;
@@ -677,7 +681,7 @@ export default defineComponent({
     padding-right: 8px;
     padding-top: 6px;
     padding-bottom: 6px;
-    font-size: 13px;
+    font-size: var(--font-size-base);
     font-weight: 400;
 }
 body.vscode-light .urlInput {
@@ -696,7 +700,7 @@ body.vscode-dark .urlInput {
     padding-right: 8px;
     padding-top: 6px;
     padding-bottom: 6px;
-    font-size: 13px;
+    font-size: var(--font-size-base);
     font-weight: 400;
 }
 body.vscode-light .iamInput {
@@ -714,18 +718,18 @@ body.vscode-dark .iamInput {
     padding-right: 8px;
     padding-top: 6px;
     padding-bottom: 6px;
-    font-size: 13px;
+    font-size: var(--font-size-base);
     font-weight: 400;
 }
 body.vscode-light .regionSelect {
     color: black;
 }
 body.vscode-dark .regionSelect {
-    color: #cccccc;
+    color: white;
 }
 .start-url-error {
     color: #ff0000;
-    font-size: 8px;
+    font-size: var(--font-size-sm);
 }
 #logo {
     fill: var(--vscode-button-foreground);

--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -117,21 +117,20 @@ export default defineComponent({
 }
 
 .title {
-    font-size: 12px;
-    font-weight: bold;
+    font-size: var(--font-size-base);
 }
 
 .text {
     display: flex;
     flex-direction: column;
-    font-size: 12px;
+    font-size: var(--font-size-sm);
     justify-content: center;
 }
 
-.text.vscode-dark {
+.vscode-dark .text {
     color: white;
 }
-.text.vscode-light {
+.vscode-light .text {
     color: black;
 }
 .icon {


### PR DESCRIPTION
## Problem
Update font-sizes in Login Page for AWS Toolkits and Amazon Q

## Solution
- Use CSS Variables
- Initially used `rem` though now using `var(--vscode-font-size)` for base font size. This way the extension's base fon't will be as set by user for their VSCode
- fixed colors for dark and light theme

| Dark Theme | Light Theme |
| --- | --- |
| ![Screenshot 2024-05-22 at 12 42 41 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/f93ffb6c-151a-4f1c-a454-90cfbfe2efc2) | ![Screenshot 2024-05-22 at 12 42 50 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/e8f2fcf8-8ff5-475c-842c-187078b91e12) |
 | ![Screenshot 2024-05-22 at 12 43 02 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/6baa01fb-b2d8-47df-9512-3b1d9cd5ae52) | ![Screenshot 2024-05-22 at 12 43 08 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/3b686d76-3b4d-480a-9228-044604627cc8) |
| ![Screenshot 2024-05-22 at 12 55 47 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/08e177ba-8732-4932-a6de-dc03a4dc98d7) | ![Screenshot 2024-05-22 at 12 55 56 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/6286b766-cb60-4c68-92b0-7869b060ad72) | 
| ![Screenshot 2024-05-22 at 12 56 08 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/c806b8b6-13b2-4e8f-ada5-2426e44e64d3) | ![Screenshot 2024-05-22 at 12 56 18 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/5a280f1b-eb3e-46b0-bfdc-46e92a25f476) | 
| ![Screenshot 2024-05-22 at 12 56 41 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/d4058cc5-94a9-440f-bc16-4e45ebb449cc) | ![Screenshot 2024-05-22 at 12 56 47 PM](https://github.com/aws/aws-toolkit-vscode/assets/371007/6ab9f047-7211-4913-b6d3-cad1aa758372) | 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
