### PR TITLE
web: setup web mode for Q inline suggestions

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -154,13 +154,13 @@
                     "type": "webview",
                     "id": "aws.amazonq.AmazonCommonAuth",
                     "name": "%AWS.amazonq.login%",
-                    "when": "!aws.isSageMaker && aws.amazonq.showLoginView"
+                    "when": "!aws.isSageMaker && !aws.isWebExtHost && aws.amazonq.showLoginView"
                 },
                 {
                     "type": "webview",
                     "id": "aws.AmazonQChatView",
                     "name": "%AWS.amazonq.chat%",
-                    "when": "!aws.isSageMaker && !aws.amazonq.showLoginView"
+                    "when": "!aws.isSageMaker && !aws.isWebExtHost && !aws.amazonq.showLoginView"
                 },
                 {
                     "id": "aws.AmazonQNeverShowBadge",

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -32,7 +32,11 @@ async function activateAmazonQNonCommon(context: vscode.ExtensionContext) {
     await activateCWChat(context)
     await activateQGumby(extContext as ExtContext)
 
-    const authProvider = new CommonAuthViewProvider(context, amazonQContextPrefix, DefaultAmazonQAppInitContext.instance.onDidChangeAmazonQVisibility)
+    const authProvider = new CommonAuthViewProvider(
+        context,
+        amazonQContextPrefix,
+        DefaultAmazonQAppInitContext.instance.onDidChangeAmazonQVisibility
+    )
     context.subscriptions.push(
         vscode.window.registerWebviewViewProvider(authProvider.viewType, authProvider, {
             webviewOptions: {

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -4,10 +4,72 @@
  */
 
 import * as vscode from 'vscode'
-import { activateCommon, deactivateCommon } from './extensionCommon'
+import { activateAmazonQCommon, amazonQContextPrefix, deactivateCommon } from './extensionCommon'
+import { DefaultAmazonQAppInitContext, activate as activateCWChat } from 'aws-core-vscode/amazonq'
+import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
+import { ExtContext } from 'aws-core-vscode/shared'
+import { updateDevMode } from 'aws-core-vscode/dev'
+import { CommonAuthViewProvider } from 'aws-core-vscode/login'
+import { isExtensionActive, VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
+import { registerSubmitFeedback } from 'aws-core-vscode/feedback'
+import { DevFunction } from 'aws-core-vscode/dev'
 
 export async function activate(context: vscode.ExtensionContext) {
-    await activateCommon(context, false)
+    // IMPORTANT: No other code should be added to this function. Place it in one of the following 2 functions where appropriate.
+    await activateAmazonQCommon(context, false)
+    await activateAmazonQNonCommon(context)
+}
+
+/**
+ * The code in this function is not common, implying it only works in Node.js and not web.
+ * The goal should be for this to not exist and that all code is "common". So if possible make
+ * the code compatible with web and move it to {@link activateAmazonQCommon}.
+ */
+async function activateAmazonQNonCommon(context: vscode.ExtensionContext) {
+    const extContext = {
+        extensionContext: context,
+    }
+    await activateCWChat(context)
+    await activateQGumby(extContext as ExtContext)
+
+    const authProvider = new CommonAuthViewProvider(context, amazonQContextPrefix, DefaultAmazonQAppInitContext.instance.onDidChangeAmazonQVisibility)
+    context.subscriptions.push(
+        vscode.window.registerWebviewViewProvider(authProvider.viewType, authProvider, {
+            webviewOptions: {
+                retainContextWhenHidden: true,
+            },
+        }),
+        registerSubmitFeedback(context, 'Amazon Q', amazonQContextPrefix)
+    )
+
+    await setupDevMode(context)
+}
+
+/**
+ * Some parts of this do not work in Web mode so we need to set Dev Mode up here.
+ *
+ * TODO: Get the following working in web mode as well and then move this function.
+ */
+async function setupDevMode(context: vscode.ExtensionContext) {
+    // At some point this imports CodeCatalyst code which breaks in web mode.
+    // TODO: Make this work in web mode and move it to extensionCommon.ts
+    await updateDevMode()
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('amazonq.dev.openMenu', async () => {
+            if (!isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)) {
+                void vscode.window.showErrorMessage('AWS Toolkit must be installed to access the Developer Menu.')
+                return
+            }
+            await vscode.commands.executeCommand('_aws.dev.invokeMenu', context, [
+                'editStorage',
+                'showEnvVars',
+                'deleteSsoConnections',
+                'expireSsoConnections',
+                'editAuthConnections',
+            ] as DevFunction[])
+        })
+    )
 }
 
 export async function deactivate() {

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -4,12 +4,12 @@
  */
 
 import * as vscode from 'vscode'
-import { activateShared, deactivateShared } from './extensionShared'
+import { activateCommon, deactivateCommon } from './extensionCommon'
 
 export async function activate(context: vscode.ExtensionContext) {
-    await activateShared(context, false)
+    await activateCommon(context, false)
 }
 
 export async function deactivate() {
-    await deactivateShared()
+    await deactivateCommon()
 }

--- a/packages/amazonq/src/extensionCommon.ts
+++ b/packages/amazonq/src/extensionCommon.ts
@@ -9,7 +9,7 @@ import { join } from 'path'
 import {
     CodeSuggestionsState,
     activate as activateCodeWhisperer,
-    shutdown as codewhispererShutdown,
+    shutdown as shutdownCodeWhisperer,
     amazonQDismissedKey,
 } from 'aws-core-vscode/codewhisperer'
 import {
@@ -27,22 +27,22 @@ import {
     getMachineId,
 } from 'aws-core-vscode/shared'
 import { initializeAuth, CredentialsStore, LoginManager, AuthUtils } from 'aws-core-vscode/auth'
-import { DefaultAmazonQAppInitContext, activate as activateCWChat } from 'aws-core-vscode/amazonq'
-import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
-import { CommonAuthViewProvider, CommonAuthWebview } from 'aws-core-vscode/login'
-import { isExtensionActive, VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
-import { registerSubmitFeedback } from 'aws-core-vscode/feedback'
+import { CommonAuthWebview } from 'aws-core-vscode/login'
+import { VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
 import { telemetry, ExtStartUpSources } from 'aws-core-vscode/telemetry'
-import { DevFunction, updateDevMode } from 'aws-core-vscode/dev'
 import { getAuthStatus } from './auth/util'
-import { registerCommands } from './commands'
 import { makeEndpointsProvider, registerGenericCommands } from 'aws-core-vscode/common'
+import { registerCommands } from './commands'
 
-export async function activateCommon(context: vscode.ExtensionContext, isWeb: boolean) {
+export const amazonQContextPrefix = 'amazonq'
+
+/**
+ * Activation code for Amazon Q that will we want in all environments (eg Node.js, web mode)
+ */
+export async function activateAmazonQCommon(context: vscode.ExtensionContext, isWeb: boolean) {
     initialize(context, isWeb)
     await initializeComputeRegion()
 
-    const contextPrefix = 'amazonq'
     globals.contextPrefix = 'amazonq.' //todo: disconnect from above line
 
     // Avoid activation if older toolkit is installed
@@ -61,7 +61,7 @@ export async function activateCommon(context: vscode.ExtensionContext, isWeb: bo
                     () =>
                         vscode.window
                             .showInformationMessage(
-                                `The Amazon Q extension is incompatible with AWS Toolkit ${toolkitVersion} and older. Your AWS Toolkit was updated to version 3.0 or later.`,
+                                `The Amazon Q extension is incompatible with AWS Toolkit ${toolkitVersion as any} and older. Your AWS Toolkit was updated to version 3.0 or later.`,
                                 'Reload Now'
                             )
                             .then(async resp => {
@@ -85,7 +85,7 @@ export async function activateCommon(context: vscode.ExtensionContext, isWeb: bo
 
     const qOutputChannel = vscode.window.createOutputChannel('Amazon Q', { log: true })
     const qLogChannel = vscode.window.createOutputChannel('Amazon Q Logs', { log: true })
-    await activateLogger(context, contextPrefix, qOutputChannel, qLogChannel)
+    await activateLogger(context, amazonQContextPrefix, qOutputChannel, qLogChannel)
     globals.outputChannel = qOutputChannel
     globals.logOutputChannel = qLogChannel
     globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
@@ -98,43 +98,12 @@ export async function activateCommon(context: vscode.ExtensionContext, isWeb: bo
         extensionContext: context,
     }
     await activateCodeWhisperer(extContext as ExtContext)
-    await activateCWChat(context)
-    await activateQGumby(extContext as ExtContext)
 
     // Generic extension commands
-    registerGenericCommands(context, contextPrefix)
+    registerGenericCommands(context, amazonQContextPrefix)
 
     // Amazon Q specific commands
     registerCommands(context)
-
-    const authProvider = new CommonAuthViewProvider(
-        context,
-        contextPrefix,
-        DefaultAmazonQAppInitContext.instance.onDidChangeAmazonQVisibility
-    )
-    context.subscriptions.push(
-        vscode.commands.registerCommand('amazonq.dev.openMenu', async () => {
-            if (!isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)) {
-                void vscode.window.showErrorMessage('AWS Toolkit must be installed to access the Developer Menu.')
-                return
-            }
-            await vscode.commands.executeCommand('_aws.dev.invokeMenu', context, [
-                'editStorage',
-                'showEnvVars',
-                'deleteSsoConnections',
-                'expireSsoConnections',
-            ] as DevFunction[])
-        }),
-        vscode.window.registerWebviewViewProvider(authProvider.viewType, authProvider, {
-            webviewOptions: {
-                retainContextWhenHidden: true,
-            },
-        }),
-        registerSubmitFeedback(context, 'Amazon Q', contextPrefix)
-    )
-
-    // Check for dev mode
-    await updateDevMode()
 
     // Hide the Amazon Q tree in toolkit explorer
     await vscode.commands.executeCommand('setContext', amazonQDismissedKey, true)
@@ -174,5 +143,5 @@ export async function activateCommon(context: vscode.ExtensionContext, isWeb: bo
 }
 
 export async function deactivateCommon() {
-    await codewhispererShutdown()
+    await shutdownCodeWhisperer()
 }

--- a/packages/amazonq/src/extensionCommon.ts
+++ b/packages/amazonq/src/extensionCommon.ts
@@ -61,7 +61,9 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
                     () =>
                         vscode.window
                             .showInformationMessage(
-                                `The Amazon Q extension is incompatible with AWS Toolkit ${toolkitVersion as any} and older. Your AWS Toolkit was updated to version 3.0 or later.`,
+                                `The Amazon Q extension is incompatible with AWS Toolkit ${
+                                    toolkitVersion as any
+                                } and older. Your AWS Toolkit was updated to version 3.0 or later.`,
                                 'Reload Now'
                             )
                             .then(async resp => {

--- a/packages/amazonq/src/extensionCommon.ts
+++ b/packages/amazonq/src/extensionCommon.ts
@@ -38,7 +38,7 @@ import { getAuthStatus } from './auth/util'
 import { registerCommands } from './commands'
 import { makeEndpointsProvider, registerGenericCommands } from 'aws-core-vscode/common'
 
-export async function activateShared(context: vscode.ExtensionContext, isWeb: boolean) {
+export async function activateCommon(context: vscode.ExtensionContext, isWeb: boolean) {
     initialize(context, isWeb)
     await initializeComputeRegion()
 
@@ -61,9 +61,7 @@ export async function activateShared(context: vscode.ExtensionContext, isWeb: bo
                     () =>
                         vscode.window
                             .showInformationMessage(
-                                `The Amazon Q extension is incompatible with AWS Toolkit ${
-                                    toolkitVersion as any
-                                } and older. Your AWS Toolkit was updated to version 3.0 or later.`,
+                                `The Amazon Q extension is incompatible with AWS Toolkit ${toolkitVersion} and older. Your AWS Toolkit was updated to version 3.0 or later.`,
                                 'Reload Now'
                             )
                             .then(async resp => {
@@ -175,6 +173,6 @@ export async function activateShared(context: vscode.ExtensionContext, isWeb: bo
     })
 }
 
-export async function deactivateShared() {
+export async function deactivateCommon() {
     await codewhispererShutdown()
 }

--- a/packages/amazonq/src/extensionShared.ts
+++ b/packages/amazonq/src/extensionShared.ts
@@ -27,7 +27,6 @@ import {
     getMachineId,
 } from 'aws-core-vscode/shared'
 import { initializeAuth, CredentialsStore, LoginManager, AuthUtils } from 'aws-core-vscode/auth'
-import { makeEndpointsProvider, registerGenericCommands } from 'aws-core-vscode'
 import { DefaultAmazonQAppInitContext, activate as activateCWChat } from 'aws-core-vscode/amazonq'
 import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
 import { CommonAuthViewProvider, CommonAuthWebview } from 'aws-core-vscode/login'
@@ -37,6 +36,7 @@ import { telemetry, ExtStartUpSources } from 'aws-core-vscode/telemetry'
 import { DevFunction, updateDevMode } from 'aws-core-vscode/dev'
 import { getAuthStatus } from './auth/util'
 import { registerCommands } from './commands'
+import { makeEndpointsProvider, registerGenericCommands } from 'aws-core-vscode/common'
 
 export async function activateShared(context: vscode.ExtensionContext, isWeb: boolean) {
     initialize(context, isWeb)

--- a/packages/amazonq/src/extensionWeb.ts
+++ b/packages/amazonq/src/extensionWeb.ts
@@ -4,12 +4,14 @@
  */
 
 import type { ExtensionContext } from 'vscode'
-import { activate as activateWeb, deactivate as deactivateWeb } from 'aws-core-vscode/web'
+import { activateWebShared } from 'aws-core-vscode/webShared'
+import { activateAmazonQCommon, deactivateCommon } from './extensionCommon'
 
 export async function activate(context: ExtensionContext) {
-    return activateWeb(context)
+    await activateWebShared(context)
+    await activateAmazonQCommon(context, true)
 }
 
 export async function deactivate() {
-    await deactivateWeb()
+    await deactivateCommon()
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "exports": {
         ".": "./dist/src/extension.js",
         "./web": "./dist/src/extensionWeb.js",
+        "./common": "./dist/src/extensionCommon.js",
         "./amazonq": "./dist/src/amazonq/index.js",
         "./codewhisperer": "./dist/src/codewhisperer/index.js",
         "./shared": "./dist/src/shared/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "exports": {
         ".": "./dist/src/extension.js",
         "./web": "./dist/src/extensionWeb.js",
+        "./webShared": "./dist/src/extensionWebShared.js",
         "./common": "./dist/src/extensionCommon.js",
         "./amazonq": "./dist/src/amazonq/index.js",
         "./codewhisperer": "./dist/src/codewhisperer/index.js",

--- a/packages/core/src/amazonq/onboardingPage/walkthrough.ts
+++ b/packages/core/src/amazonq/onboardingPage/walkthrough.ts
@@ -4,6 +4,7 @@
  */
 
 import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
+import { getLogger } from '../../shared'
 import globals, { isWeb } from '../../shared/extensionGlobals'
 import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
 import { Commands, placeholder } from '../../shared/vscode/commands2'
@@ -17,14 +18,17 @@ export async function showAmazonQWalkthroughOnce(
     state = globals.context.globalState,
     showWalkthrough = () => openAmazonQWalkthrough.execute()
 ) {
-    if (isWeb()) {
-        return
-    }
     const hasShownWalkthroughId = 'aws.amazonq.hasShownWalkthrough'
     const hasShownWalkthrough = state.get(hasShownWalkthroughId, false)
     if (hasShownWalkthrough) {
         return
     }
+
+    if (isWeb()) {
+        getLogger().debug(`amazonq: Not showing walkthrough since we are in web mode`)
+        return
+    }
+
     await state.update(hasShownWalkthroughId, true)
     await showWalkthrough()
 }

--- a/packages/core/src/amazonq/onboardingPage/walkthrough.ts
+++ b/packages/core/src/amazonq/onboardingPage/walkthrough.ts
@@ -4,7 +4,7 @@
  */
 
 import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
-import globals from '../../shared/extensionGlobals'
+import globals, { isWeb } from '../../shared/extensionGlobals'
 import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
 import { Commands, placeholder } from '../../shared/vscode/commands2'
 import vscode from 'vscode'
@@ -17,6 +17,9 @@ export async function showAmazonQWalkthroughOnce(
     state = globals.context.globalState,
     showWalkthrough = () => openAmazonQWalkthrough.execute()
 ) {
+    if (isWeb()) {
+        return
+    }
     const hasShownWalkthroughId = 'aws.amazonq.hasShownWalkthrough'
     const hasShownWalkthrough = state.get(hasShownWalkthroughId, false)
     if (hasShownWalkthrough) {

--- a/packages/core/src/amazonq/onboardingPage/walkthrough.ts
+++ b/packages/core/src/amazonq/onboardingPage/walkthrough.ts
@@ -4,9 +4,9 @@
  */
 
 import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
-import { getLogger } from '../../shared'
 import globals, { isWeb } from '../../shared/extensionGlobals'
 import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
+import { getLogger } from '../../shared/logger'
 import { Commands, placeholder } from '../../shared/vscode/commands2'
 import vscode from 'vscode'
 

--- a/packages/core/src/codewhisperer/service/classifierTrigger.ts
+++ b/packages/core/src/codewhisperer/service/classifierTrigger.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as os from 'os'
+import os from 'os'
 import * as vscode from 'vscode'
 import { CodewhispererAutomatedTriggerType } from '../../shared/telemetry/telemetry'
 import { extractContextForCodeWhisperer } from '../util/editorContext'

--- a/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
+++ b/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
@@ -27,6 +27,7 @@ import { cwQuickPickSource } from '../commands/types'
 import { AuthUtil } from '../util/authUtil'
 import { submitFeedback } from '../../feedback/vue/submitFeedback'
 import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
+import { isWeb } from '../../shared/extensionGlobals'
 
 export function createAutoSuggestions(pause: boolean): DataQuickPickItem<'autoSuggestions'> {
     const labelResume = localize('AWS.codewhisperer.resumeCodeWhispererNode.label', 'Resume Auto-Suggestions')
@@ -216,9 +217,19 @@ export function createSignIn(): DataQuickPickItem<'signIn'> {
     const label = localize('AWS.codewhisperer.signInNode.label', 'Sign in to get started')
     const icon = getIcon('vscode-account')
 
+    let onClick = () => {
+        void focusAmazonQPanel.execute(placeholder, 'codewhispererQuickPick')
+    }
+    if (isWeb()) {
+        // TODO: nkomonen, call a Command instead
+        onClick = () => {
+            void AuthUtil.instance.connectToAwsBuilderId()
+        }
+    }
+
     return {
         data: 'signIn',
         label: codicon`${icon} ${label}`,
-        onClick: () => focusAmazonQPanel.execute(placeholder, 'codewhispererQuickPick'),
+        onClick,
     }
 }

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -129,6 +129,7 @@ export class AuthUtil {
             if (this.isValidEnterpriseSsoInUse() || (this.isBuilderIdInUse() && !this.isConnectionExpired())) {
                 // start the feature config polling job
                 await vscode.commands.executeCommand('aws.amazonq.fetchFeatureConfigs')
+                await showAmazonQWalkthroughOnce()
             }
             await this.setVscodeContextProps()
         })
@@ -222,8 +223,6 @@ export class AuthUtil {
             conn = await this.auth.reauthenticate(conn)
         }
 
-        await showAmazonQWalkthroughOnce()
-
         return this.secondaryAuth.useNewConnection(conn)
     }
 
@@ -242,8 +241,6 @@ export class AuthUtil {
         if (this.auth.getConnectionState(conn) === 'invalid') {
             conn = await this.auth.reauthenticate(conn)
         }
-
-        await showAmazonQWalkthroughOnce()
 
         return this.secondaryAuth.useNewConnection(conn)
     }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -50,7 +50,7 @@ import { isReleaseVersion } from './shared/vscode/env'
 import { telemetry } from './shared/telemetry/telemetry'
 import { Auth } from './auth/auth'
 import { registerSubmitFeedback } from './feedback/vue/submitFeedback'
-import { activateShared, deactivateShared, emitUserState } from './extensionShared'
+import { activateCommon, deactivateCommon, emitUserState } from './extensionCommon'
 import { learnMoreAmazonQCommand, qExtensionPageCommand, dismissQTree } from './amazonq/explorer/amazonQChildrenNodes'
 import { AuthUtil, isPreviousQUser } from './codewhisperer/util/authUtil'
 import { installAmazonQExtension } from './codewhisperer/commands/basicCommands'
@@ -58,8 +58,6 @@ import { isExtensionInstalled, VSCODE_EXTENSION_ID } from './shared/utilities'
 import { amazonQInstallDismissedKey } from './codewhisperer/models/constants'
 import { ExtensionUse } from './auth/utils'
 import { ExtStartUpSources } from './shared/telemetry'
-
-export { makeEndpointsProvider, registerGenericCommands } from './extensionShared'
 import { activate as activateThreatComposerEditor } from './threatComposer/activation'
 
 let localize: nls.LocalizeFunc
@@ -68,7 +66,7 @@ let localize: nls.LocalizeFunc
  * The entrypoint for the nodejs version of the toolkit
  *
  * **CONTRIBUTORS** If you are adding code to this function prioritize adding it to
- * {@link activateShared} if appropriate
+ * {@link activateCommon} if appropriate
  */
 export async function activate(context: vscode.ExtensionContext) {
     const activationStartedOn = Date.now()
@@ -77,7 +75,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     try {
         // IMPORTANT: If you are doing setup that should also work in web mode (browser), it should be done in the function below
-        const extContext = await activateShared(context, contextPrefix, false)
+        const extContext = await activateCommon(context, contextPrefix, false)
 
         initializeCredentialsProviderManager()
 
@@ -275,7 +273,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate() {
-    await deactivateShared()
+    await deactivateCommon()
     await globals.resourceManager.dispose()
 }
 

--- a/packages/core/src/extensionCommon.ts
+++ b/packages/core/src/extensionCommon.ts
@@ -6,6 +6,8 @@
 /**
  * This module contains shared code between the main extension and browser/web
  * extension entrypoints.
+ *
+ * See `arch_develop.md` in `docs/` for more info.
  */
 
 import vscode from 'vscode'
@@ -61,7 +63,7 @@ let localize: nls.LocalizeFunc
  * Activation/setup code that is shared by the regular (nodejs) extension AND web mode extension.
  * Most setup code should live here, unless there is a reason not to.
  */
-export async function activateShared(
+export async function activateCommon(
     context: vscode.ExtensionContext,
     contextPrefix: string,
     isWeb: boolean
@@ -163,7 +165,7 @@ export async function activateShared(
 }
 
 /** Deactivation code that is shared between nodejs and web implementations */
-export async function deactivateShared() {
+export async function deactivateCommon() {
     await globals.telemetry.shutdown()
 }
 /**

--- a/packages/core/src/extensionWeb.ts
+++ b/packages/core/src/extensionWeb.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { getLogger } from './shared/logger'
-import { activateShared, deactivateShared } from './extensionShared'
+import { activateCommon, deactivateCommon } from './extensionCommon'
 import os from 'os'
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -18,7 +18,7 @@ export async function activate(context: vscode.ExtensionContext) {
         // it is web mode specific activation code.
         // This should happen as early as possible, as initialize() must be called before
         // isWeb() calls will work.
-        await activateShared(context, contextPrefix, true)
+        await activateCommon(context, contextPrefix, true)
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')
         // truncate if the stacktrace is unusually long
@@ -38,5 +38,5 @@ function patchOsVersion() {
 }
 
 export async function deactivate() {
-    await deactivateShared()
+    await deactivateCommon()
 }

--- a/packages/core/src/extensionWeb.ts
+++ b/packages/core/src/extensionWeb.ts
@@ -6,14 +6,14 @@
 import * as vscode from 'vscode'
 import { getLogger } from './shared/logger'
 import { activateCommon, deactivateCommon } from './extensionCommon'
-import os from 'os'
+import { activateWebShared } from './extensionWebShared'
 
 export async function activate(context: vscode.ExtensionContext) {
     const contextPrefix = 'toolkit'
 
-    try {
-        patchOsVersion()
+    await activateWebShared(context)
 
+    try {
         // IMPORTANT: Any new activation code should be done in the function below unless
         // it is web mode specific activation code.
         // This should happen as early as possible, as initialize() must be called before
@@ -27,14 +27,6 @@ export async function activate(context: vscode.ExtensionContext) {
         }
         getLogger().error(`Failed to activate extension`, error)
     }
-}
-
-/**
- * The browserfied version of os does not have a `version()` method,
- * so we patch it.
- */
-function patchOsVersion() {
-    ;(os.version as any) = () => '1.0.0'
 }
 
 export async function deactivate() {

--- a/packages/core/src/extensionWebShared.ts
+++ b/packages/core/src/extensionWebShared.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { getLogger } from './shared/logger'
+import os from 'os'
+
+/**
+ * This executes the web activation code that all extensions share. So any extension supporting web
+ * should run this as part of their web activation.
+ */
+export async function activateWebShared(context: vscode.ExtensionContext) {
+    try {
+        patchOsVersion()
+    } catch (error) {
+        getLogger().error(`Failed activation in extensionWebShared:`, error)
+    }
+}
+
+/**
+ * The browserfied version of os does not have a `version()` method,
+ * so we patch it.
+ */
+function patchOsVersion() {
+    ;(os.version as any) = () => '1.0.0'
+}

--- a/packages/core/src/shared/extensionGlobals.ts
+++ b/packages/core/src/shared/extensionGlobals.ts
@@ -16,6 +16,7 @@ import { SchemaService } from './schemas'
 import { TelemetryLogger } from './telemetry/telemetryLogger'
 import { TelemetryService } from './telemetry/telemetryService'
 import { UriHandler } from './vscode/uriHandler'
+import vscode from 'vscode'
 
 type Clock = Pick<
     typeof globalThis,
@@ -148,6 +149,7 @@ export function initialize(context: ExtensionContext, isWeb: boolean = false): T
         visualizationResourcePaths: {} as ToolkitGlobals['visualizationResourcePaths'],
         isWeb,
     })
+    void vscode.commands.executeCommand('setContext', 'aws.isWebExtHost', isWeb)
 
     initialized = true
 


### PR DESCRIPTION
## Problem
With inline suggestions moved to the Q extension we need to get the Q extension working in Web mode, including the debug mode to run Web locally.

## Solution
This PR is mainly refactors, see individual commits for each specific change.

The refactors to the code were so that Amazon Q can now be run in Web mode. This PR will have the following limitations:
- You can only use Builder ID to sign in
- It will not work in vscode.dev due to auth/cors limitations (temporary issue)
- You must run things locally with `Extension (web) (amazonq` in the Run + Debug menu
- Local storage is not setup, so your login session will not be remembered when testing.

The Timeout class was modified to support it in both Web and Node runtimes. The inline suggestion feature indirectly relied on this so this was necessary to get working in Web mode.

### Additional
As part of the solution this PR creates a doc in `arch_development.md` that explains the new naming structure for code that can only run in certain environments. See that doc for more explanation as this will influence the project structure moving forward.

https://github.com/aws/aws-toolkit-vscode/assets/118216176/bdd3e9a0-e920-476d-a904-941b288e1236

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
