### PR TITLE
fix(amazonq): increase fuzz factor for diff patch

### DIFF
--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -517,7 +517,7 @@ describe('CodeWhisperer-basicCommands', function () {
         })
 
         it('handles patch failure', async function () {
-            const textDocumentMock = createMockDocument()
+            const textDocumentMock = createMockDocument('first line\nsecond line\nthird line\nfourth line\nfifth line')
 
             openTextDocumentMock.resolves(textDocumentMock)
 
@@ -526,7 +526,7 @@ describe('CodeWhisperer-basicCommands', function () {
             targetCommand = testCommand(applySecurityFix)
             codeScanIssue.suggestedFixes = [
                 {
-                    code: '@@ -1,1 -1,1 @@\n-mock\n+line5',
+                    code: "@@ -3,1 +3,1 @@\n fix\n that\n-doesn't\n+match\n the\n document",
                     description: 'dummy',
                 },
             ]
@@ -539,6 +539,30 @@ describe('CodeWhisperer-basicCommands', function () {
                 component: 'webview',
                 result: 'Failed',
                 reason: 'Error: Failed to get updated content from applying diff patch',
+            })
+        })
+
+        it('should allow up to 4 differing lines', async function () {
+            const textDocumentMock = createMockDocument('first line\nsecond line\nthird line\nfourth line\nfifth line')
+            openTextDocumentMock.resolves(textDocumentMock)
+            sandbox.stub(vscode.workspace, 'openTextDocument').value(openTextDocumentMock)
+            sandbox.stub(vscode.WorkspaceEdit.prototype, 'replace').value(replaceMock)
+            applyEditMock.resolves(true)
+            sandbox.stub(vscode.workspace, 'applyEdit').value(applyEditMock)
+            sandbox.stub(diagnosticsProvider, 'removeDiagnostic').value(removeDiagnosticMock)
+            sandbox.stub(SecurityIssueHoverProvider.instance, 'removeIssue').value(removeIssueMock)
+            sandbox.stub(SecurityIssueCodeActionProvider.instance, 'removeIssue').value(removeIssueMock)
+
+            targetCommand = testCommand(applySecurityFix)
+            codeScanIssue.suggestedFixes = [
+                {
+                    code: '@@ -1,1 +1,1 @@\n first line\n changed\n-third line\n+changed\n foobar\n fifth line',
+                    description: 'dummy',
+                },
+            ]
+            await targetCommand.execute(codeScanIssue, 'test.py', 'webview')
+            assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
+                result: 'Succeeded',
             })
         })
 


### PR DESCRIPTION
## Problem

Consecutive patches usually result in error because the document changed after the first patch

## Solution

Increase the fuzz factor for patches up to 4 differing lines

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
