### PR TITLE
lint: catch incorrect usages of once(), fix current usages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -152,6 +152,7 @@ module.exports = {
 
         'aws-toolkits/no-only-in-tests': 'error',
         'aws-toolkits/no-await-on-vscode-msg': 'error',
+        'aws-toolkits/no-incorrect-once-usage': 'error',
 
         'no-restricted-imports': [
             'error',

--- a/packages/core/src/awsexplorer/activationShared.ts
+++ b/packages/core/src/awsexplorer/activationShared.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode'
 import { createToolView, ToolView } from './toolView'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { CdkRootNode } from '../cdk/explorer/rootNode'
-import { once } from '../shared/utilities/functionUtils'
 
 /**
  * Activates vscode Views (eg tree view) that work in any vscode environment (nodejs or browser).
@@ -25,8 +24,7 @@ export function registerToolView(viewNode: ToolView, context: vscode.ExtensionCo
     toolView.onDidExpandElement(e => {
         if (e.element.resource instanceof CdkRootNode) {
             // Legacy CDK metric, remove this when we add something generic
-            const recordExpandCdkOnce = once(() => telemetry.cdk_appExpanded.emit())
-            recordExpandCdkOnce()
+            telemetry.cdk_appExpanded.emit()
         }
     })
 }

--- a/packages/core/src/codewhisperer/ui/statusBarMenu.ts
+++ b/packages/core/src/codewhisperer/ui/statusBarMenu.ts
@@ -29,7 +29,6 @@ import { CodeScansState, CodeSuggestionsState, vsCodeState } from '../models/mod
 import { Commands } from '../../shared/vscode/commands2'
 import { createExitButton } from '../../shared/ui/buttons'
 import { telemetry } from '../../shared/telemetry/telemetry'
-import { once } from '../../shared/utilities/functionUtils'
 import { getLogger } from '../../shared/logger'
 
 function getAmazonQCodeWhispererNodes() {
@@ -101,7 +100,7 @@ export function getQuickPickItems(): DataQuickPickItem<string>[] {
 
 export const listCodeWhispererCommandsId = 'aws.amazonq.listCommands'
 export const listCodeWhispererCommands = Commands.declare({ id: listCodeWhispererCommandsId }, () => () => {
-    once(() => telemetry.ui_click.emit({ elementId: 'cw_statusBarMenu' }))()
+    telemetry.ui_click.emit({ elementId: 'cw_statusBarMenu' })
     Commands.tryExecute('aws.amazonq.refreshAnnotation', true)
         .then()
         .catch(e => {

--- a/plugins/eslint-plugin-aws-toolkits/index.ts
+++ b/plugins/eslint-plugin-aws-toolkits/index.ts
@@ -5,10 +5,12 @@
 
 import NoOnlyInTests from './lib/rules/no-only-in-tests'
 import NoAwaitOnVscodeMsg from './lib/rules/no-await-on-vscode-msg'
+import NoIncorrectOnceUsage from './lib/rules/no-incorrect-once-usage'
 
 const rules = {
     'no-only-in-tests': NoOnlyInTests,
     'no-await-on-vscode-msg': NoAwaitOnVscodeMsg,
+    'no-incorrect-once-usage': NoIncorrectOnceUsage,
 }
 
 export { rules }

--- a/plugins/eslint-plugin-aws-toolkits/lib/rules/no-incorrect-once-usage.ts
+++ b/plugins/eslint-plugin-aws-toolkits/lib/rules/no-incorrect-once-usage.ts
@@ -1,0 +1,171 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This rule aims to prevent developers from misusing the once() util function. It is possible
+ * that they intended for code to run only once, but due to certain usage patterns it is actually
+ * executed many times due to the nature of the once() function.
+ *
+ * NOTE: This problem is not trivial and there may be false positives/negatives. It may not be
+ * complete. We can ignore the rule and amend this function if edge cases are found. As of this
+ * writing it correctly identified all known good and bad cases in the codebase.
+ *
+ * Details:
+ * once() is a commonly used util function defined in src/shared/utilities/functionUtils.ts.
+ * It works by accepting a function as input, and returns a new function that can only ever be
+ * executed one time. This "one time use" only applies to that specific instance of once, so if
+ * the instance is not re-used, then once() serves no purpose. Examples:
+ *
+ * ```
+ * function log() {
+ *     const logOnce = once(() => console.log('hello'))
+ *     logOnce()
+ * }
+ * log()
+ * log()
+ * ```
+ *
+ * This prints 'hello' multiple times.
+ *
+ * The correct usage is:
+ * ```
+ * let logOnce
+ * function log() {
+ *     logOnce ?= once(() => console.log('hello'))
+ *     logOnce()
+ * }
+ * log()
+ * log()
+ * ```
+ *
+ * This prints 'hello' only one time.
+ *
+ * This rule will try to detect when once() has been used in a way that could make the
+ * developer think the code will only run once, but in reality will run each time since a new
+ * once() instance is being created each time.
+ */
+
+import { ESLintUtils } from '@typescript-eslint/utils'
+import { AST_NODE_TYPES } from '@typescript-eslint/types'
+import { Node, Identifier } from '@typescript-eslint/types/dist/generated/ast-spec'
+import { Rule } from 'eslint'
+
+export const oneOffErr =
+    '`once()` is being called immediately after it returns, which will make a new `once` instance each time. This means the passed function can effectively run many times. Remove once or assign to a higher level-variable that can be re-used.'
+export const notAssignedErr =
+    '`once()` is not being assigned, so it cannot be re-used. This may result in the inner function being called multiple times.'
+export const notReusableErr =
+    '`once()` does not appear to be used in a re-usable context, e.g. a nested loop scope, object property assignment, top-level declaration, or literally only called a single time. If it is not re-usable, then once() serves no purpose. (If this error seems incorrect, disable with // eslint-disable-line)'
+
+export default ESLintUtils.RuleCreator.withoutDocs({
+    meta: {
+        docs: {
+            description: 'disallow usages of once() where the function can be called multiple times',
+            recommended: 'error',
+        },
+        messages: {
+            oneOffErr,
+            notAssignedErr,
+            notReusableErr,
+        },
+        type: 'problem',
+        fixable: 'code',
+        schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+        return {
+            // Check for calls of once (e.g. once()()) and assignment of once (e.g. const x = once())
+            CallExpression(node) {
+                if (
+                    node.callee.type !== AST_NODE_TYPES.Identifier || // check for any func()
+                    node.callee.name !== 'once' // check for once() and not myFunc()
+                ) {
+                    return
+                }
+
+                // Check for once()()
+                if (node.parent?.type === AST_NODE_TYPES.CallExpression) {
+                    return context.report({
+                        node: node.parent,
+                        messageId: 'oneOffErr',
+                    })
+                }
+
+                // Check for cases where we don't assign once() to anything.
+                if (
+                    node.parent?.type !== AST_NODE_TYPES.VariableDeclarator &&
+                    node.parent?.type !== AST_NODE_TYPES.AssignmentExpression &&
+                    node.parent?.type !== AST_NODE_TYPES.PropertyDefinition
+                ) {
+                    return context.report({
+                        node: node,
+                        messageId: 'notAssignedErr',
+                    })
+                }
+            },
+            // Check that assignments of once() are valid, e.g. re-usable in other scopes.
+            VariableDeclaration(node) {
+                // Top-level module assignment is ok
+                if (
+                    node.parent?.type === AST_NODE_TYPES.Program ||
+                    node.parent?.type === AST_NODE_TYPES.ExportNamedDeclaration
+                ) {
+                    return
+                }
+
+                node.declarations.forEach(declaration => {
+                    if (
+                        declaration.init?.type === AST_NODE_TYPES.CallExpression &&
+                        declaration.id.type === AST_NODE_TYPES.Identifier &&
+                        declaration.init.callee?.type === AST_NODE_TYPES.Identifier &&
+                        declaration.init.callee.name === 'once'
+                    ) {
+                        const scope = context.getScope()
+                        const variable = scope.variables.find(v => v.name === (declaration.id as Identifier).name) // we already confirmed the type in the if statement... why is TS mad?
+                        let isUsedInLoopScope = false
+
+                        if (variable) {
+                            const refs = variable.references.filter(ref => ref.identifier !== declaration.id)
+
+                            // Check if it is being referenced multiple times
+                            // TODO: expand to check if it is being referenced inside nested scopes only? (currently checks current scope as well)
+                            if (refs.length > 1) {
+                                return
+                            }
+
+                            // Check if it is being referenced once, but inside a loop.
+                            refs.forEach(ref => {
+                                let currNode: Node | undefined = ref.identifier
+
+                                while (currNode && currNode !== scope.block) {
+                                    if (
+                                        currNode.type === AST_NODE_TYPES.ForStatement ||
+                                        currNode.type === AST_NODE_TYPES.ForInStatement ||
+                                        currNode.type === AST_NODE_TYPES.ForOfStatement ||
+                                        currNode.type === AST_NODE_TYPES.WhileStatement ||
+                                        currNode.type === AST_NODE_TYPES.DoWhileStatement
+                                    ) {
+                                        isUsedInLoopScope = true
+                                        break
+                                    }
+                                    currNode = currNode.parent
+                                }
+                            })
+                        }
+
+                        // If the variable is somehow not assigned? or only used once and not in a loop.
+                        if (variable === undefined || !isUsedInLoopScope) {
+                            return context.report({
+                                node: declaration.init.callee,
+                                messageId: 'notReusableErr',
+                            })
+                        }
+                    }
+                })
+            },
+        }
+    },
+}) as unknown as Rule.RuleModule

--- a/plugins/eslint-plugin-aws-toolkits/test/rules/no-incorrect-once-usage.test.ts
+++ b/plugins/eslint-plugin-aws-toolkits/test/rules/no-incorrect-once-usage.test.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { rules } from '../../index'
+import { notAssignedErr, notReusableErr, oneOffErr } from '../../lib/rules/no-incorrect-once-usage'
+import { getRuleTester } from '../testUtil'
+
+getRuleTester().run('no-incorrect-once-usage', rules['no-incorrect-once-usage'], {
+    valid: [
+        'class A { private readonly logOnce = once(() => {}) }', // class property
+        'const logOnce = once(() => {})', // top-level declaration
+        'export const logOnce = once(() => {})', // top-level declaration
+        'function test() { const logOnce = once(() => {}); while (true) { if (myVal) { logOnce() } } }', // used in a lower while loop scope
+        'function test() { const logOnce = once(() => {}); for (let i = 0; i < 10; i++) { if (myVal) { logOnce() } } }', // used in a lower for loop scope
+        'function test() { const logOnce = once(() => {}); for (let t in types) { if (myVal) { logOnce() } } }', // used in a lower for in loop scope
+        'function test() { const logOnce = once(() => {}); for (let t of types) { if (myVal) { logOnce() } } }', // used in a lower for of loop scope
+        'function test() { logOnce = once(() => {}) }', // assigned a higher-level variable (NOT FOOLPROOF)
+        'class A { test() { this.logOnce = once(() => {}) } }', // assigned a property
+        'function test() { const logOnce = once(() => {}); logOnce(); logOnce();}', // used multiple times, even if the usage is questionable.
+    ],
+
+    invalid: [
+        {
+            code: 'once(() => {})()',
+            errors: [oneOffErr],
+        },
+        {
+            code: 'function test() { once(() => {})() }',
+            errors: [oneOffErr],
+        },
+        {
+            code: 'const logOnce = once(() => {})()',
+            errors: [oneOffErr],
+        },
+        {
+            code: 'once(() => {})',
+            errors: [notAssignedErr],
+        },
+        {
+            code: 'function test() { const logOnce = once(() => {}); logOnce() }',
+            errors: [notReusableErr],
+        },
+        {
+            code: 'function test() { const logOnce = once(() => {}); if (myCond) { logOnce() } }',
+            errors: [notReusableErr],
+        },
+    ],
+})

--- a/plugins/eslint-plugin-aws-toolkits/test/testUtil.ts
+++ b/plugins/eslint-plugin-aws-toolkits/test/testUtil.ts
@@ -8,10 +8,9 @@ import { RuleTester } from 'eslint'
 export function getRuleTester() {
     return new RuleTester({
         // TODO: For tests that need to access TS types, we will need to pass a parser:
-        // parser: require.resolve('@typescript-eslint/parser'),
+        parser: require.resolve('@typescript-eslint/parser'),
         parserOptions: {
-            project: './tsconfig.json',
-            tsconfigRootDir: __dirname,
+            tsconfigRootDir: '../..',
             ecmaVersion: 2021,
         },
     })


### PR DESCRIPTION
Problem: `once()` can be used incorrectly such that code can be executed multiple times, even if it seems that that the developer just wanted it to run a single time.

Solution: Custom lint rule to try to catch these cases. It is not foolproof, but it should catch most issues.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
