### PR TITLE
fix(featureDev): File Rejection stopped working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3335,9 +3335,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.9.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.0.tgz",
-            "integrity": "sha512-XlvtQ89km6NI9EwJ0DRTbFv6hvs+0vW/gdsmwoD6fBJLSl8kfiRUCteUjTDsnfVMMqtfx+7FnmHo5p6+xbG0gg==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.1.tgz",
+            "integrity": "sha512-mVatvO/08jndDaCdVQnJu9DrBoTPxjdmxXE1koQi/BGqm4Wqs1dm7FQfhUpfX3LlRzgmMjAwMafAvABjGkTQ8w==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",
@@ -18879,7 +18879,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.9.0",
+                "@aws/mynah-ui": "^4.9.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-17e8d1cc-e35e-45d3-9dfd-f03c818c197e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-17e8d1cc-e35e-45d3-9dfd-f03c818c197e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Feature Development: File rejection is not rejecting a file when code is generated"
+}

--- a/packages/amazonq/CHANGELOG.md
+++ b/packages/amazonq/CHANGELOG.md
@@ -3,7 +3,7 @@
 - **Bug Fix** Amazon Q Chat: Inside chat body, if there is a code block inside a list item it shows <br/> tags
 - **Bug Fix** Amazon Q Chat: Prompt input field allows additional input beyond the character limit
 - **Bug Fix** Amazon Q Chat: Prompt input field not getting focus when chat window opens
-- **Bug Fix** Amazon Q Chat: File rejection is not rejecting a file when code is generated
+- **Bug Fix** Amazon Q Chat: File rejection is not rejecting a file when code is generated.
 
 ## 1.5.0 2024-05-17
 

--- a/packages/amazonq/CHANGELOG.md
+++ b/packages/amazonq/CHANGELOG.md
@@ -3,7 +3,6 @@
 - **Bug Fix** Amazon Q Chat: Inside chat body, if there is a code block inside a list item it shows <br/> tags
 - **Bug Fix** Amazon Q Chat: Prompt input field allows additional input beyond the character limit
 - **Bug Fix** Amazon Q Chat: Prompt input field not getting focus when chat window opens
-- **Bug Fix** Amazon Q Chat: File rejection is not rejecting a file when code is generated.
 
 ## 1.5.0 2024-05-17
 

--- a/packages/amazonq/CHANGELOG.md
+++ b/packages/amazonq/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **Bug Fix** Amazon Q Chat: Inside chat body, if there is a code block inside a list item it shows <br/> tags
 - **Bug Fix** Amazon Q Chat: Prompt input field allows additional input beyond the character limit
 - **Bug Fix** Amazon Q Chat: Prompt input field not getting focus when chat window opens
+- **Bug Fix** Amazon Q Chat: File rejection is not rejecting a file when code is generated
 
 ## 1.5.0 2024-05-17
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4054,7 +4054,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.9.0",
+        "@aws/mynah-ui": "^4.9.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",

--- a/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
@@ -23,7 +23,12 @@ export interface ConnectorProps {
     sendFeedback?: (tabId: string, feedbackPayload: FeedbackPayload) => void | undefined
     onError: (tabID: string, message: string, title: string) => void
     onWarning: (tabID: string, message: string, title: string) => void
-    onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => void
+    onFileComponentUpdate: (
+        tabID: string,
+        filePaths: DiffTreeFileInfo[],
+        deletedFiles: DiffTreeFileInfo[],
+        messageId: string
+    ) => void
     onFileActionClick: (tabID: string, messageId: string, filePath: string, actionName: string) => void
     onUpdatePlaceholder: (tabID: string, newPlaceholder: string) => void
     onChatInputEnabled: (tabID: string, enabled: boolean) => void
@@ -198,7 +203,12 @@ export class Connector {
 
     handleMessageReceive = async (messageData: any): Promise<void> => {
         if (messageData.type === 'updateFileComponent') {
-            this.onFileComponentUpdate(messageData.tabID, messageData.filePaths, messageData.deletedFiles)
+            this.onFileComponentUpdate(
+                messageData.tabID,
+                messageData.filePaths,
+                messageData.deletedFiles,
+                messageData.messageId
+            )
             return
         }
         if (messageData.type === 'errorMessage') {

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -40,7 +40,12 @@ export interface ConnectorProps {
     onCWCContextCommandMessage: (message: ChatItem, command?: string) => string | undefined
     onError: (tabID: string, message: string, title: string) => void
     onWarning: (tabID: string, message: string, title: string) => void
-    onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => void
+    onFileComponentUpdate: (
+        tabID: string,
+        filePaths: DiffTreeFileInfo[],
+        deletedFiles: DiffTreeFileInfo[],
+        messageId: string
+    ) => void
     onUpdatePlaceholder: (tabID: string, newPlaceholder: string) => void
     onChatInputEnabled: (tabID: string, enabled: boolean) => void
     onUpdateAuthentication: (featureDevEnabled: boolean, authenticatingTabIDs: string[]) => void

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -230,7 +230,12 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
         onMessageReceived: (tabID: string, messageData: MynahUIDataModel) => {
             mynahUI.updateStore(tabID, messageData)
         },
-        onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => {
+        onFileComponentUpdate: (
+            tabID: string,
+            filePaths: DiffTreeFileInfo[],
+            deletedFiles: DiffTreeFileInfo[],
+            messageId: string
+        ) => {
             const updateWith: Partial<ChatItem> = {
                 type: ChatItemType.ANSWER,
                 fileList: {
@@ -241,7 +246,7 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
                     actions: getActions([...filePaths, ...deletedFiles]),
                 },
             }
-            mynahUI.updateLastChatAnswer(tabID, updateWith)
+            mynahUI.updateChatAnswerWithMessageId(tabID, messageId, updateWith)
         },
         onWarning: (tabID: string, message: string, title: string) => {
             mynahUI.notify({

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -694,6 +694,7 @@ export class FeatureDevController {
     private async fileClicked(message: fileClickedMessage) {
         // TODO: add Telemetry here
         const tabId: string = message.tabID
+        const messageId = message.messageId
         const filePathToUpdate: string = message.filePath
 
         const session = await this.sessionStorage.getSession(tabId)
@@ -709,7 +710,12 @@ export class FeatureDevController {
                 !session.state.deletedFiles[deletedFilePathIndex].rejected
         }
 
-        await session.updateFilesPaths(tabId, session.state.filePaths ?? [], session.state.deletedFiles ?? [])
+        await session.updateFilesPaths(
+            tabId,
+            session.state.filePaths ?? [],
+            session.state.deletedFiles ?? [],
+            messageId
+        )
     }
 
     private async openDiff(message: OpenDiffMessage) {

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -144,8 +144,13 @@ export class Messenger {
         this.dispatcher.sendAsyncEventProgress(new AsyncEventProgressMessage(tabID, inProgress, message))
     }
 
-    public updateFileComponent(tabID: string, filePaths: NewFileInfo[], deletedFiles: DeletedFileInfo[]) {
-        this.dispatcher.updateFileComponent(new FileComponent(tabID, filePaths, deletedFiles))
+    public updateFileComponent(
+        tabID: string,
+        filePaths: NewFileInfo[],
+        deletedFiles: DeletedFileInfo[],
+        messageId: string
+    ) {
+        this.dispatcher.updateFileComponent(new FileComponent(tabID, filePaths, deletedFiles, messageId))
     }
 
     public sendUpdatePlaceholder(tabID: string, newPlaceholder: string) {

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -166,8 +166,13 @@ export class Session {
         return resp.interaction
     }
 
-    public async updateFilesPaths(tabID: string, filePaths: NewFileInfo[], deletedFiles: DeletedFileInfo[]) {
-        this.messenger.updateFileComponent(tabID, filePaths, deletedFiles)
+    public async updateFilesPaths(
+        tabID: string,
+        filePaths: NewFileInfo[],
+        deletedFiles: DeletedFileInfo[],
+        messageId: string
+    ) {
+        this.messenger.updateFileComponent(tabID, filePaths, deletedFiles, messageId)
     }
 
     public async insertChanges() {

--- a/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
+++ b/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
@@ -83,11 +83,13 @@ export class FileComponent extends UiMessage {
     readonly filePaths: NewFileInfo[]
     readonly deletedFiles: DeletedFileInfo[]
     override type = 'updateFileComponent'
+    readonly messageId: string
 
-    constructor(tabID: string, filePaths: NewFileInfo[], deletedFiles: DeletedFileInfo[]) {
+    constructor(tabID: string, filePaths: NewFileInfo[], deletedFiles: DeletedFileInfo[], messageId: string) {
         super(tabID)
         this.filePaths = filePaths
         this.deletedFiles = deletedFiles
+        this.messageId = messageId
     }
 }
 


### PR DESCRIPTION
## Problem
when clicking on the X to reject change nothing happens

Fix was introduced to Mynah in 4.9.1 version.

On our side we needed to update mynah chat card update by messageId.

Tested:
![Screenshot 2024-05-24 at 14 47 51](https://github.com/aws/aws-toolkit-vscode/assets/144136687/28945611-4b79-409c-9da1-7669d7264d26)


## Solution

<!---
![Screenshot 2024-05-24 at 14 47 15](https://github.com/aws/aws-toolkit-vscode/assets/144136687/2ce7f987-91ba-4f93-a0e4-5b45786224a5)

    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
