### PR TITLE
fix(login): update margin for login screen

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -610,6 +610,7 @@ export default defineComponent({
     width: 260px;
     /* Centers all content in to middle of page since the height is the whole screen*/
     justify-content: center;
+    margin: auto;
 }
 
 .header {


### PR DESCRIPTION
## Problem
Content in Login Page gets clipped with width is decreased beyond min width and only partial content is visible.

## Solution
- Update margin to `auto` for auth container.

https://github.com/aws/aws-toolkit-vscode/assets/371007/d43b1bbf-9e48-4397-8715-e7a44d7dac0f


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
