### PR TITLE
fix: use device code auth when running in a web browser

### DIFF
--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -252,7 +252,16 @@ export abstract class SsoAccessTokenProvider {
         profile: Pick<SsoProfile, 'startUrl' | 'region' | 'scopes' | 'identifier'>,
         cache = getCache(),
         oidc: OidcClient = OidcClient.create(profile.region),
-        useDeviceFlow: () => boolean = isRemoteWorkspace
+        useDeviceFlow: () => boolean = () => {
+            /**
+             * Device code flow is neccessary when:
+             * 1. We are in a workspace connected through ssh (codecatalyst, etc)
+             * 2. We are connected to a remote backend through the web browser (code server, openshift dev spaces)
+             *
+             * Since we are unable to serve the final authorization page
+             */
+            return isRemoteWorkspace() || vscode.env.uiKind === vscode.UIKind.Web
+        }
     ) {
         if (useDeviceFlow()) {
             return new DeviceFlowAuthorization(profile, cache, oidc)

--- a/packages/toolkit/.changes/next-release/Bug Fix-e3e035eb-3cd6-478c-a0ab-1e0b54061b12.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-e3e035eb-3cd6-478c-a0ab-1e0b54061b12.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "auth: use device code auth when running in a web browser"
+}


### PR DESCRIPTION
## Problem
- Logging into the toolkit using the authorization grant flow in code server/openshift dev spaces does not fully work. This is because the authorization grant page is being served from the backend compute and the browser is unable to access it

## Solution
- Disable the authorization grant flow when you are running in a web browser

## Extra notes:
- It was done this way rather than relying on vscode.env.remoteName because remoteName can change with different remote instances. e.g. openshift dev spaces assigns a remoteName that is unique to each workspace
- VSCode itself disables remote extension hosts and web workers for this flow: https://github.com/microsoft/vscode/blob/main/extensions/github-authentication/src/flows.ts#L210
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
