### PR TITLE
fix(amazonq): offset fix line number on document change

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-90ec7784-f6a2-45b4-a91e-955e01597277.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-90ec7784-f6a2-45b4-a91e-955e01597277.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Security Scan: Improved accuracy when applying security fixes"
+}

--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -9,6 +9,10 @@ import { SecurityIssueHoverProvider } from './securityIssueHoverProvider'
 import { SecurityIssueCodeActionProvider } from './securityIssueCodeActionProvider'
 import { CodeAnalysisScope, codewhispererDiagnosticSourceLabel } from '../models/constants'
 
+export interface SecurityDiagnostic extends vscode.Diagnostic {
+    findingId?: string
+}
+
 interface SecurityScanRender {
     securityDiagnosticCollection: vscode.DiagnosticCollection | undefined
     initialized: boolean
@@ -64,7 +68,7 @@ export function updateSecurityDiagnosticCollection(securityRecommendation: Aggre
 
 export function createSecurityDiagnostic(securityIssue: CodeScanIssue) {
     const range = new vscode.Range(securityIssue.startLine, 0, securityIssue.endLine, 0)
-    const securityDiagnostic: vscode.Diagnostic = new vscode.Diagnostic(
+    const securityDiagnostic: SecurityDiagnostic = new vscode.Diagnostic(
         range,
         securityIssue.title,
         vscode.DiagnosticSeverity.Warning
@@ -74,6 +78,7 @@ export function createSecurityDiagnostic(securityIssue: CodeScanIssue) {
         value: securityIssue.detectorId,
         target: vscode.Uri.parse(securityIssue.recommendation.url),
     }
+    securityDiagnostic.findingId = securityIssue.findingId
     return securityDiagnostic
 }
 
@@ -92,9 +97,19 @@ export function disposeSecurityDiagnostic(event: vscode.TextDocumentChangeEvent)
     }
     const currentSecurityDiagnostics = securityScanRender.securityDiagnosticCollection?.get(uri)
     const newSecurityDiagnostics: vscode.Diagnostic[] = []
-    const changedRange = event.contentChanges[0].range
-    const changedText = event.contentChanges[0].text
-    const lineOffset = getLineOffset(changedRange, changedText)
+
+    const { changedRange, changedText, lineOffset } = event.contentChanges.reduce(
+        (acc, change) => ({
+            changedRange: acc.changedRange.union(change.range),
+            changedText: acc.changedText + change.text,
+            lineOffset: acc.lineOffset + getLineOffset(change.range, change.text),
+        }),
+        {
+            changedRange: event.contentChanges[0].range,
+            changedText: '',
+            lineOffset: 0,
+        }
+    )
 
     currentSecurityDiagnostics?.forEach(issue => {
         const intersection = changedRange.intersection(issue.range)
@@ -129,15 +144,8 @@ function getLineOffset(range: vscode.Range, text: string) {
 export function removeDiagnostic(uri: vscode.Uri, issue: CodeScanIssue) {
     const currentSecurityDiagnostics = securityScanRender.securityDiagnosticCollection?.get(uri)
     if (currentSecurityDiagnostics) {
-        const newSecurityDiagnostics = currentSecurityDiagnostics.filter(diagnostic => {
-            return !(
-                typeof diagnostic.code !== 'string' &&
-                typeof diagnostic.code !== 'number' &&
-                diagnostic.code?.value === issue.detectorId &&
-                diagnostic.message === issue.title &&
-                diagnostic.range.start.line === issue.startLine &&
-                diagnostic.range.end.line === issue.endLine
-            )
+        const newSecurityDiagnostics = currentSecurityDiagnostics.filter((diagnostic: SecurityDiagnostic) => {
+            return diagnostic.findingId !== issue.findingId
         })
         securityScanRender.securityDiagnosticCollection?.set(uri, newSecurityDiagnostics)
     }

--- a/packages/core/src/test/codewhisperer/service/diagnosticsProvider.test.ts
+++ b/packages/core/src/test/codewhisperer/service/diagnosticsProvider.test.ts
@@ -1,0 +1,81 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode from 'vscode'
+import sinon from 'sinon'
+import assert from 'assert'
+import * as diagnosticsProvider from '../../../codewhisperer/service/diagnosticsProvider'
+import { createCodeScanIssue, createMockDocument, createTextDocumentChangeEvent } from '../testUtil'
+import { SecurityDiagnostic } from '../../../codewhisperer/service/diagnosticsProvider'
+
+describe('diagnosticsProvider', function () {
+    let mockDocument: vscode.TextDocument
+    let mockCollection: vscode.DiagnosticCollection
+
+    beforeEach(function () {
+        mockDocument = createMockDocument()
+        mockCollection = diagnosticsProvider.createSecurityDiagnosticCollection()
+        diagnosticsProvider.securityScanRender.initialized = true
+    })
+
+    afterEach(function () {
+        sinon.restore()
+        mockCollection.clear()
+    })
+
+    it('should remove diagnostic by findingId', function () {
+        mockCollection.set(mockDocument.uri, [
+            { findingId: 'finding1' },
+            { findingId: 'finding2' },
+        ] as SecurityDiagnostic[])
+        sinon.stub(diagnosticsProvider.securityScanRender, 'securityDiagnosticCollection').returns(mockCollection)
+
+        diagnosticsProvider.removeDiagnostic(mockDocument.uri, createCodeScanIssue({ findingId: 'finding1' }))
+        const actual = mockCollection.get(mockDocument.uri) as SecurityDiagnostic[]
+        assert.strictEqual(actual.length, 1)
+        assert.strictEqual(actual[0].findingId, 'finding2')
+    })
+
+    it('should offset diagnostics and fixes by 1 line', function () {
+        mockCollection.set(mockDocument.uri, [
+            { findingId: 'finding1', range: new vscode.Range(1, 0, 2, 0) },
+            { findingId: 'finding2', range: new vscode.Range(3, 0, 4, 0) },
+        ] as SecurityDiagnostic[])
+        sinon.stub(diagnosticsProvider.securityScanRender, 'securityDiagnosticCollection').returns(mockCollection)
+
+        const mockEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(0, 0, 0, 0), '\n')
+        diagnosticsProvider.disposeSecurityDiagnostic(mockEvent)
+        const actual = mockCollection.get(mockDocument.uri)
+        assert.strictEqual(actual?.length, 2)
+        assert.strictEqual(actual[0].range.start.line, 2)
+        assert.strictEqual(actual[0].range.end.line, 3)
+        assert.strictEqual(actual[1].range.start.line, 4)
+        assert.strictEqual(actual[1].range.end.line, 5)
+    })
+
+    it('should handle change event with multiple content changes', function () {
+        mockCollection.set(mockDocument.uri, [
+            { findingId: 'finding1', range: new vscode.Range(1, 0, 2, 0) },
+            { findingId: 'finding2', range: new vscode.Range(3, 0, 4, 0) },
+        ] as SecurityDiagnostic[])
+        sinon.stub(diagnosticsProvider.securityScanRender, 'securityDiagnosticCollection').returns(mockCollection)
+
+        const mockEvent: vscode.TextDocumentChangeEvent = {
+            reason: undefined,
+            document: mockDocument,
+            contentChanges: [
+                { range: new vscode.Range(0, 0, 0, 0), rangeOffset: 1, rangeLength: 1, text: 'a\n' },
+                { range: new vscode.Range(0, 0, 0, 0), rangeOffset: 1, rangeLength: 1, text: 'b\n' },
+            ],
+        }
+        diagnosticsProvider.disposeSecurityDiagnostic(mockEvent)
+        const actual = mockCollection.get(mockDocument.uri)
+        assert.strictEqual(actual?.length, 2)
+        assert.strictEqual(actual[0].range.start.line, 3)
+        assert.strictEqual(actual[0].range.end.line, 4)
+        assert.strictEqual(actual[1].range.start.line, 5)
+        assert.strictEqual(actual[1].range.end.line, 6)
+    })
+})

--- a/packages/core/src/test/codewhisperer/service/securityIssueProvider.test.ts
+++ b/packages/core/src/test/codewhisperer/service/securityIssueProvider.test.ts
@@ -38,12 +38,14 @@ describe('securityIssueProvider', () => {
         ]
         assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 1)
         assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 2)
+        assert.ok(mockProvider.issues[0].issues[0].suggestedFixes[0].code.startsWith('@@ -1,1 +1,1 @@'))
 
         const changeEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(0, 0, 0, 0), '\n')
         mockProvider.handleDocumentChange(changeEvent)
 
         assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 2)
         assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 3)
+        assert.ok(mockProvider.issues[0].issues[0].suggestedFixes[0].code.startsWith('@@ -2,1 +2,1 @@'))
     })
 
     it('does not move the issue if the document changed below the line', () => {
@@ -51,12 +53,14 @@ describe('securityIssueProvider', () => {
 
         assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 0)
         assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 1)
+        assert.ok(mockProvider.issues[0].issues[0].suggestedFixes[0].code.startsWith('@@ -1,1 +1,1 @@'))
 
         const changeEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(2, 0, 2, 0), '\n')
         mockProvider.handleDocumentChange(changeEvent)
 
         assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 0)
         assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 1)
+        assert.ok(mockProvider.issues[0].issues[0].suggestedFixes[0].code.startsWith('@@ -1,1 +1,1 @@'))
     })
 
     it('should do nothing if no content changes', () => {
@@ -66,6 +70,7 @@ describe('securityIssueProvider', () => {
 
         assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 1)
         assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 2)
+        assert.ok(mockProvider.issues[0].issues[0].suggestedFixes[0].code.startsWith('@@ -1,1 +1,1 @@'))
 
         const changeEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(0, 0, 0, 0), '')
         changeEvent.contentChanges = []
@@ -73,18 +78,21 @@ describe('securityIssueProvider', () => {
 
         assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 1)
         assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 2)
+        assert.ok(mockProvider.issues[0].issues[0].suggestedFixes[0].code.startsWith('@@ -1,1 +1,1 @@'))
     })
 
     it('should do nothing if file path does not match', () => {
         mockProvider.issues = [{ filePath: 'some/path', issues: [createCodeScanIssue({ startLine: 1, endLine: 2 })] }]
         assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 1)
         assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 2)
+        assert.ok(mockProvider.issues[0].issues[0].suggestedFixes[0].code.startsWith('@@ -1,1 +1,1 @@'))
 
         const changeEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(0, 0, 0, 0), '\n')
         mockProvider.handleDocumentChange(changeEvent)
 
         assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 1)
         assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 2)
+        assert.ok(mockProvider.issues[0].issues[0].suggestedFixes[0].code.startsWith('@@ -1,1 +1,1 @@'))
     })
 
     describe('removeIssue', () => {


### PR DESCRIPTION
## Problem

1. Line numbers of suggested fixes can be out of sync if the document changes.
2. Line offset calculation is incorrect in some cases if the change event contains multiple `contentChanges`
3. Remove diagnostic method is not reliable

## Solution

1. Add line offset to suggested fix code during document changes using regex replace
2. Handle all elements in `contentChanges` array instead of just the first one
3. Assign `findingId` to diagnostic and update remove diagnostic method

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
