### PR TITLE
bug fix: fixed typo in package.json that prevented the proper use of certain ec2 instance related commands.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1155,11 +1155,11 @@
                 },
                 {
                     "command": "aws.ec2.stopInstance",
-                    "whem": "aws.isDevMode"
+                    "when": "aws.isDevMode"
                 },
                 {
                     "command": "aws.ec2.rebootInstance",
-                    "whem": "aws.isDevMode"
+                    "when": "aws.isDevMode"
                 },
                 {
                     "command": "aws.dev.openMenu",


### PR DESCRIPTION

## Problem
The ec2 stop and reboot instance commands can be seen without dev mode being enabled on the user. 

## Solution
Correct the typo on the lines 1157 and 1162 in the package.json file. Changed "whem" to "when"

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
