### PR TITLE
docs: add non vue webviews documentation

### DIFF
--- a/docs/arch_develop.md
+++ b/docs/arch_develop.md
@@ -283,7 +283,7 @@ Some webviews (amazon q chat view, codewhisperer security panel) rely on the nat
 
 ### Importing css
 
-css imports for non vue webviews should be imported when generating the webview provider html, rather than loaded inside of the javascript. This allows the javascript to be used in e2e tests:
+css imports for non vue webviews should be imported when generating the webview provider html, rather than loaded inside of the javascript otherwise you will get "Error: Cannot find module 'some/path/to/my.css'" when running the e2e tests:
 
 e.g. when creating the html do:
 


### PR DESCRIPTION
## Problem
- no docs for non vue webviews

## Solution
- add some basic docs
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
