### PR TITLE
Revert "fix(featureDev): File Rejection stopped working #5055"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3335,9 +3335,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.1.tgz",
-            "integrity": "sha512-mVatvO/08jndDaCdVQnJu9DrBoTPxjdmxXE1koQi/BGqm4Wqs1dm7FQfhUpfX3LlRzgmMjAwMafAvABjGkTQ8w==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.0.tgz",
+            "integrity": "sha512-XlvtQ89km6NI9EwJ0DRTbFv6hvs+0vW/gdsmwoD6fBJLSl8kfiRUCteUjTDsnfVMMqtfx+7FnmHo5p6+xbG0gg==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",
@@ -18879,7 +18879,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.9.1",
+                "@aws/mynah-ui": "^4.9.0",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-17e8d1cc-e35e-45d3-9dfd-f03c818c197e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-17e8d1cc-e35e-45d3-9dfd-f03c818c197e.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "Feature Development: File rejection is not rejecting a file when code is generated"
-}

--- a/packages/amazonq/.changes/next-release/Bug Fix-a8f7f6ef-7d2f-444e-a4da-491401c383ea.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-a8f7f6ef-7d2f-444e-a4da-491401c383ea.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "(featureDev): Revert fix for file rejection. Reason: The plan disappears after clicking generate Code"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4056,7 +4056,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.9.1",
+        "@aws/mynah-ui": "^4.9.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",

--- a/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
@@ -23,12 +23,7 @@ export interface ConnectorProps {
     sendFeedback?: (tabId: string, feedbackPayload: FeedbackPayload) => void | undefined
     onError: (tabID: string, message: string, title: string) => void
     onWarning: (tabID: string, message: string, title: string) => void
-    onFileComponentUpdate: (
-        tabID: string,
-        filePaths: DiffTreeFileInfo[],
-        deletedFiles: DiffTreeFileInfo[],
-        messageId: string
-    ) => void
+    onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => void
     onFileActionClick: (tabID: string, messageId: string, filePath: string, actionName: string) => void
     onUpdatePlaceholder: (tabID: string, newPlaceholder: string) => void
     onChatInputEnabled: (tabID: string, enabled: boolean) => void
@@ -203,12 +198,7 @@ export class Connector {
 
     handleMessageReceive = async (messageData: any): Promise<void> => {
         if (messageData.type === 'updateFileComponent') {
-            this.onFileComponentUpdate(
-                messageData.tabID,
-                messageData.filePaths,
-                messageData.deletedFiles,
-                messageData.messageId
-            )
+            this.onFileComponentUpdate(messageData.tabID, messageData.filePaths, messageData.deletedFiles)
             return
         }
         if (messageData.type === 'errorMessage') {

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -40,12 +40,7 @@ export interface ConnectorProps {
     onCWCContextCommandMessage: (message: ChatItem, command?: string) => string | undefined
     onError: (tabID: string, message: string, title: string) => void
     onWarning: (tabID: string, message: string, title: string) => void
-    onFileComponentUpdate: (
-        tabID: string,
-        filePaths: DiffTreeFileInfo[],
-        deletedFiles: DiffTreeFileInfo[],
-        messageId: string
-    ) => void
+    onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => void
     onUpdatePlaceholder: (tabID: string, newPlaceholder: string) => void
     onChatInputEnabled: (tabID: string, enabled: boolean) => void
     onUpdateAuthentication: (featureDevEnabled: boolean, authenticatingTabIDs: string[]) => void

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -229,12 +229,7 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
         onMessageReceived: (tabID: string, messageData: MynahUIDataModel) => {
             mynahUI.updateStore(tabID, messageData)
         },
-        onFileComponentUpdate: (
-            tabID: string,
-            filePaths: DiffTreeFileInfo[],
-            deletedFiles: DiffTreeFileInfo[],
-            messageId: string
-        ) => {
+        onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => {
             const updateWith: Partial<ChatItem> = {
                 type: ChatItemType.ANSWER,
                 fileList: {
@@ -245,7 +240,7 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
                     actions: getActions([...filePaths, ...deletedFiles]),
                 },
             }
-            mynahUI.updateChatAnswerWithMessageId(tabID, messageId, updateWith)
+            mynahUI.updateLastChatAnswer(tabID, updateWith)
         },
         onWarning: (tabID: string, message: string, title: string) => {
             mynahUI.notify({

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -694,7 +694,6 @@ export class FeatureDevController {
     private async fileClicked(message: fileClickedMessage) {
         // TODO: add Telemetry here
         const tabId: string = message.tabID
-        const messageId = message.messageId
         const filePathToUpdate: string = message.filePath
 
         const session = await this.sessionStorage.getSession(tabId)
@@ -710,12 +709,7 @@ export class FeatureDevController {
                 !session.state.deletedFiles[deletedFilePathIndex].rejected
         }
 
-        await session.updateFilesPaths(
-            tabId,
-            session.state.filePaths ?? [],
-            session.state.deletedFiles ?? [],
-            messageId
-        )
+        await session.updateFilesPaths(tabId, session.state.filePaths ?? [], session.state.deletedFiles ?? [])
     }
 
     private async openDiff(message: OpenDiffMessage) {

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -144,13 +144,8 @@ export class Messenger {
         this.dispatcher.sendAsyncEventProgress(new AsyncEventProgressMessage(tabID, inProgress, message))
     }
 
-    public updateFileComponent(
-        tabID: string,
-        filePaths: NewFileInfo[],
-        deletedFiles: DeletedFileInfo[],
-        messageId: string
-    ) {
-        this.dispatcher.updateFileComponent(new FileComponent(tabID, filePaths, deletedFiles, messageId))
+    public updateFileComponent(tabID: string, filePaths: NewFileInfo[], deletedFiles: DeletedFileInfo[]) {
+        this.dispatcher.updateFileComponent(new FileComponent(tabID, filePaths, deletedFiles))
     }
 
     public sendUpdatePlaceholder(tabID: string, newPlaceholder: string) {

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -166,13 +166,8 @@ export class Session {
         return resp.interaction
     }
 
-    public async updateFilesPaths(
-        tabID: string,
-        filePaths: NewFileInfo[],
-        deletedFiles: DeletedFileInfo[],
-        messageId: string
-    ) {
-        this.messenger.updateFileComponent(tabID, filePaths, deletedFiles, messageId)
+    public async updateFilesPaths(tabID: string, filePaths: NewFileInfo[], deletedFiles: DeletedFileInfo[]) {
+        this.messenger.updateFileComponent(tabID, filePaths, deletedFiles)
     }
 
     public async insertChanges() {

--- a/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
+++ b/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
@@ -83,13 +83,11 @@ export class FileComponent extends UiMessage {
     readonly filePaths: NewFileInfo[]
     readonly deletedFiles: DeletedFileInfo[]
     override type = 'updateFileComponent'
-    readonly messageId: string
 
-    constructor(tabID: string, filePaths: NewFileInfo[], deletedFiles: DeletedFileInfo[], messageId: string) {
+    constructor(tabID: string, filePaths: NewFileInfo[], deletedFiles: DeletedFileInfo[]) {
         super(tabID)
         this.filePaths = filePaths
         this.deletedFiles = deletedFiles
-        this.messageId = messageId
     }
 }
 


### PR DESCRIPTION
This reverts commit 03e5e294360b56e4cf9cd2c112120336f3c99230.

## Problem
- After bumping mynah UI and making changes to onFileComponentUpdate. The plan disappears after clicking generate Code.
This is a critical functionality for us to have.

## Tested
Yes, after reverting this change plan stays, but it re-introduces bug when reverting file changes.
![Screenshot 2024-05-29 at 19 37 02](https://github.com/aws/aws-toolkit-vscode/assets/144136687/6ab2d9cb-97ac-4139-9185-ebe7f0e61225)

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
