### PR TITLE
lint: child_process

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
         mocha: true,
         es2024: true,
     },
-    plugins: ['@typescript-eslint', 'unicorn', 'header', 'aws-toolkits'],
+    plugins: ['@typescript-eslint', 'unicorn', 'header', 'security-node', 'aws-toolkits'],
     extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/eslint-recommended',
@@ -142,6 +142,7 @@ module.exports = {
         'unicorn/prefer-reflect-apply': 'error',
         'unicorn/prefer-string-trim-start-end': 'error',
         'unicorn/prefer-type-error': 'error',
+        'security-node/detect-child-process': 'error',
 
         'header/header': [
             'error',
@@ -156,6 +157,7 @@ module.exports = {
         'aws-toolkits/no-only-in-tests': 'error',
         'aws-toolkits/no-await-on-vscode-msg': 'error',
         'aws-toolkits/no-incorrect-once-usage': 'error',
+        'aws-toolkits/no-string-exec-for-child-process': 'error',
 
         'no-restricted-imports': [
             'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
                 "eslint-config-prettier": "9.1",
                 "eslint-plugin-aws-toolkits": "file:plugins/eslint-plugin-aws-toolkits",
                 "eslint-plugin-header": "^3.1.1",
+                "eslint-plugin-security-node": "^1.1.4",
                 "eslint-plugin-unicorn": "^50.0.1",
                 "husky": "^9.0.7",
                 "prettier": "^2.8.8",
@@ -9760,6 +9761,15 @@
             "dev": true,
             "peerDependencies": {
                 "eslint": ">=7.7.0"
+            }
+        },
+        "node_modules/eslint-plugin-security-node": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-security-node/-/eslint-plugin-security-node-1.1.4.tgz",
+            "integrity": "sha512-8+agTMb2glNbP1zFhqo/Ixwtz16Hn0TvJW5KgpoHkAzGjDUhQf9iT+D6OgbhvZCMWRKMjc+5FbJ2Lh0UEUz7fQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/eslint-plugin-unicorn": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "eslint-plugin-aws-toolkits": "file:plugins/eslint-plugin-aws-toolkits",
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-unicorn": "^50.0.1",
+        "eslint-plugin-security-node": "^1.1.4",
         "husky": "^9.0.7",
         "prettier": "^2.8.8",
         "prettier-plugin-sh": "^0.12.8",

--- a/packages/core/src/lambda/commands/createNewSamApp.ts
+++ b/packages/core/src/lambda/commands/createNewSamApp.ts
@@ -41,7 +41,7 @@ import { openLaunchJsonFile } from '../../shared/sam/debugger/commands/addSamDeb
 import { waitUntil } from '../../shared/utilities/timeoutUtils'
 import { debugNewSamAppUrl, launchConfigDocUrl } from '../../shared/constants'
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { writeFile } from 'fs-extra'
 import { checklogs } from '../../shared/localizedText'
 import globals from '../../shared/extensionGlobals'
@@ -211,7 +211,7 @@ export async function createNewSamApplication(
         // Needs to be done or else gopls won't start
         if (goRuntimes.includes(createRuntime)) {
             try {
-                execSync('go mod tidy', { cwd: path.join(path.dirname(templateUri.fsPath), 'hello-world') })
+                execFileSync('go', ['mod', 'tidy'], { cwd: path.join(path.dirname(templateUri.fsPath), 'hello-world') })
             } catch (err) {
                 getLogger().warn(
                     localize(

--- a/plugins/eslint-plugin-aws-toolkits/index.ts
+++ b/plugins/eslint-plugin-aws-toolkits/index.ts
@@ -6,11 +6,13 @@
 import NoOnlyInTests from './lib/rules/no-only-in-tests'
 import NoAwaitOnVscodeMsg from './lib/rules/no-await-on-vscode-msg'
 import NoIncorrectOnceUsage from './lib/rules/no-incorrect-once-usage'
+import NoStringExecForChildProcess from './lib/rules/no-string-exec-for-child-process'
 
 const rules = {
     'no-only-in-tests': NoOnlyInTests,
     'no-await-on-vscode-msg': NoAwaitOnVscodeMsg,
     'no-incorrect-once-usage': NoIncorrectOnceUsage,
+    'no-string-exec-for-child-process': NoStringExecForChildProcess,
 }
 
 export { rules }

--- a/plugins/eslint-plugin-aws-toolkits/lib/rules/no-string-exec-for-child-process.ts
+++ b/plugins/eslint-plugin-aws-toolkits/lib/rules/no-string-exec-for-child-process.ts
@@ -1,0 +1,92 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Developers sometimes use string input form of child_process.exec (and similar functions), e.g.:
+ * `child_process.execSync(`vsce package --ignoreFile "../.vscodeignore.packages"`, { stdio: 'inherit' })`
+ * However, the array input form functions should be used instead:
+ * child_process.execFile('vsce', ['package', '--ignoreFile', '../.vscodeignore.packages'], { stdio: 'inherit' })
+ *
+ * The "string form" is highly discouraged because
+ * (1) it invokes a shell, which has security and performance costs, and
+ * (2) it causes bugs related to platform specific quoting rules (and other shell forms such as $foo vs %foo%, etc).
+ */
+
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils'
+import { AST_NODE_TYPES } from '@typescript-eslint/types'
+import { Rule } from 'eslint'
+
+export const errMsg =
+    "do not use child_process functions that accept string inputs (e.g. `exec('ls -h')`), instead use those with array inputs, e.g. `execFile('ls', ['-h'])`"
+
+// child_process functions that accept string input
+const disallowedFunctions = new Set(['exec', 'execSync'])
+
+export default ESLintUtils.RuleCreator.withoutDocs({
+    meta: {
+        docs: {
+            description: 'disallow child_process functions that allow string inputs over array inputs',
+            recommended: 'recommended',
+        },
+        messages: {
+            errMsg,
+        },
+        type: 'problem',
+        fixable: 'code',
+        schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+        let libImportName: string | undefined
+
+        return {
+            ImportDeclaration(node: TSESTree.ImportDeclaration) {
+                // Detect imports for child_process
+                if (node.source.value === 'child_process') {
+                    node.specifiers.forEach(specifier => {
+                        if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+                            // Detect the name of the import, e.g. "proc" from "import * as proc from child_process"
+                            libImportName = specifier.local.name
+                        } else if (
+                            // Detect importing directly, e.g. "import { exec } from child_process"
+                            specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+                            disallowedFunctions.has(specifier.imported.name)
+                        ) {
+                            context.report({
+                                node,
+                                messageId: 'errMsg',
+                            })
+                        }
+                    })
+                }
+            },
+            CallExpression(node: TSESTree.CallExpression) {
+                // Example: proc.execSync('...')
+                if (
+                    !libImportName || // child_process not imported
+                    node.callee.type !== AST_NODE_TYPES.MemberExpression || // proc.execSync
+                    node.callee.object.type !== AST_NODE_TYPES.Identifier || // object is proc
+                    node.callee.property.type !== AST_NODE_TYPES.Identifier // property is execSync
+                ) {
+                    return
+                }
+                if (
+                    node.callee.object.name === libImportName && // "proc" is the name from the statement "import * as proc from child_process"
+                    disallowedFunctions.has(node.callee.property.name)
+                ) {
+                    return context.report({
+                        node,
+                        messageId: 'errMsg',
+                    })
+                }
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'Program:exit'() {
+                // Reset after each file is checked
+                libImportName = undefined
+            },
+        }
+    },
+}) as unknown as Rule.RuleModule

--- a/plugins/eslint-plugin-aws-toolkits/test/rules/no-string-exec-for-child-process.test.ts
+++ b/plugins/eslint-plugin-aws-toolkits/test/rules/no-string-exec-for-child-process.test.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { rules } from '../../index'
+import { errMsg } from '../../lib/rules/no-string-exec-for-child-process'
+import { getRuleTester } from '../testUtil'
+
+getRuleTester().run('no-string-exec-for-child-process', rules['no-string-exec-for-child-process'], {
+    valid: [
+        "import * as proc from 'child_process'; proc.execFile('ls -h')",
+        "import * as child_process from 'child_process'; child_process.execFile('ls -h')",
+        "import { execFileSync } from 'child_process'; execFile('ls -h')",
+    ],
+    invalid: [
+        {
+            code: "import * as proc from 'child_process'; proc.execSync('ls -h');",
+            errors: [errMsg],
+        },
+        {
+            code: "import * as child_process from 'child_process'; child_process.exec('ls -h');",
+            errors: [errMsg],
+        },
+        {
+            code: "import { execSync } from 'child_process'; execSync('ls -h');",
+            errors: [errMsg],
+        },
+        {
+            code: "import { exec } from 'child_process'; exec('ls -h')",
+            errors: [errMsg],
+        },
+        {
+            code: "import { exec, execSync } from 'child_process'; execSync('ls -h');",
+            errors: [errMsg, errMsg],
+        },
+    ],
+})


### PR DESCRIPTION
- Add eslint rule to prevent insecure usage of child_process functions
  - 3P package, security-node/detect-child-process
- Add custom lint rule to prevent usage of "string forms" of child_process functions, e.g. `exec`, `execSync`. Use `execFile`, `execFileSync` instead.

Additional commit:
- [fix: child_process lint rule violations typo in policy checks command](https://github.com/aws/aws-toolkit-vscode/pull/5074/commits/a6c56e2191654b49be46539ce304413c79e5edc1)

### TODO
- Disallow `shell: true` ?

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
