### PR TITLE
fix(/dev): conversation id log message is now homogeneous and similar to the customer facing text

### DIFF
--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -34,7 +34,14 @@ import { placeholder } from '../../../shared/vscode/commands2'
 import { EditorContentController } from '../../../amazonq/commons/controllers/contentController'
 import { openUrl } from '../../../shared/utilities/vsCodeUtils'
 import { getPathsFromZipFilePath } from '../../util/files'
-import { examples, newTaskChanges, approachCreation, sessionClosed, updateCode } from '../../userFacingText'
+import {
+    examples,
+    newTaskChanges,
+    approachCreation,
+    sessionClosed,
+    updateCode,
+    logWithConversationId,
+} from '../../userFacingText'
 import { getWorkspaceFoldersByPrefixes } from '../../../shared/utilities/workspaceUtils'
 
 export interface ChatControllerEventEmitters {
@@ -321,7 +328,7 @@ export class FeatureDevController {
     private async onApproachGeneration(session: Session, message: string, tabID: string) {
         await session.preloader(message)
 
-        getLogger().info(`${featureName} conversation id: ${session.conversationId}`)
+        getLogger().info(logWithConversationId(session.conversationId))
 
         // This is a loading animation
         this.messenger.sendAnswer({
@@ -366,7 +373,7 @@ export class FeatureDevController {
      * Handle a regular incoming message when a user is in the code generation phase
      */
     private async onCodeGeneration(session: Session, message: string, tabID: string) {
-        getLogger().info(`Q - Dev chat conversation id: ${session.conversationId}`)
+        getLogger().info(logWithConversationId(session.conversationId))
 
         // lock the UI/show loading bubbles
         this.messenger.sendAsyncEventProgress(

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../views/connector/connector'
 import { AppToWebViewMessageDispatcher } from '../../../views/connector/connector'
 import { ChatItemAction } from '@aws/mynah-ui'
+import { messageWithConversationId } from '../../../userFacingText'
 
 export class Messenger {
     public constructor(private readonly dispatcher: AppToWebViewMessageDispatcher) {}
@@ -62,8 +63,6 @@ export class Messenger {
         phase?: SessionStatePhase,
         conversationId?: string
     ) {
-        const conversationIdText = conversationId ? `\n\nConversation ID: **${conversationId}**` : ''
-
         if (retries === 0) {
             this.sendAnswer({
                 type: 'answer',
@@ -90,7 +89,7 @@ export class Messenger {
                 this.dispatcher.sendErrorMessage(
                     new ErrorMessage(
                         `Sorry, we're experiencing an issue on our side. Would you like to try again?`,
-                        errorMessage + conversationIdText,
+                        errorMessage + messageWithConversationId(conversationId),
                         tabID
                     )
                 )
@@ -99,7 +98,7 @@ export class Messenger {
                 this.dispatcher.sendErrorMessage(
                     new ErrorMessage(
                         `Sorry, we're experiencing an issue on our side. Would you like to try again?`,
-                        errorMessage + conversationIdText,
+                        errorMessage + messageWithConversationId(conversationId),
                         tabID
                     )
                 )
@@ -109,7 +108,7 @@ export class Messenger {
                 this.dispatcher.sendErrorMessage(
                     new ErrorMessage(
                         `Sorry, we encountered a problem when processing your request.`,
-                        errorMessage + conversationIdText,
+                        errorMessage + messageWithConversationId(conversationId),
                         tabID
                     )
                 )

--- a/packages/core/src/amazonqFeatureDev/userFacingText.ts
+++ b/packages/core/src/amazonqFeatureDev/userFacingText.ts
@@ -5,11 +5,12 @@
 
 import { manageAccessGuideURL } from '../amazonq/webview/ui/texts/constants'
 import { userGuideURL } from '../amazonq/webview/ui/texts/constants'
+import { featureName } from './constants'
 
 export const examples = `
 You can use /dev to:
 - Add a new feature or logic
-- Write tests 
+- Write tests
 - Fix a bug in your project
 - Generate a README for a file, folder, or project
 
@@ -21,3 +22,8 @@ export const updateCode = 'Code has been updated. Would you like to work on anot
 export const sessionClosed = 'Your session is now closed.'
 export const newTaskChanges = 'What change would you like to make?'
 export const uploadCodeError = `Amazon Q is unable to upload workspace artifacts to S3 for feature development. For more information, see the [Amazon Q documentation](${manageAccessGuideURL}) or contact your network or organization administrator.`
+
+// Utils for logging and showing customer facing conversation id text
+export const messageWithConversationId = (conversationId?: string) =>
+    conversationId ? `\n\nConversation ID: **${conversationId}**` : ''
+export const logWithConversationId = (conversationId: string) => `${featureName} Conversation ID: ${conversationId}`


### PR DESCRIPTION
## Problem

The log lines for helping the customer get its conversation ID where not homogeneous between the plan and code generation phase, as well as with the ui chat message.

## Solution

Now all logs will have the same format `featureName Conversation ID: conversationId`. Note that Conversation ID text is now similar to the ui chat message.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
