### PR TITLE
fix(featureDev): The plan disappears after clicking generate Code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3336,9 +3336,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.1.tgz",
-            "integrity": "sha512-mVatvO/08jndDaCdVQnJu9DrBoTPxjdmxXE1koQi/BGqm4Wqs1dm7FQfhUpfX3LlRzgmMjAwMafAvABjGkTQ8w==",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.2.tgz",
+            "integrity": "sha512-w8xAyFhi5nTy+aMBo/AEGSx+FtPhzaVrjjtfQz5g8gJDFoWmVdGI1vIJCZcz6cHHyV/7acb7ULcOYY5Do4uWoQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",
@@ -18889,7 +18889,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.9.1",
+                "@aws/mynah-ui": "^4.9.2",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-9585bc97-bea1-4abe-8928-6c753e18047e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-9585bc97-bea1-4abe-8928-6c753e18047e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "fix(featureDev): The plan disappears after clicking generate Code"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-9585bc97-bea1-4abe-8928-6c753e18047e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-9585bc97-bea1-4abe-8928-6c753e18047e.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "fix(featureDev): The plan disappears after clicking generate Code"
-}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4042,7 +4042,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.9.1",
+        "@aws/mynah-ui": "^4.9.2",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -323,24 +323,20 @@ export class FeatureDevController {
 
         getLogger().info(`${featureName} conversation id: ${session.conversationId}`)
 
+        // This is a loading animation
         this.messenger.sendAnswer({
-            type: 'answer',
+            type: 'answer-stream',
             tabID,
             message: approachCreation,
         })
 
-        // Ensure that the loading icon stays showing
-        this.messenger.sendAsyncEventProgress(tabID, true, undefined)
-
-        this.messenger.sendUpdatePlaceholder(tabID, 'Generating plan ...')
-
         const interactions = await session.send(message)
         this.messenger.sendUpdatePlaceholder(tabID, 'How can this plan be improved?')
 
-        // Resolve the "..." with the content
+        // This is were we get the plan fully and add it to the chat.
         this.messenger.sendAnswer({
             message: interactions.content,
-            type: 'answer-part',
+            type: 'answer',
             tabID: tabID,
             canBeVoted: true,
         })

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -330,6 +330,8 @@ export class FeatureDevController {
             message: approachCreation,
         })
 
+        this.messenger.sendUpdatePlaceholder(tabID, 'Generating plan ...')
+
         const interactions = await session.send(message)
         this.messenger.sendUpdatePlaceholder(tabID, 'How can this plan be improved?')
 


### PR DESCRIPTION
## Problem
The plan disappears after clicking generate Code

This is a _critical_ bug for featureDev.
How it was fixed:
Initially, 'ANSWER_STREAM' card is created (with a loading animation). When the plan content is ready, the card type is updated  to 'ANSWER'. This prevents the updateLastChatAnswer method from catching and updating the card, allowing the complete plan content to be displayed correctly.

What is being fixed:
- Plan is shown at all times

Note:
- File rejection is still in place
![image](https://github.com/aws/aws-toolkit-vscode/assets/144136687/6f8dbe9a-945f-4fbf-a6aa-c4c86684e121)
![Screenshot 2024-05-30 at 13 24 27](https://github.com/aws/aws-toolkit-vscode/assets/144136687/660d6294-eb4b-43bb-9a3a-c1d652dfbc31)

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
