### PR TITLE
fix: race condition between globals registration and extension test activation

### DIFF
--- a/packages/core/src/testInteg/globalSetup.test.ts
+++ b/packages/core/src/testInteg/globalSetup.test.ts
@@ -9,7 +9,6 @@
 import vscode from 'vscode'
 import { getLogger } from '../shared/logger'
 import { WinstonToolkitLogger } from '../shared/logger/winstonToolkitLogger'
-import { activateExtension } from '../shared/utilities/vsCodeUtils'
 import { mapTestErrors, normalizeError, patchObject, setRunnableTimeout } from '../test/setupUtil'
 import { getTestWindow, resetTestWindow } from '../test/shared/vscode/window'
 
@@ -33,7 +32,7 @@ export async function mochaGlobalSetup(extensionId: string) {
         patchWindow()
 
         // Needed for getLogger().
-        await activateExtension(extensionId, false)
+        await vscode.extensions.getExtension(extensionId)?.activate()
 
         // Log as much as possible, useful for debugging integration tests.
         getLogger().setLogLevel('debug')


### PR DESCRIPTION
## Problem:
- In globalSetup we use activateExtension which relies on globals being registered under the hood (inside of the Timeout). If globals aren't registered before we get to that code then the toolkit immediately stops running. This is evident when you use the VSCode current file test launch configs. I _think_ the reason why this doesn't happen when running all the e2e/integ tests is because the glob pattern takes longer to find all the files to load into mocha, giving more time for the extension to activate before the tests are actually ran

## Solution:
- Just use vscode.extensions.getExtension directly though we technically lose the 60000 timeout. ~~In the worst case I think VSCode would just close anyways because that means the extension failed to activate~~. In the worst case the editor just stays open, which is what happens now anyways since errors don't cause VSCode tests to close

## Alternative solutions:
- Re-implement the timeout without using global clock but that could mean a lot of refactoring for tests that rely on it
- Re-implement a seperate timeout that doesn't use global clock but is essentially duplicate code except for the fact it just uses Date directly vs global.clock.Date
- Don't use the waitUntil function inside of activeExtension and just re-implement a small function that activates the extension or fails after 60000 seconds inside of global setup

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
