### PR TITLE
ci: add compile checking to subprojects

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -46,7 +46,7 @@
     "browser": "./dist/src/extensionWeb",
     "scripts": {
         "vscode:prepublish": "npm run clean && npm run buildScripts && webpack --mode production",
-        "buildScripts": "npm run generateNonCodeFiles && npm run copyFiles && npm run syncPackageJson",
+        "buildScripts": "npm run generateNonCodeFiles && npm run copyFiles && npm run syncPackageJson && tsc -p ./ --noEmit",
         "generateNonCodeFiles": "ts-node ../../scripts/generateNonCodeFiles.ts",
         "copyFiles": "ts-node ./scripts/build/copyFiles.ts",
         "syncPackageJson": "ts-node ./scripts/build/syncPackageJson.ts",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -55,7 +55,7 @@
     "contributes": "This field will be autopopulated from the core module during debugging and packaging.",
     "scripts": {
         "vscode:prepublish": "npm run clean && npm run buildScripts && webpack --mode production",
-        "buildScripts": "npm run generateNonCodeFiles && npm run copyFiles",
+        "buildScripts": "npm run generateNonCodeFiles && npm run copyFiles && tsc -p ./ --noEmit",
         "generateNonCodeFiles": "ts-node ../../scripts/generateNonCodeFiles.ts",
         "copyFiles": "ts-node ./scripts/build/copyFiles.ts",
         "clean": "ts-node ../../scripts/clean.ts dist/ LICENSE NOTICE quickStart*",


### PR DESCRIPTION
Problem: Subprojects (not core/) are not compiled normally, and webpack uses `esbuild-loader`. This results in no typescript compilation checks during build and packaging.
Note: by design `esbuild-loader` does not offer this, see https://github.com/privatenumber/esbuild-loader?tab=readme-ov-file#type-checking

Solution: Add a type check to buildScripts.

I did not notice any significant slow down, but if this is noticed later, we can instead use this recommended dependency https://github.com/TypeStrong/fork-ts-checker-webpack-plugin

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
