### PR TITLE
release: update publish vsix node version

### DIFF
--- a/buildspec/release/60publish.yml
+++ b/buildspec/release/60publish.yml
@@ -7,7 +7,7 @@ version: 0.2
 phases:
     install:
         runtime-versions:
-            nodejs: 16
+            nodejs: 20
         commands:
             - apt-get update
             - apt-get install -y libsecret-1-dev


### PR DESCRIPTION
## Problem
- the lowest node version that can be used for open vsx is node 18. We currently use node 16 which fails the release process with `ovsx requires at least NodeJS version 18. Check your installed version with node --version.`

## Solution
- use node 20

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
