### PR TITLE
fix(codelens): set AmazonQ chat to open by default

### DIFF
--- a/packages/core/src/codewhispererChat/editor/codelens.ts
+++ b/packages/core/src/codewhispererChat/editor/codelens.ts
@@ -38,7 +38,8 @@ export class TryChatCodeLensProvider implements vscode.CodeLensProvider {
     private static providerDisposable: vscode.Disposable | undefined = undefined
     private disposables: vscode.Disposable[] = []
 
-    private isAmazonQVisible: boolean = false
+    // Assumption: Amazon Q is visible by default and codelens should be hidden
+    private isAmazonQVisible: boolean = true
 
     constructor(
         isAmazonQVisibleEvent: vscode.Event<boolean>,

--- a/packages/core/src/test/codewhispererChat/editor/codelens.test.ts
+++ b/packages/core/src/test/codewhispererChat/editor/codelens.test.ts
@@ -63,7 +63,7 @@ describe('TryChatCodeLensProvider', () => {
 
     it('keeps returning a code lense until it hits the max times it should show', async function () {
         stubConnection('connected')
-
+        isAmazonQVisibleEventEmitter.fire(false)
         let codeLensCount = 0
         const modifierKey = resolveModifierKey()
         while (codeLensCount < 10) {
@@ -123,6 +123,7 @@ describe('TryChatCodeLensProvider', () => {
 
     it('does show codelens if lineAnnotationController (tips) is in end state', async function () {
         stubConnection('connected')
+        isAmazonQVisibleEventEmitter.fire(false)
         // indicate lineAnnotationController is not visible and in end state
         await globals.context.globalState.update(inlinehintKey, EndState.id)
 


### PR DESCRIPTION
## Problem
- Default Case: New user installs Amazon Q and Chat is open with Tips.
- When a user closes the tip, the codelens is visible. This is because the `isAmazonQChatVisible` event is not triggered until explicit action by the user

## Solution
- Set default value for `isAmazonQVisible` to `true`. 
- Now codelens will be only be visible when the user manually opens the chat window.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
