### PR TITLE
fix(login): pre-select auth option for the user

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -366,13 +366,16 @@ export default defineComponent({
         await this.emitUpdate('created')
     },
 
-    mounted() {
+    async mounted() {
         this.fetchRegions()
-        void this.updateExistingConnections()
+        await this.updateExistingConnections()
 
         // Reset gathered telemetry data each time we view the login page.
         // The webview panel is reset on each view of the login page by design.
-        void client.resetStoredMetricMetadata()
+        client.resetStoredMetricMetadata()
+
+        // Pre-select the first available login option
+        await this.preselectLoginOption()
     },
     methods: {
         toggleItemSelection(itemId: number) {
@@ -562,6 +565,17 @@ export default defineComponent({
         },
         handleHelpLinkClick() {
             void client.emitUiClick('auth_helpLink')
+        },
+        async preselectLoginOption() {
+            // Select the first available option for Login
+            if (this.existingLogins.length > 0) {
+                this.selectedLoginOption = LoginOption.EXISTING_LOGINS
+            } else if (this.app === 'AMAZONQ') {
+                this.selectedLoginOption = LoginOption.BUILDER_ID
+            } else if (this.app === 'TOOLKIT') {
+                this.selectedLoginOption = LoginOption.ENTERPRISE_SSO
+            }
+            this.$forceUpdate()
         },
         shouldDisableSsoContinue() {
             return this.startUrl.length == 0 || this.startUrlError.length > 0 || !this.selectedRegion


### PR DESCRIPTION
## Problem
Users have to manually select one of the auth options for Login

## Solution
In order to reduce the friction and one click, we pre-select the first option by default. 

**Note**
- In case of existing logins, we still select the default option as we are in process of separating out auth.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
