### PR TITLE
feat(featureDev): Include credentialStartUrl in all featureDev telemetry events

### DIFF
--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -187,12 +187,14 @@ export class FeatureDevController {
                         amazonqConversationId: session?.conversationId,
                         value: 1,
                         result: 'Succeeded',
+                        credentialStartUrl: AuthUtil.instance.startUrl,
                     })
                 } else if (vote === 'downvote') {
                     telemetry.amazonq_codeGenerationThumbsDown.emit({
                         amazonqConversationId: session?.conversationId,
                         value: 1,
                         result: 'Succeeded',
+                        credentialStartUrl: AuthUtil.instance.startUrl,
                     })
                 }
                 break
@@ -490,6 +492,7 @@ export class FeatureDevController {
                 acceptedFiles(session.state.filePaths) + acceptedFiles(session.state.deletedFiles)
 
             telemetry.amazonq_isAcceptedCodeChanges.emit({
+                credentialStartUrl: AuthUtil.instance.startUrl,
                 amazonqConversationId: session.conversationId,
                 amazonqNumberOfFilesAccepted,
                 enabled: true,
@@ -540,6 +543,7 @@ export class FeatureDevController {
             amazonqConversationId: session.conversationId,
             enabled: true,
             result: 'Succeeded',
+            credentialStartUrl: AuthUtil.instance.startUrl,
         })
         // Unblock the message button
         this.messenger.sendAsyncEventProgress(message.tabID, false, undefined)

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -125,6 +125,7 @@ export class Session {
             amazonqConversationId: this.conversationId,
             enabled: true,
             result: 'Succeeded',
+            credentialStartUrl: AuthUtil.instance.startUrl,
         })
     }
 

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -309,7 +309,11 @@ export class CodeGenState extends CodeGenBase implements SessionState {
     async interact(action: SessionStateAction): Promise<SessionStateInteraction> {
         return telemetry.amazonq_codeGenerationInvoke.run(async span => {
             try {
-                span.record({ amazonqConversationId: this.config.conversationId })
+                span.record({
+                    amazonqConversationId: this.config.conversationId,
+                    credentialStartUrl: AuthUtil.instance.startUrl,
+                })
+
                 action.telemetry.setGenerateCodeIteration(this.currentIteration)
                 action.telemetry.setGenerateCodeLastInvocationTime()
 
@@ -471,6 +475,10 @@ export class PrepareCodeGenState implements SessionState {
         })
 
         const uploadId = await telemetry.amazonq_createUpload.run(async span => {
+            span.record({
+                amazonqConversationId: this.config.conversationId,
+                credentialStartUrl: AuthUtil.instance.startUrl,
+            })
             const { zipFileBuffer, zipFileChecksum } = await prepareRepoData(
                 this.config.workspaceRoots,
                 this.config.workspaceFolders,


### PR DESCRIPTION
## Problem

Some of the featureDev telemetry events were missing the `credentialStartUrl` field.

## Solution

Added the missing field to all the featureDev telemetry events that didn't already have it.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
