### PR TITLE
Amazon Q Transform: increase project size limit to 2GB

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-671df6a0-7485-4d2d-a010-a3e39ac126d4.json
+++ b/packages/amazonq/.changes/next-release/Feature-671df6a0-7485-4d2d-a010-a3e39ac126d4.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Amazon Q Transform: Increase project upload size limit to 5GB"
+	"description": "Amazon Q Transform: Increase project upload size limit to 2GB"
 }

--- a/packages/amazonq/.changes/next-release/Feature-671df6a0-7485-4d2d-a010-a3e39ac126d4.json
+++ b/packages/amazonq/.changes/next-release/Feature-671df6a0-7485-4d2d-a010-a3e39ac126d4.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q Transform: Increase project upload size limit to 5GB"
+}

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -336,8 +336,7 @@ export const newCustomizationMessage = 'You have access to new Amazon Q customiz
 export const newCustomizationsAvailableKey = 'aws.amazonq.codewhisperer.newCustomizations'
 
 // Start of QCT Strings
-
-export const uploadZipSizeLimitInBytes = 5000000000 // 5GB
+export const uploadZipSizeLimitInBytes = 2000000000 // 2GB
 
 export const maxBufferSize = 1024 * 1024 * 8 // this is 8MB; the default max buffer size for stdout for spawnSync is 1MB
 
@@ -598,10 +597,10 @@ export const nonWindowsJava11HomeHelpChatMessage =
     'To find the JDK path, run the following command in a new IDE terminal:  `/usr/libexec/java_home -v 11`'
 
 export const projectSizeTooLargeChatMessage =
-    'Sorry, your project size exceeds the Amazon Q Code Transformation upload limit of 5GB. For more information, see the [Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-size-limit).'
+    'Sorry, your project size exceeds the Amazon Q Code Transformation upload limit of 2GB. For more information, see the [Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-size-limit).'
 
 export const projectSizeTooLargeNotification =
-    'Your project size exceeds the Amazon Q Code Transformation upload limit of 5GB. For more information, see the [Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-size-limit).'
+    'Your project size exceeds the Amazon Q Code Transformation upload limit of 2GB. For more information, see the [Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-size-limit).'
 
 export const JDK8VersionNumber = '52'
 

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -337,7 +337,7 @@ export const newCustomizationsAvailableKey = 'aws.amazonq.codewhisperer.newCusto
 
 // Start of QCT Strings
 
-export const uploadZipSizeLimitInBytes = 1000000000 // 1GB
+export const uploadZipSizeLimitInBytes = 5000000000 // 5GB
 
 export const maxBufferSize = 1024 * 1024 * 8 // this is 8MB; the default max buffer size for stdout for spawnSync is 1MB
 
@@ -598,10 +598,10 @@ export const nonWindowsJava11HomeHelpChatMessage =
     'To find the JDK path, run the following command in a new IDE terminal:  `/usr/libexec/java_home -v 11`'
 
 export const projectSizeTooLargeChatMessage =
-    'Sorry, your project size exceeds the Amazon Q Code Transformation upload limit of 1GB. For more information, see the [Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-size-limit).'
+    'Sorry, your project size exceeds the Amazon Q Code Transformation upload limit of 5GB. For more information, see the [Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-size-limit).'
 
 export const projectSizeTooLargeNotification =
-    'Your project size exceeds the Amazon Q Code Transformation upload limit of 1GB. For more information, see the [Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-size-limit).'
+    'Your project size exceeds the Amazon Q Code Transformation upload limit of 5GB. For more information, see the [Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-size-limit).'
 
 export const JDK8VersionNumber = '52'
 


### PR DESCRIPTION
## Problem
Increase Code Transform project upload limit from 1GB to 2GB

## Solution
Increase Code Transform project upload limit from 1GB to 2GB

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
