### PR TITLE
feat(amazonq): display notification for sign in

### DIFF
--- a/packages/amazonq/src/extensionShared.ts
+++ b/packages/amazonq/src/extensionShared.ts
@@ -28,7 +28,7 @@ import {
 } from 'aws-core-vscode/shared'
 import { initializeAuth, CredentialsStore, LoginManager, AuthUtils } from 'aws-core-vscode/auth'
 import { makeEndpointsProvider, registerGenericCommands } from 'aws-core-vscode'
-import { activate as activateCWChat } from 'aws-core-vscode/amazonq'
+import { DefaultAmazonQAppInitContext, activate as activateCWChat } from 'aws-core-vscode/amazonq'
 import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
 import { CommonAuthViewProvider, CommonAuthWebview } from 'aws-core-vscode/login'
 import { isExtensionActive, VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
@@ -109,7 +109,11 @@ export async function activateShared(context: vscode.ExtensionContext, isWeb: bo
     // Amazon Q specific commands
     registerCommands(context)
 
-    const authProvider = new CommonAuthViewProvider(context, contextPrefix)
+    const authProvider = new CommonAuthViewProvider(
+        context,
+        contextPrefix,
+        DefaultAmazonQAppInitContext.instance.onDidChangeAmazonQVisibility
+    )
     context.subscriptions.push(
         vscode.commands.registerCommand('amazonq.dev.openMenu', async () => {
             if (!isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)) {

--- a/packages/core/src/amazonq/activation.ts
+++ b/packages/core/src/amazonq/activation.ts
@@ -14,9 +14,15 @@ import { activateBadge } from './util/viewBadgeHandler'
 import { amazonQHelpUrl } from '../shared/constants'
 import { focusAmazonQChatWalkthrough, openAmazonQWalkthrough } from './onboardingPage/walkthrough'
 import { listCodeWhispererCommandsWalkthrough } from '../codewhisperer/ui/statusBarMenu'
-import { Commands } from '../shared/vscode/commands2'
+import { Commands, placeholder } from '../shared/vscode/commands2'
 import { focusAmazonQPanel, focusAmazonQPanelKeybinding } from '../codewhispererChat/commands/registerCommands'
 import { TryChatCodeLensProvider, tryChatCodeLensCommand } from '../codewhispererChat/editor/codelens'
+import { Auth } from '../auth'
+import { learnMoreUri } from '../codewhisperer/models/constants'
+import { openUrl } from '../shared/utilities/vsCodeUtils'
+import { AuthUtil } from '../codewhisperer'
+import { ConnectionStateChangeEvent } from '../auth/auth'
+import { telemetry } from '../shared/telemetry'
 
 export async function activate(context: ExtensionContext) {
     const appInitContext = DefaultAmazonQAppInitContext.instance
@@ -51,10 +57,101 @@ export async function activate(context: ExtensionContext) {
     })
 
     await activateBadge()
+    void setupAuthNotification(
+        appInitContext.onDidChangeAmazonQVisibility.event,
+        Auth.instance.onDidChangeConnectionState
+    )
 }
 
 function registerApps(appInitContext: AmazonQAppInitContext) {
     cwChatAppInit(appInitContext)
     featureDevChatAppInit(appInitContext)
     gumbyChatAppInit(appInitContext)
+}
+
+/**
+ * Display a notification to user for Log In.
+ *
+ * Authentication Notification is displayed when:
+ * - The user closes the Amazon Q chat panel, and
+ * - The user has not performed any authentication action.
+ *
+ * Error Notification is displayed when:
+ * - The user closes the Amazon Q chat panel, and
+ * - The user attempts an authentication action but is not logged in.
+ *
+ * @param {Event} onAmazonQChatVisibility - Event indicating the visibility status of the Amazon Q chat.
+ * @param {Event} onDidUpdateConnection - Event indicating the authentication connection update.
+ */
+async function setupAuthNotification(
+    onAmazonQChatVisibility: vscode.Event<boolean>,
+    onDidUpdateConnection: vscode.Event<ConnectionStateChangeEvent | undefined>
+) {
+    let isAmazonQVisible = true // Assume Chat is open by default.
+    let notificationDisplayed = false // Auth Notification should be displayed only once.
+    let authConnection: ConnectionStateChangeEvent
+
+    // Updates the visibility state of the Amazon Q chat.
+    const updateVisibility = async (visible: boolean) => {
+        isAmazonQVisible = visible
+        await tryShowNotification()
+    }
+
+    // Updates the source of the connection for Amazon Q sign in.
+    const updateConnection = async (connection: ConnectionStateChangeEvent | undefined) => {
+        if (connection) {
+            authConnection = connection
+            await tryShowNotification()
+        }
+    }
+
+    const disposables: vscode.Disposable[] = [
+        onAmazonQChatVisibility(updateVisibility),
+        onDidUpdateConnection(updateConnection),
+    ]
+
+    async function tryShowNotification() {
+        if (notificationDisplayed || Auth.instance.activeConnection) {
+            return
+        }
+
+        const source = 'authNotification'
+
+        if (!isAmazonQVisible && !authConnection && !AuthUtil.instance.isConnectionExpired()) {
+            const buttonAction = 'Sign In'
+            notificationDisplayed = true
+            disposables.forEach(item => item.dispose())
+
+            telemetry.toolkit_showNotification.emit({
+                component: 'editor',
+                id: source,
+                reason: 'notLoggedIn',
+                result: 'Succeeded',
+            })
+            const selection = await vscode.window.showWarningMessage('Start using Amazon Q', buttonAction)
+
+            if (selection === buttonAction) {
+                void focusAmazonQPanel.execute(placeholder, source)
+            }
+        } else if (!isAmazonQVisible && authConnection.state === 'authenticating') {
+            const buttonAction = 'Open documentation'
+            notificationDisplayed = true
+            disposables.forEach(item => item.dispose())
+
+            telemetry.toolkit_showNotification.emit({
+                component: 'editor',
+                id: source,
+                reason: 'authenticating',
+                result: 'Succeeded',
+            })
+            const selection = await vscode.window.showWarningMessage(
+                'See Amazon Q documentation for help on signing in',
+                buttonAction
+            )
+
+            if (selection === buttonAction) {
+                void openUrl(vscode.Uri.parse(`${learnMoreUri}#q-in-IDE-setup-bid`), source)
+            }
+        }
+    }
 }

--- a/packages/core/src/shared/utilities/vsCodeUtils.ts
+++ b/packages/core/src/shared/utilities/vsCodeUtils.ts
@@ -214,9 +214,9 @@ export function reloadWindowPrompt(message: string): void {
  * Opens a URL in the system web browser. Throws `CancellationError`
  * if user dismisses the vscode confirmation prompt.
  */
-export async function openUrl(url: vscode.Uri): Promise<boolean> {
+export async function openUrl(url: vscode.Uri, source?: string): Promise<boolean> {
     return telemetry.aws_openUrl.run(async span => {
-        span.record({ url: url.toString() })
+        span.record({ url: url.toString(), source })
         const didOpen = await vscode.env.openExternal(url)
         if (!didOpen) {
             throw new CancellationError('user')


### PR DESCRIPTION
## Problem
- Prompt user to sign-in into Amazon Q if they close the chat and haven't logged in. Display the notification only once. 
- Prompt the user with help link if they close the chat and were still authenticating. 

## Solution
Display a notification to the user prompting for Sign In int Amazon Q.

User will see the notification if both the following conditions are met (i.e AND condition)
- User has manually closed the Amazon Q Sidepanel (this is necessary because by default we assume the sidebar is open).
- User has never attempted auth (aka clicked on the final continue button that opened the browser either for builder id or for idc connection).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
