### PR TITLE
feat(featureDev): generated plan being shown from top

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-b82b73bc-9076-4cf3-8938-281f79de96a9.json
+++ b/packages/amazonq/.changes/next-release/Feature-b82b73bc-9076-4cf3-8938-281f79de96a9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "feat(featureDev): generated plan being shown from top"
+}

--- a/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
@@ -141,6 +141,7 @@ export class Connector {
                 messageId: messageData.messageID ?? messageData.triggerID ?? '',
                 relatedContent: undefined,
                 canBeVoted: messageData.canBeVoted,
+                snapToTop: messageData.snapToTop,
                 followUp:
                     messageData.followUps !== undefined && messageData.followUps.length > 0
                         ? {

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -348,6 +348,7 @@ export class FeatureDevController {
             type: 'answer',
             tabID: tabID,
             canBeVoted: true,
+            snapToTop: true,
         })
 
         if (interactions.responseType === 'VALID') {

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -32,6 +32,7 @@ export class Messenger {
         followUps?: ChatItemAction[]
         tabID: string
         canBeVoted?: boolean
+        snapToTop?: boolean
     }) {
         this.dispatcher.sendChatMessage(
             new ChatMessage(
@@ -41,6 +42,7 @@ export class Messenger {
                     followUps: params.followUps,
                     relatedSuggestions: undefined,
                     canBeVoted: params.canBeVoted ?? false,
+                    snapToTop: params.snapToTop ?? false,
                 },
                 params.tabID
             )

--- a/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
+++ b/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
@@ -150,6 +150,7 @@ export interface ChatMessageProps {
     readonly followUps: ChatItemAction[] | undefined
     readonly relatedSuggestions: SourceLink[] | undefined
     readonly canBeVoted: boolean
+    readonly snapToTop: boolean
 }
 
 export class ChatMessage extends UiMessage {
@@ -159,6 +160,7 @@ export class ChatMessage extends UiMessage {
     readonly relatedSuggestions: SourceLink[] | undefined
     readonly canBeVoted: boolean
     readonly requestID!: string
+    readonly snapToTop: boolean
     override type = 'chatMessage'
 
     constructor(props: ChatMessageProps, tabID: string) {
@@ -168,6 +170,7 @@ export class ChatMessage extends UiMessage {
         this.followUps = props.followUps
         this.relatedSuggestions = props.relatedSuggestions
         this.canBeVoted = props.canBeVoted
+        this.snapToTop = props.snapToTop
     }
 }
 


### PR DESCRIPTION
## Problem 
feat(featureDev): add snapToTop prop for geneterated plan

when a WB response comes out, we don’t auto scroll all the way to the bottom or at all.
So once the Plan is generated the customer will see the the top of the plan instead of the end of it
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
