### PR TITLE
fix(featureDev): fix file rejection for multi-workspaces

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-ebf9c5eb-9b16-4e14-acd9-85323144b08d.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-ebf9c5eb-9b16-4e14-acd9-85323144b08d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "fix(featureDev): fix file rejection for multi-workspaces"
+}

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -239,8 +239,8 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
                 type: ChatItemType.ANSWER,
                 fileList: {
                     rootFolderTitle: 'Changes',
-                    filePaths: filePaths.map(i => i.relativePath),
-                    deletedFiles: deletedFiles.map(i => i.relativePath),
+                    filePaths: filePaths.map(i => i.zipFilePath),
+                    deletedFiles: deletedFiles.map(i => i.zipFilePath),
                     details: getDetails(filePaths),
                     actions: getActions([...filePaths, ...deletedFiles]),
                 },


### PR DESCRIPTION
## Problem
Notes: 
File rejections **works** when using a multirepo at the moment, though it doesn't work inside of some packaging extensions, because special characters can be appended, eg this packaging emoji.
Example:
<img width="793" alt="Screenshot 2024-06-04 at 10 37 00" src="https://github.com/aws/aws-toolkit-vscode/assets/144136687/6d5ef0ed-5ec4-4fe0-8951-5e365caf4c5d">
The file is hovered but cannot be rejected. This is [redacted] workspace.

When I tried with a "simple" multirepo it was working as expected.
## Solution
When we processCodeResultMessage we use zipFilePath
When we are calling to updateFile state, eg(reject/accept) we use relativePath.
Using zipFilePath in both places fixed the issue:
<img width="608" alt="Screenshot 2024-06-04 at 17 35 27" src="https://github.com/aws/aws-toolkit-vscode/assets/144136687/cc946d56-77b2-41b7-b9c3-b81125605ead">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
