### PR TITLE
refactor(auth): remove connection sharing between extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Coverage](https://img.shields.io/codecov/c/github/aws/aws-toolkit-vscode/master.svg)](https://codecov.io/gh/aws/aws-toolkit-vscode/branch/master)
 
-This project is open source. We love issues, feature requests, code reviews, pull requests or any
-positive contribution. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+This project is open source. We encourage issues, feature requests, code reviews, pull requests or
+any positive contribution. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
 
 ### Amazon Q
 

--- a/packages/amazonq/.changes/next-release/Bug Fix-17572ed1-4601-4554-9144-9eb5143bf0ff.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-17572ed1-4601-4554-9144-9eb5143bf0ff.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q inline suggestions: remember `Pause Auto-Suggestions` after IDE restart"
+}

--- a/packages/amazonq/README.md
+++ b/packages/amazonq/README.md
@@ -5,7 +5,7 @@
 
 # Getting Started
 
-**Free Tier** - create or log in with an AWS Builder ID (no AWS account needed!).
+**Free Tier** - create or log in with an AWS Builder ID (a personal profile from AWS).
 
 **Pro Tier** - if your organization is on the Amazon Q Developer Pro tier, log in with single sign-on.
 

--- a/packages/amazonq/README.md
+++ b/packages/amazonq/README.md
@@ -1,11 +1,7 @@
-[![Twitter Follow](https://img.shields.io/twitter/follow/aws?logo=twitter&style=social)](https://twitter.com/awscloud)
-[![Youtube Channel Views](https://img.shields.io/youtube/channel/views/UCd6MoB9NC6uYN2grvUNT-Zg?style=social)](https://www.youtube.com/@amazonwebservices)
-[![Try Amazon Q free trial](https://img.shields.io/badge/Try%20Amazon%20Q-Free%20trial-success)](https://aws.amazon.com/q/developer/?editor=vscode)
-![Marketplace Downloads](https://img.shields.io/vscode-marketplace/d/AmazonWebServices.amazon-q-vscode.svg)
-
-# Inline code suggestions
-
-Code faster with inline code suggestions as you type.
+![Try Amazon Q Free Tier](https://img.shields.io/badge/Try%20Amazon%20Q-Free%20Tier-success?style=flat-square)
+[![Twitter Follow](https://img.shields.io/badge/follow-@aws-1DA1F2?style=flat-square&logo=aws&logoColor=white&label=Follow)](https://x.com/awscloud)
+[![Youtube Channel Views](https://img.shields.io/youtube/channel/views/UCd6MoB9NC6uYN2grvUNT-Zg?style=flat-square&logo=youtube&label=Youtube)](https://www.youtube.com/@amazonwebservices)
+![Marketplace Installs](https://img.shields.io/vscode-marketplace/i/AmazonWebServices.amazon-q-vscode.svg?label=Installs&style=flat-square)
 
 # Getting Started
 
@@ -16,6 +12,10 @@ Code faster with inline code suggestions as you type.
 ![Authentication gif](https://raw.githubusercontent.com/aws/aws-toolkit-vscode/HEAD/docs/marketplace/vscode/amazonq/auth-Q.gif)
 
 # Features
+
+## Inline code suggestions
+
+Code faster with inline code suggestions as you type.
 
 ![Inline code suggestion demo](https://raw.githubusercontent.com/aws/aws-toolkit-vscode/HEAD/docs/marketplace/vscode/amazonq/inline.gif)
 

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -154,13 +154,13 @@
                     "type": "webview",
                     "id": "aws.amazonq.AmazonCommonAuth",
                     "name": "%AWS.amazonq.login%",
-                    "when": "!aws.isSageMaker && aws.amazonq.showLoginView"
+                    "when": "!aws.isSageMaker && !aws.isWebExtHost && aws.amazonq.showLoginView"
                 },
                 {
                     "type": "webview",
                     "id": "aws.AmazonQChatView",
                     "name": "%AWS.amazonq.chat%",
-                    "when": "!aws.isSageMaker && !aws.amazonq.showLoginView"
+                    "when": "!aws.isSageMaker && !aws.isWebExtHost && !aws.amazonq.showLoginView"
                 },
                 {
                     "id": "aws.AmazonQNeverShowBadge",

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -4,12 +4,78 @@
  */
 
 import * as vscode from 'vscode'
-import { activateShared, deactivateShared } from './extensionShared'
+import { activateAmazonQCommon, amazonQContextPrefix, deactivateCommon } from './extensionCommon'
+import { DefaultAmazonQAppInitContext, activate as activateCWChat } from 'aws-core-vscode/amazonq'
+import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
+import { ExtContext } from 'aws-core-vscode/shared'
+import { updateDevMode } from 'aws-core-vscode/dev'
+import { CommonAuthViewProvider } from 'aws-core-vscode/login'
+import { isExtensionActive, VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
+import { registerSubmitFeedback } from 'aws-core-vscode/feedback'
+import { DevFunction } from 'aws-core-vscode/dev'
 
 export async function activate(context: vscode.ExtensionContext) {
-    await activateShared(context, false)
+    // IMPORTANT: No other code should be added to this function. Place it in one of the following 2 functions where appropriate.
+    await activateAmazonQCommon(context, false)
+    await activateAmazonQNonCommon(context)
+}
+
+/**
+ * The code in this function is not common, implying it only works in Node.js and not web.
+ * The goal should be for this to not exist and that all code is "common". So if possible make
+ * the code compatible with web and move it to {@link activateAmazonQCommon}.
+ */
+async function activateAmazonQNonCommon(context: vscode.ExtensionContext) {
+    const extContext = {
+        extensionContext: context,
+    }
+    await activateCWChat(context)
+    await activateQGumby(extContext as ExtContext)
+
+    const authProvider = new CommonAuthViewProvider(
+        context,
+        amazonQContextPrefix,
+        DefaultAmazonQAppInitContext.instance.onDidChangeAmazonQVisibility
+    )
+    context.subscriptions.push(
+        vscode.window.registerWebviewViewProvider(authProvider.viewType, authProvider, {
+            webviewOptions: {
+                retainContextWhenHidden: true,
+            },
+        }),
+        registerSubmitFeedback(context, 'Amazon Q', amazonQContextPrefix)
+    )
+
+    await setupDevMode(context)
+}
+
+/**
+ * Some parts of this do not work in Web mode so we need to set Dev Mode up here.
+ *
+ * TODO: Get the following working in web mode as well and then move this function.
+ */
+async function setupDevMode(context: vscode.ExtensionContext) {
+    // At some point this imports CodeCatalyst code which breaks in web mode.
+    // TODO: Make this work in web mode and move it to extensionCommon.ts
+    await updateDevMode()
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('amazonq.dev.openMenu', async () => {
+            if (!isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)) {
+                void vscode.window.showErrorMessage('AWS Toolkit must be installed to access the Developer Menu.')
+                return
+            }
+            await vscode.commands.executeCommand('_aws.dev.invokeMenu', context, [
+                'editStorage',
+                'showEnvVars',
+                'deleteSsoConnections',
+                'expireSsoConnections',
+                'editAuthConnections',
+            ] as DevFunction[])
+        })
+    )
 }
 
 export async function deactivate() {
-    await deactivateShared()
+    await deactivateCommon()
 }

--- a/packages/amazonq/src/extensionCommon.ts
+++ b/packages/amazonq/src/extensionCommon.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode'
 import * as semver from 'semver'
 import { join } from 'path'
 import {
-    CodeSuggestionsState,
     activate as activateCodeWhisperer,
     shutdown as shutdownCodeWhisperer,
     amazonQDismissedKey,
@@ -112,9 +111,6 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
 
     // reload webviews
     await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction')
-
-    // enable auto suggestions on activation
-    await CodeSuggestionsState.instance.setSuggestionsEnabled(true)
 
     if (AuthUtils.ExtensionUse.instance.isFirstUse()) {
         CommonAuthWebview.authSource = ExtStartUpSources.firstStartUp

--- a/packages/amazonq/src/extensionWeb.ts
+++ b/packages/amazonq/src/extensionWeb.ts
@@ -4,12 +4,14 @@
  */
 
 import type { ExtensionContext } from 'vscode'
-import { activate as activateWeb, deactivate as deactivateWeb } from 'aws-core-vscode/web'
+import { activateWebShared } from 'aws-core-vscode/webShared'
+import { activateAmazonQCommon, deactivateCommon } from './extensionCommon'
 
 export async function activate(context: ExtensionContext) {
-    return activateWeb(context)
+    await activateWebShared(context)
+    await activateAmazonQCommon(context, true)
 }
 
 export async function deactivate() {
-    await deactivateWeb()
+    await deactivateCommon()
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,8 @@
     "exports": {
         ".": "./dist/src/extension.js",
         "./web": "./dist/src/extensionWeb.js",
+        "./webShared": "./dist/src/extensionWebShared.js",
+        "./common": "./dist/src/extensionCommon.js",
         "./amazonq": "./dist/src/amazonq/index.js",
         "./codewhisperer": "./dist/src/codewhisperer/index.js",
         "./shared": "./dist/src/shared/index.js",

--- a/packages/core/src/amazonq/onboardingPage/walkthrough.ts
+++ b/packages/core/src/amazonq/onboardingPage/walkthrough.ts
@@ -4,8 +4,9 @@
  */
 
 import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
-import globals from '../../shared/extensionGlobals'
+import globals, { isWeb } from '../../shared/extensionGlobals'
 import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
+import { getLogger } from '../../shared/logger'
 import { Commands, placeholder } from '../../shared/vscode/commands2'
 import vscode from 'vscode'
 
@@ -22,6 +23,12 @@ export async function showAmazonQWalkthroughOnce(
     if (hasShownWalkthrough) {
         return
     }
+
+    if (isWeb()) {
+        getLogger().debug(`amazonq: Not showing walkthrough since we are in web mode`)
+        return
+    }
+
     await state.update(hasShownWalkthroughId, true)
     await showWalkthrough()
 }

--- a/packages/core/src/codewhisperer/service/classifierTrigger.ts
+++ b/packages/core/src/codewhisperer/service/classifierTrigger.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as os from 'os'
+import os from 'os'
 import * as vscode from 'vscode'
 import { CodewhispererAutomatedTriggerType } from '../../shared/telemetry/telemetry'
 import { extractContextForCodeWhisperer } from '../util/editorContext'

--- a/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
+++ b/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
@@ -27,6 +27,7 @@ import { cwQuickPickSource } from '../commands/types'
 import { AuthUtil } from '../util/authUtil'
 import { submitFeedback } from '../../feedback/vue/submitFeedback'
 import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
+import { isWeb } from '../../shared/extensionGlobals'
 
 export function createAutoSuggestions(pause: boolean): DataQuickPickItem<'autoSuggestions'> {
     const labelResume = localize('AWS.codewhisperer.resumeCodeWhispererNode.label', 'Resume Auto-Suggestions')
@@ -216,9 +217,19 @@ export function createSignIn(): DataQuickPickItem<'signIn'> {
     const label = localize('AWS.codewhisperer.signInNode.label', 'Sign in to get started')
     const icon = getIcon('vscode-account')
 
+    let onClick = () => {
+        void focusAmazonQPanel.execute(placeholder, 'codewhispererQuickPick')
+    }
+    if (isWeb()) {
+        // TODO: nkomonen, call a Command instead
+        onClick = () => {
+            void AuthUtil.instance.connectToAwsBuilderId()
+        }
+    }
+
     return {
         data: 'signIn',
         label: codicon`${icon} ${label}`,
-        onClick: () => focusAmazonQPanel.execute(placeholder, 'codewhispererQuickPick'),
+        onClick,
     }
 }

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -129,6 +129,7 @@ export class AuthUtil {
             if (this.isValidEnterpriseSsoInUse() || (this.isBuilderIdInUse() && !this.isConnectionExpired())) {
                 // start the feature config polling job
                 await vscode.commands.executeCommand('aws.amazonq.fetchFeatureConfigs')
+                await showAmazonQWalkthroughOnce()
             }
             await this.setVscodeContextProps()
         })
@@ -222,8 +223,6 @@ export class AuthUtil {
             conn = await this.auth.reauthenticate(conn)
         }
 
-        await showAmazonQWalkthroughOnce()
-
         return this.secondaryAuth.useNewConnection(conn)
     }
 
@@ -242,8 +241,6 @@ export class AuthUtil {
         if (this.auth.getConnectionState(conn) === 'invalid') {
             conn = await this.auth.reauthenticate(conn)
         }
-
-        await showAmazonQWalkthroughOnce()
 
         return this.secondaryAuth.useNewConnection(conn)
     }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -50,7 +50,7 @@ import { isReleaseVersion } from './shared/vscode/env'
 import { telemetry } from './shared/telemetry/telemetry'
 import { Auth } from './auth/auth'
 import { registerSubmitFeedback } from './feedback/vue/submitFeedback'
-import { activateShared, deactivateShared, emitUserState } from './extensionShared'
+import { activateCommon, deactivateCommon, emitUserState } from './extensionCommon'
 import { learnMoreAmazonQCommand, qExtensionPageCommand, dismissQTree } from './amazonq/explorer/amazonQChildrenNodes'
 import { AuthUtil, isPreviousQUser } from './codewhisperer/util/authUtil'
 import { installAmazonQExtension } from './codewhisperer/commands/basicCommands'
@@ -58,8 +58,6 @@ import { isExtensionInstalled, VSCODE_EXTENSION_ID } from './shared/utilities'
 import { amazonQInstallDismissedKey } from './codewhisperer/models/constants'
 import { ExtensionUse } from './auth/utils'
 import { ExtStartUpSources } from './shared/telemetry'
-
-export { makeEndpointsProvider, registerGenericCommands } from './extensionShared'
 import { activate as activateThreatComposerEditor } from './threatComposer/activation'
 
 let localize: nls.LocalizeFunc
@@ -68,7 +66,7 @@ let localize: nls.LocalizeFunc
  * The entrypoint for the nodejs version of the toolkit
  *
  * **CONTRIBUTORS** If you are adding code to this function prioritize adding it to
- * {@link activateShared} if appropriate
+ * {@link activateCommon} if appropriate
  */
 export async function activate(context: vscode.ExtensionContext) {
     const activationStartedOn = Date.now()
@@ -77,7 +75,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     try {
         // IMPORTANT: If you are doing setup that should also work in web mode (browser), it should be done in the function below
-        const extContext = await activateShared(context, contextPrefix, false)
+        const extContext = await activateCommon(context, contextPrefix, false)
 
         initializeCredentialsProviderManager()
 
@@ -275,7 +273,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate() {
-    await deactivateShared()
+    await deactivateCommon()
     await globals.resourceManager.dispose()
 }
 

--- a/packages/core/src/extensionCommon.ts
+++ b/packages/core/src/extensionCommon.ts
@@ -6,6 +6,8 @@
 /**
  * This module contains shared code between the main extension and browser/web
  * extension entrypoints.
+ *
+ * See `arch_develop.md` in `docs/` for more info.
  */
 
 import vscode from 'vscode'
@@ -61,7 +63,7 @@ let localize: nls.LocalizeFunc
  * Activation/setup code that is shared by the regular (nodejs) extension AND web mode extension.
  * Most setup code should live here, unless there is a reason not to.
  */
-export async function activateShared(
+export async function activateCommon(
     context: vscode.ExtensionContext,
     contextPrefix: string,
     isWeb: boolean
@@ -163,7 +165,7 @@ export async function activateShared(
 }
 
 /** Deactivation code that is shared between nodejs and web implementations */
-export async function deactivateShared() {
+export async function deactivateCommon() {
     await globals.telemetry.shutdown()
 }
 /**

--- a/packages/core/src/extensionWeb.ts
+++ b/packages/core/src/extensionWeb.ts
@@ -5,20 +5,20 @@
 
 import * as vscode from 'vscode'
 import { getLogger } from './shared/logger'
-import { activateShared, deactivateShared } from './extensionShared'
-import os from 'os'
+import { activateCommon, deactivateCommon } from './extensionCommon'
+import { activateWebShared } from './extensionWebShared'
 
 export async function activate(context: vscode.ExtensionContext) {
     const contextPrefix = 'toolkit'
 
-    try {
-        patchOsVersion()
+    await activateWebShared(context)
 
+    try {
         // IMPORTANT: Any new activation code should be done in the function below unless
         // it is web mode specific activation code.
         // This should happen as early as possible, as initialize() must be called before
         // isWeb() calls will work.
-        await activateShared(context, contextPrefix, true)
+        await activateCommon(context, contextPrefix, true)
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')
         // truncate if the stacktrace is unusually long
@@ -29,14 +29,6 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 }
 
-/**
- * The browserfied version of os does not have a `version()` method,
- * so we patch it.
- */
-function patchOsVersion() {
-    ;(os.version as any) = () => '1.0.0'
-}
-
 export async function deactivate() {
-    await deactivateShared()
+    await deactivateCommon()
 }

--- a/packages/core/src/extensionWebShared.ts
+++ b/packages/core/src/extensionWebShared.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { getLogger } from './shared/logger'
+import os from 'os'
+
+/**
+ * This executes the web activation code that all extensions share. So any extension supporting web
+ * should run this as part of their web activation.
+ */
+export async function activateWebShared(context: vscode.ExtensionContext) {
+    try {
+        patchOsVersion()
+    } catch (error) {
+        getLogger().error(`Failed activation in extensionWebShared:`, error)
+    }
+}
+
+/**
+ * The browserfied version of os does not have a `version()` method,
+ * so we patch it.
+ */
+function patchOsVersion() {
+    ;(os.version as any) = () => '1.0.0'
+}

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -102,8 +102,8 @@
                     @toggle="toggleItemSelection"
                     :isSelected="selectedLoginOption === LoginOption.BUILDER_ID"
                     :itemId="LoginOption.BUILDER_ID"
-                    :itemText="'No AWS account required'"
-                    :itemTitle="'Use For Free'"
+                    :itemText="'with Builder ID, a personal profile from AWS'"
+                    :itemTitle="'Use for Free'"
                     :itemType="LoginOption.BUILDER_ID"
                     class="selectable-item bottomMargin"
                 ></SelectableItem>

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -366,13 +366,16 @@ export default defineComponent({
         await this.emitUpdate('created')
     },
 
-    mounted() {
+    async mounted() {
         this.fetchRegions()
-        void this.updateExistingConnections()
+        await this.updateExistingConnections()
 
         // Reset gathered telemetry data each time we view the login page.
         // The webview panel is reset on each view of the login page by design.
-        void client.resetStoredMetricMetadata()
+        client.resetStoredMetricMetadata()
+
+        // Pre-select the first available login option
+        await this.preselectLoginOption()
     },
     methods: {
         toggleItemSelection(itemId: number) {
@@ -562,6 +565,17 @@ export default defineComponent({
         },
         handleHelpLinkClick() {
             void client.emitUiClick('auth_helpLink')
+        },
+        async preselectLoginOption() {
+            // Select the first available option for Login
+            if (this.existingLogins.length > 0) {
+                this.selectedLoginOption = LoginOption.EXISTING_LOGINS
+            } else if (this.app === 'AMAZONQ') {
+                this.selectedLoginOption = LoginOption.BUILDER_ID
+            } else if (this.app === 'TOOLKIT') {
+                this.selectedLoginOption = LoginOption.ENTERPRISE_SSO
+            }
+            this.$forceUpdate()
         },
         shouldDisableSsoContinue() {
             return this.startUrl.length == 0 || this.startUrlError.length > 0 || !this.selectedRegion

--- a/packages/core/src/shared/extensionGlobals.ts
+++ b/packages/core/src/shared/extensionGlobals.ts
@@ -16,6 +16,7 @@ import { SchemaService } from './schemas'
 import { TelemetryLogger } from './telemetry/telemetryLogger'
 import { TelemetryService } from './telemetry/telemetryService'
 import { UriHandler } from './vscode/uriHandler'
+import vscode from 'vscode'
 
 type Clock = Pick<
     typeof globalThis,
@@ -148,6 +149,7 @@ export function initialize(context: ExtensionContext, isWeb: boolean = false): T
         visualizationResourcePaths: {} as ToolkitGlobals['visualizationResourcePaths'],
         isWeb,
     })
+    void vscode.commands.executeCommand('setContext', 'aws.isWebExtHost', isWeb)
 
     initialized = true
 

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -179,7 +179,7 @@ describe('transformByQ', function () {
                 status: 'COMPLETED',
             },
         }
-        assert.deepStrictEqual(actual, expected)
+        assert.equal(actual['abc-123'].projectName, expected['abc-123'].projectName)
     })
 
     it(`WHEN get headers for upload artifact to S3 THEN returns correct header with kms key arn`, function () {

--- a/packages/toolkit/.changes/next-release/Bug Fix-7a3ed468-dad2-4867-933b-1cfc101e99b9.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-7a3ed468-dad2-4867-933b-1cfc101e99b9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "UX: Amazon Q continues to install even if users uninstall it."
+}

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -1,3 +1,11 @@
+[![Twitter Follow](https://img.shields.io/badge/follow-@aws-1DA1F2?style=flat-square&logo=aws&logoColor=white&label=Follow)](https://x.com/awscloud)
+[![Youtube Channel Views](https://img.shields.io/youtube/channel/views/UCd6MoB9NC6uYN2grvUNT-Zg?style=flat-square&logo=youtube&label=Youtube)](https://www.youtube.com/@amazonwebservices)
+![Marketplace Installs](https://img.shields.io/vscode-marketplace/i/AmazonWebServices.aws-toolkit-vscode.svg?label=Installs&style=flat-square)
+
+# Amazon Q and CodeWhisperer
+
+Amazon CodeWhisperer is now part of Amazon Q. [Try the Amazon Q extension](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.amazon-q-vscode).
+
 # Getting Started
 
 1. Open the AWS Toolkit extension
@@ -16,10 +24,6 @@ Integrate threat modeling practices into your development workflow by creating a
 Threat Composer for the AWS Toolkit for Visual Studio Code allows you to create, view and edit [Threat Composer](https://github.com/awslabs/threat-composer#readme) threat models `.tc.json` directly within VSCode.
 
 ![Threat Composer](https://raw.githubusercontent.com/aws/aws-toolkit-vscode/HEAD/docs/marketplace/vscode/threatComposer.gif)
-
-## Amazon Q and CodeWhisperer
-
-Amazon CodeWhisperer is now part of Amazon Q. [Try the Amazon Q extension](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.amazon-q-vscode).
 
 ## [Application Composer](https://aws.amazon.com/application-composer/)
 

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -99,7 +99,8 @@ function getVersionSuffix(feature: string, debug: boolean): string {
     const debugSuffix = debug ? '-debug' : ''
     const featureSuffix = feature === '' ? '' : `-${feature}`
     const commitId = child_process.execFileSync('git', ['rev-parse', '--short=7', 'HEAD']).toString().trim()
-    const commitSuffix = commitId ? `-${commitId}` : ''
+    // Commit id is prefixed with "g" because "-0abc123" is not a valid semver prerelease, and will cause vsce to fail.
+    const commitSuffix = commitId ? `-g${commitId}` : ''
     return `${debugSuffix}${featureSuffix}${commitSuffix}`
 }
 


### PR DESCRIPTION
**Note that this is going to branch feature/separate-sessions**

Initial work for splitting auth sessions between amazon q and toolkit extensions.

- Remove UI elements for selecting existing connections.
- Remove amazon q usage of the toolkit api.
- API published by toolkit is retained so it can be used by other extensions to get auth in the future.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
