### PR TITLE
build: remove --vueHr flag

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -56,7 +56,7 @@
         "format": "prettier --ignore-path ../../.prettierignore --check src scripts",
         "formatfix": "prettier --ignore-path ../../.prettierignore --write src scripts",
         "lint": "echo 'Nothing to lint yet!'",
-        "watch": "npm run clean && npm run buildScripts -- --vueHr && tsc -watch -p ./",
+        "watch": "npm run clean && npm run buildScripts && tsc -watch -p ./",
         "webRun": "npx @vscode/test-web --open-devtools --browserOption=--disable-web-security --waitForDebugger=9222 --extensionDevelopmentPath=. .",
         "webWatch": "npm run clean && npm run buildScripts && webpack --mode development --watch",
         "serve": "webpack serve --config-name mainServe --mode development",


### PR DESCRIPTION
Problem: arg should go to `npm run copyFiles` in `buildScripts`, but it isn't and hasn't been. Now with the addition it of `tsc -p ./ --noEmit` it is going to that instead and it's an unrecognized arg.

Solution: remove it

Not sure if the arg ever worked. We can revisit this if the feature is desirable.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
