### PR TITLE
fix(amazonq): rename menu title to Amazon Q

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -221,7 +221,7 @@
     "AWS.codecatalyst.explorerTitle": "CodeCatalyst",
     "AWS.cwl.limit.desc": "Maximum amount of log entries pulled per request from CloudWatch Logs (max 10000)",
     "AWS.samcli.deploy.bucket.recentlyUsed": "Buckets recently used for SAM deployments",
-    "AWS.submenu.amazonqEditorContextSubmenu.title": "Send to Amazon Q",
+    "AWS.submenu.amazonqEditorContextSubmenu.title": "Amazon Q",
     "AWS.submenu.auth.title": "Authentication",
     "AWS.generic.feedback": "Feedback",
     "AWS.generic.help": "Help",


### PR DESCRIPTION
rename menu title to Amazon Q

<img width="490" alt="Screenshot 2024-06-06 at 9 20 46 AM" src="https://github.com/aws/aws-toolkit-vscode/assets/371007/ce4c61a4-1b58-48ee-8500-56667d45dd7d">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
