### PR TITLE
fix(build): huksy "install command is deprecated"

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 git secrets --register-aws || (echo 'Please install git-secrets https://github.com/awslabs/git-secrets to check for accidentally commited secrets!' && exit 1)
 git secrets --pre_commit_hook -- ""
 node_modules/.bin/pretty-quick --staged

--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -27,7 +27,7 @@ function main() {
         console.log('prepare: skipped (running in CI)')
         return
     }
-    child_process.execSync('husky install', { stdio: 'inherit' })
+    child_process.execSync('husky', { stdio: 'inherit' })
 }
 
 main()


### PR DESCRIPTION
Problem:
husky prints "install command is deprecated" during "npm install".

Solution:
Migrate as described in https://github.com/typicode/husky/releases/tag/v9.0.1


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
