### PR TITLE
fix(build): package task fails if commit id starts with zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Coverage](https://img.shields.io/codecov/c/github/aws/aws-toolkit-vscode/master.svg)](https://codecov.io/gh/aws/aws-toolkit-vscode/branch/master)
 
-This project is open source. We love issues, feature requests, code reviews, pull requests or any
-positive contribution. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+This project is open source. We encourage issues, feature requests, code reviews, pull requests or
+any positive contribution. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
 
 ### Amazon Q
 

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -99,7 +99,8 @@ function getVersionSuffix(feature: string, debug: boolean): string {
     const debugSuffix = debug ? '-debug' : ''
     const featureSuffix = feature === '' ? '' : `-${feature}`
     const commitId = child_process.execFileSync('git', ['rev-parse', '--short=7', 'HEAD']).toString().trim()
-    const commitSuffix = commitId ? `-${commitId}` : ''
+    // Commit id is prefixed with "g" because "-0abc123" is not a valid semver prerelease, and will cause vsce to fail.
+    const commitSuffix = commitId ? `-g${commitId}` : ''
     return `${debugSuffix}${featureSuffix}${commitSuffix}`
 }
 


### PR DESCRIPTION
# Problem:
package task fails if commit id starts with zero.

    ERROR  Invalid extension version '3.9.0-0238109'

semver [disallows](https://semver.org/#spec-item-9) leading zero for prerelease. This is why `git describe` always adds a "g" prefix, for example.

# Solution:
Prefix the prerelease string with "g", similar to `git describe`.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
