### PR TITLE
docs(amazonq): update marketplace documentation

### DIFF
--- a/packages/amazonq/README.md
+++ b/packages/amazonq/README.md
@@ -1,11 +1,7 @@
-[![Twitter Follow](https://img.shields.io/twitter/follow/aws?logo=twitter&style=social)](https://twitter.com/awscloud)
-[![Youtube Channel Views](https://img.shields.io/youtube/channel/views/UCd6MoB9NC6uYN2grvUNT-Zg?style=social)](https://www.youtube.com/@amazonwebservices)
-[![Try Amazon Q free trial](https://img.shields.io/badge/Try%20Amazon%20Q-Free%20trial-success)](https://aws.amazon.com/q/developer/?editor=vscode)
-![Marketplace Downloads](https://img.shields.io/vscode-marketplace/d/AmazonWebServices.amazon-q-vscode.svg)
-
-# Inline code suggestions
-
-Code faster with inline code suggestions as you type.
+![Try Amazon Q Free Tier](https://img.shields.io/badge/Try%20Amazon%20Q-Free%20Tier-success?style=flat-square)
+[![Twitter Follow](https://img.shields.io/badge/follow-@aws-1DA1F2?style=flat-square&logo=aws&logoColor=white&label=Follow)](https://x.com/awscloud)
+[![Youtube Channel Views](https://img.shields.io/youtube/channel/views/UCd6MoB9NC6uYN2grvUNT-Zg?style=flat-square&logo=youtube&label=Youtube)](https://www.youtube.com/@amazonwebservices)
+![Marketplace Installs](https://img.shields.io/vscode-marketplace/i/AmazonWebServices.amazon-q-vscode.svg?label=Installs&style=flat-square)
 
 # Getting Started
 
@@ -16,6 +12,10 @@ Code faster with inline code suggestions as you type.
 ![Authentication gif](https://raw.githubusercontent.com/aws/aws-toolkit-vscode/HEAD/docs/marketplace/vscode/amazonq/auth-Q.gif)
 
 # Features
+
+## Inline code suggestions
+
+Code faster with inline code suggestions as you type.
 
 ![Inline code suggestion demo](https://raw.githubusercontent.com/aws/aws-toolkit-vscode/HEAD/docs/marketplace/vscode/amazonq/inline.gif)
 

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -1,3 +1,11 @@
+[![Twitter Follow](https://img.shields.io/badge/follow-@aws-1DA1F2?style=flat-square&logo=aws&logoColor=white&label=Follow)](https://x.com/awscloud)
+[![Youtube Channel Views](https://img.shields.io/youtube/channel/views/UCd6MoB9NC6uYN2grvUNT-Zg?style=flat-square&logo=youtube&label=Youtube)](https://www.youtube.com/@amazonwebservices)
+![Marketplace Installs](https://img.shields.io/vscode-marketplace/i/AmazonWebServices.aws-toolkit-vscode.svg?label=Installs&style=flat-square)
+
+# Amazon Q and CodeWhisperer
+
+Amazon CodeWhisperer is now part of Amazon Q. [Try the Amazon Q extension](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.amazon-q-vscode).
+
 # Getting Started
 
 1. Open the AWS Toolkit extension
@@ -16,10 +24,6 @@ Integrate threat modeling practices into your development workflow by creating a
 Threat Composer for the AWS Toolkit for Visual Studio Code allows you to create, view and edit [Threat Composer](https://github.com/awslabs/threat-composer#readme) threat models `.tc.json` directly within VSCode.
 
 ![Threat Composer](https://raw.githubusercontent.com/aws/aws-toolkit-vscode/HEAD/docs/marketplace/vscode/threatComposer.gif)
-
-## Amazon Q and CodeWhisperer
-
-Amazon CodeWhisperer is now part of Amazon Q. [Try the Amazon Q extension](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.amazon-q-vscode).
 
 ## [Application Composer](https://aws.amazon.com/application-composer/)
 


### PR DESCRIPTION
- Reorder content.
- Removed link for `Try Amazon Q Free Tier` tag. 

<img width="664" alt="Screenshot 2024-06-07 at 1 36 46 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/371007/ed63b027-8994-4ecc-aa5c-8ee436359693">

<img width="646" alt="Screenshot 2024-06-07 at 1 52 15 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/371007/1f2010f2-9d35-4b41-ab12-757ef1036d55">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
