### PR TITLE
fix: only install Q once for previous users

### DIFF
--- a/packages/toolkit/.changes/next-release/Bug Fix-7a3ed468-dad2-4867-933b-1cfc101e99b9.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-7a3ed468-dad2-4867-933b-1cfc101e99b9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "UX: Amazon Q continues to install even if users uninstall it."
+}


### PR DESCRIPTION
Problem: Q installs whenever a past connection is detected. If users don't log out of that connection, then they will forever have Q auto-installed on startup even if they don't want it.
Solution: Only install once, then store to global state that we did.

- Cleanup the install code a bit
- Use the same global state key for dismissing the install q notification.

Fixes https://github.com/aws/aws-toolkit-vscode/issues/4898

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
