### PR TITLE
fix(amazonq): remember "Pause Auto-Suggestions" after IDE restart

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-17572ed1-4601-4554-9144-9eb5143bf0ff.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-17572ed1-4601-4554-9144-9eb5143bf0ff.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Do not turn on auto trigger when IDE reloads"
+	"description": "Amazon Q inline suggestions: remember `Pause Auto-Suggestions` after IDE restart"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-17572ed1-4601-4554-9144-9eb5143bf0ff.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-17572ed1-4601-4554-9144-9eb5143bf0ff.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Do not turn on auto trigger when IDE reloads"
+}

--- a/packages/amazonq/src/extensionCommon.ts
+++ b/packages/amazonq/src/extensionCommon.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode'
 import * as semver from 'semver'
 import { join } from 'path'
 import {
-    CodeSuggestionsState,
     activate as activateCodeWhisperer,
     shutdown as shutdownCodeWhisperer,
     amazonQDismissedKey,

--- a/packages/amazonq/src/extensionCommon.ts
+++ b/packages/amazonq/src/extensionCommon.ts
@@ -113,9 +113,6 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     // reload webviews
     await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction')
 
-    // enable auto suggestions on activation
-    await CodeSuggestionsState.instance.setSuggestionsEnabled(true)
-
     if (AuthUtils.ExtensionUse.instance.isFirstUse()) {
         CommonAuthWebview.authSource = ExtStartUpSources.firstStartUp
         await vscode.commands.executeCommand('workbench.view.extension.amazonq')


### PR DESCRIPTION
## Problem
IDE restart will auto enable auto trigger.

## Solution
Do not auto turn on auto trigger whenever IDE restarts.

Tested with local builds. 


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
