### PR TITLE
Security scans: VSC triggers to calculate codeScanProjectBytes only for Project scans

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-939bbbf1-39fb-4482-8f98-10cdca69ae2a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-939bbbf1-39fb-4482-8f98-10cdca69ae2a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Security Scan: Fixes an issue where auto-scans cause the editor to become unresponsive for larger projects."
+}

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -255,7 +255,7 @@ export async function startSecurityScan(
         codeScanState.setToNotStarted()
         codeScanTelemetryEntry.duration = performance.now() - codeScanStartTime
         codeScanTelemetryEntry.codeScanServiceInvocationsDuration = performance.now() - serviceInvocationStartTime
-        await emitCodeScanTelemetry(codeScanTelemetryEntry)
+        await emitCodeScanTelemetry(codeScanTelemetryEntry, scope)
     }
 }
 
@@ -283,15 +283,20 @@ export function showSecurityScanResults(
     }
 }
 
-export async function emitCodeScanTelemetry(codeScanTelemetryEntry: CodeScanTelemetryEntry) {
+export async function emitCodeScanTelemetry(
+    codeScanTelemetryEntry: CodeScanTelemetryEntry,
+    scope: CodeWhispererConstants.CodeAnalysisScope
+) {
     codeScanTelemetryEntry.codewhispererCodeScanProjectBytes = 0
     const now = performance.now()
-    for (const folder of vscode.workspace.workspaceFolders ?? []) {
-        codeScanTelemetryEntry.codewhispererCodeScanProjectBytes += await getDirSize(
-            folder.uri.fsPath,
-            now,
-            CodeWhispererConstants.projectSizeCalculateTimeoutSeconds * 1000
-        )
+    if (scope === CodeWhispererConstants.CodeAnalysisScope.PROJECT) {
+        for (const folder of vscode.workspace.workspaceFolders ?? []) {
+            codeScanTelemetryEntry.codewhispererCodeScanProjectBytes += await getDirSize(
+                folder.uri.fsPath,
+                now,
+                CodeWhispererConstants.projectSizeCalculateTimeoutSeconds * 1000
+            )
+        }
     }
     telemetry.codewhisperer_securityScan.emit({
         ...codeScanTelemetryEntry,


### PR DESCRIPTION

## Problem
- VSC triggers `getDirSize()` function to calculate `codeScanProjectBytes` for telemetry for both `Auto-scans` and `Project scans`.
## Solution

- Disable the `codeScanProjectBytes` calculation for `Auto-scans`: Since the `codeScanProjectBytes`
 parameter is optional for `Auto-scans` and is affecting the performance, it makes sense to disable the calculation for this scenario. This will help improve the overall performance of the Auto-scans.

- Enable the `codeScanProjectBytes` calculation for `Project scans`: For `Project scans`, you should continue to calculate the `codeScanProjectBytes` using the `getDirSize()` function, as this information is likely valuable for the telemetry.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
