### PR TITLE
fix(codecatalyst): always send heartbeat activity

### DIFF
--- a/packages/core/src/codecatalyst/activation.ts
+++ b/packages/core/src/codecatalyst/activation.ts
@@ -83,15 +83,15 @@ export async function activate(ctx: ExtContext): Promise<void> {
     }
 
     const thisDevenv = (await getThisDevEnv(authProvider))?.unwrapOrElse(err => {
-        getLogger().warn('codecatalyst: failed to get current Dev Enviroment: %s', err)
+        getLogger().error('codecatalyst: failed to get current Dev Enviroment: %s', err)
         return undefined
     })
 
     if (!thisDevenv) {
         if (isInDevEnv()) {
-            getLogger().error('codecatalyst: cannot initialize because getThisDevEnv() failed')
+            getLogger().info('codecatalyst: Dev Environment timeout=unknown')
         } else {
-            getLogger().verbose('codecatalyst: not a devenv')
+            getLogger().verbose('codecatalyst: not a Dev Environment ($__DEV_ENVIRONMENT_ID is undefined)')
         }
     } else {
         ctx.extensionContext.subscriptions.push(DevEnvClient.instance)
@@ -99,7 +99,9 @@ export async function activate(ctx: ExtContext): Promise<void> {
             ctx.extensionContext.subscriptions.push(registerDevfileWatcher(DevEnvClient.instance))
         }
 
-        getLogger().info('codecatalyst: Dev Environment ides=%O', thisDevenv?.summary.ides)
+        const timeoutMin = thisDevenv.summary.inactivityTimeoutMinutes
+        const timeout = timeoutMin === 0 ? 'never' : `${timeoutMin} min`
+        getLogger().info('codecatalyst: Dev Environment timeout=%s, ides=%O', timeout, thisDevenv.summary.ides)
         if (!isCloud9() && thisDevenv && !isDevenvVscode(thisDevenv.summary.ides)) {
             // Prevent Toolkit from reconnecting to a "non-vscode" devenv by actively closing it.
             // Can happen if devenv is switched to ides="cloud9", etc.
@@ -136,7 +138,7 @@ async function showReadmeFileOnFirstLoad(workspaceState: vscode.ExtensionContext
         return
     }
 
-    getLogger().info('codecatalyst: showReadmeFileOnFirstLoad()')
+    getLogger().debug('codecatalyst: showReadmeFileOnFirstLoad()')
     // Check dev env state to see if this is the first time the user has connected to a dev env
     const isFirstLoad = workspaceState.get('aws.codecatalyst.devEnv.isFirstLoad', true)
 
@@ -157,7 +159,7 @@ async function showReadmeFileOnFirstLoad(workspaceState: vscode.ExtensionContext
     })
 
     if (readmeUri === undefined) {
-        getLogger().info(`codecatalyst: README.md not found in path '${readmePath}'`)
+        getLogger().debug(`codecatalyst: README.md not found in path '${readmePath}'`)
         return
     }
 

--- a/packages/core/src/codecatalyst/activation.ts
+++ b/packages/core/src/codecatalyst/activation.ts
@@ -24,6 +24,7 @@ import { codeCatalystConnectCommand, getThisDevEnv } from './model'
 import { getLogger } from '../shared/logger/logger'
 import { DevEnvActivityStarter } from './devEnv'
 import { learnMoreCommand, onboardCommand, reauth } from './explorer'
+import { isInDevEnv } from '../shared/vscode/env'
 
 const localize = nls.loadMessageBundle()
 
@@ -87,7 +88,11 @@ export async function activate(ctx: ExtContext): Promise<void> {
     })
 
     if (!thisDevenv) {
-        getLogger().verbose('codecatalyst: not a devenv, getThisDevEnv() returned empty')
+        if (isInDevEnv()) {
+            getLogger().error('codecatalyst: cannot initialize because getThisDevEnv() failed')
+        } else {
+            getLogger().verbose('codecatalyst: not a devenv')
+        }
     } else {
         ctx.extensionContext.subscriptions.push(DevEnvClient.instance)
         if (DevEnvClient.instance.id) {
@@ -123,7 +128,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
     }
 
     // This must always be called on activation
-    DevEnvActivityStarter.register(authProvider)
+    DevEnvActivityStarter.init(authProvider)
 }
 
 async function showReadmeFileOnFirstLoad(workspaceState: vscode.ExtensionContext['workspaceState']): Promise<void> {

--- a/packages/core/src/codecatalyst/devEnv.ts
+++ b/packages/core/src/codecatalyst/devEnv.ts
@@ -295,6 +295,7 @@ class Message implements vscode.Disposable {
             return vscode.window
                 .showWarningMessage(
                     `Your CodeCatalyst Dev Environment has been inactive for ${minutesUserWasInactive} minutes, and will stop soon.`,
+                    { modal: true },
                     imHere
                 )
                 .then(res => {

--- a/packages/core/src/codecatalyst/devEnv.ts
+++ b/packages/core/src/codecatalyst/devEnv.ts
@@ -178,8 +178,17 @@ export class InactivityMessage implements vscode.Disposable {
 
             const { millisToWait, minutesSinceTimestamp } = this.millisUntilNextWholeMinute(lastActivity, oneMin)
             const minutesUntilShutdown = maxInactivityMinutes - minutesSinceTimestamp
-            const minutesUntilFirstMessage = minutesUntilShutdown - InactivityMessage.shutdownWarningThreshold
+            const minutesUntilFirstMessage = Math.max(
+                0,
+                minutesUntilShutdown - InactivityMessage.shutdownWarningThreshold
+            )
             const timerInterval = millisToWait + minutesUntilFirstMessage * oneMin
+            getLogger().debug(
+                'InactivityMessage: millisToWait=%d minutesUntilFirstMessage=%d oneMin=%d',
+                millisToWait,
+                minutesUntilFirstMessage,
+                oneMin
+            )
 
             /** Wait until we are {@link InactivityMessage.shutdownWarningThreshold} minutes before shutdown. */
             this.#beforeMessageShown = globals.clock.setTimeout(() => {
@@ -196,8 +205,8 @@ export class InactivityMessage implements vscode.Disposable {
                 this.#message = new Message()
                 this.#message
                     .show(
-                        minutesSinceTimestamp + minutesUntilFirstMessage,
-                        minutesUntilShutdown - minutesUntilFirstMessage,
+                        Math.max(0, minutesSinceTimestamp + minutesUntilFirstMessage),
+                        Math.max(0, minutesUntilShutdown - minutesUntilFirstMessage),
                         userIsActive,
                         willRefreshOnStaleTimestamp,
                         oneMin

--- a/packages/core/src/codecatalyst/devEnv.ts
+++ b/packages/core/src/codecatalyst/devEnv.ts
@@ -15,6 +15,7 @@ import { CodeCatalystAuthenticationProvider } from './auth'
 import { getThisDevEnv } from './model'
 import { isInDevEnv } from '../shared/vscode/env'
 import { shared } from '../shared/utilities/functionUtils'
+import { DevSettings } from '../shared/settings'
 
 /** Starts the {@link DevEnvActivity} Hearbeat mechanism. */
 export class DevEnvActivityStarter {
@@ -93,8 +94,13 @@ export class DevEnvActivityStarter {
             )
         }
 
+        const devenvTimeoutMs = DevSettings.instance.get('devenvTimeoutMs', 0)
+        if (devenvTimeoutMs) {
+            getLogger().warn('codecatalyst: using devenvTimeoutMs=%d', devenvTimeoutMs)
+        }
         // If user is not authenticated, assume 15 minutes.
-        const inactivityTimeoutMin = thisDevenv?.summary.inactivityTimeoutMinutes ?? 15
+        const inactivityTimeoutMin =
+            devenvTimeoutMs > 0 ? devenvTimeoutMs : thisDevenv?.summary.inactivityTimeoutMinutes ?? 15
         if (!shouldSendActivity(inactivityTimeoutMin)) {
             getLogger().info(
                 `codecatalyst: disabling DevEnvActivity heartbeat: configured to never timeout (inactivityTimeoutMinutes=${inactivityTimeoutMin})`

--- a/packages/core/src/shared/clients/devenvClient.ts
+++ b/packages/core/src/shared/clients/devenvClient.ts
@@ -106,7 +106,7 @@ export class DevEnvClient implements vscode.Disposable {
     })
 
     /**
-     * WARNING: You should use {@link DevEnvActivity} unless you have a reason not to.
+     * WARNING: Use {@link DevEnvActivity} instead of calling this directly.
      */
     async updateActivity(timestamp: number = Date.now()): Promise<number> {
         await this.got.put('activity', { json: { timestamp: timestamp.toString() } })
@@ -123,10 +123,8 @@ export class DevEnvClient implements vscode.Disposable {
 }
 
 /**
- * This allows you to easily work with Dev Env user activity timestamps.
- *
- * An activity is a timestamp that the server uses to
- * determine when the user was last active.
+ * Posts user activity timestamps to the dev env "/activity" API, which are used by MDE to decide
+ * when the user was last active, and thus prevent auto-shutdown of the dev env.
  */
 export class DevEnvActivity implements vscode.Disposable {
     private activityUpdatedEmitter = new vscode.EventEmitter<number>()
@@ -138,10 +136,8 @@ export class DevEnvActivity implements vscode.Disposable {
 
     static readonly activityUpdateDelay = 10_000
 
-    /**
-     * Returns an instance if the activity mechanism is confirmed to be working.
-     */
-    static async instanceIfActivityTrackingEnabled(
+    /** Gets a new DevEnvActivity, or undefined if service is failed. */
+    static async create(
         client: DevEnvClient,
         extensionUserActivity?: ExtensionUserActivity
     ): Promise<DevEnvActivity | undefined> {
@@ -150,7 +146,7 @@ export class DevEnvActivity implements vscode.Disposable {
             getLogger().debug('codecatalyst: DevEnvActivity: Activity API is enabled')
         } catch (e) {
             const error = e instanceof HTTPError ? e.response.body : e
-            getLogger().error(`codecatalyst: DevEnvActivity: Activity API failed:%s`, error)
+            getLogger().error(`codecatalyst: DevEnvActivity: Activity API failed: %s`, error)
             return undefined
         }
 
@@ -167,10 +163,10 @@ export class DevEnvActivity implements vscode.Disposable {
         ))
     }
 
-    /** Send activity timestamp to the Dev Env */
+    /** Send activity timestamp to the MDE environment endpoint. */
     async sendActivityUpdate(timestamp: number = Date.now()): Promise<number> {
         await this.client.updateActivity()
-        getLogger().debug(`codecatalyst: DevEnvActivity: heartbeat sent at ${timestamp}`)
+        getLogger().debug('codecatalyst: DevEnvActivity: heartbeat sent')
         this.lastLocalActivity = timestamp
         this.activityUpdatedEmitter.fire(timestamp)
         return timestamp

--- a/packages/core/src/shared/clients/devenvClient.ts
+++ b/packages/core/src/shared/clients/devenvClient.ts
@@ -33,7 +33,7 @@ export class DevEnvClient implements vscode.Disposable {
             getLogger().debug('codecatalyst: DevEnvClient skipped (local)')
             this.timer = undefined
         } else {
-            getLogger().info('codecatalyst: DevEnvClient started')
+            getLogger().debug('codecatalyst: DevEnvClient started')
             this.timer = globals.clock.setInterval(async () => {
                 const r = await this.getStatus()
                 if (this.lastStatus !== r.status) {

--- a/packages/core/src/shared/clients/devenvClient.ts
+++ b/packages/core/src/shared/clients/devenvClient.ts
@@ -192,7 +192,12 @@ export class DevEnvActivity implements vscode.Disposable {
         return (await this.getLatestActivity()) !== this.lastLocalActivity
     }
 
-    /** Runs the given callback when the activity is updated */
+    /**
+     * Subscribes to the "user activity sent" event.
+     *
+     * @param callback Called when event is fired.
+     * @param callback.timestamp Timestamp (milliseconds since 1970), see {@link Date.now}
+     */
     onActivityUpdate(callback: (timestamp: number) => any) {
         this.activityUpdatedEmitter.event(callback)
     }

--- a/packages/core/src/shared/clients/devenvClient.ts
+++ b/packages/core/src/shared/clients/devenvClient.ts
@@ -106,6 +106,8 @@ export class DevEnvClient implements vscode.Disposable {
     })
 
     /**
+     * Notifies the MDE API of user activity.
+     *
      * WARNING: Use {@link DevEnvActivity} instead of calling this directly.
      */
     async updateActivity(timestamp: number = Date.now()): Promise<number> {
@@ -114,7 +116,9 @@ export class DevEnvClient implements vscode.Disposable {
     }
 
     /**
-     * WARNING: You should use {@link DevEnvActivity} unless you have a reason not to.
+     * Gets the latest user activity timestamp from MDE API.
+     *
+     * WARNING: Use {@link DevEnvActivity} instead of calling this directly.
      */
     async getActivity(): Promise<number | undefined> {
         const response = await this.got<GetActivityResponse>('activity')

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -725,6 +725,7 @@ const devSettings = {
     telemetryEndpoint: String,
     telemetryUserPool: String,
     renderDebugDetails: Boolean,
+    devenvTimeoutMs: Number,
     endpoints: Record(String, String),
     codecatalystService: Record(String, String),
     codewhispererService: Record(String, String),

--- a/packages/core/src/shared/utilities/messages.ts
+++ b/packages/core/src/shared/utilities/messages.ts
@@ -241,7 +241,8 @@ async function showProgressWithTimeout(
                         return new Promise(timeout.onCompletion)
                     })
                 } catch (e) {
-                    getLogger().error('report(): progressPromise failed', e)
+                    const err = e as Error
+                    getLogger().error('report(): progressPromise failed: %s: %s', err.name, err.message)
                     reject(e)
                 }
             }, showAfterMs)

--- a/packages/core/src/shared/utilities/timeoutUtils.ts
+++ b/packages/core/src/shared/utilities/timeoutUtils.ts
@@ -192,7 +192,7 @@ interface WaitUntilOptions {
 }
 
 /**
- * Invokes `fn()` until it returns a non-undefined value.
+ * Invokes `fn()` until it returns a truthy value (or non-undefined if `truthy:false`).
  *
  * @param fn  Function whose result is checked
  * @param options  See {@link WaitUntilOptions}

--- a/packages/core/src/test/shared/clients/devenvClient.test.ts
+++ b/packages/core/src/test/shared/clients/devenvClient.test.ts
@@ -40,7 +40,7 @@ describe('DevEnvActivity', function () {
 
         devEnvClientStub = createStubInstance(DevEnvClient)
 
-        devEnvActivity = (await DevEnvActivity.instanceIfActivityTrackingEnabled(
+        devEnvActivity = (await DevEnvActivity.create(
             devEnvClientStub as unknown as DevEnvClient,
             new ExtensionUserActivity(0, [userActivityEvent])
         ))!
@@ -56,7 +56,7 @@ describe('DevEnvActivity', function () {
 
     it('does not allow instance to be created if activity API not working', async function () {
         devEnvClientStub.getActivity.throws()
-        const instance = await DevEnvActivity.instanceIfActivityTrackingEnabled(
+        const instance = await DevEnvActivity.create(
             devEnvClientStub as unknown as DevEnvClient,
             new ExtensionUserActivity(0, [userActivityEvent])
         )

--- a/packages/core/src/testInteg/codecatalyst/devEnv.test.ts
+++ b/packages/core/src/testInteg/codecatalyst/devEnv.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import { InactivityMessage, shouldSendActivity } from '../../codecatalyst/devEnv'
 import * as sinon from 'sinon'
-import { sleep } from '../../shared/utilities/timeoutUtils'
+import { sleep, waitUntil } from '../../shared/utilities/timeoutUtils'
 import { TestWindow, getTestWindow } from '../../test/shared/vscode/window'
 import { DevEnvActivity } from '../../shared/clients/devenvClient'
 
@@ -28,15 +28,15 @@ describe('InactivityMessages', function () {
     let testWindow: TestWindow
     let devEnvActivity: sinon.SinonStubbedInstance<DevEnvActivity>
     let actualMessages: { message: string; minute: number }[] = []
-    let instance: InactivityMessage
+    let inactivityMsg: InactivityMessage
 
     beforeEach(function () {
         relativeMinuteMillis = 200
         testWindow = getTestWindow()
-        instance = new InactivityMessage()
+        inactivityMsg = new InactivityMessage()
 
         devEnvActivity = sinon.createStubInstance(DevEnvActivity)
-        // Setup for DevEnvClient stub to call the onUserActivity event callback code when updateUserActivity() is called
+        // Setup for DevEnvClient stub to call the onUserActivity event callback code when sendActivityUpdate() is called
         devEnvActivity.onActivityUpdate.callsFake(activityCallback => {
             devEnvActivity.sendActivityUpdate.callsFake(async () => {
                 const timestamp = getLatestTimestamp()
@@ -52,31 +52,40 @@ describe('InactivityMessages', function () {
     })
 
     afterEach(function () {
-        instance.dispose()
+        inactivityMsg.dispose()
         testWindow.dispose()
     })
 
     it('shows expected messages 5 minutes before shutdown on a 15 minute inactivity timeout', async function () {
-        await instance.setupMessage(15, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        await inactivityMsg.init(15, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
 
         await assertMessagesShown([
-            ['Your CodeCatalyst Dev Environment has been inactive for 10 minutes, shutting it down in 5 minutes.', 10],
-            ['Your CodeCatalyst Dev Environment has been inactive for 11 minutes, shutting it down in 4 minutes.', 11],
-            ['Your CodeCatalyst Dev Environment has been inactive for 12 minutes, shutting it down in 3 minutes.', 12],
-            ['Your CodeCatalyst Dev Environment has been inactive for 13 minutes, shutting it down in 2 minutes.', 13],
+            ['Your CodeCatalyst Dev Environment has been inactive for 10 minutes, and will stop in 5 minutes.', 10],
+            ['Your CodeCatalyst Dev Environment has been inactive for 11 minutes, and will stop in 4 minutes.', 11],
+            ['Your CodeCatalyst Dev Environment has been inactive for 12 minutes, and will stop in 3 minutes.', 12],
+            ['Your CodeCatalyst Dev Environment has been inactive for 13 minutes, and will stop in 2 minutes.', 13],
             ['Your CodeCatalyst Dev Environment has been inactive for 14 minutes, and will stop soon.', 14],
         ])
     })
 
     it('shows expected messages 5 minutes before shutdown on a 60 minute inactivity timeout', async function () {
-        await instance.setupMessage(60, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        await inactivityMsg.init(60, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        setInitialOffset(57)
+        await devEnvActivity.sendActivityUpdate()
+        await waitUntil(async () => actualMessages.length > 0, { interval: 10 })
+        setInitialOffset(58)
+        await devEnvActivity.sendActivityUpdate()
+        await waitUntil(async () => actualMessages.length > 2, { interval: 10 })
 
         await assertMessagesShown([
-            ['Your CodeCatalyst Dev Environment has been inactive for 55 minutes, shutting it down in 5 minutes.', 55],
-            ['Your CodeCatalyst Dev Environment has been inactive for 56 minutes, shutting it down in 4 minutes.', 56],
-            ['Your CodeCatalyst Dev Environment has been inactive for 57 minutes, shutting it down in 3 minutes.', 57],
-            ['Your CodeCatalyst Dev Environment has been inactive for 58 minutes, shutting it down in 2 minutes.', 58],
-            ['Your CodeCatalyst Dev Environment has been inactive for 59 minutes, and will stop soon.', 59],
+            ['Your CodeCatalyst Dev Environment has been inactive for 57 minutes, and will stop in 3 minutes.', 0],
+            ['Your CodeCatalyst Dev Environment has been inactive for 58 minutes, and will stop in 2 minutes.', 0],
+            ['Your CodeCatalyst Dev Environment has been inactive for 59 minutes, and will stop soon.', 1],
         ])
     })
 
@@ -84,8 +93,8 @@ describe('InactivityMessages', function () {
         let isFirstMessage = true
         testWindow.onDidShowMessage(async message => {
             if (message.message.endsWith('stop soon.')) {
-                // User hits the 'I'm here!' button on the inactivity shutdown message
-                message.selectItem(`I'm here!`)
+                // User hits the "I'm here!" button on the inactivity shutdown message
+                message.selectItem("I'm here!")
                 return
             }
 
@@ -97,59 +106,43 @@ describe('InactivityMessages', function () {
             message.selectItem('Cancel')
         })
 
-        await instance.setupMessage(7, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        await inactivityMsg.init(7, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
 
         await assertMessagesShown([
-            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, shutting it down in 5 minutes.', 2],
+            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, and will stop in 5 minutes.', 2],
             // User clicked 'Cancel' on the warning message so timer was reset
-            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, shutting it down in 5 minutes.', 4],
-            ['Your CodeCatalyst Dev Environment has been inactive for 3 minutes, shutting it down in 4 minutes.', 5],
-            ['Your CodeCatalyst Dev Environment has been inactive for 4 minutes, shutting it down in 3 minutes.', 6],
-            ['Your CodeCatalyst Dev Environment has been inactive for 5 minutes, shutting it down in 2 minutes.', 7],
+            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, and will stop in 5 minutes.', 4],
+            ['Your CodeCatalyst Dev Environment has been inactive for 3 minutes, and will stop in 4 minutes.', 5],
+            ['Your CodeCatalyst Dev Environment has been inactive for 4 minutes, and will stop in 3 minutes.', 6],
+            ['Your CodeCatalyst Dev Environment has been inactive for 5 minutes, and will stop in 2 minutes.', 7],
             ['Your CodeCatalyst Dev Environment has been inactive for 6 minutes, and will stop soon.', 8],
             // User clicked "I'm here!" on the shutdown message so timer was reset
-            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, shutting it down in 5 minutes.', 10],
+            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, and will stop in 5 minutes.', 10],
         ])
     })
 
     it('takes in to consideration 2 1/2 minutes have already passed for an inactive external client.', async function () {
-        const inactiveMinutes = 9
-        const initialOffsetMinutes = 2.5
-        // We normally show the warning message after 6 inactive minutes of user percieved time
-        // in this scenario (9 inactive minutes till shutdown).
-        //
-        // But because we are taking in to consideration 2 1/2 minutes have already passed, we show the warning
-        // 3 minutes before it typically would.
-        // Remember that minutesElapsedSinceLatestTimestamp() sleeps till the next whole minute,
-        // which is why 2 1/2 minutes becomes 3 minutes. Then we start the countdown to show the
-        // first warning message.
-        const minuteFirstMessageShown =
-            inactiveMinutes - Math.ceil(initialOffsetMinutes) - InactivityMessage.shutdownWarningThreshold
-        setInitialOffset(initialOffsetMinutes)
-
-        await instance.setupMessage(inactiveMinutes, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        setInitialOffset(2.5)
+        await inactivityMsg.init(9, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
+        await devEnvActivity.sendActivityUpdate()
 
         await assertMessagesShown([
-            [
-                'Your CodeCatalyst Dev Environment has been inactive for 4 minutes, shutting it down in 5 minutes.',
-                minuteFirstMessageShown,
-            ],
-            [
-                'Your CodeCatalyst Dev Environment has been inactive for 5 minutes, shutting it down in 4 minutes.',
-                minuteFirstMessageShown + 1,
-            ],
-            [
-                'Your CodeCatalyst Dev Environment has been inactive for 6 minutes, shutting it down in 3 minutes.',
-                minuteFirstMessageShown + 2,
-            ],
-            [
-                'Your CodeCatalyst Dev Environment has been inactive for 7 minutes, shutting it down in 2 minutes.',
-                minuteFirstMessageShown + 3,
-            ],
-            [
-                'Your CodeCatalyst Dev Environment has been inactive for 8 minutes, and will stop soon.',
-                minuteFirstMessageShown + 4,
-            ],
+            ['Your CodeCatalyst Dev Environment has been inactive for 4 minutes, and will stop in 5 minutes.', 4],
+            ['Your CodeCatalyst Dev Environment has been inactive for 5 minutes, and will stop in 4 minutes.', 5],
+            ['Your CodeCatalyst Dev Environment has been inactive for 6 minutes, and will stop in 3 minutes.', 6],
+            ['Your CodeCatalyst Dev Environment has been inactive for 7 minutes, and will stop in 2 minutes.', 7],
+            ['Your CodeCatalyst Dev Environment has been inactive for 8 minutes, and will stop soon.', 8],
         ])
     })
 
@@ -160,11 +153,12 @@ describe('InactivityMessages', function () {
             return true
         })
 
-        await instance.setupMessage(
-            InactivityMessage.shutdownWarningThreshold + 1,
+        await inactivityMsg.init(
+            inactivityMsg.shutdownWarningThreshold + 1,
             devEnvActivity as unknown as DevEnvActivity,
             relativeMinuteMillis
         )
+        await devEnvActivity.sendActivityUpdate()
         await sleep(relativeMinuteMillis * 3)
         assert.strictEqual(testWindow.shownMessages.length, 0)
         assert.strictEqual(devEnvActivity.isLocalActivityStale.calledOnce, true)
@@ -178,23 +172,22 @@ describe('InactivityMessages', function () {
      * @param minute The minute the message was expected to be shown at
      */
     async function assertMessagesShown(expectedMessages: [text: string, minute: number][]) {
-        // Sleep until all messages should have been shown.
-        //
-        // This buffer gives us a bit more time to wrap things up.
-        // Be careful setting it to >relativeMinuteMillis, as it could
-        // start a new cycle of messages if too large.
-        const expectedMinuteLastMessageShown = expectedMessages[expectedMessages.length - 1][1]
-        const buffer = relativeMinuteMillis - 1
-        await sleep(expectedMinuteLastMessageShown * relativeMinuteMillis + buffer)
-
+        await waitUntil(
+            async () => {
+                return expectedMessages.length === actualMessages.length
+            },
+            { truthy: true, interval: 200, timeout: 10_000 }
+        )
         if (expectedMessages.length !== actualMessages.length) {
             assert.fail(`Expected ${expectedMessages.length} messages, but got ${actualMessages.length}`)
         }
 
-        let i: number
-        for (i = 0; i < expectedMessages.length; i++) {
-            assert.strictEqual(actualMessages[i].message, expectedMessages[i][0])
-            assert.strictEqual(actualMessages[i].minute, expectedMessages[i][1])
+        for (let i = 0; i < expectedMessages.length; i++) {
+            const expected = {
+                message: expectedMessages[i][0],
+                minute: expectedMessages[i][1],
+            }
+            assert.deepStrictEqual(actualMessages[i], expected)
         }
     }
 
@@ -214,7 +207,7 @@ describe('InactivityMessages', function () {
         actualMessages = messages
     }
 
-    let _initialOffset: number | undefined
+    let _initialOffset = 0
     /**
      * This is used for the edge case where the MDE was previously updated with an activity
      * timestamp, but once our client retrieves this value some time has already passed.
@@ -225,10 +218,8 @@ describe('InactivityMessages', function () {
 
     function getLatestTimestamp() {
         let timestamp = Date.now()
-        if (_initialOffset) {
-            timestamp -= _initialOffset
-            _initialOffset = undefined
-        }
+        timestamp -= _initialOffset
+        _initialOffset = 0
 
         return timestamp
     }

--- a/packages/core/src/testInteg/codecatalyst/devEnv.test.ts
+++ b/packages/core/src/testInteg/codecatalyst/devEnv.test.ts
@@ -4,21 +4,21 @@
  */
 
 import assert from 'assert'
-import { InactivityMessage, shouldTrackUserActivity } from '../../codecatalyst/devEnv'
+import { InactivityMessage, shouldSendActivity } from '../../codecatalyst/devEnv'
 import * as sinon from 'sinon'
 import { sleep } from '../../shared/utilities/timeoutUtils'
 import { TestWindow, getTestWindow } from '../../test/shared/vscode/window'
 import { DevEnvActivity } from '../../shared/clients/devenvClient'
 
-describe('shouldTrackUserActivity', function () {
+describe('shouldSendActivity', function () {
     it('returns true when inactivity timeout > 0', function () {
-        assert.strictEqual(shouldTrackUserActivity(1), true)
-        assert.strictEqual(shouldTrackUserActivity(15), true)
+        assert.strictEqual(shouldSendActivity(1), true)
+        assert.strictEqual(shouldSendActivity(15), true)
     })
 
     it('returns false when inactivity timeout <== 0', function () {
-        assert.strictEqual(shouldTrackUserActivity(0), false)
-        assert.strictEqual(shouldTrackUserActivity(-1), false)
+        assert.strictEqual(shouldSendActivity(0), false)
+        assert.strictEqual(shouldSendActivity(-1), false)
     })
 })
 
@@ -124,7 +124,7 @@ describe('InactivityMessages', function () {
         // which is why 2 1/2 minutes becomes 3 minutes. Then we start the countdown to show the
         // first warning message.
         const minuteFirstMessageShown =
-            inactiveMinutes - Math.ceil(initialOffsetMinutes) - InactivityMessage.firstMessageBeforeShutdown
+            inactiveMinutes - Math.ceil(initialOffsetMinutes) - InactivityMessage.shutdownWarningThreshold
         setInitialOffset(initialOffsetMinutes)
 
         await instance.setupMessage(inactiveMinutes, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
@@ -161,7 +161,7 @@ describe('InactivityMessages', function () {
         })
 
         await instance.setupMessage(
-            InactivityMessage.firstMessageBeforeShutdown + 1,
+            InactivityMessage.shutdownWarningThreshold + 1,
             devEnvActivity as unknown as DevEnvActivity,
             relativeMinuteMillis
         )

--- a/packages/toolkit/.changes/next-release/Bug Fix-ebea70a6-ac18-4394-a543-c9422ef5ccb7.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-ebea70a6-ac18-4394-a543-c9422ef5ccb7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeCatalyst: Dev Environment may time out if user is not authenticated"
+}


### PR DESCRIPTION
## Problem
Toolkit requires a connection / auth session token to send heartbeat activity: https://github.com/aws/aws-toolkit-vscode/blob/4512e2052ec29bed0b11184e606b3937daa99346/packages/core/src/codecatalyst/devEnv.ts#L73-L94 This means if the user is not connected, the dev env will time out.

## Solution
- Always send heartbeat activity (except when we know that `inactivityTimeoutMinutes=0`).
- If `inactivityTimeoutMinutes` is unknown, assume it is 15 minutes.


<img width="532" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/55561878/2197e7b0-a878-4e5b-8a98-28cb0b65b3fb">



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
