### PR TITLE
fix(amazonq): update walkthrough

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -686,6 +686,17 @@
                 "description": "Your generative AI-powered assistant across the software development lifecycle.",
                 "steps": [
                     {
+                        "id": "aws.amazonq.walkthrough.inlineSuggestions",
+                        "title": "Get inline code suggestions",
+                        "description": "Amazon Q suggests code as you type based on your open files. Accepted suggestions from licensed code will go into the Code Reference Log.\n\n[Try Example](command:_aws.amazonq.walkthrough.inlineSuggestionsExample)\n\n**TIP: Invoke manually with opt/alt + c**",
+                        "media": {
+                            "markdown": "./resources/walkthrough/amazonq/inline.md"
+                        },
+                        "completionEvents": [
+                            "onCommand:_aws.amazonq.walkthrough.inlineSuggestionsExample"
+                        ]
+                    },
+                    {
                         "id": "aws.amazonq.walkthrough.chat",
                         "title": "Ask using chat",
                         "description": "Amazon Q answers software development questions, writes code based on your current file, and cites sources.\n\nUse the right-click menu for quick commands.\n\n**TIP: Drag and drop the Q panel to dock on the right**",
@@ -695,20 +706,15 @@
                         "completionEvents": []
                     },
                     {
-                        "id": "aws.amazonq.walkthrough.inlineSuggestions",
-                        "title": "Get inline code suggestions",
-                        "description": "Amazon Q suggests code as you type based on your open files. Accepted suggestions from licensed code will go into the Code Reference Log.\n\n[Try inline code examples](command:aws.amazonq.gettingStarted)\n\n**TIP: Invoke manually with opt/alt + c**",
-                        "media": {
-                            "markdown": "./resources/walkthrough/amazonq/inline.md"
-                        }
-                    },
-                    {
                         "id": "aws.amazonq.walkthrough.securityScan",
                         "title": "Check for security vulnerabilities",
-                        "description": "Amazon Q scans your code to identify security vulnerabilities and suggests fixes.\n\nStart a scan from the status bar menu.\n\n**TIP: identifies vulnerabilities in Python, Typescript, Ruby, AWS CDK, and more**",
+                        "description": "Amazon Q scans your code to identify security vulnerabilities and suggests fixes.\n\nStart a scan from the status bar menu.\n\n[Scan your current project](command:_aws.amazonq.walkthrough.securityScanExample)\n\nIdentifies vulnerabilities in Python, Typescript, Ruby, AWS CDK, and [more](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/q-language-ide-support.html#security-scans-language-support)",
                         "media": {
                             "markdown": "./resources/walkthrough/amazonq/scans.md"
-                        }
+                        },
+                        "completionEvents": [
+                            "onCommand:_aws.amazonq.walkthrough.securityScanExample"
+                        ]
                     },
                     {
                         "id": "aws.amazonq.walkthrough.settings",

--- a/packages/core/src/amazonq/activation.ts
+++ b/packages/core/src/amazonq/activation.ts
@@ -12,7 +12,12 @@ import { init as gumbyChatAppInit } from '../amazonqGumby/app'
 import { AmazonQAppInitContext, DefaultAmazonQAppInitContext } from './apps/initContext'
 import { activateBadge } from './util/viewBadgeHandler'
 import { amazonQHelpUrl } from '../shared/constants'
-import { focusAmazonQChatWalkthrough, openAmazonQWalkthrough } from './onboardingPage/walkthrough'
+import {
+    focusAmazonQChatWalkthrough,
+    openAmazonQWalkthrough,
+    walkthroughInlineSuggestionsExample,
+    walkthroughSecurityScanExample,
+} from './onboardingPage/walkthrough'
 import { listCodeWhispererCommandsWalkthrough } from '../codewhisperer/ui/statusBarMenu'
 import { Commands, placeholder } from '../shared/vscode/commands2'
 import { focusAmazonQPanel, focusAmazonQPanelKeybinding } from '../codewhispererChat/commands/registerCommands'
@@ -45,6 +50,8 @@ export async function activate(context: ExtensionContext) {
             },
         }),
         focusAmazonQChatWalkthrough.register(),
+        walkthroughInlineSuggestionsExample.register(),
+        walkthroughSecurityScanExample.register(),
         openAmazonQWalkthrough.register(),
         listCodeWhispererCommandsWalkthrough.register(),
         focusAmazonQPanel.register(),

--- a/packages/core/src/amazonq/onboardingPage/walkthrough.ts
+++ b/packages/core/src/amazonq/onboardingPage/walkthrough.ts
@@ -7,6 +7,7 @@ import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerComm
 import globals, { isWeb } from '../../shared/extensionGlobals'
 import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
 import { getLogger } from '../../shared/logger'
+import { localize } from '../../shared/utilities/vsCodeUtils'
 import { Commands, placeholder } from '../../shared/vscode/commands2'
 import vscode from 'vscode'
 
@@ -48,3 +49,31 @@ export const openAmazonQWalkthrough = Commands.declare(`_aws.amazonq.walkthrough
 export const focusAmazonQChatWalkthrough = Commands.declare('_aws.amazonq.walkthrough.focusChat', () => async () => {
     await focusAmazonQPanel.execute(placeholder, 'walkthrough')
 })
+
+export const walkthroughInlineSuggestionsExample = Commands.declare(
+    `_aws.amazonq.walkthrough.inlineSuggestionsExample`,
+    () => async () => {
+        const fileName = 'AmazonQ_generate_suggestion.py'
+        const fileContents = `# TODO: place your cursor at the end of line 5 and press Enter to generate a suggestion.
+# Tip: press tab to accept the suggestion
+
+fake_users = [
+    { "name": "User 1", "id": "user1", "city": "San Francisco", "state": "CA" },`
+
+        const uri = vscode.Uri.parse(`untitled:${fileName}`)
+        const document = await vscode.workspace.openTextDocument(uri)
+        const editor = await vscode.window.showTextDocument(document)
+
+        await editor.edit(editBuilder => {
+            editBuilder.insert(new vscode.Position(0, 0), fileContents)
+        })
+    }
+)
+
+export const walkthroughSecurityScanExample = Commands.declare(
+    `_aws.amazonq.walkthrough.securityScanExample`,
+    () => async () => {
+        const filterText = localize('AWS.command.amazonq.security.scan', 'Run Project Scan')
+        void vscode.commands.executeCommand('workbench.action.quickOpen', `> ${filterText}`)
+    }
+)


### PR DESCRIPTION
Notes
- Make inline suggestion as the first item for walkthrough
- Do not redirect user to Try inline suggestion example
- Add CTA and directly open an example
- add example for security scan in walkthrough

## Inline Suggestions Example
### Metrics
```
{
  Metadata: {
    command: '_aws.amazonq.walkthrough.inlineSuggestionsExample',
    duration: '76',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: true
}
```

### Attachments

https://github.com/aws/aws-toolkit-vscode/assets/371007/73007977-bfae-46f9-a854-593caed1f6c9

## Security Scan

### Metrics
```
{
  Metadata: {
    command: '_aws.amazonq.walkthrough.securityScanExample',
    duration: '26',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: true
}
```

### Attachments

https://github.com/aws/aws-toolkit-vscode/assets/371007/11d60503-24e4-4cb2-97df-44b9035589ad

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
