### PR TITLE
Amazon Q Code Transform: Failure Build Log

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-a74ecc5a-9493-40e1-8211-c197b905ac87.json
+++ b/packages/amazonq/.changes/next-release/Feature-a74ecc5a-9493-40e1-8211-c197b905ac87.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q Code Transform: Allow user to view transformation build log"
+}

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -460,9 +460,9 @@ export class GumbyController {
             this.messenger.sendKnownErrorResponse('no-alternate-dependencies-found', message.tabID)
             await this.continueTransformationWithoutHIL(message)
         } else if (message.error instanceof ModuleUploadError) {
-            this.messenger.sendUnrecoverableErrorResponse('upload-to-s3-failed', message.tabID)
+            this.resetTransformationChatFlow()
         } else if (message.error instanceof JobStartError) {
-            this.messenger.sendUnrecoverableErrorResponse('job-start-failed', message.tabID)
+            this.resetTransformationChatFlow()
         } else if (message.error instanceof TransformationPreBuildError) {
             this.messenger.sendJobSubmittedMessage(message.tabID, true)
             this.messenger.sendAsyncEventProgress(

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -20,9 +20,11 @@ import {
     compileProject,
     finishHumanInTheLoop,
     getValidCandidateProjects,
+    openBuildLogFile,
     openHilPomFile,
     postTransformationJob,
     processTransformFormInput,
+    resetDebugArtifacts,
     startTransformByQ,
     stopTransformByQ,
     validateCanCompileProject,
@@ -35,6 +37,7 @@ import {
     ModuleUploadError,
     NoJavaProjectsFoundError,
     NoMavenJavaProjectsFoundError,
+    TransformationPreBuildError,
 } from '../../errors'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
 import MessengerUtils, { ButtonActions, GumbyCommands } from './messenger/messengerUtils'
@@ -263,6 +266,7 @@ export class GumbyController {
 
     private async formActionClicked(message: any) {
         const typedAction = MessengerUtils.stringToEnumValue(ButtonActions, message.action as any)
+        console.log(`typedAction: ${typedAction}`)
         switch (typedAction) {
             case ButtonActions.CONFIRM_TRANSFORMATION_FORM:
                 await this.initiateTransformationOnProject(message)
@@ -280,6 +284,8 @@ export class GumbyController {
                 await cleanupTransformationJob()
                 break
             case ButtonActions.CONFIRM_START_TRANSFORMATION_FLOW:
+                this.resetTransformationChatFlow()
+                await resetDebugArtifacts()
                 this.messenger.sendCommandMessage({ ...message, command: GumbyCommands.CLEAR_CHAT })
                 await this.transformInitiated(message)
                 break
@@ -292,6 +298,10 @@ export class GumbyController {
                 break
             case ButtonActions.OPEN_FILE:
                 await openHilPomFile()
+                break
+            case ButtonActions.OPEN_BUILD_LOG:
+                await openBuildLogFile()
+                this.messenger.sendViewBuildLog(message.tabID)
                 break
         }
     }
@@ -451,9 +461,18 @@ export class GumbyController {
             this.messenger.sendKnownErrorResponse('no-alternate-dependencies-found', message.tabID)
             await this.continueTransformationWithoutHIL(message)
         } else if (message.error instanceof ModuleUploadError) {
-            this.resetTransformationChatFlow()
+            this.messenger.sendUnrecoverableErrorResponse('upload-to-s3-failed', message.tabID)
         } else if (message.error instanceof JobStartError) {
-            this.resetTransformationChatFlow()
+            this.messenger.sendUnrecoverableErrorResponse('job-start-failed', message.tabID)
+        } else if (message.error instanceof TransformationPreBuildError) {
+            this.messenger.sendJobSubmittedMessage(message.tabID, true)
+            this.messenger.sendAsyncEventProgress(
+                message.tabID,
+                true,
+                undefined,
+                GumbyNamedMessages.JOB_FAILED_IN_PRE_BUILD
+            )
+            this.messenger.sendViewBuildLog(message.tabID)
         }
     }
 

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -266,7 +266,6 @@ export class GumbyController {
 
     private async formActionClicked(message: any) {
         const typedAction = MessengerUtils.stringToEnumValue(ButtonActions, message.action as any)
-        console.log(`typedAction: ${typedAction}`)
         switch (typedAction) {
             case ButtonActions.CONFIRM_TRANSFORMATION_FORM:
                 await this.initiateTransformationOnProject(message)

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -10,7 +10,7 @@
 
 import { AuthFollowUpType, expiredText, enableQText, reauthenticateText } from '../../../../amazonq/auth/model'
 import { ChatItemType } from '../../../../amazonqFeatureDev/models'
-import { JDKVersion, TransformationCandidateProject } from '../../../../codewhisperer/models/model'
+import { JDKVersion, TransformationCandidateProject, transformByQState } from '../../../../codewhisperer/models/model'
 import { FeatureAuthState } from '../../../../codewhisperer/util/authUtil'
 import * as CodeWhispererConstants from '../../../../codewhisperer/models/constants'
 import {
@@ -52,6 +52,7 @@ export enum GumbyNamedMessages {
     COMPILATION_PROGRESS_MESSAGE = 'gumbyProjectCompilationMessage',
     JOB_SUBMISSION_STATUS_MESSAGE = 'gumbyJobSubmissionMessage',
     JOB_SUBMISSION_WITH_DEPENDENCY_STATUS_MESSAGE = 'gumbyJobSubmissionWithDependencyMessage',
+    JOB_FAILED_IN_PRE_BUILD = 'gumbyJobFailedInPreBuildMessage',
 }
 
 export class Messenger {
@@ -548,6 +549,32 @@ ${codeSnippet}
             false,
             message,
             GumbyNamedMessages.JOB_SUBMISSION_WITH_DEPENDENCY_STATUS_MESSAGE
+        )
+    }
+
+    public sendViewBuildLog(tabID: string) {
+        const message = `I am having trouble building your project in the secure build environment and could not complete the transformation.`
+        const messageId = GumbyNamedMessages.JOB_FAILED_IN_PRE_BUILD
+        const buttons: ChatItemButton[] = []
+
+        if (transformByQState.getPreBuildLogFilePath() !== '') {
+            buttons.push({
+                keepCardAfterClick: true,
+                text: `View Build Log`,
+                id: ButtonActions.OPEN_BUILD_LOG,
+            })
+        }
+
+        this.dispatcher.sendChatMessage(
+            new ChatMessage(
+                {
+                    message,
+                    messageType: 'ai-prompt',
+                    messageId,
+                    buttons,
+                },
+                tabID
+            )
         )
     }
 }

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
@@ -21,6 +21,7 @@ export enum ButtonActions {
     CANCEL_JAVA_HOME_FORM = 'gumbyJavaHomeFormCancel',
     CONFIRM_START_TRANSFORMATION_FLOW = 'gumbyStartTransformation',
     OPEN_FILE = 'gumbyOpenFile',
+    OPEN_BUILD_LOG = 'gumbyOpenBuildLog',
 }
 
 export enum GumbyCommands {

--- a/packages/core/src/amazonqGumby/errors.ts
+++ b/packages/core/src/amazonqGumby/errors.ts
@@ -48,6 +48,12 @@ export class JobStoppedError extends Error {
     }
 }
 
+export class TransformationPreBuildError extends Error {
+    constructor(message: string) {
+        super(message)
+    }
+}
+
 export class ModuleUploadError extends Error {
     constructor() {
         super('Failed to upload module to S3')

--- a/packages/core/src/amazonqGumby/errors.ts
+++ b/packages/core/src/amazonqGumby/errors.ts
@@ -49,8 +49,8 @@ export class JobStoppedError extends Error {
 }
 
 export class TransformationPreBuildError extends Error {
-    constructor(message: string) {
-        super(message)
+    constructor() {
+        super('Job failed to build after submission')
     }
 }
 

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -22,6 +22,7 @@ import {
 import { convertDateToTimestamp } from '../../shared/utilities/textUtilities'
 import {
     createZipManifest,
+    downloadAndExtractResultArchive,
     downloadHilResultArchive,
     findDownloadArtifactStep,
     getArtifactsFromProgressUpdate,
@@ -54,6 +55,7 @@ import {
     JobStartError,
     ModuleUploadError,
     PollJobError,
+    TransformationPreBuildError,
 } from '../../amazonqGumby/errors'
 import { ChatSessionManager } from '../../amazonqGumby/chat/storages/chatSession'
 import {
@@ -377,6 +379,12 @@ export async function openHilPomFile() {
     )
 }
 
+export async function openBuildLogFile() {
+    const logFilePath = transformByQState.getPreBuildLogFilePath()
+    const doc = await vscode.workspace.openTextDocument(logFilePath)
+    await vscode.window.showTextDocument(doc)
+}
+
 export async function terminateHILEarly(jobID: string) {
     // Call resume with "REJECTED" state which will put our service
     // back into the normal flow and will not trigger HIL again for this step
@@ -501,12 +509,23 @@ export async function pollTransformationStatusUntilPlanReady(jobId: string) {
         await pollTransformationJob(jobId, CodeWhispererConstants.validStatesForPlanGenerated)
     } catch (error) {
         getLogger().error(`CodeTransformation: ${CodeWhispererConstants.failedToCompleteJobNotification}`, error)
+
         if (!transformByQState.getJobFailureErrorNotification()) {
             transformByQState.setJobFailureErrorNotification(CodeWhispererConstants.failedToCompleteJobNotification)
         }
         if (!transformByQState.getJobFailureErrorChatMessage()) {
             transformByQState.setJobFailureErrorChatMessage(CodeWhispererConstants.failedToCompleteJobChatMessage)
         }
+
+        if (error instanceof TransformationPreBuildError) {
+            const tmpDir = path.join(os.tmpdir(), 'q-transformation-build-logs')
+            await downloadAndExtractResultArchive(jobId, undefined, tmpDir, 'Logs')
+            const pathToLog = path.join(tmpDir, 'buildCommandOutput.log')
+            transformByQState.setPreBuildLogFilePath(pathToLog)
+
+            throw error
+        }
+
         throw new PollJobError()
     }
     let plan = undefined
@@ -696,6 +715,14 @@ export async function cleanupTransformationJob() {
         CodeTransformTelemetryState.instance.getStartTime()
     )
     CodeTransformTelemetryState.instance.resetCodeTransformMetaDataField()
+}
+
+export async function resetDebugArtifacts() {
+    const buildLogPath = transformByQState.getPreBuildLogFilePath()
+    if (buildLogPath && fs.existsSync(buildLogPath)) {
+        fs.rmSync(path.dirname(transformByQState.getPreBuildLogFilePath()), { recursive: true, force: true })
+    }
+    transformByQState.setPreBuildLogFilePath('')
 }
 
 export async function stopTransformByQ(

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -381,6 +381,7 @@ export class TransformByQState {
 
     private planFilePath: string = ''
     private summaryFilePath: string = ''
+    private preBuildLogFilePath: string = ''
 
     private resultArchiveFilePath: string = ''
     private projectCopyFilePath: string = ''
@@ -439,6 +440,10 @@ export class TransformByQState {
 
     public getProjectPath() {
         return this.projectPath
+    }
+
+    public getPreBuildLogFilePath() {
+        return this.preBuildLogFilePath
     }
 
     public getStartTime() {
@@ -635,6 +640,10 @@ export class TransformByQState {
 
     public setPlanSteps(steps: TransformationSteps) {
         this.planSteps = steps
+    }
+
+    public setPreBuildLogFilePath(path: string) {
+        this.preBuildLogFilePath = path
     }
 
     public resetPlanSteps() {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -38,7 +38,7 @@ import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/cod
 import { calculateTotalLatency } from '../../../amazonqGumby/telemetry/codeTransformTelemetry'
 import { MetadataResult } from '../../../shared/telemetry/telemetryClient'
 import request from '../../../common/request'
-import { JobStoppedError, TransformationPreBuildError, ZipExceedsSizeLimitError } from '../../../amazonqGumby/errors'
+import { JobStoppedError, ZipExceedsSizeLimitError } from '../../../amazonqGumby/errors'
 import { writeLogs } from './transformFileHandler'
 import { AuthUtil } from '../../util/authUtil'
 import { createCodeWhispererChatStreamingClient } from '../../../shared/clients/codewhispererChatClient'
@@ -764,16 +764,12 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
                         CodeWhispererConstants.failedToStartJobLinesLimitChatMessage
                     )
                 }
-                if (errorMessage.includes('The requested module could not be built')) {
-                    throw new TransformationPreBuildError(response.transformationJob.reason || '')
-                } else {
-                    transformByQState.setJobFailureErrorChatMessage(
-                        `${CodeWhispererConstants.failedToCompleteJobGenericChatMessage} ${errorMessage}`
-                    )
-                    transformByQState.setJobFailureErrorNotification(
-                        `${CodeWhispererConstants.failedToCompleteJobGenericNotification} ${errorMessage}`
-                    )
-                }
+                transformByQState.setJobFailureErrorChatMessage(
+                    `${CodeWhispererConstants.failedToCompleteJobGenericChatMessage} ${errorMessage}`
+                )
+                transformByQState.setJobFailureErrorNotification(
+                    `${CodeWhispererConstants.failedToCompleteJobGenericNotification} ${errorMessage}`
+                )
                 transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
             }
             if (validStates.includes(status)) {
@@ -881,6 +877,7 @@ export async function downloadResultArchive(
             result: MetadataResult.Fail,
             reason: 'ExportResultArchiveFailed',
         })
+        throw e
     } finally {
         cwStreamingClient.destroy()
     }

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -311,29 +311,20 @@ describe('resetDebugArtifacts', () => {
         assert.strictEqual(transformByQState.getPreBuildLogFilePath(), '')
     })
 
-    it.skip('should not remove any directory if the pre-build log file path is not set', async () => {
+    it('should not remove any directory if the pre-build log file path is not set', async () => {
         transformByQState.setPreBuildLogFilePath('')
-
-        const fsSpy = sinon.spy(fs, 'rmSync')
 
         await resetDebugArtifacts()
 
-        sinon.assert.notCalled(fsSpy)
         assert.strictEqual(transformByQState.getPreBuildLogFilePath(), '')
-        sinon.restore()
     })
 
-    it.skip('should not remove any directory if the pre-build log file does not exist', async () => {
+    it('should not remove any directory if the pre-build log file does not exist', async () => {
         const preBuildLogFilePath = 'non/existent/path/to/pre-build.log'
         transformByQState.setPreBuildLogFilePath(preBuildLogFilePath)
 
-        const fsSpy = sinon.spy(fs, 'rmSync')
-
         await resetDebugArtifacts()
 
-        sinon.assert.notCalled(fsSpy)
         assert.strictEqual(transformByQState.getPreBuildLogFilePath(), '')
-
-        sinon.restore()
     })
 })

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs-extra'
 import * as sinon from 'sinon'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { transformByQState, TransformByQStoppedError } from '../../../codewhisperer/models/model'
-import { stopTransformByQ } from '../../../codewhisperer/commands/startTransformByQ'
+import { resetDebugArtifacts, stopTransformByQ } from '../../../codewhisperer/commands/startTransformByQ'
 import { HttpResponse } from 'aws-sdk'
 import * as codeWhisperer from '../../../codewhisperer/client/codewhisperer'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
@@ -295,5 +295,45 @@ describe('transformByQ', function () {
             '-1': '{"columnNames":["relativePath","action"],"rows":[{"relativePath":"pom.xml","action":"Update"}, {"relativePath":"src/main/java/com/bhoruka/bloodbank/BloodbankApplication.java","action":"Update"}]}',
         }
         assert.deepStrictEqual(actual, expected)
+    })
+})
+
+describe('resetDebugArtifacts', () => {
+    it('should remove the directory containing the pre-build log file if it exists', async () => {
+        const dirPath = await createTestWorkspaceFolder()
+        const preBuildLogFilePath = path.join(dirPath.uri.fsPath, 'DummyLog.log')
+        await toFile('', preBuildLogFilePath)
+        transformByQState.setPreBuildLogFilePath(preBuildLogFilePath)
+
+        await resetDebugArtifacts()
+
+        assert.strictEqual(fs.existsSync(preBuildLogFilePath), false)
+        assert.strictEqual(transformByQState.getPreBuildLogFilePath(), '')
+    })
+
+    it.skip('should not remove any directory if the pre-build log file path is not set', async () => {
+        transformByQState.setPreBuildLogFilePath('')
+
+        const fsSpy = sinon.spy(fs, 'rmSync')
+
+        await resetDebugArtifacts()
+
+        sinon.assert.notCalled(fsSpy)
+        assert.strictEqual(transformByQState.getPreBuildLogFilePath(), '')
+        sinon.restore()
+    })
+
+    it.skip('should not remove any directory if the pre-build log file does not exist', async () => {
+        const preBuildLogFilePath = 'non/existent/path/to/pre-build.log'
+        transformByQState.setPreBuildLogFilePath(preBuildLogFilePath)
+
+        const fsSpy = sinon.spy(fs, 'rmSync')
+
+        await resetDebugArtifacts()
+
+        sinon.assert.notCalled(fsSpy)
+        assert.strictEqual(transformByQState.getPreBuildLogFilePath(), '')
+
+        sinon.restore()
     })
 })


### PR DESCRIPTION
This change enables customers to view the server-side build logs that are generated for a code transform after a project has been submitted. The build log will be downloaded locally, and the option is given to view it in the chat.

<img width="408" alt="Screenshot 2024-06-12 at 4 28 50 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/624190/c96f678d-1340-4912-939d-6dece6eae9d6">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
