### PR TITLE
feat(amazonq): reauth enforces amazon q scopes only

### DIFF
--- a/packages/core/src/auth/connection.ts
+++ b/packages/core/src/auth/connection.ts
@@ -63,6 +63,15 @@ export function hasScopes(target: SsoConnection | SsoProfile | string[], scopes:
     return scopes?.every(s => (Array.isArray(target) ? target : target.scopes)?.includes(s))
 }
 
+/**
+ * Stricter version of hasScopes that checks for all and only all of the predicate scopes.
+ * Not optimized, but the set of possible scopes is currently very small (< 8)
+ */
+export function hasExactScopes(target: SsoConnection | SsoProfile | string[], scopes: string[]): boolean {
+    const targetScopes = Array.isArray(target) ? target : target.scopes ?? []
+    return scopes.length === targetScopes.length && scopes.every(s => targetScopes.includes(s))
+}
+
 export function createBuilderIdProfile(
     scopes = [...scopesSsoAccountAccess]
 ): SsoProfile & { readonly scopes: string[] } {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import * as localizedText from '../../shared/localizedText'
 import { Auth } from '../../auth/auth'
 import { ToolkitError } from '../../shared/errors'
-import { getSecondaryAuth } from '../../auth/secondaryAuth'
+import { getSecondaryAuth, setScopes } from '../../auth/secondaryAuth'
 import { isCloud9, isSageMaker } from '../../shared/extensionUtilities'
 import { AmazonQPromptSettings } from '../../shared/settings'
 import {
@@ -25,6 +25,7 @@ import {
     scopesGumby,
     isIdcSsoConnection,
     AwsConnection,
+    hasExactScopes,
 } from '../../auth/connection'
 import { getLogger } from '../../shared/logger'
 import { Commands } from '../../shared/vscode/commands2'
@@ -341,10 +342,9 @@ export class AuthUtil {
                 return
             }
 
-            if (!isValidAmazonQConnection(this.conn)) {
-                const conn = await this.secondaryAuth.addScopes(this.conn, amazonQScopes)
+            if (!hasExactScopes(this.conn, amazonQScopes)) {
+                const conn = await setScopes(this.conn, amazonQScopes, this.auth)
                 await this.secondaryAuth.useNewConnection(conn)
-                return
             }
 
             await this.auth.reauthenticate(this.conn)


### PR DESCRIPTION
**Session split commit**

Problem: Amazon Q will continue to use connections it already has. These connections may contain scopes from toolkit.

Solution: Reauth with only amazon q scopes once the connection expires.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
