### PR TITLE
[split sessions] feat(auth): forget about Amazon Q connections in toolkit

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -328,6 +328,23 @@ export class Auth implements AuthService, ConnectionManager {
         this.#onDidDeleteConnection.fire(connId)
     }
 
+    /**
+     * @warning Intended for a specific use case. May have unintended side effects. Use `deleteConnection()` instead.
+     *
+     * Forget about a connection without logging out, invalidating it, or deleting it from disk.
+     */
+    public async forgetConnection(connection: Pick<Connection, 'id'>): Promise<void> {
+        const connId = connection.id
+        const profile = this.store.getProfile(connId)
+        if (profile) {
+            await this.store.deleteProfile(connId)
+            if (profile.type === 'sso') {
+                await this.clearStaleLinkedIamConnections()
+            }
+        }
+        this.#onDidDeleteConnection.fire(connId)
+    }
+
     private async clearStaleLinkedIamConnections() {
         // Updates our store, evicting stale IAM credential profiles if the
         // SSO they are linked to was removed.

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -189,14 +189,26 @@ export class SecondaryAuth<T extends Connection = Connection> {
         }
     }
 
+    /**
+     * @warning Intended for a single use case where we need to let one service "forget" about a
+     * connection but leave it intact for other services. This may have unintended consequences.
+     * Use `deleteConnection()` instead.
+     *
+     * Clears the connection in use without deleting it or logging out.
+     */
+    public async forgetConnection() {
+        await this.clearSavedConnection()
+        await this.clearActiveConnection()
+    }
+
     /** Stop using the saved connection and fallback to using the active connection, if it is usable. */
-    private async clearSavedConnection() {
+    public async clearSavedConnection() {
         await this.memento.update(this.key, undefined)
         this.#savedConnection = undefined
         this.#onDidChangeActiveConnection.fire(this.activeConnection)
     }
 
-    private async clearActiveConnection() {
+    public async clearActiveConnection() {
         this.#activeConnection = undefined
         if (this.#savedConnection) {
             /**

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -52,13 +52,14 @@ import { Auth } from './auth/auth'
 import { registerSubmitFeedback } from './feedback/vue/submitFeedback'
 import { activateCommon, deactivateCommon, emitUserState } from './extensionCommon'
 import { learnMoreAmazonQCommand, qExtensionPageCommand, dismissQTree } from './amazonq/explorer/amazonQChildrenNodes'
-import { AuthUtil, isPreviousQUser } from './codewhisperer/util/authUtil'
+import { AuthUtil, codeWhispererCoreScopes, isPreviousQUser } from './codewhisperer/util/authUtil'
 import { installAmazonQExtension } from './codewhisperer/commands/basicCommands'
 import { isExtensionInstalled, VSCODE_EXTENSION_ID } from './shared/utilities'
 import { amazonQInstallDismissedKey } from './codewhisperer/models/constants'
 import { ExtensionUse } from './auth/utils'
 import { ExtStartUpSources } from './shared/telemetry'
 import { activate as activateThreatComposerEditor } from './threatComposer/activation'
+import { isSsoConnection, hasScopes } from './auth/connection'
 
 let localize: nls.LocalizeFunc
 
@@ -119,6 +120,16 @@ export async function activate(context: vscode.ExtensionContext) {
             await codecatalyst.activate(extContext)
         } else {
             await vscode.commands.executeCommand('setContext', 'aws.isSageMaker', true)
+        }
+
+        // Clean up remaining logins after codecatalyst activated and ran its cleanup.
+        // Because we are splitting auth sessions by extension, we can't use Amazon Q
+        // connections anymore.
+        // TODO: Remove after some time?
+        for (const conn of await Auth.instance.listConnections()) {
+            if (isSsoConnection(conn) && hasScopes(conn, codeWhispererCoreScopes)) {
+                await Auth.instance.forgetConnection(conn)
+            }
         }
 
         await activateCloudFormationTemplateRegistry(context)


### PR DESCRIPTION
**Separate sessions commit**

If the Toolkit has a connection with Amazon Q scopes, it must be in use by Amazon Q. We will forget these in Toolkit's auth. They will remain on disk. This will log out Q + Toolkit auth connections in Toolkit only.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
