### PR TITLE
fix(dev mode): startup fails on invalid dev.logfile

### DIFF
--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -24,7 +24,7 @@ export async function activate(
 ): Promise<void> {
     const settings = Settings.instance.getSection('aws')
     const devLogfile = settings.get('dev.logfile', '')
-    const logUri = devLogfile ? vscode.Uri.file(resolvePath(devLogfile)) : undefined
+    const logUri = typeof devLogfile === 'string' ? vscode.Uri.file(resolvePath(devLogfile)) : undefined
     const chanLogLevel = fromVscodeLogLevel(logChannel.logLevel)
 
     await fsCommon.mkdir(extensionContext.logUri)
@@ -64,6 +64,9 @@ export async function activate(
     )
 
     getLogger().debug(`Logging started: ${logUri ?? '(no file)'}`)
+    if (devLogfile && typeof devLogfile !== 'string') {
+        getLogger().error('invalid aws.dev.logfile setting')
+    }
 
     Logging.init(logUri, mainLogger, contextPrefix)
     extensionContext.subscriptions.push(Logging.instance.viewLogs, Logging.instance.viewLogsAtMessage)

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -168,6 +168,8 @@ export class Settings {
     /**
      * Returns a scoped "slice" (or "view") of the settings configuration.
      *
+     * TODO(jmkeyes): This lacks all the type checking and error handling of {@link Settings}.
+     *
      * The returned {@link Settings} interface is limited to the provided section.
      *
      * Example:


### PR DESCRIPTION
Problem:
Extension fails to start if the "aws.dev.logfile" setting returns nonsense.
`settings.getSection().get()` is a very thin wrapper around
`vscode.workspace.getConfiguration()`, so it doesn't have the type checking and
coercion of the `Settings` class.

Solution:
Check the type.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
