### PR TITLE
fix(featureDev): stop showing spinner when there is error

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-6f801ee1-63c1-4688-aa74-40a67d3a9193.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-6f801ee1-63c1-4688-aa74-40a67d3a9193.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "fix(featureDev): stop showing spinerText when there is an error."
+	"description": "Amazon Q /dev command: stop showing spinner when there is an error."
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-6f801ee1-63c1-4688-aa74-40a67d3a9193.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-6f801ee1-63c1-4688-aa74-40a67d3a9193.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "fix(featureDev): stop showing spinerText when there is an error."
+}

--- a/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
@@ -158,11 +158,6 @@ export class QuickActionHandler {
                     body: realPromptText,
                 })
 
-                this.mynahUI.addChatItem(affectedTabId, {
-                    type: ChatItemType.ANSWER_STREAM,
-                    body: '',
-                })
-
                 this.mynahUI.updateStore(affectedTabId, {
                     loadingChat: true,
                     promptInputDisabledState: true,


### PR DESCRIPTION
## Problem

Steps to reproduce:
- Get the Latest Q plugin for VsCode
- Open the VsCode without opening any project or workspace
- Open Q, and type /dev
- In Dev chat tab, type sometinng and hit enter/Send button
- You'll see that `Generating your anwer...` response is still there even though there is an error message below that.

It should be fixed so that, if there is an error we don't show the loading message.

![bug](https://github.com/aws/aws-toolkit-vscode/assets/143654391/8413260c-ea01-4237-9c0e-09b0be61e7a2)


## Solution

- The initial streaming loading message is unnecessary when users do `/dev <User prompt>`.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
