### PR TITLE
[split sessions] feat(auth): update api for split sessions

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -353,7 +353,7 @@ export class Auth implements AuthService, ConnectionManager {
     }
 
     /**
-     * @warning Only intended for Dev mode purposes
+     * @warning Only intended for Dev mode purposes.
      *
      * Put the SSO connection in to an expired state
      */

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -130,11 +130,11 @@ export class SecondaryAuth<T extends Connection = Connection> {
             getLogger().error('handleConnectionChanged() failed: %s', (e as Error).message)
         })
         this.auth.onDidChangeActiveConnection(handleConnectionChanged)
-        this.auth.onDidDeleteConnection(async (deletedConnId: Connection['id']) => {
-            if (deletedConnId === this.#activeConnection?.id) {
+        this.auth.onDidDeleteConnection(async event => {
+            if (event.connId === this.#activeConnection?.id) {
                 await this.clearActiveConnection()
             }
-            if (deletedConnId === this.#savedConnection?.id) {
+            if (event.connId === this.#savedConnection?.id) {
                 // Our saved connection does not exist anymore, delete the reference to it.
                 await this.clearSavedConnection()
             }

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -15,7 +15,7 @@ import { CodeScanIssue, CodeScansState, codeScanState, CodeSuggestionsState, vsC
 import { connectToEnterpriseSso, getStartUrl } from '../util/getStartUrl'
 import { showCodeWhispererConnectionPrompt } from '../util/showSsoPrompt'
 import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
-import { amazonQScopes, AuthUtil } from '../util/authUtil'
+import { AuthUtil } from '../util/authUtil'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { getLogger } from '../../shared/logger'
 import { isExtensionActive, isExtensionInstalled, openUrl } from '../../shared/utilities/vsCodeUtils'
@@ -41,7 +41,7 @@ import { SsoAccessTokenProvider } from '../../auth/sso/ssoAccessTokenProvider'
 import { SystemUtilities } from '../../shared/systemUtilities'
 import { ToolkitError } from '../../shared/errors'
 import { isRemoteWorkspace } from '../../shared/vscode/env'
-import { hasScopes, isBuilderIdConnection } from '../../auth/connection'
+import { isBuilderIdConnection } from '../../auth/connection'
 import globals from '../../shared/extensionGlobals'
 
 const MessageTimeOut = 5_000
@@ -424,64 +424,34 @@ export const signoutCodeWhisperer = Commands.declare(
 
 let _toolkitApi: any = undefined
 
-const registerToolkitApiCallbackOnce = once(async () => {
+const registerToolkitApiCallbackOnce = once(() => {
     getLogger().info(`toolkitApi: Registering callbacks of toolkit api`)
     const auth = Auth.instance
 
     auth.onDidChangeConnectionState(async e => {
-        // when changing connection state in Q, also change connection state in toolkit
-        if (_toolkitApi && 'setConnection' in _toolkitApi) {
+        if (_toolkitApi && 'declareConnection' in _toolkitApi) {
             const id = e.id
             const conn = await auth.getConnection({ id })
-            if (conn && conn.type === 'sso') {
-                getLogger().info(`toolkitApi: set connection ${id}`)
-                await _toolkitApi.setConnection({
-                    type: conn.type,
-                    ssoRegion: conn.ssoRegion,
-                    scopes: conn.scopes,
-                    startUrl: conn.startUrl,
-                    state: e.state,
-                    id: id,
-                    label: conn.label,
-                } as AwsConnection)
+            if (conn?.type === 'sso') {
+                getLogger().info(`toolkitApi: declare connection ${id}`)
+                _toolkitApi.declareConnection(
+                    {
+                        type: conn.type,
+                        ssoRegion: conn.ssoRegion,
+                        startUrl: conn.startUrl,
+                        id: id,
+                    } as AwsConnection,
+                    'Amazon Q'
+                )
             }
         }
     })
-    // when deleting connection in Q, also delete same connection in toolkit
     auth.onDidDeleteConnection(async id => {
-        if (_toolkitApi && 'deleteConnection' in _toolkitApi) {
-            getLogger().info(`toolkitApi: delete connection ${id}`)
-            await _toolkitApi.deleteConnection(id)
+        if (_toolkitApi && 'undeclareConnection' in _toolkitApi) {
+            getLogger().info(`toolkitApi: undeclare connection ${id}`)
+            _toolkitApi.undeclareConnection(id)
         }
     })
-
-    if (_toolkitApi) {
-        // when toolkit connection changes
-        if ('onDidChangeConnection' in _toolkitApi) {
-            _toolkitApi.onDidChangeConnection(
-                async (connection: AwsConnection) => {
-                    getLogger().info(`toolkitApi: connection change callback ${connection.id}`)
-                    await AuthUtil.instance.onUpdateConnection(connection)
-                },
-
-                async (id: string) => {
-                    getLogger().info(`toolkitApi: connection delete callback ${id}`)
-                    await AuthUtil.instance.onDeleteConnection(id)
-                }
-            )
-        }
-
-        // HACK
-        // If the user has an old 3 scope Amazon Q connection, we will use it and expire it to
-        // bring the user to the new 5 scope connection. The code for this lives in the webview,
-        // so we will force show the webview if we have a connection that fits this criteria.
-        if ('listConnections' in _toolkitApi && !AuthUtil.instance.isConnected()) {
-            const conn = AuthUtil.instance.findMinimalQConnection(await _toolkitApi.listConnections())
-            if (conn !== undefined && !hasScopes(conn.scopes!, amazonQScopes)) {
-                focusQAfterDelay()
-            }
-        }
-    }
 })
 
 export const registerToolkitApiCallback = Commands.declare(
@@ -502,7 +472,20 @@ export const registerToolkitApiCallback = Commands.declare(
                 _toolkitApi = toolkitExt?.exports.getApi(VSCODE_EXTENSION_ID.amazonq)
             }
             if (_toolkitApi) {
-                await registerToolkitApiCallbackOnce()
+                registerToolkitApiCallbackOnce()
+                // Declare current conn immediately
+                const currentConn = AuthUtil.instance.conn
+                if (currentConn?.type === 'sso') {
+                    _toolkitApi.declareConnection(
+                        {
+                            type: currentConn.type,
+                            ssoRegion: currentConn.ssoRegion,
+                            startUrl: currentConn.startUrl,
+                            id: currentConn.id,
+                        } as AwsConnection,
+                        'Amazon Q'
+                    )
+                }
             }
         }
     }

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -436,20 +436,19 @@ const registerToolkitApiCallbackOnce = once(() => {
                 getLogger().info(`toolkitApi: declare connection ${id}`)
                 _toolkitApi.declareConnection(
                     {
-                        type: conn.type,
                         ssoRegion: conn.ssoRegion,
                         startUrl: conn.startUrl,
-                        id: id,
-                    } as AwsConnection,
+                    },
                     'Amazon Q'
                 )
             }
         }
     })
-    auth.onDidDeleteConnection(async id => {
-        if (_toolkitApi && 'undeclareConnection' in _toolkitApi) {
-            getLogger().info(`toolkitApi: undeclare connection ${id}`)
-            _toolkitApi.undeclareConnection(id)
+    auth.onDidDeleteConnection(async event => {
+        if (_toolkitApi && 'undeclareConnection' in _toolkitApi && event.storedProfile?.type === 'sso') {
+            const startUrl = event.storedProfile.startUrl
+            getLogger().info(`toolkitApi: undeclare connection ${event.connId} with starturl: ${startUrl}`)
+            _toolkitApi.undeclareConnection({ startUrl })
         }
     })
 })

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -130,8 +130,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
         Auth.instance.declaredConnections.forEach(conn => {
             if (conn.startUrl !== builderIdStartUrl) {
                 connections.push({
-                    id: conn.id,
-                    ssoRegion: conn.region,
+                    ssoRegion: conn.ssoRegion,
                     startUrl: conn.startUrl,
                 } as AwsConnection)
             }

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -18,6 +18,7 @@ import {
 import { Auth } from '../../../../auth/auth'
 import { CodeCatalystAuthenticationProvider } from '../../../../codecatalyst/auth'
 import { AuthError, AuthFlowState, TelemetryMetadata } from '../types'
+import { builderIdStartUrl } from '../../../../auth/sso/model'
 import { addScopes } from '../../../../auth/secondaryAuth'
 
 export class ToolkitLoginWebview extends CommonAuthWebview {
@@ -126,18 +127,12 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
      */
     async fetchConnections(): Promise<AwsConnection[] | undefined> {
         const connections: AwsConnection[] = []
-        const _connections = await Auth.instance.listConnections()
-        _connections.forEach(c => {
-            const status = Auth.instance.getConnectionState({ id: c.id })
-            const source = Auth.instance.getConnectionSource({ id: c.id })
-            if (c.type === 'sso' && source === 'amazonq' && status) {
+        Auth.instance.declaredConnections.forEach(conn => {
+            if (conn.startUrl !== builderIdStartUrl) {
                 connections.push({
-                    id: c.id,
-                    label: c.label,
-                    type: c.type,
-                    ssoRegion: c.ssoRegion,
-                    startUrl: c.startUrl,
-                    state: status,
+                    id: conn.id,
+                    ssoRegion: conn.region,
+                    startUrl: conn.startUrl,
                 } as AwsConnection)
             }
         })

--- a/packages/toolkit/src/api.ts
+++ b/packages/toolkit/src/api.ts
@@ -50,6 +50,26 @@ export const awsToolkitApi = {
             },
 
             /**
+             * Declares a connection to toolkit to re-use SSO SSO metadata (e.g. region, startURL),
+             * but the connection is not re-used directly. These do not persist across restarts.
+             * @param connection The AWS connection of the source extension that is intended to be shared with toolkit
+             */
+            declareConnection(conn: AwsConnection, source: string) {
+                getLogger().debug(`declareConnection: extension ${extensionId}, connection id ${conn.id}`)
+                Auth.instance.declareConnectionFromApi(conn, source)
+            },
+
+            /**
+             * Undeclares a connection (e.g. logged out in the API caller). This will remove the
+             * connection's parameters (startURL, region) from the list of available logins.
+             * @param connId The connection id of a declared connection.
+             */
+            undeclareConnection(connId: string) {
+                getLogger().debug(`declareConnection: extension ${extensionId}, connection id ${connId}`)
+                Auth.instance.undeclareConnectionFromApi(connId)
+            },
+
+            /**
              * Exposing deleteConnection API for other extension to push connection deletion event to AWS toolkit
              * @param id The connection id of the to be deleted connection in aws toolkit
              */

--- a/packages/toolkit/src/api.ts
+++ b/packages/toolkit/src/api.ts
@@ -54,8 +54,8 @@ export const awsToolkitApi = {
              * but the connection is not re-used directly. These do not persist across restarts.
              * @param connection The AWS connection of the source extension that is intended to be shared with toolkit
              */
-            declareConnection(conn: AwsConnection, source: string) {
-                getLogger().debug(`declareConnection: extension ${extensionId}, connection id ${conn.id}`)
+            declareConnection(conn: Pick<AwsConnection, 'startUrl' | 'ssoRegion'>, source: string) {
+                getLogger().debug(`declareConnection: extension ${extensionId}, connection starturl: ${conn.startUrl}`)
                 Auth.instance.declareConnectionFromApi(conn, source)
             },
 
@@ -64,9 +64,9 @@ export const awsToolkitApi = {
              * connection's parameters (startURL, region) from the list of available logins.
              * @param connId The connection id of a declared connection.
              */
-            undeclareConnection(connId: string) {
-                getLogger().debug(`declareConnection: extension ${extensionId}, connection id ${connId}`)
-                Auth.instance.undeclareConnectionFromApi(connId)
+            undeclareConnection(conn: Pick<AwsConnection, 'startUrl'>) {
+                getLogger().debug(`declareConnection: extension ${extensionId}, connection starturl: ${conn.startUrl}`)
+                Auth.instance.undeclareConnectionFromApi(conn)
             },
 
             /**
@@ -102,8 +102,8 @@ export const awsToolkitApi = {
                         } as AwsConnection)
                     }
                 })
-                Auth.instance.onDidDeleteConnection(async id => {
-                    await onConnectionDeletion(id)
+                Auth.instance.onDidDeleteConnection(async event => {
+                    await onConnectionDeletion(event.connId)
                 })
             },
         }


### PR DESCRIPTION
**Separate sessions commit**

- Add new API to Toolkit to "declare" and "undeclare" a connection. Unlike the other API methods, this will inform the toolkit of existing connections without accepting them into its auth environment. This allows it to use params from other connections, e.g. start url region. It does not persist. 
- Retain original API because it may be beneficial in the future for other extensions/use cases
- Change Amazon Q's usage of the API to declare instead of direct session sharing.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
