### PR TITLE
fix(codecatalyst): avoid self-triggered UserActivity

### DIFF
--- a/packages/core/src/codecatalyst/devEnv.ts
+++ b/packages/core/src/codecatalyst/devEnv.ts
@@ -287,6 +287,7 @@ export class InactivityMessage implements vscode.Disposable {
         // Show a new message every minute
         this.progressTimeout = new Timeout(oneMin)
         this.progressTimeout.token.onCancellationRequested(c => {
+            getLogger().debug('InactivityMessage.show: CancelEvent.agent=%s', c.agent)
             if (c.agent === 'user') {
                 // User clicked the 'Cancel' button, indicate they are active.
                 userIsActive()

--- a/packages/core/src/shared/clients/devenvClient.ts
+++ b/packages/core/src/shared/clients/devenvClient.ts
@@ -8,7 +8,7 @@ import got, { HTTPError } from 'got'
 import globals from '../extensionGlobals'
 import { getLogger } from '../logger/logger'
 import { getCodeCatalystDevEnvId } from '../vscode/env'
-import { ExtensionUserActivity } from '../extensionUtilities'
+import { UserActivity } from '../extensionUtilities'
 
 const environmentAuthToken = '__MDE_ENV_API_AUTHORIZATION_TOKEN'
 const environmentEndpoint = process.env['__MDE_ENVIRONMENT_API'] ?? 'http://127.0.0.1:1339'
@@ -135,15 +135,15 @@ export class DevEnvActivity implements vscode.Disposable {
     private ideActivityListener: vscode.Disposable | undefined
     /** The last known activity timestamp, but there could be a newer one on the server. */
     private lastLocalActivity: number | undefined
-    private extensionUserActivity: ExtensionUserActivity
-    private static _defaultExtensionUserActivity: ExtensionUserActivity | undefined
+    private extensionUserActivity: UserActivity
+    private static _defaultUserActivity: UserActivity | undefined
 
     static readonly activityUpdateDelay = 10_000
 
     /** Gets a new DevEnvActivity, or undefined if service is failed. */
     static async create(
         client: DevEnvClient,
-        extensionUserActivity?: ExtensionUserActivity
+        extensionUserActivity?: UserActivity
     ): Promise<DevEnvActivity | undefined> {
         try {
             await client.getActivity()
@@ -157,14 +157,12 @@ export class DevEnvActivity implements vscode.Disposable {
         return new DevEnvActivity(client, extensionUserActivity)
     }
 
-    private constructor(private readonly client: DevEnvClient, extensionUserActivity?: ExtensionUserActivity) {
-        this.extensionUserActivity = extensionUserActivity ?? this.defaultExtensionUserActivity
+    private constructor(private readonly client: DevEnvClient, extensionUserActivity?: UserActivity) {
+        this.extensionUserActivity = extensionUserActivity ?? this.defaultUserActivity
     }
 
-    private get defaultExtensionUserActivity(): ExtensionUserActivity {
-        return (DevEnvActivity._defaultExtensionUserActivity ??= new ExtensionUserActivity(
-            DevEnvActivity.activityUpdateDelay
-        ))
+    private get defaultUserActivity(): UserActivity {
+        return (DevEnvActivity._defaultUserActivity ??= new UserActivity(DevEnvActivity.activityUpdateDelay))
     }
 
     /** Send activity timestamp to the MDE environment endpoint. */

--- a/packages/core/src/test/shared/clients/devenvClient.test.ts
+++ b/packages/core/src/test/shared/clients/devenvClient.test.ts
@@ -6,7 +6,7 @@ import { SinonStub, SinonStubbedInstance, SinonStubbedMember, createSandbox, cre
 import assert from 'assert'
 import * as vscode from 'vscode'
 
-import { ExtensionUserActivity } from '../../../shared/extensionUtilities'
+import { UserActivity } from '../../../shared/extensionUtilities'
 import { DevEnvClient, DevEnvActivity } from '../../../shared/clients/devenvClient'
 import { sleep } from '../../../shared/utilities/timeoutUtils'
 
@@ -42,7 +42,7 @@ describe('DevEnvActivity', function () {
 
         devEnvActivity = (await DevEnvActivity.create(
             devEnvClientStub as unknown as DevEnvClient,
-            new ExtensionUserActivity(0, [userActivityEvent])
+            new UserActivity(0, [userActivityEvent])
         ))!
     })
 
@@ -58,7 +58,7 @@ describe('DevEnvActivity', function () {
         devEnvClientStub.getActivity.throws()
         const instance = await DevEnvActivity.create(
             devEnvClientStub as unknown as DevEnvClient,
-            new ExtensionUserActivity(0, [userActivityEvent])
+            new UserActivity(0, [userActivityEvent])
         )
         assert.strictEqual(instance, undefined)
     })

--- a/packages/core/src/test/shared/extensionUtilities.test.ts
+++ b/packages/core/src/test/shared/extensionUtilities.test.ts
@@ -12,7 +12,7 @@ import * as sinon from 'sinon'
 import { DefaultEc2MetadataClient } from '../../shared/clients/ec2MetadataClient'
 import * as vscode from 'vscode'
 import {
-    ExtensionUserActivity,
+    UserActivity,
     getComputeRegion,
     initializeComputeRegion,
     mostRecentVersionKey,
@@ -184,7 +184,7 @@ describe('initializeComputeRegion, getComputeRegion', async function () {
     })
 })
 
-describe('ExtensionUserActivity', function () {
+describe('UserActivity', function () {
     let count: number
     let sandbox: sinon.SinonSandbox
 
@@ -209,7 +209,7 @@ describe('ExtensionUserActivity', function () {
             secondIntervalStart + 201,
             secondIntervalStart + 202,
         ]
-        const instance = new ExtensionUserActivity(throttleDelay, [
+        const instance = new UserActivity(throttleDelay, [
             ...firstInvervalMillisUntilFire.map(delayedTriggeredEvent),
             ...secondIntervalMillisUntilFire.map(delayedTriggeredEvent),
         ])
@@ -222,12 +222,12 @@ describe('ExtensionUserActivity', function () {
     describe('does not fire user activity events in specific scenarios', function () {
         let userActivitySubscriber: sinon.SinonStubbedMember<() => void>
         let _triggerUserActivity: (obj: any) => void
-        let instance: ExtensionUserActivity
+        let instance: UserActivity
 
         beforeEach(function () {
             userActivitySubscriber = sandbox.stub()
             _triggerUserActivity = () => {
-                throw Error('Called before ExtensionUserActivity was instantiated')
+                throw Error('Called before UserActivity was instantiated')
             }
         })
 
@@ -329,11 +329,10 @@ describe('ExtensionUserActivity', function () {
         }
 
         function createTriggerActivityFunc() {
-            instance = new ExtensionUserActivity(0)
+            instance = new UserActivity(0)
             instance.onUserActivity(userActivitySubscriber)
-            // Creation of the ExtensionUserActivity instance
-            // will call the stubbed event and set the value
-            // for _triggerUserActivity
+            // Creation of the UserActivity instance will call the stubbed event and set the value
+            // for _triggerUserActivity.
             return _triggerUserActivity
         }
     })


### PR DESCRIPTION
Problem:
UserActivity may fire when the extension writes to its own logfile.

Solution:
Special-case the `onDidOpenTextDocument` event.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
