### PR TITLE
ci: fix windows global activation

### DIFF
--- a/docs/arch_develop.md
+++ b/docs/arch_develop.md
@@ -523,3 +523,17 @@ tester.bar.assertDoesNotShow() // True since `foo` is not assigned an explicit v
 tester.foo.applyInput('Hello, world!') // Manipulate 'user' state
 tester.bar.assertShow() // True since 'foo' has a defined value
 ```
+
+## Module path debugging
+
+Node has an environment variable `NODE_DEBUG=module` that helps to debug module imports. This can be helpful on windows, which can load node modules into uppercase or lower case drive letters, depending on the drive letter of the parent module.
+
+You can enable this by adding `"NODE_DEBUG": "module"` into the env of your launch config that you are using.
+
+When enabled you can see the file that the import is looking for, the module load request, and the relative file requested.
+
+```
+MODULE 88184: looking for ["/aws-toolkit-vscode/packages/core/dist/src"]
+MODULE 88184: Module._load REQUEST ./codewhisperer/commands/basicCommands parent: /aws-toolkit-vscode/packages/core/dist/src/extension.js
+MODULE 88184: RELATIVE: requested: ./codewhisperer/commands/basicCommands from parent.id /aws-toolkit-vscode/packages/core/dist/src/extension.js
+```

--- a/packages/core/src/test/testRunner.ts
+++ b/packages/core/src/test/testRunner.ts
@@ -31,20 +31,40 @@ export async function runTests(
 
     function getRoot(): string {
         const abs = process.env['DEVELOPMENT_PATH'] ?? process.cwd()
-
         if (process.platform !== 'win32') {
             return abs
         }
 
-        // Force all drive letters (or whatever else is before the first colon) to be lowercase.
-        //
-        // Node's `require` will always cache modules based off case-sensitive paths, regardless
-        // of the underlying file system. This is normally not a problem, but VS Code also happens
-        // to normalize paths on Windows to use lowercase drive letters when using its bootstrap loader.
-        // This means that each module ends up getting loaded twice, once by the extension and once
-        // by any test code, causing all sorts of bizarre behavior during tests.
+        /**
+         * Node's `require` will always cache modules based off case-sensitive paths, regardless
+         * of the underlying file system. This is normally not a problem, but VS Code also happens
+         * to normalize paths on Windows to use lowercase drive letters when using its bootstrap loader.
+         * This means that each module ends up getting loaded twice, once by the extension and once
+         * by any test code, causing all sorts of bizarre behavior during tests unless you normalize
+         * paths like below.
+         *
+         * In multi root npm workspaces on windows it looks like imports into other npm workspace packages
+         * makes the loaded module id an uppercase drive letter in the node require cache.
+         *
+         * E.g. when we import a file from core the module ids inside of amazonq/toolkits node require
+         * cache are something like:
+         *  - C:\${pathToWorkspace}\packages\core\myfile.js
+         *
+         * However, internal workspace package imports are lower case drive letters. That means when
+         * core imports a module inside of core we see this as:
+         *  - c:\${pathToWorkspace}\packages\core\myfile.js
+         *
+         * This can cause things like globals to be undefined, since tests inside of amazonq/toolkit
+         * are looking for upper case module ids, whereas tests inside of core are always looking
+         * for lower case module ids (since the tests live inside of core itself)
+         */
         const [drive, ...rest] = abs.split(':')
-        return rest.length === 0 ? abs : [drive.toLowerCase(), ...rest].join(':')
+        return rest.length === 0
+            ? abs
+            : [
+                  extensionId === VSCODE_EXTENSION_ID.awstoolkitcore ? drive.toLowerCase() : drive.toUpperCase(),
+                  ...rest,
+              ].join(':')
     }
 
     const root = getRoot()


### PR DESCRIPTION
### Problem:
- Windows ci is no longer working after we moved amazonq tests to the
  amazonq package

### Solution:
- Utilize upper case drive letters for getting the root in
  amazonq/toolkit. That way imports will resolve correctly.

### Additional info:
In multi root npm workspaces on windows it looks like imports into other npm workspace packages makes the loaded module id an uppercase drive letter in the node require cache.

E.g. when we import a file from core the module ids inside of amazonq/toolkits node require cache are something like:
- C:\${pathToWorkspace}\packages\core\myfile.js

However, internal workspace package imports are lower case drive letters. That means when core imports a module inside of core we see this as:
- c:\${pathToWorkspace}\packages\core\myfile.js

This can cause things like globals to be undefined, since tests inside of amazonq/toolkit are looking for upper case module ids, whereas tests inside of core are always looking
for lower case module ids (since the tests live inside of core itself)
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
