### PR TITLE
fix(amazonq): add ellipsis for long text in login

### DIFF
--- a/packages/core/src/login/webview/vue/selectableItem.vue
+++ b/packages/core/src/login/webview/vue/selectableItem.vue
@@ -56,8 +56,8 @@
             </svg>
         </div>
         <div class="text">
-            <div class="title">{{ itemTitle }}</div>
-            <div class="p" v-if="itemText">{{ itemText }}</div>
+            <div class="title" :title="itemTitle">{{ itemTitle }}</div>
+            <div class="p" v-if="itemText" :title="itemText">{{ itemText }}</div>
         </div>
     </div>
 </template>
@@ -118,6 +118,9 @@ export default defineComponent({
 
 .title {
     font-size: var(--font-size-base);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .text {
@@ -125,6 +128,7 @@ export default defineComponent({
     flex-direction: column;
     font-size: var(--font-size-sm);
     justify-content: center;
+    overflow: hidden;
 }
 
 .vscode-dark .text {


### PR DESCRIPTION
Add ellipsis for Long text

| Before | After |
| -- | -- |
|  ![Screenshot 2024-06-13 at 11 54 53 AM](https://github.com/aws/aws-toolkit-vscode/assets/371007/3e1a10e2-441a-4e85-bdd9-e2f96dbd3ae2) | ![Screenshot 2024-06-13 at 11 52 52 AM](https://github.com/aws/aws-toolkit-vscode/assets/371007/31b7687b-3446-4f1e-b6fa-9df0b193beb6) |

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
