### PR TITLE
fix(telemetry): set UserAgent in Q, OIDC/SSO requests

### DIFF
--- a/packages/core/src/auth/sso/cache.ts
+++ b/packages/core/src/auth/sso/cache.ts
@@ -12,6 +12,7 @@ import { hasProps, selectFrom } from '../../shared/utilities/tsUtils'
 import { SsoToken, ClientRegistration } from './model'
 import { SystemUtilities } from '../../shared/systemUtilities'
 import { DevSettings } from '../../shared/settings'
+import { onceChanged } from '../../shared/utilities/functionUtils'
 
 interface RegistrationKey {
     readonly startUrl: string
@@ -105,8 +106,8 @@ export function getTokenCache(directory = getCacheDir()): KeyedCache<SsoAccess> 
         }
     }
 
-    const logger = (message: string) => getLogger().debug(`SSO token cache: ${message}`)
-    const cache = createDiskCache<StoredToken, string>((key: string) => getTokenCacheFile(directory, key), logger)
+    const logIfChanged = onceChanged((message: string) => getLogger().debug(`SSO token cache: ${message}`))
+    const cache = createDiskCache<StoredToken, string>((key: string) => getTokenCacheFile(directory, key), logIfChanged)
 
     return mapCache(cache, read, write)
 }

--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -88,6 +88,7 @@ export class OidcClient {
 
         return {
             ...selectFrom(response, 'accessToken', 'refreshToken', 'tokenType'),
+            requestId: response.$metadata.requestId,
             expiresAt: new this.clock.Date(response.expiresIn * 1000 + this.clock.Date.now()),
         }
     }

--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -35,6 +35,7 @@ import { HttpRequest, HttpResponse } from '@smithy/protocol-http'
 import { StandardRetryStrategy, defaultRetryDecider } from '@smithy/middleware-retry'
 import { AuthenticationFlow } from './model'
 import { toSnakeCase } from '../../shared/utilities/textUtilities'
+import { getUserAgent } from '../../shared/telemetry/util'
 
 export class OidcClient {
     public constructor(private readonly client: SSOOIDC, private readonly clock: { Date: typeof Date }) {}
@@ -108,6 +109,7 @@ export class OidcClient {
                 () => Promise.resolve(3), // Maximum number of retries
                 { retryDecider: updatedRetryDecider }
             ),
+            customUserAgent: getUserAgent({ includePlatform: true, includeClientId: true }),
         })
 
         addLoggingMiddleware(client)
@@ -214,6 +216,7 @@ export class SsoClient {
             new SSO({
                 region,
                 endpoint: DevSettings.instance.get('endpoints', {})['sso'],
+                customUserAgent: getUserAgent({ includePlatform: true, includeClientId: true }),
             }),
             provider
         )

--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -95,12 +95,21 @@ export class OidcClient {
 
     public static create(region: string) {
         const updatedRetryDecider = (err: SdkError) => {
-            // Check the default retry conditions
             if (defaultRetryDecider(err)) {
                 return true
             }
 
-            // Custom retry rules
+            // Sessions may "expire" earlier than expected due to network faults.
+            // TODO: add more cases from node_modules/@aws-sdk/client-sso-oidc/dist-types/models/models_0.d.ts
+            // ExpiredTokenException
+            // InternalServerException
+            // InvalidClientException
+            // InvalidRequestException
+            // SlowDownException
+            // UnsupportedGrantTypeException
+            // InvalidRequestRegionException
+            // InvalidRedirectUriException
+            // InvalidRedirectUriException
             return err.name === 'InvalidGrantException'
         }
         const client = new SSOOIDC({

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -31,10 +31,11 @@ import {
     getTelemetryResult,
     isClientFault,
     isNetworkError,
+    resolveErrorMessageToDisplay,
 } from '../../shared/errors'
 import { getLogger } from '../../shared/logger'
 import { AwsLoginWithBrowser, AwsRefreshCredentials, Metric, telemetry } from '../../shared/telemetry/telemetry'
-import { indent, toBase64URL } from '../../shared/utilities/textUtilities'
+import { indent, toBase64URL, truncate } from '../../shared/utilities/textUtilities'
 import { AuthSSOServer } from './server'
 import { CancellationError, sleep } from '../../shared/utilities/timeoutUtils'
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
@@ -157,6 +158,7 @@ export abstract class SsoAccessTokenProvider {
                 telemetry.aws_refreshCredentials.emit({
                     result: getTelemetryResult(err),
                     reason: getTelemetryReason(err),
+                    reasonDesc: truncate(resolveErrorMessageToDisplay(err, ''), 200, ''),
                     requestId: getRequestId(err),
                     ...metric,
                 } as AwsRefreshCredentials)
@@ -282,6 +284,7 @@ async function pollForTokenWithProgress<T>(
             await sleep(interval)
         }
 
+        // TODO: verify that this emits telemetry
         throw new ToolkitError('Timed-out waiting for browser login flow to complete', {
             code: 'TimedOut',
         })

--- a/packages/core/src/codewhisperer/client/codewhisperer.ts
+++ b/packages/core/src/codewhisperer/client/codewhisperer.ts
@@ -258,7 +258,7 @@ export class DefaultCodeWhispererClient {
                 ideCategory: 'VSCODE',
                 operatingSystem: this.getOperatingSystem(),
                 product: 'CodeWhisperer', // TODO: update this?
-                clientId: await getClientId(globals.context.globalState),
+                clientId: getClientId(globals.context.globalState),
                 ideVersion: extensionVersion,
             },
         }
@@ -275,7 +275,7 @@ export class DefaultCodeWhispererClient {
                 ideCategory: 'VSCODE',
                 operatingSystem: this.getOperatingSystem(),
                 product: 'CodeWhisperer', // TODO: update this?
-                clientId: await getClientId(globals.context.globalState),
+                clientId: getClientId(globals.context.globalState),
                 ideVersion: extensionVersion,
             },
         }

--- a/packages/core/src/shared/awsClientBuilder.ts
+++ b/packages/core/src/shared/awsClientBuilder.ts
@@ -133,7 +133,7 @@ export class DefaultAWSClientBuilder implements AWSClientBuilder {
         }
 
         if (userAgent && !opt.customUserAgent) {
-            opt.customUserAgent = await getUserAgent({ includePlatform: true, includeClientId: true })
+            opt.customUserAgent = getUserAgent({ includePlatform: true, includeClientId: true })
         }
 
         const apiConfig = (opt as { apiConfig?: { metadata?: Record<string, string> } } | undefined)?.apiConfig

--- a/packages/core/src/shared/clients/codewhispererChatClient.ts
+++ b/packages/core/src/shared/clients/codewhispererChatClient.ts
@@ -6,6 +6,7 @@ import { CodeWhispererStreaming } from '@amzn/codewhisperer-streaming'
 import { ConfiguredRetryStrategy } from '@smithy/util-retry'
 import { getCodewhispererConfig } from '../../codewhisperer/client/codewhisperer'
 import { AuthUtil } from '../../codewhisperer/util/authUtil'
+import { getUserAgent } from '../telemetry/util'
 
 // Create a client for featureDev streaming based off of aws sdk v3
 export async function createCodeWhispererChatStreamingClient(): Promise<CodeWhispererStreaming> {
@@ -15,6 +16,7 @@ export async function createCodeWhispererChatStreamingClient(): Promise<CodeWhis
         region: cwsprConfig.region,
         endpoint: cwsprConfig.endpoint,
         token: { token: bearerToken },
+        customUserAgent: getUserAgent(),
         // SETTING max attempts to 0 FOR BETA. RE-ENABLE FOR RE-INVENT
         // Implement exponential back off starting with a base of 500ms (500 + attempt^10)
         retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),

--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -12,6 +12,7 @@ import { Logging } from './commands'
 import { resolvePath } from '../utilities/pathUtils'
 import { fsCommon } from '../../srcShared/fs'
 import { isWeb } from '../extensionGlobals'
+import { getUserAgent } from '../telemetry/util'
 
 /**
  * Activate Logger functionality for the extension.
@@ -44,7 +45,6 @@ export async function activate(
     })
 
     setLogger(mainLogger)
-    getLogger().info(`Log level: ${chanLogLevel}`)
 
     // Logs to "AWS Toolkit" output channel.
     setLogger(
@@ -66,7 +66,8 @@ export async function activate(
         'debugConsole'
     )
 
-    getLogger().debug(`Logging started: ${logUri ?? '(no file)'}`)
+    getLogger().info('Log level: %s%s', chanLogLevel, logUri ? `, file: ${logUri.fsPath}` : '')
+    getLogger().debug('User agent: %s', getUserAgent({ includePlatform: true, includeClientId: true }))
     if (devLogfile && typeof devLogfile !== 'string') {
         getLogger().error('invalid aws.dev.logfile setting')
     }

--- a/packages/core/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/packages/core/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -133,7 +133,7 @@ export async function addTelemetryEnvVar(options: SpawnOptions | undefined): Pro
     return {
         ...options,
         env: {
-            AWS_TOOLING_USER_AGENT: await getUserAgent({ includeClientId: false }),
+            AWS_TOOLING_USER_AGENT: getUserAgent({ includeClientId: false }),
             ...samEnv,
             ...options?.env,
         },

--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -15,7 +15,7 @@ import {
     MetricShapes,
     TelemetryBase,
 } from './telemetry.gen'
-import { getTelemetryReason, getTelemetryResult } from '../errors'
+import { getRequestId, getTelemetryReason, getTelemetryReasonDesc, getTelemetryResult } from '../errors'
 import { entries, NumericKeys } from '../utilities/tsUtils'
 
 const AsyncLocalStorage: typeof AsyncLocalStorageClass =
@@ -150,16 +150,14 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
      */
     public stop(err?: unknown): void {
         const duration = this.startTime !== undefined ? globals.clock.Date.now() - this.startTime.getTime() : undefined
-        const msg = (err as any)?.message
-        // Truncate error message to 200 chars.
-        const reasonDesc = typeof msg === 'string' && msg.trim() !== '' ? msg.substring(0, 200) : undefined
 
-        // TODO: add MetricBase.reasonDesc so we can remove `as any` below.
+        // TODO: add reasonDesc/requestId to `MetricBase` so we can remove `as any` below.
         this.emit({
             duration,
             result: getTelemetryResult(err),
             reason: getTelemetryReason(err),
-            reasonDesc: reasonDesc,
+            reasonDesc: getTelemetryReasonDesc(err),
+            requestId: getRequestId(err),
         } as any as Partial<T>)
 
         this.#startTime = undefined

--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -150,12 +150,17 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
      */
     public stop(err?: unknown): void {
         const duration = this.startTime !== undefined ? globals.clock.Date.now() - this.startTime.getTime() : undefined
+        const msg = (err as any)?.message
+        // Truncate error message to 200 chars.
+        const reasonDesc = typeof msg === 'string' && msg.trim() !== '' ? msg.substring(0, 200) : undefined
 
+        // TODO: add MetricBase.reasonDesc so we can remove `as any` below.
         this.emit({
             duration,
             result: getTelemetryResult(err),
             reason: getTelemetryReason(err),
-        } as Partial<T>)
+            reasonDesc: reasonDesc,
+        } as any as Partial<T>)
 
         this.#startTime = undefined
     }

--- a/packages/core/src/shared/telemetry/telemetryService.ts
+++ b/packages/core/src/shared/telemetry/telemetryService.ts
@@ -206,7 +206,7 @@ export class DefaultTelemetryService {
     private async createDefaultPublisher(): Promise<TelemetryPublisher | undefined> {
         try {
             // grab our clientId and generate one if it doesn't exist
-            const clientId = await getClientId(this.context.globalState)
+            const clientId = getClientId(this.context.globalState)
             // grab our Cognito identityId
             const poolId = DefaultTelemetryClient.config.identityPool
             const identityMapJson = this.context.globalState.get<string>(
@@ -291,7 +291,7 @@ export class DefaultTelemetryService {
     private static async readEventsFromCache(cachePath: string): Promise<MetricDatum[]> {
         try {
             if ((await fsCommon.existsFile(cachePath)) === false) {
-                getLogger().info(`telemetry cache not found: '${cachePath}'`)
+                getLogger().debug('telemetry cache not found, skipping')
 
                 return []
             }

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -236,9 +236,8 @@ export async function setupTelemetryId(extensionContext: vscode.ExtensionContext
                 getLogger().debug(`telemetry: Write telemetry client id to env ${currentClientId}`)
                 process.env[telemetryClientIdEnvKey] = currentClientId
             } else {
-                const clientId = randomUUID()
+                const clientId = getClientId(globals.context.globalState)
                 getLogger().debug(`telemetry: Setup telemetry client id ${clientId}`)
-                await globals.context.globalState.update(telemetryClientIdGlobalStatekey, clientId)
                 process.env[telemetryClientIdEnvKey] = clientId
             }
         }

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import { env, Memento, version } from 'vscode'
 import { getLogger } from '../logger'
 import { fromExtensionManifest, migrateSetting, Settings } from '../settings'
-import { shared } from '../utilities/functionUtils'
+import { memoize } from '../utilities/functionUtils'
 import { isInDevEnv, extensionVersion, isAutomation, isRemoteWorkspace } from '../vscode/env'
 import { addTypeName } from '../utilities/typeConstructors'
 import globals, { isWeb } from '../extensionGlobals'
@@ -84,8 +84,11 @@ export function convertLegacy(value: unknown): boolean {
     }
 }
 
-export const getClientId = shared(
-    async (globalState: Memento, isTelemetryEnabled = new TelemetryConfig().isEnabled(), isTest?: false) => {
+export const getClientId = memoize(
+    /**
+     * @param nonce Dummy parameter to allow tests to defeat memoize().
+     */
+    (globalState: Memento, isTelemetryEnabled = new TelemetryConfig().isEnabled(), isTest?: false, nonce?: string) => {
         if (isTest ?? isAutomation()) {
             return 'ffffffff-ffff-ffff-ffff-ffffffffffff'
         }
@@ -96,12 +99,14 @@ export const getClientId = shared(
             let clientId = globalState.get<string>(telemetryClientIdGlobalStatekey)
             if (!clientId) {
                 clientId = randomUUID()
-                await globalState.update(telemetryClientIdGlobalStatekey, clientId)
+                globalState.update(telemetryClientIdGlobalStatekey, clientId).then(undefined, e => {
+                    getLogger().error('getClientId: globalState.update failed: %O', e)
+                })
             }
             return clientId
-        } catch (error) {
+        } catch (e) {
+            getLogger().error('getClientId: failed to create client id: %O', e)
             const clientId = '00000000-0000-0000-0000-000000000000'
-            getLogger().error('Could not create a client id. Reason: %O ', error)
             return clientId
         }
     }
@@ -114,10 +119,10 @@ export const platformPair = () => `${env.appName.replace(/\s/g, '-')}/${version}
  *
  * Omits the platform and `ClientId` pairs by default.
  */
-export async function getUserAgent(
+export function getUserAgent(
     opt?: { includePlatform?: boolean; includeClientId?: boolean },
     globalState = globals.context.globalState
-): Promise<string> {
+): string {
     const pairs = isAmazonQ()
         ? [`AmazonQ-For-VSCode/${extensionVersion}`]
         : [`AWS-Toolkit-For-VSCode/${extensionVersion}`]
@@ -127,7 +132,7 @@ export async function getUserAgent(
     }
 
     if (opt?.includeClientId) {
-        const clientId = await getClientId(globalState)
+        const clientId = getClientId(globalState)
         pairs.push(`ClientId/${clientId}`)
     }
 

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -44,7 +44,6 @@ describe('SsoAccessTokenProvider', function () {
         return {
             accessToken: 'dummyAccessToken',
             expiresAt: new clock.Date(clock.Date.now() + timeDelta),
-            requestId: 'be62f79a-e9cf-41cd-a755-e6920c56e4fb',
             ...extras,
         }
     }
@@ -135,7 +134,9 @@ describe('SsoAccessTokenProvider', function () {
 
         it('refreshes expired tokens', async function () {
             const refreshedToken = createToken(hourInMs, { accessToken: 'newToken' })
-            oidcClient.createToken.resolves(refreshedToken)
+            oidcClient.createToken.resolves({
+                ...refreshedToken,
+            } as any)
 
             const refreshableToken = createToken(-hourInMs, { refreshToken: 'refreshToken' })
             const validRegistation = createRegistration(hourInMs)
@@ -210,7 +211,9 @@ describe('SsoAccessTokenProvider', function () {
             if (!opts?.skipAuthorization) {
                 oidcClient.startDeviceAuthorization.resolves(authorization)
             }
-            oidcClient.createToken.resolves(token)
+            oidcClient.createToken.resolves({
+                ...token,
+            } as any)
 
             return { token, registration, authorization }
         }

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -44,6 +44,7 @@ describe('SsoAccessTokenProvider', function () {
         return {
             accessToken: 'dummyAccessToken',
             expiresAt: new clock.Date(clock.Date.now() + timeDelta),
+            requestId: 'be62f79a-e9cf-41cd-a755-e6920c56e4fb',
             ...extras,
         }
     }

--- a/packages/core/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/packages/core/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -23,7 +23,7 @@ describe('DefaultAwsClientBuilder', function () {
     describe('createAndConfigureSdkClient', function () {
         it('includes Toolkit user-agent if no options are specified', async function () {
             const service = await builder.createAwsService(Service)
-            const clientId = await getClientId(new FakeMemento())
+            const clientId = getClientId(new FakeMemento())
 
             assert.strictEqual(!!service.config.customUserAgent, true)
             assert.strictEqual(
@@ -34,7 +34,7 @@ describe('DefaultAwsClientBuilder', function () {
 
         it('adds Client-Id to user agent', async function () {
             const service = await builder.createAwsService(Service)
-            const clientId = await getClientId(new FakeMemento())
+            const clientId = getClientId(new FakeMemento())
             const regex = new RegExp(`ClientId/${clientId}`)
             assert.ok(service.config.customUserAgent?.match(regex))
         })

--- a/packages/core/src/test/shared/telemetry/util.test.ts
+++ b/packages/core/src/test/shared/telemetry/util.test.ts
@@ -100,22 +100,15 @@ describe('TelemetryConfig', function () {
 
 describe('getClientId', function () {
     it('should generate a unique id', async function () {
-        const c1 = await getClientId(new FakeMemento(), true, false)
-        const c2 = await getClientId(new FakeMemento(), true, false)
+        const c1 = getClientId(new FakeMemento(), true, false, 'x1')
+        const c2 = getClientId(new FakeMemento(), true, false, 'x2')
         assert.notStrictEqual(c1, c2)
-    })
-
-    it('returns the same value across the calls', async function () {
-        const memento = new FakeMemento()
-        const c1 = getClientId(memento, true, false)
-        const c2 = getClientId(memento, true, false)
-        assert.strictEqual(await c1, await c2, 'Expected client ids to be same')
     })
 
     it('returns the same value across the calls sequentially', async function () {
         const memento = new FakeMemento()
-        const c1 = await getClientId(memento, true, false)
-        const c2 = await getClientId(memento, true, false)
+        const c1 = getClientId(memento, true, false, 'y1')
+        const c2 = getClientId(memento, true, false, 'y2')
         assert.strictEqual(c1, c2)
     })
 
@@ -129,7 +122,7 @@ describe('getClientId', function () {
                 throw new Error()
             },
         }
-        const clientId = await getClientId(mememto, true, false)
+        const clientId = getClientId(mememto, true, false, 'x3')
         assert.strictEqual(clientId, '00000000-0000-0000-0000-000000000000')
     })
 
@@ -141,52 +134,52 @@ describe('getClientId', function () {
             },
             async update(key, value) {},
         }
-        const clientId = await getClientId(mememto, true, false)
+        const clientId = getClientId(mememto, true, false, 'x4')
         assert.strictEqual(clientId, '00000000-0000-0000-0000-000000000000')
     })
 
     it('should be ffffffff-ffff-ffff-ffff-ffffffffffff if in test enviroment', async function () {
-        const clientId = await getClientId(new FakeMemento(), true)
+        const clientId = getClientId(new FakeMemento(), true)
         assert.strictEqual(clientId, 'ffffffff-ffff-ffff-ffff-ffffffffffff')
     })
 
     it('should be ffffffff-ffff-ffff-ffff-ffffffffffff if telemetry is not enabled in test enviroment', async function () {
-        const clientId = await getClientId(new FakeMemento(), false)
+        const clientId = getClientId(new FakeMemento(), false)
         assert.strictEqual(clientId, 'ffffffff-ffff-ffff-ffff-ffffffffffff')
     })
 
     it('should be 11111111-1111-1111-1111-111111111111 if telemetry is not enabled', async function () {
-        const clientId = await getClientId(new FakeMemento(), false, false)
+        const clientId = getClientId(new FakeMemento(), false, false)
         assert.strictEqual(clientId, '11111111-1111-1111-1111-111111111111')
     })
 })
 
 describe('getUserAgent', function () {
     it('includes product name and version', async function () {
-        const userAgent = await getUserAgent()
+        const userAgent = getUserAgent()
         const lastPair = userAgent.split(' ')[0]
         assert.ok(lastPair?.startsWith(`AWS-Toolkit-For-VSCode/${extensionVersion}`))
     })
 
     it('includes only one pair by default', async function () {
-        const userAgent = await getUserAgent()
+        const userAgent = getUserAgent()
         const pairs = userAgent.split(' ')
         assert.strictEqual(pairs.length, 1)
     })
 
     it('omits `ClientId` by default', async function () {
-        const userAgent = await getUserAgent()
+        const userAgent = getUserAgent()
         assert.ok(!userAgent.includes('ClientId'))
     })
 
     it('includes `ClientId` at the end if opted in', async function () {
-        const userAgent = await getUserAgent({ includeClientId: true })
+        const userAgent = getUserAgent({ includeClientId: true })
         const lastPair = userAgent.split(' ').pop()
         assert.ok(lastPair?.startsWith('ClientId/'))
     })
 
     it('includes the platform before `ClientId` if opted in', async function () {
-        const userAgent = await getUserAgent({ includePlatform: true, includeClientId: true })
+        const userAgent = getUserAgent({ includePlatform: true, includeClientId: true })
         const pairs = userAgent.split(' ')
         const clientPairIndex = pairs.findIndex(pair => pair.startsWith('ClientId/'))
         const beforeClient = pairs[clientPairIndex - 1]

--- a/packages/core/src/threatComposer/threatComposerEditorProvider.ts
+++ b/packages/core/src/threatComposer/threatComposerEditorProvider.ts
@@ -130,7 +130,7 @@ export class ThreatComposerEditorProvider implements vscode.CustomTextEditorProv
         if (threatComposerSettings.defaultEditor) {
             await telemetry.threatComposer_opened.run(async span => {
                 if (clientId === '') {
-                    clientId = await getClientId(globals.context.globalState)
+                    clientId = getClientId(globals.context.globalState)
                 }
                 // Attempt to retrieve existing visualization if it exists.
                 const existingVisualization = this.getExistingVisualization(document.uri.fsPath)


### PR DESCRIPTION
## Problem

missing user agent, clientid, requestid for failed OIDC and Amazon Q requests.

## Solution

- set `customUserAgent` in the SSO and OIDC clients
- set `customUserAgent` in the `CodeWhispererStreaming` (Amazon Q) client
- set `requestId` and `reasonDesc` on all failed metrics


### Example headers:  

```
user-agent: aws-sdk-js/3.574.0 ua/2.0 os/darwin#23.5.0 lang/js md/nodejs#20.9.0 api/sso-oidc#3.574.0 AmazonQ-For-VSCode/testPluginVersion-Visual-Studio-Code/1.90.1-ClientId/96be923b-a00d-46d4-add1-c877abfcb01c
x-amz-user-agent: aws-sdk-js/3.574.0 AmazonQ-For-VSCode/testPluginVersion-Visual-Studio-Code/1.90.1-ClientId/96be923b-a00d-46d4-add1-c877abfcb01c
```

<img width="744" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/55561878/2b3dba49-8344-4a40-95a3-34fdff346df5">



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
