### PR TITLE
auth: add temporary auth for web mode

### DIFF
--- a/packages/core/src/auth/sso/model.ts
+++ b/packages/core/src/auth/sso/model.ts
@@ -45,7 +45,7 @@ export interface SsoToken {
     readonly refreshToken?: string
 }
 
-export type AuthenticationFlow = 'auth code'
+export type AuthenticationFlow = 'auth code' | 'web auth code'
 
 export interface ClientRegistration {
     /**

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -730,6 +730,7 @@ const devSettings = {
     codewhispererService: Record(String, String),
     ssoCacheDirectory: String,
     autofillStartUrl: String,
+    webAuth: Boolean,
 }
 type ResolvedDevSettings = FromDescriptor<typeof devSettings>
 type AwsDevSetting = keyof ResolvedDevSettings

--- a/packages/core/src/shared/utilities/textUtilities.ts
+++ b/packages/core/src/shared/utilities/textUtilities.ts
@@ -376,3 +376,14 @@ export function getRandomString(length = 32) {
     }
     return text
 }
+
+/**
+ * Convert a base 64 string to a base 64 url string
+ *
+ * See: https://datatracker.ietf.org/doc/html/rfc4648#section-5
+ * @param base64 a base 64 string
+ * @returns a base 64 url string
+ */
+export function toBase64URL(base64: string) {
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}

--- a/packages/core/src/shared/vscode/env.ts
+++ b/packages/core/src/shared/vscode/env.ts
@@ -96,6 +96,10 @@ export function isRemoteWorkspace(): boolean {
     return vscode.env.remoteName === 'ssh-remote'
 }
 
+export function isWebWorkspace(): boolean {
+    return vscode.env.uiKind === vscode.UIKind.Web
+}
+
 export function getCodeCatalystProjectName(): string | undefined {
     return process.env['__DEV_ENVIRONMENT_PROJECT_NAME']
 }


### PR DESCRIPTION
## Problem
- We currently can't auth on web mode. Device code doesn't work because of cors and we can't start a local server without remote compute

## Solution
- Temporarily redirect to a (hopefully) unused port and send the code there. This unblocks testing web mode

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
