### PR TITLE
telemetry: set requestId field on failure

### DIFF
--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -459,13 +459,15 @@ export function isClientFault(error: ServiceException): boolean {
     return error.$fault === 'client' && !(isThrottlingError(error) || isTransientError(error))
 }
 
-export function getRequestId(error: unknown): string | undefined {
-    if (isAwsError(error)) {
-        return error.requestId
+export function getRequestId(err: unknown): string | undefined {
+    if (isAwsError(err)) {
+        return err.requestId
     }
 
-    if (error instanceof ServiceException) {
-        return error.$metadata.requestId
+    // XXX: Checking `err instanceof ServiceException` fails for `SSOOIDCServiceException` even
+    // though it subclasses @aws-sdk/smithy-client.ServiceException
+    if (typeof (err as any)?.$metadata?.requestId === 'string') {
+        return (err as any).$metadata.requestId
     }
 }
 


### PR DESCRIPTION
Checking `err instanceof ServiceException` fails for `SSOOIDCServiceException` even though it subclasses @aws-sdk/smithy-client.ServiceException 😑 

## Example

```
2024-06-14 13:03:07.065 [debug] telemetry: aws_loginWithBrowser {
  Metadata: {
    id: 'codeWhispererConnectionExpired',
    source: 'vscodeComponent',
    action: 'connect',
    parentMetric: 'toolkit_invokeAction',
    isReAuth: 'true',
    credentialStartUrl: 'https://view.awsapps.com/start',
    duration: '25613',
    result: 'Failed',
    reason: 'InvalidRedirectUriException',
    reasonDesc: 'Requested client type must use loopback interface for redirect',
    requestId: '1aee48f3-1062-4efe-a761-b2079ae31ac9',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None'
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
