### PR TITLE
fix: remove redirectUri since it's no longer needed

### DIFF
--- a/packages/core/src/auth/sso/vue/index.html
+++ b/packages/core/src/auth/sso/vue/index.html
@@ -78,11 +78,6 @@
                     'footerText'
                 ).innerText = `You can close this window and start using ${productName}`
 
-                const redirectUri = params.get('redirectUri')
-                if (redirectUri) {
-                    window.location.replace(redirectUri)
-                }
-
                 function showErrorMessage(errorText) {
                     document.getElementById('approved-auth').classList.add('hidden')
                     document.getElementById('denied-auth').classList.remove('hidden')


### PR DESCRIPTION
## Problem
- redirectUri used to be used to redirect back to vscode but we are no longer using that

## Solution
- remove it

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
