### PR TITLE
Allow users to interact with Redshift cluster even if unable to fetch…

### DIFF
--- a/packages/core/src/redshift/wizards/connectionWizard.ts
+++ b/packages/core/src/redshift/wizards/connectionWizard.ts
@@ -10,11 +10,10 @@ import { createCommonButtons } from '../../shared/ui/buttons'
 import { ConnectionParams, ConnectionType, RedshiftWarehouseType } from '../models/models'
 import { RedshiftWarehouseNode } from '../explorer/redshiftWarehouseNode'
 import { localize } from '../../shared/utilities/vsCodeUtils'
-import { DefaultRedshiftClient } from '../../shared/clients/redshiftClient'
+import { ClustersMessageResponse, DefaultRedshiftClient } from '../../shared/clients/redshiftClient'
 import { Region } from '../../shared/regions/endpoints'
 import { RegionProvider } from '../../shared/regions/regionProvider'
 import { createRegionPrompter } from '../../shared/ui/common/region'
-import { ClustersMessage } from 'aws-sdk/clients/redshift'
 import { Prompter } from '../../shared/ui/prompter'
 import { ListSecretsResponse } from 'aws-sdk/clients/secretsmanager'
 import { SecretsManagerClient } from '../../shared/clients/secretsManagerClient'
@@ -212,9 +211,8 @@ async function* fetchWarehouses(redshiftClient: DefaultRedshiftClient) {
     let hasMoreProvisioned = true
     while (hasMoreProvisioned || hasMoreServerless) {
         if (hasMoreProvisioned) {
-            const provisionedResponse: ClustersMessage = await redshiftClient.describeProvisionedClusters(
-                provisionedToken
-            )
+            const { clustersMessageResponse: provisionedResponse }: ClustersMessageResponse =
+                await redshiftClient.describeProvisionedClusters(provisionedToken)
             provisionedToken = provisionedResponse.Marker
             hasMoreProvisioned = provisionedToken !== undefined
             if (provisionedResponse.Clusters) {
@@ -229,7 +227,9 @@ async function* fetchWarehouses(redshiftClient: DefaultRedshiftClient) {
             }
         }
         if (hasMoreServerless) {
-            const serverlessResponse = await redshiftClient.listServerlessWorkgroups(serverlessToken)
+            const { listWorkgroupsResponse: serverlessResponse } = await redshiftClient.listServerlessWorkgroups(
+                serverlessToken
+            )
             serverlessToken = serverlessResponse.nextToken
             hasMoreServerless = serverlessToken !== undefined
             if (serverlessResponse.workgroups) {

--- a/packages/core/src/test/shared/clients/defaultRedshiftClient.test.ts
+++ b/packages/core/src/test/shared/clients/defaultRedshiftClient.test.ts
@@ -69,13 +69,13 @@ describe('DefaultRedshiftClient', function () {
         it('without nextToken should not set Marker', async () => {
             const response = await defaultRedshiftClient.describeProvisionedClusters()
             describeClustersStub.alwaysCalledWith({ Marker: undefined, MaxRecords: 20 })
-            assert.deepStrictEqual(response.Clusters, [])
+            assert.deepStrictEqual(response.clustersMessageResponse.Clusters, [])
         })
 
         it('with nextToken should set the Marker', async () => {
             const response = await defaultRedshiftClient.describeProvisionedClusters(nextToken)
             describeClustersStub.alwaysCalledWith({ Marker: nextToken, MaxRecords: 20 })
-            assert.deepStrictEqual(response.Clusters, [])
+            assert.deepStrictEqual(response.clustersMessageResponse.Clusters, [])
         })
     })
 
@@ -91,13 +91,13 @@ describe('DefaultRedshiftClient', function () {
         it('without nextToken should not set nextToken in RedshiftServerless request', async () => {
             const response = await defaultRedshiftClient.listServerlessWorkgroups()
             listServerlessWorkgroupsStub.alwaysCalledWith({ nextToken: undefined, maxResults: 20 })
-            assert.deepStrictEqual(response.workgroups, [])
+            assert.deepStrictEqual(response.listWorkgroupsResponse.workgroups, [])
         })
 
         it('with nextToken should set nextToken in RedshiftServerless request', async () => {
             const response = await defaultRedshiftClient.listServerlessWorkgroups(nextToken)
             listServerlessWorkgroupsStub.alwaysCalledWith({ nextToken: nextToken, maxResults: 20 })
-            assert.deepStrictEqual(response.workgroups, [])
+            assert.deepStrictEqual(response.listWorkgroupsResponse.workgroups, [])
         })
     })
 


### PR DESCRIPTION
… Serverless workgroup

Problem: Users are not able to interact with provisioned clusters, unless fetching serverless workgroups is successful
Solution: Amend error handling for this part. Insert error node for both types of redshift resources (cluster and serverless)



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
