### PR TITLE
feat(errors): surface error_description

### DIFF
--- a/packages/core/src/shared/utilities/logAndShowUtils.ts
+++ b/packages/core/src/shared/utilities/logAndShowUtils.ts
@@ -14,15 +14,12 @@ import { Logging } from '../logger/commands'
  * Logs the error. Then determines what kind of error message should be shown, if
  * at all.
  *
+ * TODO: Currently only used for errors from commands and webview. Use in more places (explorer,
+ * nodes, ...). Must be guaranteed to initialize prior to every other Toolkit component.
+ *
  * @param error The error itself
  * @param topic The prefix of the error message
  * @param defaultMessage The message to show if once cannot be resolved from the given error
- *
- * SIDE NOTE:
- * This is only being used for errors from commands and webview, there's plenty of other places
- * (explorer, nodes, ...) where it could be used. It needs to be apart of some sort of `core`
- * module that is guaranteed to initialize prior to every other Toolkit component.
- * Logging and telemetry would fit well within this core module.
  */
 export async function logAndShowError(
     localize: nls.LocalizeFunc,

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -6,8 +6,8 @@
 import assert from 'assert'
 import vscode from 'vscode'
 import {
-    findAwsErrorInCausalChain,
-    findPrioritizedAwsError,
+    findBestErrorInChain,
+    formatError,
     getErrorMsg,
     getTelemetryReason,
     getTelemetryResult,
@@ -18,6 +18,72 @@ import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { UnauthorizedException } from '@aws-sdk/client-sso'
 import { AWSError } from 'aws-sdk'
 import { AccessDeniedException } from '@aws-sdk/client-sso-oidc'
+
+class TestAwsError extends Error implements AWSError {
+    constructor(readonly code: string, message: string, readonly time: Date) {
+        super(message)
+    }
+}
+
+// Error containing `error_description`.
+function fakeAwsErrorAccessDenied() {
+    const e = new AccessDeniedException({
+        error: 'access_denied',
+        message: 'accessdenied message',
+        $metadata: {
+            attempts: 3,
+            requestId: 'or62s79n-r9ps-41pq-n755-r6920p56r4so',
+            totalRetryDelay: 3000,
+            httpStatusCode: 403,
+        },
+    }) as any
+    e.name = 'accessdenied-name'
+    e.code = 'accessdenied-code'
+    e.error_description = 'access_denied error_description'
+    e.time = new Date()
+    return e as AccessDeniedException
+}
+
+// Error NOT containing `error_description`.
+function fakeAwsErrorUnauth() {
+    const e = new UnauthorizedException({
+        message: 'unauthorized message',
+        $metadata: {
+            attempts: 3,
+            requestId: 'be62f79a-e9cf-41cd-a755-e6920c56e4fb',
+            totalRetryDelay: 3000,
+            httpStatusCode: 403,
+        },
+    }) as any
+    e.name = 'unauthorized-name'
+    e.code = 'unauthorized-code'
+    e.time = new Date()
+    return e as UnauthorizedException
+}
+
+function fakeErrorChain() {
+    try {
+        throw new Error('generic error 1')
+    } catch (e1) {
+        try {
+            const e = fakeAwsErrorAccessDenied()
+            ;(e as any).cause = e1
+            throw e
+        } catch (e2) {
+            try {
+                throw ToolkitError.chain(e2, 'ToolkitError message', {
+                    documentationUri: vscode.Uri.parse(
+                        'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html'
+                    ),
+                })
+            } catch (e3) {
+                const e = fakeAwsErrorUnauth()
+                ;(e as any).cause = e3
+                return e
+            }
+        }
+    }
+}
 
 describe('ToolkitError', function () {
     it('can store an error message', function () {
@@ -231,157 +297,123 @@ describe('Telemetry', function () {
     })
 })
 
-describe('util', function () {
-    // Error containing `error_description`.
-    function fakeAwsError_accessDenied() {
-        const e = new AccessDeniedException({
-            error: 'access_denied',
-            message: 'accessdenied message',
-            $metadata: {
-                attempts: 3,
-                requestId: 'or62s79n-r9ps-41pq-n755-r6920p56r4so',
-                totalRetryDelay: 3000,
-                httpStatusCode: 403,
-            },
-        }) as any
-        e.name = 'accessdenied-name'
-        e.code = 'accessdenied-code'
-        e.error_description = 'access_denied error_description'
-        e.time = new Date()
-        return e as AccessDeniedException
-    }
-
-    // Error NOT containing `error_description`.
-    function fakeAwsError_unauth() {
-        const e = new UnauthorizedException({
-            message: 'unauthorized message',
-            $metadata: {
-                attempts: 3,
-                requestId: 'be62f79a-e9cf-41cd-a755-e6920c56e4fb',
-                totalRetryDelay: 3000,
-                httpStatusCode: 403,
-            },
-        }) as any
-        e.name = 'unauthorized-name'
-        e.code = 'unauthorized-code'
-        e.time = new Date()
-        return e as UnauthorizedException
-    }
-
-    function fakeErrorChain() {
-        try {
-            throw new Error('generic error 1')
-        } catch (e1) {
-            try {
-                const e = fakeAwsError_accessDenied()
-                ;(e as any).cause = e1
-                throw e
-            } catch (e2) {
-                try {
-                    throw ToolkitError.chain(e2, 'ToolkitError message', {
-                        documentationUri: vscode.Uri.parse(
-                            'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html'
-                        ),
-                    })
-                } catch (e3) {
-                    const e = fakeAwsError_unauth()
-                    ;(e as any).cause = e3
-                    return e
-                }
-            }
-        }
-    }
-
-    it('getErrorMsg()', function () {
-        assert.deepStrictEqual(getErrorMsg(fakeErrorChain()), 'unauthorized message')
-        assert.deepStrictEqual(getErrorMsg(findAwsErrorInCausalChain(fakeErrorChain())), 'unauthorized message')
-        assert.deepStrictEqual(getErrorMsg(findPrioritizedAwsError(fakeErrorChain())), 'x')
-    })
-    it('findAwsErrorInCausalChain()', function () {
-        // assert.deepStrictEqual()
-    })
-    it('findPrioritizedAwsError()', function () {
-        // assert.deepStrictEqual()
-    })
-    it('formatError()', function () {
-        // assert.deepStrictEqual()
-    })
-})
-
 describe('resolveErrorMessageToDisplay()', function () {
     const defaultMessage = 'My Default Message!'
     const normalErrorMessage = 'Normal error message'
     const toolkitErrorMessage = 'Toolkit error message'
     const awsErrorMessage = 'AWS error message'
 
-    it('returns default message if no error is given', function () {
+    const errorTime: Date = new Date()
+    const preferredErrors: string[] = [
+        'ServiceQuotaExceededException',
+        'ConflictException',
+        'ValidationException',
+        'ResourceNotFoundException',
+    ]
+    const prioritiziedAwsErrors: TestAwsError[] = preferredErrors.map(name => {
+        return new TestAwsError(name, awsErrorMessage, errorTime)
+    })
+
+    // Sanity check specific errors are resolved as expected
+    prioritiziedAwsErrors.forEach(error => {
+        it(`resolves ${error.code} message when provided directly`, function () {
+            const message = resolveErrorMessageToDisplay(error, defaultMessage)
+            assert.strictEqual(message, `${defaultMessage}: ${awsErrorMessage}`)
+        })
+    })
+
+    it('gets default message if no error is given', function () {
         const message = resolveErrorMessageToDisplay(undefined, defaultMessage)
         assert.strictEqual(message, defaultMessage)
     })
 
-    it('returns default message if normal error is given', function () {
+    it('gets default message if normal Error is given', function () {
         const message = resolveErrorMessageToDisplay(new Error(normalErrorMessage), defaultMessage)
-        assert.strictEqual(message, defaultMessage)
+        const expected = `${defaultMessage}: ${normalErrorMessage}`
+        assert.strictEqual(message, expected)
     })
 
-    it('returns toolkit message if toolkit error is given', function () {
+    it('gets ToolkitError if given', function () {
         const message = resolveErrorMessageToDisplay(new ToolkitError(toolkitErrorMessage), defaultMessage)
         assert.strictEqual(message, toolkitErrorMessage)
     })
 
-    describe('prioritized AWS errors', function () {
-        class TestAwsError extends Error implements AWSError {
-            constructor(readonly code: string, message: string, readonly time: Date) {
-                super(message)
-            }
-        }
+    it('gets AWSError nested in a ToolkitError cause', function () {
+        const awsError = prioritiziedAwsErrors[0]
+        const toolkitError = new ToolkitError(toolkitErrorMessage, { cause: awsError })
 
-        const errorTime: Date = new Date()
-        const prioritizedAwsErrorNames: string[] = [
-            'ServiceQuotaExceededException',
-            'ConflictException',
-            'ValidationException',
-            'ResourceNotFoundException',
-        ]
-        const prioritiziedAwsErrors: TestAwsError[] = prioritizedAwsErrorNames.map(name => {
-            return new TestAwsError(name, awsErrorMessage, errorTime)
-        })
+        const message = resolveErrorMessageToDisplay(toolkitError, defaultMessage)
 
-        // Sanity check specific errors are resolved as expected
-        prioritiziedAwsErrors.forEach(error => {
-            it(`resolves ${error.code} message when provided directly`, function () {
-                const message = resolveErrorMessageToDisplay(error, defaultMessage)
-                assert.strictEqual(message, `${defaultMessage}: ${awsErrorMessage}`)
-            })
-        })
+        assert.strictEqual(message, `${toolkitErrorMessage}: ${awsErrorMessage}`)
+    })
 
-        it('resolves AWS Error when nested in a ToolkitError cause', function () {
-            const awsError = prioritiziedAwsErrors[0]
-            const toolkitError = new ToolkitError(toolkitErrorMessage, { cause: awsError })
+    it('gets AWSError nested multiple levels in a ToolkitError cause', function () {
+        const awsError = prioritiziedAwsErrors[0]
+        const toolkitErrorTail = new ToolkitError(`${toolkitErrorMessage}-tail`, { cause: awsError })
+        const toolkitErrorMiddle = new ToolkitError(`${toolkitErrorMessage}-middle`, { cause: toolkitErrorTail })
+        const toolkitErrorHead = new ToolkitError(`${toolkitErrorMessage}-head`, { cause: toolkitErrorMiddle })
 
-            const message = resolveErrorMessageToDisplay(toolkitError, defaultMessage)
+        const message = resolveErrorMessageToDisplay(toolkitErrorHead, defaultMessage)
 
-            assert.strictEqual(message, `${toolkitErrorMessage}: ${awsErrorMessage}`)
-        })
+        assert.strictEqual(message, `${toolkitErrorMessage}-head: ${awsErrorMessage}`)
+    })
 
-        it('resolves AWS Error when nested multiple levels in a ToolkitError cause', function () {
-            const awsError = prioritiziedAwsErrors[0]
-            const toolkitErrorTail = new ToolkitError(`${toolkitErrorMessage}-tail`, { cause: awsError })
-            const toolkitErrorMiddle = new ToolkitError(`${toolkitErrorMessage}-middle`, { cause: toolkitErrorTail })
-            const toolkitErrorHead = new ToolkitError(`${toolkitErrorMessage}-head`, { cause: toolkitErrorMiddle })
+    it('gets first error if no preferred error in cause-chain', function () {
+        const err1 = new Error(`${toolkitErrorMessage}-middle`)
+        const err2 = new Error(`${toolkitErrorMessage}-head`)
+        ;(err2 as any).cause = err1
 
-            const message = resolveErrorMessageToDisplay(toolkitErrorHead, defaultMessage)
+        const expected = `${defaultMessage}: ${toolkitErrorMessage}-head`
+        assert.strictEqual(resolveErrorMessageToDisplay(err2, defaultMessage), expected)
+    })
 
-            assert.strictEqual(message, `${toolkitErrorMessage}-head: ${awsErrorMessage}`)
-        })
+    it('prefers AWSError matching preferredErrors', function () {
+        const awsErr1 = new TestAwsError('ValidationException', 'validation msg', errorTime)
+        const awsErr2 = new TestAwsError('NonPrioritizedAwsException', 'nonprioritized msg', errorTime)
+        ;(awsErr2 as any).cause = awsErr1
+        const err3 = new ToolkitError(toolkitErrorMessage, { cause: awsErr2 })
 
-        it('resolves toolkit message if cause is non-prioritized AWS error', function () {
-            const nonPrioritizedAwsError = new TestAwsError('NonPrioritizedAwsException', awsErrorMessage, errorTime)
-            const toolkitError = new ToolkitError(toolkitErrorMessage, { cause: nonPrioritizedAwsError })
+        const expected = `${toolkitErrorMessage}: validation msg`
+        assert.strictEqual(resolveErrorMessageToDisplay(err3, defaultMessage), expected)
+        ;(awsErr2 as any).cause = new Error('foo')
+        assert.strictEqual(
+            resolveErrorMessageToDisplay(err3, defaultMessage),
+            `${toolkitErrorMessage}: nonprioritized msg`
+        )
+    })
+})
 
-            const message = resolveErrorMessageToDisplay(toolkitError, defaultMessage)
+describe('util', function () {
+    it('findBestErrorInChain()', function () {
+        // assert.deepStrictEqual(getErrorMsg(findBestErrorInChain(fakeErrorChain())), 'access_denied error_description')
 
-            assert.strictEqual(message, toolkitErrorMessage)
-        })
+        const err1 = new TestAwsError('ValidationException', 'aws validation msg 1', new Date())
+        const err2 = new TestAwsError('ValidationException', 'aws validation msg 2', new Date())
+        ;(err2 as any).cause = err1
+        const err3 = new Error('err msg 3')
+        ;(err3 as any).cause = err2
+        assert.strictEqual(findBestErrorInChain(err3), err1)
+        ;(err2 as any).error_description = 'aws error desc 2'
+        assert.strictEqual(findBestErrorInChain(err3), err2)
+    })
+
+    it('formatError()', function () {
+        assert.deepStrictEqual(
+            formatError(fakeErrorChain()),
+            'unauthorized-name: unauthorized message [unauthorized-code] (requestId: be62f79a-e9cf-41cd-a755-e6920c56e4fb)'
+        )
+    })
+
+    it('getErrorMsg()', function () {
+        assert.deepStrictEqual(getErrorMsg(fakeErrorChain()), 'unauthorized message')
+        assert.deepStrictEqual(getErrorMsg(undefined), undefined)
+        const err = new TestAwsError('ValidationException', 'aws validation msg 1', new Date())
+        assert.deepStrictEqual(getErrorMsg(err), 'aws validation msg 1')
+        ;(err as any).error_description = ''
+        assert.deepStrictEqual(getErrorMsg(err), 'aws validation msg 1')
+        ;(err as any).error_description = {}
+        assert.deepStrictEqual(getErrorMsg(err), 'aws validation msg 1')
+        ;(err as any).error_description = 'aws error desc 1'
+        assert.deepStrictEqual(getErrorMsg(err), 'aws error desc 1')
     })
 })


### PR DESCRIPTION
## Problem

- Useful error messages are sometimes not surfaced to the user.
- Some services such as OIDC supply the non-standard `error_description` SDK field on some errors. If it is present, it contains more useful information than the default `message` field. But our error handling does not surface this field.
    - ref https://github.com/aws/aws-toolkit-jetbrains/commit/cc9ed87fa9391dd39ac05cbf99b4437112fa3d10

## Solution

- Rewrite `findBestErrorInChain()` (renamed from `findPrioritizedAwsError`) to search the full "cause chain".
- Introduce `getErrorMsg()` and use it in `findBestErrorInChain()`.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
