### PR TITLE
feat: add featureDevTelemetryEvent

### DIFF
--- a/packages/core/src/amazonqFeatureDev/client/codewhispererruntime-2022-11-11.json
+++ b/packages/core/src/amazonqFeatureDev/client/codewhispererruntime-2022-11-11.json
@@ -1036,6 +1036,15 @@
             },
             "documentation": "<p>Represents the state of an Editor</p>"
         },
+        "FeatureDevEvent": {
+            "type": "structure",
+            "required": ["conversationId"],
+            "members": {
+                "conversationId": {
+                    "shape": "ConversationId"
+                }
+            }
+        },
         "FeatureEvaluation": {
             "type": "structure",
             "required": ["feature", "variation", "value"],
@@ -1918,6 +1927,9 @@
                 },
                 "metricData": {
                     "shape": "MetricData"
+                },
+                "featureDevEvent": {
+                    "shape": "FeatureDevEvent"
                 }
             },
             "union": true

--- a/packages/core/src/amazonqFeatureDev/client/featureDev.ts
+++ b/packages/core/src/amazonqFeatureDev/client/featureDev.ts
@@ -308,4 +308,34 @@ export class FeatureDevClient {
             throw new ToolkitError((e as Error).message, { code: 'ExportResultArchiveFailed' })
         }
     }
+
+    /**
+     * This event is specific to ABTesting purposes.
+     *
+     * No need to fail currently if the event fails in the request. In addition, currently there is no need for a return value.
+     *
+     * @param conversationId
+     */
+    public async sendFeatureDevTelemetryEvent(conversationId: string) {
+        try {
+            const client = await this.getClient()
+            const params: FeatureDevProxyClient.SendTelemetryEventRequest = {
+                telemetryEvent: {
+                    featureDevEvent: {
+                        conversationId,
+                    },
+                },
+            }
+            const response = await client.sendTelemetryEvent(params).promise()
+            getLogger().debug(
+                `${featureName}: successfully sent featureDevEvent: ConversationId: ${conversationId} RequestId: ${response.$response.requestId}`
+            )
+        } catch (e) {
+            getLogger().error(
+                `${featureName}: failed to send feature dev telemetry: ${(e as Error).name}: ${
+                    (e as Error).message
+                } RequestId: ${(e as any).requestId}`
+            )
+        }
+    }
 }

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -61,6 +61,7 @@ export class Session {
             await this.setupConversation(msg)
             this.preloaderFinished = true
             this.messenger.sendAsyncEventProgress(this.tabID, true, undefined)
+            await this.proxyClient.sendFeatureDevTelemetryEvent(this.conversationId) // send the event only once per conversation.
         }
     }
 


### PR DESCRIPTION
## Problem

For testing ABTesting configuration and infrastructure, is needed to start sending telemetry events so RTS. This will create the basic implementation to track ABTests for featureDev.

## Solution

Add the new event model to the service schema, Add a sendTelemetryEvent request when a conversation is created. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
