### PR TITLE
[split sessions] fix(auth): login page displays connections that already exist

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -362,8 +362,8 @@ export default defineComponent({
 
     async mounted() {
         this.fetchRegions()
-        await this.updateImportedConnections()
         await this.updateExistingStartUrls()
+        await this.updateImportedConnections()
 
         // Reset gathered telemetry data each time we view the login page.
         // The webview panel is reset on each view of the login page by design.
@@ -520,16 +520,18 @@ export default defineComponent({
             // or fetch existing connections of Amazon Q in AWS Toolkit
             // to reuse connections in AWS Toolkit & Amazon Q
             const sharedConnections = await client.fetchConnections()
-            sharedConnections?.forEach((connection, index) => {
-                this.importedLogins.push({
-                    id: LoginOption.IMPORTED_LOGINS + index,
-                    text: this.app === 'TOOLKIT' ? 'Used by Amazon Q' : 'Used by AWS Toolkit',
-                    title: `IAM Identity Center ${connection.startUrl}`,
-                    type: LoginOption.ENTERPRISE_SSO,
-                    startUrl: connection.startUrl,
-                    region: connection.ssoRegion,
+            sharedConnections
+                ?.filter(c => !this.existingStartUrls.includes(c.startUrl))
+                .forEach((connection, index) => {
+                    this.importedLogins.push({
+                        id: LoginOption.IMPORTED_LOGINS + index,
+                        text: this.app === 'TOOLKIT' ? 'Used by Amazon Q' : 'Used by AWS Toolkit',
+                        title: `IAM Identity Center ${connection.startUrl}`,
+                        type: LoginOption.ENTERPRISE_SSO,
+                        startUrl: connection.startUrl,
+                        region: connection.ssoRegion,
+                    })
                 })
-            })
 
             this.$forceUpdate()
         },


### PR DESCRIPTION
Problem: We do not allow the SSO form to continue if the user tries putting in an IdC start url that already exists in the same extension. However, this check isn't in place for displaying connections from the other extension. This means users can duplicate the connection start url in the extension and caused undefined behavior.

Solution: Filter out existing connections from other extensions on what connections are in the current extension.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
