### PR TITLE
Security scans: Increase in payload size limit from 500MB to 1GB.

### DIFF
--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -216,7 +216,7 @@ export const fileScanPayloadSizeLimitBytes = 200 * Math.pow(2, 10) // 200 KB
 
 export const fileScanUploadIntent = 'AUTOMATIC_FILE_SECURITY_SCAN'
 
-export const projectScanPayloadSizeLimitBytes = 500 * Math.pow(2, 20) // 500 MB
+export const projectScanPayloadSizeLimitBytes = 1 * Math.pow(2, 30) // 1GB
 
 export const projectScanUploadIntent = 'FULL_PROJECT_SECURITY_SCAN'
 


### PR DESCRIPTION
## Problem
Security Scans timing out due to payload size limit.
## Solution
**Security scans:** Increase in payload size limit from `500MB` to `1GB`.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
