### PR TITLE
fix(featureDev): file rejections for files outside of src/

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3336,11 +3336,20 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.2.tgz",
-            "integrity": "sha512-w8xAyFhi5nTy+aMBo/AEGSx+FtPhzaVrjjtfQz5g8gJDFoWmVdGI1vIJCZcz6cHHyV/7acb7ULcOYY5Do4uWoQ==",
+            "version": "4.11.2",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.11.2.tgz",
+            "integrity": "sha512-tV4Ve0JoRDNGiJQ3RMinnj+xZY/4B0ysZDU+/5L80lLJqLeBUJ5hwynGvrYrJvPAihmzRVlyJnjxAN4OaGd1QA==",
             "hasInstallScript": true,
             "dependencies": {
+                "escape-html": "^1.0.3",
+                "just-clone": "^6.2.0",
+                "marked": "^12.0.2",
+                "prismjs": "1.29.0",
+                "sanitize-html": "^2.12.1",
+                "unescape-html": "^1.1.0"
+            },
+            "peerDependencies": {
+                "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
                 "marked": "^12.0.2",
                 "prismjs": "1.29.0",
@@ -9669,8 +9678,7 @@
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-            "dev": true
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -18889,7 +18897,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.9.2",
+                "@aws/mynah-ui": "^4.11.2",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-4745c9cd-5cbc-4765-89ea-4de83778e803.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-4745c9cd-5cbc-4765-89ea-4de83778e803.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /dev command: Fix file rejections for files outside of src/"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4098,7 +4098,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.9.2",
+        "@aws/mynah-ui": "^4.11.2",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
When the given path for a file starts with ./ it doesn't show the file actions and not triggering the file click. Now it uses the original file path check
It was fixed in the newest mynah release

Tested: yes, now files outside of src/ can be rejected
<img width="572" alt="Screenshot 2024-06-19 at 16 33 54" src="https://github.com/aws/aws-toolkit-vscode/assets/144136687/798a2ddc-d328-40f5-9ab0-68c38a1a7229">
## Solution



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
