### PR TITLE
telemetry(amazonq security scan): set reasonDesc

### DIFF
--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -310,11 +310,9 @@ export async function emitCodeScanTelemetry(
 
 export function errorPromptHelper(error: SecurityScanError, scope: CodeAnalysisScope) {
     if (scope === CodeAnalysisScope.PROJECT) {
-        if (error.code === 'ContentLengthError') {
-            void vscode.window.showWarningMessage(ProjectSizeExceededErrorMessage, ok)
-        } else {
-            void vscode.window.showWarningMessage(error.customerFacingMessage, ok)
-        }
+        const message =
+            error.code === 'ContentLengthError' ? ProjectSizeExceededErrorMessage : error.customerFacingMessage
+        void vscode.window.showWarningMessage(message, ok)
     }
 }
 

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -250,11 +250,10 @@ export async function startSecurityScan(
                 CodeScansState.instance.setMonthlyQuotaExceeded()
             }
         }
-        if ((error as ToolkitError).code == 'ContentLengthError') {
-            codeScanTelemetryEntry.reason = 'Payload size limit reached'
-        } else {
-            codeScanTelemetryEntry.reason = (error as SecurityScanError).message
-        }
+        codeScanTelemetryEntry.reason =
+            (error as ToolkitError)?.code === 'ContentLengthError'
+                ? 'Payload size limit reached'
+                : (error as SecurityScanError).message
     } finally {
         codeScanState.setToNotStarted()
         codeScanTelemetryEntry.duration = performance.now() - codeScanStartTime

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -31,7 +31,7 @@ import {
 import { cancel, ok } from '../../shared/localizedText'
 import { getDirSize } from '../../shared/filesystemUtilities'
 import { telemetry } from '../../shared/telemetry/telemetry'
-import { ToolkitError, isAwsError } from '../../shared/errors'
+import { ToolkitError, getTelemetryReasonDesc, isAwsError } from '../../shared/errors'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { AuthUtil } from '../util/authUtil'
 import path from 'path'
@@ -250,10 +250,11 @@ export async function startSecurityScan(
                 CodeScansState.instance.setMonthlyQuotaExceeded()
             }
         }
-        codeScanTelemetryEntry.reason =
+        codeScanTelemetryEntry.reasonDesc =
             (error as ToolkitError)?.code === 'ContentLengthError'
                 ? 'Payload size limit reached'
-                : (error as SecurityScanError).message
+                : getTelemetryReasonDesc(error)
+        codeScanTelemetryEntry.reason = (error as ToolkitError)?.code ?? 'DefaultError'
     } finally {
         codeScanState.setToNotStarted()
         codeScanTelemetryEntry.duration = performance.now() - codeScanStartTime

--- a/packages/core/src/codewhisperer/models/errors.ts
+++ b/packages/core/src/codewhisperer/models/errors.ts
@@ -79,6 +79,6 @@ export class SecurityScanTimedOutError extends SecurityScanError {
 
 export class CodeScanJobFailedError extends SecurityScanError {
     constructor() {
-        super('Security scan job failed.', 'CodeScanJobFailedError', DefaultCodeScanErrorMessage)
+        super('Security scan failed.', 'CodeScanJobFailedError', DefaultCodeScanErrorMessage)
     }
 }

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -688,6 +688,7 @@ export interface CodeScanTelemetryEntry {
     codeScanServiceInvocationsDuration: number
     result: Result
     reason?: string
+    reasonDesc?: string
     codewhispererCodeScanTotalIssues: number
     codewhispererCodeScanIssuesWithFixes: number
     credentialStartUrl: string | undefined

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -37,6 +37,7 @@ import {
     SecurityScanTimedOutError,
     UploadArtifactToS3Error,
 } from '../models/errors'
+import { getTelemetryReasonDesc } from '../../shared/errors'
 
 export async function listScanResults(
     client: DefaultCodeWhispererClient,
@@ -289,9 +290,10 @@ export async function uploadArtifactToS3(
         getLogger().error(
             `Amazon Q is unable to upload workspace artifacts to Amazon S3 for security scans. For more information, see the Amazon Q documentation or contact your network or organization administrator.`
         )
-        const errorMessage = (error as Error).message.includes(`"PUT" request failed with code "403"`)
+        const errorMessage = getTelemetryReasonDesc(error)?.includes(`"PUT" request failed with code "403"`)
             ? `UploadArtifactToS3Exception: "PUT" request failed with code "403"`
-            : (error as Error).message
+            : getTelemetryReasonDesc(error) ?? 'Security scan failed.'
+
         throw new UploadArtifactToS3Error(errorMessage)
     }
 }

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -289,7 +289,9 @@ export async function uploadArtifactToS3(
         getLogger().error(
             `Amazon Q is unable to upload workspace artifacts to Amazon S3 for security scans. For more information, see the Amazon Q documentation or contact your network or organization administrator.`
         )
-        const errorMessage = (error as Error).message
+        const errorMessage = (error as Error).message.includes(`"PUT" request failed with code "403"`)
+            ? `UploadArtifactToS3Exception: "PUT" request failed with code "403"`
+            : (error as Error).message
         throw new UploadArtifactToS3Error(errorMessage)
     }
 }

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -383,7 +383,7 @@ describe('startSecurityScan', function () {
         assertTelemetry('codewhisperer_securityScan', {
             codewhispererCodeScanScope: 'PROJECT',
             result: 'Failed',
-            reason: 'GetCodeScanException',
+            reason: 'CodeScanJobFailedError',
             reasonDesc: 'Security scan failed.',
             passive: false,
         } as unknown as CodewhispererSecurityScan)

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -325,8 +325,9 @@ describe('startSecurityScan', function () {
         assertTelemetry('codewhisperer_securityScan', [
             {
                 result: 'Cancelled',
-                reason: 'Security scan stopped by user.',
-            },
+                reasonDesc: 'Security scan stopped by user.',
+                reason: 'DefaultError',
+            } as unknown as CodewhispererSecurityScan,
             {
                 result: 'Succeeded',
             },
@@ -382,9 +383,10 @@ describe('startSecurityScan', function () {
         assertTelemetry('codewhisperer_securityScan', {
             codewhispererCodeScanScope: 'PROJECT',
             result: 'Failed',
-            reason: 'Security scan failed.',
+            reason: 'GetCodeScanException',
+            reasonDesc: 'Security scan failed.',
             passive: false,
-        })
+        } as unknown as CodewhispererSecurityScan)
     })
 
     it('Should show notification when throttled for project scans', async function () {
@@ -409,9 +411,10 @@ describe('startSecurityScan', function () {
         assertTelemetry('codewhisperer_securityScan', {
             codewhispererCodeScanScope: 'PROJECT',
             result: 'Failed',
-            reason: 'Maximum project scan count reached for this month.',
+            reason: 'ThrottlingException',
+            reasonDesc: 'Maximum project scan count reached for this month.',
             passive: false,
-        } as CodewhispererSecurityScan)
+        } as unknown as CodewhispererSecurityScan)
     })
 
     it('Should set monthly quota exceeded when throttled for file scans', async function () {
@@ -439,8 +442,9 @@ describe('startSecurityScan', function () {
         assertTelemetry('codewhisperer_securityScan', {
             codewhispererCodeScanScope: 'FILE',
             result: 'Failed',
-            reason: 'Maximum auto-scans count reached for this month.',
+            reason: 'ThrottlingException',
+            reasonDesc: 'Maximum auto-scans count reached for this month.',
             passive: true,
-        } as CodewhispererSecurityScan)
+        } as unknown as CodewhispererSecurityScan)
     })
 })

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -382,7 +382,7 @@ describe('startSecurityScan', function () {
         assertTelemetry('codewhisperer_securityScan', {
             codewhispererCodeScanScope: 'PROJECT',
             result: 'Failed',
-            reason: 'Security scan job failed.',
+            reason: 'Security scan failed.',
             passive: false,
         })
     })


### PR DESCRIPTION
## Problem
- Telemetry error messages are not consistent in VSC and JB
## Solution
-  Improving telemetry error messages to keep consistent in both IDE's
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
