### PR TITLE
fix(codecatalyst): dev env logged out on load

### DIFF
--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -197,6 +197,7 @@ export class SecondaryAuth<T extends Connection = Connection> {
      * Clears the connection in use without deleting it or logging out.
      */
     public async forgetConnection() {
+        getLogger().debug('running SecondaryAuth:forgetConnection()')
         await this.clearSavedConnection()
         await this.clearActiveConnection()
     }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -128,6 +128,9 @@ export async function activate(context: vscode.ExtensionContext) {
         // TODO: Remove after some time?
         for (const conn of await Auth.instance.listConnections()) {
             if (isSsoConnection(conn) && hasScopes(conn, codeWhispererCoreScopes)) {
+                getLogger().debug(
+                    `forgetting connection: ${conn.id} with starturl/scopes: ${conn.startUrl} / ${conn.scopes}`
+                )
                 await Auth.instance.forgetConnection(conn)
                 await SessionSeparationPrompt.instance.showForCommand('aws.toolkit.auth.manageConnections')
             }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -129,7 +129,8 @@ export async function activate(context: vscode.ExtensionContext) {
         for (const conn of await Auth.instance.listConnections()) {
             if (isSsoConnection(conn) && hasScopes(conn, codeWhispererCoreScopes)) {
                 getLogger().debug(
-                    `forgetting connection: ${conn.id} with starturl/scopes: ${conn.startUrl} / ${conn.scopes}`
+                    `forgetting connection: ${conn.id} with starturl/scopes: ${conn.startUrl} / %O`,
+                    conn.scopes
                 )
                 await Auth.instance.forgetConnection(conn)
                 await SessionSeparationPrompt.instance.showForCommand('aws.toolkit.auth.manageConnections')


### PR DESCRIPTION
**Separate sessions commit**

Problem: We forget all connections without all codecatalyst scopes only (aws account + coca scopes). However, the stored credentials in dev environments do not have the account scopes, so we are forgetting it.

Solution: Check for Q scopes explicitly.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
