### PR TITLE
fix: remove userApproachTelemetry feature dev log when telemetry is disabled

### DIFF
--- a/packages/core/src/amazonqFeatureDev/util/telemetryHelper.ts
+++ b/packages/core/src/amazonqFeatureDev/util/telemetryHelper.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { globals } from '../../shared'
 import { getLogger } from '../../shared/logger/logger'
 import { AmazonqApproachInvoke, AmazonqCodeGenerationInvoke, Metric } from '../../shared/telemetry/telemetry'
 import { LLMResponseType } from '../types'
@@ -41,7 +42,9 @@ export class TelemetryHelper {
             amazonqGenerateApproachLatency: performance.now() - this.generateApproachLastInvocationTime,
             amazonqGenerateApproachResponseType: responseType,
         }
-        getLogger().debug(`recordUserApproachTelemetry: %O`, event)
+        if (globals.telemetry.telemetryEnabled) {
+            getLogger().debug(`recordUserApproachTelemetry: %O`, event)
+        }
         span.record(event)
     }
 


### PR DESCRIPTION
## Problem
- This debug log is misleading when telemetry is disabled

## Solution
- Only use the debug log when telemetry is enabled

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
