### PR TITLE
auth: ignore vscode proxy errors on token refresh

### DIFF
--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -565,6 +565,10 @@ export class PermissionsError extends ToolkitError {
 }
 
 export function isNetworkError(err?: unknown): err is Error & { code: string } {
+    if (isVSCodeProxyError(err)) {
+        return true
+    }
+
     if (!hasCode(err)) {
         return false
     }
@@ -583,4 +587,18 @@ export function isNetworkError(err?: unknown): err is Error & { code: string } {
         'ENOBUFS', // client side memory issue during http request?
         'EADDRNOTAVAIL', // port not available/allowed?
     ].includes(err.code)
+}
+
+/**
+ * This error occurs on a network call if the user has set up a proxy in the
+ * VS Code settings but the proxy is not reachable.
+ *
+ * Setting ID: http.proxy
+ */
+function isVSCodeProxyError(err?: unknown): boolean {
+    if (!(err instanceof Error)) {
+        return false
+    }
+
+    return err.name === 'Error' && err.message.startsWith('Failed to establish a socket connection to proxies')
 }

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -11,6 +11,7 @@ import {
     getErrorMsg,
     getTelemetryReason,
     getTelemetryResult,
+    isNetworkError,
     resolveErrorMessageToDisplay,
     ToolkitError,
 } from '../../shared/errors'
@@ -415,5 +416,18 @@ describe('util', function () {
         assert.deepStrictEqual(getErrorMsg(err), 'aws validation msg 1')
         ;(err as any).error_description = 'aws error desc 1'
         assert.deepStrictEqual(getErrorMsg(err), 'aws error desc 1')
+    })
+
+    it('isNetworkError()', function () {
+        assert.deepStrictEqual(
+            isNetworkError(new Error('Failed to establish a socket connection to proxies BLAH BLAH BLAH')),
+            true,
+            'Did not return "true" on a VS Code Proxy error'
+        )
+        assert.deepStrictEqual(
+            isNetworkError(new Error('I am NOT a network error')),
+            false,
+            'Incorrectly indicated as network error'
+        )
     })
 })


### PR DESCRIPTION
## Problem

We were seeing an error in `aws_refreshCredentials` metric. This error was networking related when the user has setup a proxy in vscode, but they were not connected to it. Maybe they didn't connect to VPN.

We typically catch network errors during the SSO token refresh process so that the session does not become invalidated on it. We do not catch all errors, but will add them in incrementally as we see them in telemetry. This proxy error was not caught and caused sessions to become invalidated prematurely.

## Solution

Treat this VSCode Proxy Error as a network error so that we ignore it during token refresh, keeping the users session valid.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
