### PR TITLE
fix(amazonq): Code blocks with typewriter text inside list items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3336,9 +3336,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.11.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.11.2.tgz",
-            "integrity": "sha512-tV4Ve0JoRDNGiJQ3RMinnj+xZY/4B0ysZDU+/5L80lLJqLeBUJ5hwynGvrYrJvPAihmzRVlyJnjxAN4OaGd1QA==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.13.0.tgz",
+            "integrity": "sha512-ZOl4hggf1M7HuHipnNxf4lnh8Dt38hFD/SZPpmL1fw2pJbT+hnIAkz6nru7wUtfUSh990PshuzLRNmVrZDPpag==",
             "hasInstallScript": true,
             "dependencies": {
                 "escape-html": "^1.0.3",
@@ -18897,7 +18897,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.11.2",
+                "@aws/mynah-ui": "^4.13.0",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-8d9d0ab6-a0f7-4622-b0d9-0cd12cc568b3.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-8d9d0ab6-a0f7-4622-b0d9-0cd12cc568b3.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Fixed broken code blocks with typewriter text in list items."
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4098,7 +4098,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.11.2",
+        "@aws/mynah-ui": "^4.13.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
- `<span class='typewriter-part>...</span>` shows up in contents within list items.
- Chat card component reordering and update structure is broken sometimes depending on update type.

## Solution
- Streaming content component wrapped out from the chat-item-card and builded as a separate component
- Typewriter animation injection removed from the markdown parsing process
- Typewriter animation injection added to node process state with a check if the node type is TEXT, then we're adding the animation wrapper.

[MynahUI 4.13.0](https://github.com/aws/mynah-ui/releases/tag/v4.13.0)

### Before
<img width="666" alt="broken" src="https://github.com/aws/aws-toolkit-vscode/assets/116281103/42064797-4fdb-4a42-affa-525c7dabd4d2">

### After
<img width="670" alt="fixed" src="https://github.com/aws/aws-toolkit-vscode/assets/116281103/a83b4076-d2d7-436d-9cae-e299403abc83">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
