### PR TITLE
fix: update high vulnerability npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -971,108 +971,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.572.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
-            "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.572.0",
-                "@aws-sdk/core": "3.572.0",
-                "@aws-sdk/credential-provider-node": "3.572.0",
-                "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.568.0",
-                "@aws-sdk/middleware-recursion-detection": "3.567.0",
-                "@aws-sdk/middleware-user-agent": "3.572.0",
-                "@aws-sdk/region-config-resolver": "3.572.0",
-                "@aws-sdk/types": "3.567.0",
-                "@aws-sdk/util-endpoints": "3.572.0",
-                "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.568.0",
-                "@smithy/config-resolver": "^2.2.0",
-                "@smithy/core": "^1.4.2",
-                "@smithy/fetch-http-handler": "^2.5.0",
-                "@smithy/hash-node": "^2.2.0",
-                "@smithy/invalid-dependency": "^2.2.0",
-                "@smithy/middleware-content-length": "^2.2.0",
-                "@smithy/middleware-endpoint": "^2.5.1",
-                "@smithy/middleware-retry": "^2.3.1",
-                "@smithy/middleware-serde": "^2.3.0",
-                "@smithy/middleware-stack": "^2.2.0",
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/node-http-handler": "^2.5.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "@smithy/url-parser": "^2.2.0",
-                "@smithy/util-base64": "^2.3.0",
-                "@smithy/util-body-length-browser": "^2.2.0",
-                "@smithy/util-body-length-node": "^2.3.0",
-                "@smithy/util-defaults-mode-browser": "^2.2.1",
-                "@smithy/util-defaults-mode-node": "^2.3.1",
-                "@smithy/util-endpoints": "^1.2.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "@smithy/util-retry": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sts": {
-            "version": "3.572.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
-            "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sso-oidc": "3.572.0",
-                "@aws-sdk/core": "3.572.0",
-                "@aws-sdk/credential-provider-node": "3.572.0",
-                "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.568.0",
-                "@aws-sdk/middleware-recursion-detection": "3.567.0",
-                "@aws-sdk/middleware-user-agent": "3.572.0",
-                "@aws-sdk/region-config-resolver": "3.572.0",
-                "@aws-sdk/types": "3.567.0",
-                "@aws-sdk/util-endpoints": "3.572.0",
-                "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.568.0",
-                "@smithy/config-resolver": "^2.2.0",
-                "@smithy/core": "^1.4.2",
-                "@smithy/fetch-http-handler": "^2.5.0",
-                "@smithy/hash-node": "^2.2.0",
-                "@smithy/invalid-dependency": "^2.2.0",
-                "@smithy/middleware-content-length": "^2.2.0",
-                "@smithy/middleware-endpoint": "^2.5.1",
-                "@smithy/middleware-retry": "^2.3.1",
-                "@smithy/middleware-serde": "^2.3.0",
-                "@smithy/middleware-stack": "^2.2.0",
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/node-http-handler": "^2.5.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "@smithy/url-parser": "^2.2.0",
-                "@smithy/util-base64": "^2.3.0",
-                "@smithy/util-body-length-browser": "^2.2.0",
-                "@smithy/util-body-length-node": "^2.3.0",
-                "@smithy/util-defaults-mode-browser": "^2.2.1",
-                "@smithy/util-defaults-mode-node": "^2.3.1",
-                "@smithy/util-endpoints": "^1.2.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "@smithy/util-retry": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-ini": {
             "version": "3.572.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.572.0.tgz",
@@ -1122,108 +1020,6 @@
                 "@smithy/property-provider": "^2.2.0",
                 "@smithy/shared-ini-file-loader": "^2.4.0",
                 "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.572.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
-            "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.572.0",
-                "@aws-sdk/core": "3.572.0",
-                "@aws-sdk/credential-provider-node": "3.572.0",
-                "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.568.0",
-                "@aws-sdk/middleware-recursion-detection": "3.567.0",
-                "@aws-sdk/middleware-user-agent": "3.572.0",
-                "@aws-sdk/region-config-resolver": "3.572.0",
-                "@aws-sdk/types": "3.567.0",
-                "@aws-sdk/util-endpoints": "3.572.0",
-                "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.568.0",
-                "@smithy/config-resolver": "^2.2.0",
-                "@smithy/core": "^1.4.2",
-                "@smithy/fetch-http-handler": "^2.5.0",
-                "@smithy/hash-node": "^2.2.0",
-                "@smithy/invalid-dependency": "^2.2.0",
-                "@smithy/middleware-content-length": "^2.2.0",
-                "@smithy/middleware-endpoint": "^2.5.1",
-                "@smithy/middleware-retry": "^2.3.1",
-                "@smithy/middleware-serde": "^2.3.0",
-                "@smithy/middleware-stack": "^2.2.0",
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/node-http-handler": "^2.5.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "@smithy/url-parser": "^2.2.0",
-                "@smithy/util-base64": "^2.3.0",
-                "@smithy/util-body-length-browser": "^2.2.0",
-                "@smithy/util-body-length-node": "^2.3.0",
-                "@smithy/util-defaults-mode-browser": "^2.2.1",
-                "@smithy/util-defaults-mode-node": "^2.3.1",
-                "@smithy/util-endpoints": "^1.2.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "@smithy/util-retry": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sts": {
-            "version": "3.572.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
-            "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sso-oidc": "3.572.0",
-                "@aws-sdk/core": "3.572.0",
-                "@aws-sdk/credential-provider-node": "3.572.0",
-                "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.568.0",
-                "@aws-sdk/middleware-recursion-detection": "3.567.0",
-                "@aws-sdk/middleware-user-agent": "3.572.0",
-                "@aws-sdk/region-config-resolver": "3.572.0",
-                "@aws-sdk/types": "3.567.0",
-                "@aws-sdk/util-endpoints": "3.572.0",
-                "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.568.0",
-                "@smithy/config-resolver": "^2.2.0",
-                "@smithy/core": "^1.4.2",
-                "@smithy/fetch-http-handler": "^2.5.0",
-                "@smithy/hash-node": "^2.2.0",
-                "@smithy/invalid-dependency": "^2.2.0",
-                "@smithy/middleware-content-length": "^2.2.0",
-                "@smithy/middleware-endpoint": "^2.5.1",
-                "@smithy/middleware-retry": "^2.3.1",
-                "@smithy/middleware-serde": "^2.3.0",
-                "@smithy/middleware-stack": "^2.2.0",
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/node-http-handler": "^2.5.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "@smithy/url-parser": "^2.2.0",
-                "@smithy/util-base64": "^2.3.0",
-                "@smithy/util-body-length-browser": "^2.2.0",
-                "@smithy/util-body-length-node": "^2.3.0",
-                "@smithy/util-defaults-mode-browser": "^2.2.1",
-                "@smithy/util-defaults-mode-node": "^2.3.1",
-                "@smithy/util-endpoints": "^1.2.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "@smithy/util-retry": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -7052,21 +6848,21 @@
             "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
         },
         "node_modules/body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
             "dev": true,
             "dependencies": {
                 "bytes": "3.1.2",
-                "content-type": "~1.0.4",
+                "content-type": "~1.0.5",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "destroy": "1.2.0",
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.10.3",
-                "raw-body": "2.5.1",
+                "qs": "6.11.0",
+                "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
             },
@@ -7132,12 +6928,12 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -8132,9 +7928,9 @@
             }
         },
         "node_modules/content-type": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
@@ -8147,9 +7943,9 @@
             "dev": true
         },
         "node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
@@ -9221,14 +9017,15 @@
             }
         },
         "node_modules/es5-ext": {
-            "version": "0.10.62",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-            "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+            "version": "0.10.64",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+            "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
                 "es6-iterator": "^2.0.3",
                 "es6-symbol": "^3.1.3",
+                "esniff": "^2.0.1",
                 "next-tick": "^1.1.0"
             },
             "engines": {
@@ -9888,6 +9685,27 @@
                 "node": ">=8"
             }
         },
+        "node_modules/esniff": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+            "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+            "dev": true,
+            "dependencies": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.62",
+                "event-emitter": "^0.3.5",
+                "type": "^2.7.2"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/esniff/node_modules/type": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+            "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+            "dev": true
+        },
         "node_modules/espree": {
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -10080,17 +9898,17 @@
             }
         },
         "node_modules/express": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+            "version": "4.19.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+            "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.0",
+                "body-parser": "1.20.2",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.5.0",
+                "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -10106,7 +9924,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "0.1.7",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.10.3",
+                "qs": "6.11.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "0.18.0",
@@ -10334,9 +10152,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -14706,9 +14524,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
             "dev": true,
             "dependencies": {
                 "side-channel": "^1.0.4"
@@ -14798,9 +14616,9 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dev": true,
             "dependencies": {
                 "bytes": "3.1.2",
@@ -18394,9 +18212,9 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "node_modules/ws": {
-            "version": "8.14.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-            "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"


### PR DESCRIPTION
## Problem

> [!CAUTION]
Running `npm audit` reports 2 high severity vulnerability
braces + ws

#### [Braces](https://github.com/advisories/GHSA-grv7-fg5c-xmjg)
> [!WARNING]
> **Uncontrolled resource consumption in braces**
>The NPM package braces fails to limit the number of characters it can handle, which could lead to Memory Exhaustion. In lib/parse.js, if a malicious user sends "imbalanced braces" as input, the parsing will enter a loop, which will cause the program to start allocating heap memory without freeing it at any moment of the loop. Eventually, the JavaScript heap limit is reached, and the program will crash.

#### [WS](https://github.com/advisories/GHSA-3h5v-q93c-6h6q)
> [!WARNING]
> **ws affected by a DoS when handling a request with many HTTP headers**
> A request with a number of headers exceeding the [server.maxHeadersCount](https://nodejs.org/api/http.html#servermaxheaderscount) threshold could be used to crash a ws server.



## Solution

- [x] `find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +`
- [x] `npm i`
- [x] `npm audit`
- [x] `npm audit fix`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
