### PR TITLE
fix(amazonq): "Failed to run: refreshConnectionCallback"

### DIFF
--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -442,8 +442,8 @@ export class AuthUtil {
      *       a connection if it has some CW scopes.
      */
     findMinimalQConnection(connections: AwsConnection[]): AwsConnection | undefined {
-        const hasQScopes = (c: AwsConnection) => codeWhispererCoreScopes.every(s => c.scopes?.includes(s))
-        const score = (c: AwsConnection) => Number(hasQScopes(c)) * 10 + Number(c.state === 'valid')
+        const hasQScopes = (c?: AwsConnection) => codeWhispererCoreScopes.every(s => !!c?.scopes?.includes(s))
+        const score = (c?: AwsConnection) => Number(hasQScopes(c)) * 10 + Number(c?.state === 'valid')
         connections.sort(function (a, b) {
             return score(b) - score(a)
         })


### PR DESCRIPTION
## Problem


command sometimes shows an error during teardown:

    Failed to run command: aws.amazonq.refreshConnectionCallback: Cannot
    read properties of undefined (reading 'scopes')

## Solution
There may be a race somewhere, when we update the connections list. To mitigate, handle undefined AwsConnection.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
