### PR TITLE
feat(policyCheck): new/updated custom policy checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3285,10 +3285,11 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.212",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.212.tgz",
-            "integrity": "sha512-gxPTkJKqw2/9ZmC+jRI7BUKYegJM0BhuCDpbmpKzDvOAr9TTznKpKXNoFyr6FXPt1aB9p28PZkCa387rXAQcUw==",
+            "version": "1.0.216",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.216.tgz",
+            "integrity": "sha512-WoBK2FMC5Voumh+NCa+WSD1/I8iWBfwrHuuV8N0IGAG3xyKuc/DId+o5Zj1QuMySDUeI5ra9BpKIB0Gvu4id9Q==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^6.12.6",
                 "fs-extra": "^11.1.0",
@@ -18947,7 +18948,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
-                "@aws-toolkits/telemetry": "^1.0.212",
+                "@aws-toolkits/telemetry": "^1.0.216",
                 "@aws/fully-qualified-names": "^2.1.4",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
@@ -19033,12 +19034,15 @@
         "packages/toolkit": {
             "name": "aws-toolkit-vscode",
             "version": "3.12.0-SNAPSHOT",
-            "engines": "This field will be autopopulated from the core module during debugging and packaging.",
             "license": "Apache-2.0",
             "dependencies": {
                 "aws-core-vscode": "file:../core/"
             },
-            "devDependencies": {}
+            "devDependencies": {},
+            "engines": {
+                "npm": "^10.1.0",
+                "vscode": "^1.68.0"
+            }
         },
         "plugins/eslint-plugin-aws-toolkits": {
             "version": "1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4028,7 +4028,7 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws-toolkits/telemetry": "^1.0.212",
+        "@aws-toolkits/telemetry": "^1.0.216",
         "@aws/fully-qualified-names": "^2.1.4",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",

--- a/packages/core/src/accessanalyzer/vue/constants.ts
+++ b/packages/core/src/accessanalyzer/vue/constants.ts
@@ -19,13 +19,14 @@ export abstract class IamPolicyChecksConstants {
         'The file extension does not match the selected document type. Please select the correct document type, or use the proper file extension.'
     static readonly InvalidAwsCredentials =
         'AWS Role Credentials are invalid or expired. Update AWS credentials and try again.'
+    static readonly MissingActionsOrResourcesError = 'Please provide at least one of actions or resources.'
 }
 
 export type PolicyChecksErrorCode = 'FileReadError' | 'ValidatePolicyError' | 'CustomChecksError'
 
 export type PolicyChecksDocumentType = 'Terraform Plan' | 'CloudFormation' | 'JSON Policy Language'
 
-export type PolicyChecksCheckType = 'CheckNoNewAccess' | 'CheckAccessNotGranted'
+export type PolicyChecksCheckType = 'CheckNoNewAccess' | 'CheckAccessNotGranted' | 'CheckNoPublicAccess'
 
 export type PolicyChecksPolicyType = 'Identity' | 'Resource'
 


### PR DESCRIPTION
## Problem
IAM Access Analyzer recently released an update to custom policy checks adding support for public access and critical resources: https://aws.amazon.com/about-aws/whats-new/2024/06/aws-iam-access-analyzer-policy-checks/

## Solution
This PR updates the policyCheck toolkits integration to support the updated checks.

## References
PR for adding telemetry for IamPolicyChecks: https://github.com/aws/aws-toolkit-common/pull/735
PR for updating telemetry for updated checks: https://github.com/aws/aws-toolkit-common/pull/756
PR for release of the IamPolicyChecks feature in toolkits: https://github.com/aws/aws-toolkit-vscode/pull/5028

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
