### PR TITLE
fix: cwd should use workspaceFolder

### DIFF
--- a/packages/amazonq/.vscode/tasks.json
+++ b/packages/amazonq/.vscode/tasks.json
@@ -22,7 +22,7 @@
             "isBackground": true,
             "problemMatcher": "$tsc-watch",
             "options": {
-                "cwd": "../core"
+                "cwd": "${workspaceFolder}/../../packages/core"
             }
         },
         {
@@ -32,7 +32,7 @@
             "isBackground": true,
             "problemMatcher": "$ts-webpack-watch",
             "options": {
-                "cwd": "../core"
+                "cwd": "${workspaceFolder}/../../packages/core"
             }
         },
         {
@@ -43,7 +43,7 @@
             "isBackground": true,
             "problemMatcher": "$ts-webpack-watch",
             "options": {
-                "cwd": "../core"
+                "cwd": "${workspaceFolder}/../../packages/core"
             }
         },
         {
@@ -111,7 +111,7 @@
             "problemMatcher": "$ts-webpack-watch",
             "dependsOn": ["copyPackageJson"],
             "options": {
-                "cwd": "../core"
+                "cwd": "${workspaceFolder}/../../packages/core"
             }
         },
         /**

--- a/packages/toolkit/.vscode/tasks.json
+++ b/packages/toolkit/.vscode/tasks.json
@@ -31,7 +31,7 @@
             "isBackground": true,
             "problemMatcher": "$tsc-watch",
             "options": {
-                "cwd": "../core"
+                "cwd": "${workspaceFolder}/../../packages/core"
             }
         },
         {
@@ -41,7 +41,7 @@
             "isBackground": true,
             "problemMatcher": "$ts-webpack-watch",
             "options": {
-                "cwd": "../core"
+                "cwd": "${workspaceFolder}/../../packages/core"
             }
         },
         {
@@ -52,7 +52,7 @@
             "isBackground": true,
             "problemMatcher": "$ts-webpack-watch",
             "options": {
-                "cwd": "../core"
+                "cwd": "${workspaceFolder}/../../packages/core"
             }
         },
         {
@@ -148,7 +148,7 @@
             "problemMatcher": "$ts-webpack-watch",
             "dependsOn": ["copyPackageJson"],
             "options": {
-                "cwd": "../core"
+                "cwd": "${workspaceFolder}/../../packages/core"
             }
         },
         /**


### PR DESCRIPTION
## Problem
- amazonq/toolkit fail to build on windows with: "The terminal process failed to launch: Starting directory (cwd) "\\..\core" does not exist." inside of their tasks

## Solution
- Use cwd that is relative to the workspace folder

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
