### PR TITLE
fix: activateExtension is used before globals is registered

### DIFF
--- a/packages/core/src/test/globalSetup.test.ts
+++ b/packages/core/src/test/globalSetup.test.ts
@@ -11,13 +11,11 @@ import * as sinon from 'sinon'
 import vscode from 'vscode'
 import { appendFileSync, mkdirpSync, remove } from 'fs-extra'
 import { join } from 'path'
-import { format } from 'util'
 import globals from '../shared/extensionGlobals'
 import { CodelensRootRegistry } from '../shared/fs/codelensRootRegistry'
 import { CloudFormationTemplateRegistry } from '../shared/fs/templateRegistry'
 import { getLogger, LogLevel } from '../shared/logger'
 import { setLogger } from '../shared/logger/logger'
-import { activateExtension } from '../shared/utilities/vsCodeUtils'
 import { FakeExtensionContext, FakeMemento } from './fakeExtensionContext'
 import { TestLogger } from './testLogger'
 import * as testUtil from './testUtil'
@@ -49,10 +47,7 @@ export async function mochaGlobalSetup(extensionId: string) {
         // Shows the full error chain when tests fail
         mapTestErrors(this, normalizeError)
 
-        // Extension activation has many side-effects such as changing globals
-        // For stability in tests we will wait until the extension has activated prior to injecting mocks
-        const activationLogger = (msg: string, ...meta: any[]) => console.log(format(msg, ...meta))
-        await activateExtension(extensionId, false, activationLogger)
+        await vscode.extensions.getExtension(extensionId)?.activate()
         const fakeContext = await FakeExtensionContext.create()
         fakeContext.globalStorageUri = (await testUtil.createTestWorkspaceFolder('globalStoragePath')).uri
         fakeContext.extensionPath = globals.context.extensionPath


### PR DESCRIPTION
## Problem
- Unit test setup is using activateExtension before globals is registered when running `extension tests (current file)`

## Solution
- Instead of activateExtension just use vscode.extensions.getExtension directly
- Similiar problem was fixed in integ/e2e in https://github.com/aws/aws-toolkit-vscode/pull/5078

This is a seperate issue from: https://github.com/aws/aws-toolkit-vscode/pull/5154 where the problem is the tests won't run. This fix just makes it so that `extension tests (current file) work`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
