### PR TITLE
chore: Add core outFiles to amazon q launch configs

### DIFF
--- a/packages/amazonq/.vscode/launch.json
+++ b/packages/amazonq/.vscode/launch.json
@@ -61,7 +61,7 @@
                 "DEVELOPMENT_PATH": "${workspaceFolder}",
                 "AWS_TOOLKIT_AUTOMATION": "local"
             },
-            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+            "outFiles": ["${workspaceFolder}/dist/**/*.js", "${workspaceFolder}/../core/dist/**/*.js"],
             "preLaunchTask": "watch"
         },
         {
@@ -80,7 +80,7 @@
                 "DEVELOPMENT_PATH": "${workspaceFolder}",
                 "AWS_TOOLKIT_AUTOMATION": "local"
             },
-            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+            "outFiles": ["${workspaceFolder}/dist/**/*.js", "${workspaceFolder}/../core/dist/**/*.js"],
             "preLaunchTask": "watch"
         },
         {
@@ -99,7 +99,7 @@
                 "DEVELOPMENT_PATH": "${workspaceFolder}",
                 "AWS_TOOLKIT_AUTOMATION": "local"
             },
-            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+            "outFiles": ["${workspaceFolder}/dist/**/*.js", "${workspaceFolder}/../core/dist/**/*.js"],
             "preLaunchTask": "watch"
         }
     ]


### PR DESCRIPTION
## Problem
- We didn't have the outFiles set in some q launch configs

## Solution
- Set them so we can use breakpoints

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
