### PR TITLE
auth: TimeoutError OIDC client fix attempt

### DIFF
--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -120,6 +120,9 @@ export class OidcClient {
                 { retryDecider: updatedRetryDecider }
             ),
             customUserAgent: getUserAgent({ includePlatform: true, includeClientId: true }),
+            requestHandler: {
+                requestTimeout: 30_000,
+            },
         })
 
         addLoggingMiddleware(client)


### PR DESCRIPTION
## Problem

During API calls with the OIDC client the request would time out and we would get TimeoutError.

## Solution:

See if adding an explicit request timeout amount will avoid this. We'll need to observe telemetry to see if this
specific type of error goes down.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
