### PR TITLE
fix: pass workspace folder to amazon q e2e tests

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -60,7 +60,7 @@
         "watch": "npm run clean && npm run buildScripts && tsc -watch -p ./",
         "testCompile": "npm run clean && npm run buildScripts && npm run compileOnly",
         "test": "npm run testCompile && c8 ts-node ../core/scripts/test/test.ts dist/test/unit/index.js ../core/dist/src/testFixtures/workspaceFolder",
-        "testE2E": "npm run testCompile && c8 ts-node ../core/scripts/test/testE2E.ts dist/test/e2e/index.js",
+        "testE2E": "npm run testCompile && c8 ts-node ../core/scripts/test/testE2E.ts dist/test/e2e/index.js ../core/dist/src/testFixtures/workspaceFolder",
         "webRun": "npx @vscode/test-web --open-devtools --browserOption=--disable-web-security --waitForDebugger=9222 --extensionDevelopmentPath=. .",
         "webWatch": "npm run clean && npm run buildScripts && webpack --mode development --watch",
         "serve": "webpack serve --config-name mainServe --mode development",

--- a/packages/core/scripts/test/testE2E.ts
+++ b/packages/core/scripts/test/testE2E.ts
@@ -9,5 +9,7 @@ void (async () => {
     if (!relativeEntrypoint) {
         throw new Error('Relative entrypoint is required')
     }
-    await runToolkitTests('e2e', relativeEntrypoint)
+
+    const relativeWorkspaceFolder = process.argv[3]
+    await runToolkitTests('e2e', relativeEntrypoint, relativeWorkspaceFolder)
 })()


### PR DESCRIPTION
## Problem
- workspace folder does not open when running testE2E for amazon q through command line

## Solution
- open the workspace folder

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
