### PR TITLE
feat: update sendFeatureDevTelemetry to include user context and opt in/out telemetry options

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/service/codewhisperer.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/codewhisperer.test.ts
@@ -11,10 +11,9 @@ import {
     AuthUtil,
     codeWhispererClient,
 } from 'aws-core-vscode/codewhisperer'
-import { globals, getClientId } from 'aws-core-vscode/shared'
+import { globals, getClientId, getOperatingSystem } from 'aws-core-vscode/shared'
 import { AWSError, Request } from 'aws-sdk'
 import { createSpyClient } from 'aws-core-vscode/test'
-import * as os from 'os'
 
 describe('codewhisperer', async function () {
     let clientSpy: CodeWhispererUserClient
@@ -122,17 +121,6 @@ describe('codewhisperer', async function () {
         await codeWhispererClient.sendTelemetryEvent({ telemetryEvent: userTriggerDecisionPayload })
         sinon.assert.calledWith(clientSpyStub, sinon.match({ userContext: expectedUserContext }))
     })
-
-    function getOperatingSystem(): string {
-        const osId = os.platform() // 'darwin', 'win32', 'linux', etc.
-        if (osId === 'darwin') {
-            return 'MAC'
-        } else if (osId === 'win32') {
-            return 'WINDOWS'
-        } else {
-            return 'LINUX'
-        }
-    }
 
     async function sendTelemetryEventOptoutCheckHelper(
         payload: TelemetryEvent,

--- a/packages/core/src/amazonqFeatureDev/client/codewhispererruntime-2022-11-11.json
+++ b/packages/core/src/amazonqFeatureDev/client/codewhispererruntime-2022-11-11.json
@@ -2210,6 +2210,12 @@
                 },
                 "product": {
                     "shape": "UserContextProductString"
+                },
+                "clientId": {
+                    "shape": "UUID"
+                },
+                "ideVersion": {
+                    "shape": "String"
                 }
             }
         },

--- a/packages/core/src/amazonqFeatureDev/client/featureDev.ts
+++ b/packages/core/src/amazonqFeatureDev/client/featureDev.ts
@@ -25,6 +25,8 @@ import { ToolkitError, isAwsError, isCodeWhispererStreamingServiceException } fr
 import { getCodewhispererConfig } from '../../codewhisperer/client/codewhisperer'
 import { LLMResponseType } from '../types'
 import { createCodeWhispererChatStreamingClient } from '../../shared/clients/codewhispererChatClient'
+import { getClientId, getOptOutPreference, getOperatingSystem } from '../../shared/telemetry/util'
+import { extensionVersion } from '../../shared/vscode/env'
 
 // Create a client for featureDev proxy client based off of aws sdk v2
 export async function createFeatureDevProxyClient(): Promise<FeatureDevProxyClient> {
@@ -324,6 +326,14 @@ export class FeatureDevClient {
                     featureDevEvent: {
                         conversationId,
                     },
+                },
+                optOutPreference: getOptOutPreference(),
+                userContext: {
+                    ideCategory: 'VSCODE',
+                    operatingSystem: getOperatingSystem(),
+                    product: 'FeatureDev', // Should be the same as in JetBrains
+                    clientId: getClientId(globals.context.globalState),
+                    ideVersion: extensionVersion,
                 },
             }
             const response = await client.sendTelemetryEvent(params).promise()

--- a/packages/core/src/codewhisperer/client/codewhisperer.ts
+++ b/packages/core/src/codewhisperer/client/codewhisperer.ts
@@ -26,9 +26,7 @@ import { session } from '../util/codeWhispererSession'
 import { getLogger } from '../../shared/logger'
 import { indent } from '../../shared/utilities/textUtilities'
 import { keepAliveHeader } from './agent'
-import { getOptOutPreference } from '../util/commonUtil'
-import * as os from 'os'
-import { getClientId } from '../../shared/telemetry/util'
+import { getClientId, getOptOutPreference, getOperatingSystem } from '../../shared/telemetry/util'
 import { extensionVersion, getServiceEnvVarConfig } from '../../shared/vscode/env'
 import { DevSettings } from '../../shared/settings'
 
@@ -256,7 +254,7 @@ export class DefaultCodeWhispererClient {
             optOutPreference: getOptOutPreference(),
             userContext: {
                 ideCategory: 'VSCODE',
-                operatingSystem: this.getOperatingSystem(),
+                operatingSystem: getOperatingSystem(),
                 product: 'CodeWhisperer', // TODO: update this?
                 clientId: getClientId(globals.context.globalState),
                 ideVersion: extensionVersion,
@@ -273,24 +271,13 @@ export class DefaultCodeWhispererClient {
         const request: ListFeatureEvaluationsRequest = {
             userContext: {
                 ideCategory: 'VSCODE',
-                operatingSystem: this.getOperatingSystem(),
+                operatingSystem: getOperatingSystem(),
                 product: 'CodeWhisperer', // TODO: update this?
                 clientId: getClientId(globals.context.globalState),
                 ideVersion: extensionVersion,
             },
         }
         return (await this.createUserSdkClient()).listFeatureEvaluations(request).promise()
-    }
-
-    private getOperatingSystem(): string {
-        const osId = os.platform() // 'darwin', 'win32', 'linux', etc.
-        if (osId === 'darwin') {
-            return 'MAC'
-        } else if (osId === 'win32') {
-            return 'WINDOWS'
-        } else {
-            return 'LINUX'
-        }
     }
 
     /**

--- a/packages/core/src/codewhisperer/util/commonUtil.ts
+++ b/packages/core/src/codewhisperer/util/commonUtil.ts
@@ -8,7 +8,6 @@ import * as semver from 'semver'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { getInlineSuggestEnabled } from '../../shared/utilities/editorUtilities'
 import { getLogger } from '../../shared/logger'
-import globals from '../../shared/extensionGlobals'
 import { AWSTemplateCaseInsensitiveKeyWords, AWSTemplateKeyWords } from '../models/constants'
 
 export function getLocalDatetime() {
@@ -61,10 +60,6 @@ export function getPrefixSuffixOverlap(firstString: string, secondString: string
         i--
     }
     return secondString.slice(0, i)
-}
-
-export function getOptOutPreference() {
-    return globals.telemetry.telemetryEnabled ? 'OPTIN' : 'OPTOUT'
 }
 
 export function get(key: string, context: vscode.Memento): any {

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -16,7 +16,7 @@ import { getSelectedCustomization } from './customizationUtil'
 import { selectFrom } from '../../shared/utilities/tsUtils'
 import { checkLeftContextKeywordsForJsonAndYaml } from './commonUtil'
 import { CodeWhispererSupplementalContext } from '../models/model'
-import { getOptOutPreference } from './commonUtil'
+import { getOptOutPreference } from '../../shared/telemetry/util'
 
 let tabSize: number = getTabSizeSetting()
 

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -21,7 +21,7 @@ export { Prompter } from './ui/prompter'
 export { VirtualFileSystem } from './virtualFilesystem'
 export { VirtualMemoryFile } from './virtualMemoryFile'
 export { AmazonqCreateUpload, Metric } from './telemetry/telemetry'
-export { getClientId } from './telemetry/util'
+export { getClientId, getOperatingSystem } from './telemetry/util'
 export { extensionVersion } from './vscode/env'
 export { cast } from './utilities/typeConstructors'
 export {

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode'
 import { env, Memento, version } from 'vscode'
+import * as os from 'os'
 import { getLogger } from '../logger'
 import { fromExtensionManifest, migrateSetting, Settings } from '../settings'
 import { memoize } from '../utilities/functionUtils'
@@ -262,3 +263,28 @@ export const ExtStartUpSources = {
 } as const
 
 export type ExtStartUpSource = (typeof ExtStartUpSources)[keyof typeof ExtStartUpSources]
+
+/**
+ * Useful for populating the sendTelemetryEvent request from codewhisperer's api for publishing custom telemetry events for AB Testing.
+ *
+ * Returns one of the enum values of OptOutPreferences model (see SendTelemetryRequest model in the codebase)
+ */
+export function getOptOutPreference() {
+    return globals.telemetry.telemetryEnabled ? 'OPTIN' : 'OPTOUT'
+}
+
+/**
+ * Useful for populating the sendTelemetryEvent request from codewhisperer's api for publishing custom telemetry events for AB Testing.
+ *
+ * Returns one of the enum values of the OperatingSystem model (see SendTelemetryRequest model in the codebase)
+ */
+export function getOperatingSystem(): 'MAC' | 'WINDOWS' | 'LINUX' {
+    const osId = os.platform() // 'darwin', 'win32', 'linux', etc.
+    if (osId === 'darwin') {
+        return 'MAC'
+    } else if (osId === 'win32') {
+        return 'WINDOWS'
+    } else {
+        return 'LINUX'
+    }
+}


### PR DESCRIPTION
## Problem

User context and opt in/out telemetry options are needed for the sendTelemetryEvent activity to parse the event. This were missing from the initial implemention.

## Solution

It is being added the above fields to the request. It has been tested locally sending these events to the server and checking for their correct processing.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
