### PR TITLE
fix(ci): feature branch name missing from toolkit artifact

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -63,7 +63,7 @@
         "webWatch": "npm run clean && npm run buildScripts && webpack --mode development --watch",
         "webCompile": "npm run clean && npm run buildScripts && webpack --config-name web",
         "webRun": "npx @vscode/test-web --open-devtools --browserOption=--disable-web-security --waitForDebugger=9222 --extensionDevelopmentPath=. .",
-        "package": "npm run copyPackageJson && ts-node ../../scripts/package.ts && npm run restorePackageJson",
+        "package": "npm run copyPackageJson && ts-node ../../scripts/package.ts",
         "install-plugin": "vsce package --ignoreFile '../.vscodeignore.packages' -o aws-toolkit-vscode-test.vsix && code --install-extension aws-toolkit-vscode-test.vsix",
         "format": "prettier --ignore-path ../../.prettierignore --check src scripts",
         "formatfix": "prettier --ignore-path ../../.prettierignore --write src scripts",
@@ -71,8 +71,7 @@
         "createRelease": "ts-node ../../scripts/createRelease.ts",
         "newChange": "ts-node ../../scripts/newChange.ts",
         "watch": "npm run clean && npm run buildScripts && tsc -watch -p ./",
-        "copyPackageJson": "ts-node ./scripts/build/handlePackageJson",
-        "restorePackageJson": "ts-node ./scripts/build/handlePackageJson --restore"
+        "copyPackageJson": "ts-node ./scripts/build/handlePackageJson"
     },
     "devDependencies": {},
     "dependencies": {

--- a/packages/toolkit/scripts/build/handlePackageJson.ts
+++ b/packages/toolkit/scripts/build/handlePackageJson.ts
@@ -10,10 +10,10 @@
  * To avoid having duplicate code, we copy the necessary fields from the core library to the separate toolkit
  * extension when required (e.g. debugging, packaging).
  *
- * TODO: Find a better way to do this, hopefully remove the need for this in the core library.
+ * TODO: IDE-12831 tracks work to eliminate this script.
  *
  * Args:
- *   --restore : reverts the package json changes to the original state
+ *   --restore: (XXX: this mode was inlined into the package.ts script.)
  *   --development: performs actions that should only be done during development and not production
  */
 
@@ -21,7 +21,8 @@ import * as fs from 'fs-extra'
 
 function main() {
     const args = process.argv.slice(2)
-    const restoreMode = args.includes('--restore')
+    // XXX: --restore mode was inlined into the package.ts script.
+    const restoreMode = false
 
     if (args.includes('--development')) {
         /** When we actually package the extension the null extension does not occur, so we will skip this hack */
@@ -33,12 +34,14 @@ function main() {
     const coreLibPackageJsonFile = '../core/package.json'
 
     if (restoreMode) {
-        try {
-            fs.copyFileSync(backupJsonFile, packageJsonFile)
-            fs.unlinkSync(backupJsonFile)
-        } catch (err) {
-            console.log(`Could not restore package.json. Error: ${err}`)
-        }
+        // XXX: --restore mode was inlined into the package.ts script.
+        // TODO: IDE-12831 will eliminate this entire script.
+        // try {
+        //     fs.copyFileSync(backupJsonFile, packageJsonFile)
+        //     fs.unlinkSync(backupJsonFile)
+        // } catch (err) {
+        //     console.log(`Could not restore package.json. Error: ${err}`)
+        // }
     } else {
         fs.copyFileSync(packageJsonFile, backupJsonFile)
         const packageJson = JSON.parse(fs.readFileSync(packageJsonFile, { encoding: 'utf-8' }))

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -86,6 +86,22 @@ function isBeta(): boolean {
 }
 
 /**
+ * Restores package.json after `scripts/build/handlePackageJson.ts` overwrote it.
+ *
+ * TODO: remove this after IDE-12831 is resolved.
+ */
+function restorePackageJson() {
+    const packageJsonFile = './package.json'
+    const backupJsonFile = `${packageJsonFile}.handlePackageJson.bk`
+
+    if (fs.existsSync(backupJsonFile)) {
+        fs.copyFileSync(backupJsonFile, packageJsonFile)
+        fs.unlinkSync(backupJsonFile)
+        console.log(`package.ts: restored package.json from ${backupJsonFile}`)
+    }
+}
+
+/**
  * Gets a suffix to append to the version-string, or empty for release builds.
  *
  * TODO: use `git describe` instead.
@@ -177,6 +193,7 @@ function main() {
             fs.copyFileSync(backupWebpackConfigFile, webpackConfigJsFile)
             fs.unlinkSync(backupWebpackConfigFile)
         }
+        restorePackageJson()
     }
 }
 


### PR DESCRIPTION
## Problem:
Because of the `npm run restorePackageJson` step, the `--feature separate-sessions` arg is not passed to `package.ts`:

    npm run copyPackageJson && ts-node ../../scripts/package.ts && npm run restorePackageJson --feature separate-sessions

Thus the feature branch name is not in the toolkit artifact name. For example, the feature/separate-sessions branch artifacts are:

    amazon-q-vscode-1.10.0-separate-sessions-g8a563a7.vsix
    aws-toolkit-vscode-3.11.0-g8a563a7.vsix

## Solution:
Inline the `--restore` logic into `package.ts`. This is hacky, but should be temporary after we resolved IDE-12831 so that these hacks are no longer needed.

## Example

https://github.com/justinmk3/aws-toolkit-vscode/releases/tag/pre-smurf

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
