### PR TITLE
cleanup: moved a bunch of static text into types

### DIFF
--- a/packages/core/src/amazonq/auth/model.ts
+++ b/packages/core/src/amazonq/auth/model.ts
@@ -5,8 +5,25 @@
 
 export type AuthFollowUpType = 'full-auth' | 're-auth' | 'missing_scopes' | 'use-supported-auth'
 
-export const reauthenticateText = `You don't have access to Amazon Q. Please authenticate to get started.`
+export type AuthMessageData = {
+    message: string
+}
 
-export const enableQText = `You haven't enabled Amazon Q in VSCode`
+const reauthenticateData: AuthMessageData = {
+    message: `You don't have access to Amazon Q. Please authenticate to get started.`,
+}
 
-export const expiredText = `Your Amazon Q session has timed out. Re-authenticate to continue.`
+const enableQData: AuthMessageData = {
+    message: `You haven't enabled Amazon Q in VSCode`,
+}
+
+const expiredData: AuthMessageData = {
+    message: `Your Amazon Q session has timed out. Re-authenticate to continue.`,
+}
+
+export const AuthMessageDataMap: Record<AuthFollowUpType, AuthMessageData> = {
+    'full-auth': reauthenticateData,
+    're-auth': reauthenticateData,
+    missing_scopes: enableQData,
+    'use-supported-auth': expiredData,
+}

--- a/packages/core/src/amazonq/webview/ui/tabs/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/constants.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { TabType } from '../storages/tabsStorage'
+
+export type TabTypeData = {
+    title: string
+    placeholder: string
+    welcome: string
+}
+
+const commonTabData: TabTypeData = {
+    title: 'Chat',
+    placeholder: 'Ask a question or enter "/" for quick actions',
+    welcome: `Hi, I'm Amazon Q. I can answer your software development questions.
+  Ask me to explain, debug, or optimize your code.
+  You can enter \`/\` to see a list of quick actions.`,
+}
+
+export const TabTypeDataMap: Record<TabType, TabTypeData> = {
+    unknown: commonTabData,
+    cwc: commonTabData,
+    featuredev: {
+        title: 'Q - Dev',
+        placeholder: 'Describe your task or issue in as much detail as possible',
+        welcome: `Hi, I'm the Amazon Q Developer Agent for software development.
+
+    I can generate code to implement new functionality across your workspace. We'll start by discussing an implementation plan, and then we can review and regenerate code based on your feedback.
+
+    To get started, describe the task you are trying to accomplish.`,
+    },
+    gumby: {
+        title: 'Q - Code Transformation',
+        placeholder: 'Open a new tab to chat with Q',
+        welcome: `Welcome to Code Transformation!
+
+    I can help you upgrade your Java 8 and 11 codebases to Java 17.`,
+    },
+}

--- a/packages/core/src/amazonq/webview/ui/tabs/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/generator.ts
@@ -7,6 +7,7 @@ import { ChatItemType, MynahUIDataModel } from '@aws/mynah-ui'
 import { TabType } from '../storages/tabsStorage'
 import { FollowUpGenerator } from '../followUps/generator'
 import { QuickActionGenerator } from '../quickActions/generator'
+import { TabTypeDataMap } from './constants'
 
 export interface TabDataGeneratorProps {
     isFeatureDevEnabled: boolean
@@ -16,50 +17,6 @@ export interface TabDataGeneratorProps {
 export class TabDataGenerator {
     private followUpsGenerator: FollowUpGenerator
     public quickActionsGenerator: QuickActionGenerator
-
-    private tabTitle: Map<TabType, string> = new Map([
-        ['unknown', 'Chat'],
-        ['cwc', 'Chat'],
-        ['featuredev', 'Q - Dev'],
-        ['gumby', 'Q - Code Transformation'],
-    ])
-
-    private tabInputPlaceholder: Map<TabType, string> = new Map([
-        ['unknown', 'Ask a question or enter "/" for quick actions'],
-        ['cwc', 'Ask a question or enter "/" for quick actions'],
-        ['featuredev', 'Describe your task or issue in as much detail as possible'],
-        ['gumby', 'Open a new tab to chat with Q'],
-    ])
-
-    private tabWelcomeMessage: Map<TabType, string> = new Map([
-        [
-            'unknown',
-            `Hi, I'm Amazon Q. I can answer your software development questions. 
-        Ask me to explain, debug, or optimize your code. 
-        You can enter \`/\` to see a list of quick actions.`,
-        ],
-        [
-            'cwc',
-            `Hi, I'm Amazon Q. I can answer your software development questions. 
-        Ask me to explain, debug, or optimize your code. 
-        You can enter \`/\` to see a list of quick actions.`,
-        ],
-        [
-            'featuredev',
-            `Hi, I'm the Amazon Q Developer Agent for software development.
-
-I can generate code to implement new functionality across your workspace. We'll start by discussing an implementation plan, and then we can review and regenerate code based on your feedback. 
-            
-To get started, describe the task you are trying to accomplish.
-`,
-        ],
-        [
-            'gumby',
-            `Welcome to Code Transformation!
-
-I can help you upgrade your Java 8 and 11 codebases to Java 17.`,
-        ],
-    ])
 
     constructor(props: TabDataGeneratorProps) {
         this.followUpsGenerator = new FollowUpGenerator()
@@ -71,16 +28,16 @@ I can help you upgrade your Java 8 and 11 codebases to Java 17.`,
 
     public getTabData(tabType: TabType, needWelcomeMessages: boolean, taskName?: string): MynahUIDataModel {
         const tabData: MynahUIDataModel = {
-            tabTitle: taskName ?? this.tabTitle.get(tabType),
+            tabTitle: taskName ?? TabTypeDataMap[tabType].title,
             promptInputInfo:
                 'Use of Amazon Q is subject to the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
             quickActionCommands: this.quickActionsGenerator.generateForTab(tabType),
-            promptInputPlaceholder: this.tabInputPlaceholder.get(tabType),
+            promptInputPlaceholder: TabTypeDataMap[tabType].placeholder,
             chatItems: needWelcomeMessages
                 ? [
                       {
                           type: ChatItemType.ANSWER,
-                          body: this.tabWelcomeMessage.get(tabType),
+                          body: TabTypeDataMap[tabType].welcome,
                       },
                       {
                           type: ChatItemType.ANSWER,

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/constants.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/constants.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type MessengerTypes = 'answer' | 'answer-part' | 'answer-stream' | 'system-prompt'
+
+export const ErrorMessages = {
+    technicalDifficulties: `I'm sorry, I'm having technical difficulties and can't continue at the moment. Please try again later, and share feedback to help me improve.`,
+    monthlyLimitReached: `Sorry, you have reached the monthly limit for feature development. You can try again next month.`,
+    processingIssue: `Sorry, we encountered a problem when processing your request.`,
+    tryAgain: `Sorry, we're experiencing an issue on our side. Would you like to try again?`,
+}
+
+export const Placeholders = {
+    chatInputDisabled: 'Chat input is disabled',
+}

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -8,7 +8,7 @@
  * As much as possible, all strings used in the experience should originate here.
  */
 
-import { AuthFollowUpType, expiredText, enableQText, reauthenticateText } from '../../../../amazonq/auth/model'
+import { AuthFollowUpType, AuthMessageDataMap } from '../../../../amazonq/auth/model'
 import { ChatItemType } from '../../../../amazonqFeatureDev/models'
 import { JDKVersion, TransformationCandidateProject, transformByQState } from '../../../../codewhisperer/models/model'
 import { FeatureAuthState } from '../../../../codewhisperer/util/authUtil'
@@ -87,20 +87,21 @@ export class Messenger {
 
     public async sendAuthNeededExceptionMessage(credentialState: FeatureAuthState, tabID: string) {
         let authType: AuthFollowUpType = 'full-auth'
-        let message = reauthenticateText
-        if (credentialState.amazonQ === 'disconnected') {
-            authType = 'full-auth'
-            message = reauthenticateText
-        }
+        let message = AuthMessageDataMap[authType].message
 
-        if (credentialState.amazonQ === 'unsupported') {
-            authType = 'use-supported-auth'
-            message = enableQText
-        }
-
-        if (credentialState.amazonQ === 'expired') {
-            authType = 're-auth'
-            message = expiredText
+        switch (credentialState.amazonQ) {
+            case 'disconnected':
+                authType = 'full-auth'
+                message = AuthMessageDataMap[authType].message
+                break
+            case 'unsupported':
+                authType = 'use-supported-auth'
+                message = AuthMessageDataMap[authType].message
+                break
+            case 'expired':
+                authType = 're-auth'
+                message = AuthMessageDataMap[authType].message
+                break
         }
 
         this.dispatcher.sendAuthNeededExceptionMessage(new AuthNeededException(message, authType, tabID))
@@ -444,7 +445,7 @@ export class Messenger {
         )
 
         if (codeSnippet !== '') {
-            message = `Here is the dependency causing the issue: 
+            message = `Here is the dependency causing the issue:
 \`\`\`
 ${codeSnippet}
 \`\`\`

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -26,7 +26,7 @@ import { ToolkitError } from '../../../../shared/errors'
 import { keys } from '../../../../shared/utilities/tsUtils'
 import { getLogger } from '../../../../shared/logger/logger'
 import { FeatureAuthState } from '../../../../codewhisperer/util/authUtil'
-import { AuthFollowUpType, expiredText, enableQText, reauthenticateText } from '../../../../amazonq/auth/model'
+import { AuthFollowUpType, AuthMessageDataMap } from '../../../../amazonq/auth/model'
 import { userGuideURL } from '../../../../amazonq/webview/ui/texts/constants'
 import { CodeScanIssue } from '../../../../codewhisperer/models/model'
 import { marked } from 'marked'
@@ -42,23 +42,23 @@ export class Messenger {
 
     public async sendAuthNeededExceptionMessage(credentialState: FeatureAuthState, tabID: string, triggerID: string) {
         let authType: AuthFollowUpType = 'full-auth'
-        let message = reauthenticateText
+        let message = AuthMessageDataMap[authType].message
         if (
             credentialState.codewhispererChat === 'disconnected' &&
             credentialState.codewhispererCore === 'disconnected'
         ) {
             authType = 'full-auth'
-            message = reauthenticateText
+            message = AuthMessageDataMap[authType].message
         }
 
         if (credentialState.codewhispererCore === 'connected' && credentialState.codewhispererChat === 'expired') {
             authType = 'missing_scopes'
-            message = enableQText
+            message = AuthMessageDataMap[authType].message
         }
 
         if (credentialState.codewhispererChat === 'expired' && credentialState.codewhispererCore === 'expired') {
             authType = 're-auth'
-            message = expiredText
+            message = AuthMessageDataMap[authType].message
         }
 
         this.dispatcher.sendAuthNeededExceptionMessage(


### PR DESCRIPTION
## Problem

The current implementation contains hardcoded static text within the `Messenger` class, leading to repetitive and unmanageable code. This makes it difficult to maintain and update error messages and placeholders across the application.

## Solution

Refactor the `Messenger` class to use enums for error messages and placeholders. This approach centralizes the management of static text, improving code maintainability and readability. The changes include:
- Introduction of `ErrorMessages` and `Placeholders` enums.
- Replacement of hardcoded static text with corresponding enum values.

> [!TIP]
> As a follow up, it would be good to consolidate some of the repetitive nature of dispatcher stuff ex: `sendAuthNeededExceptionMessage` into a single utility class


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
