### PR TITLE
fix: step function language server activation

### DIFF
--- a/packages/core/src/shared/languageServer/languageModelCache.ts
+++ b/packages/core/src/shared/languageServer/languageModelCache.ts
@@ -9,7 +9,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TextDocument } from 'vscode-languageserver-textdocument'
-import globals from '../extensionGlobals'
 
 export interface LanguageModelCache<T> {
     get(document: TextDocument): T
@@ -27,8 +26,8 @@ export function getLanguageModelCache<T>(
 
     let cleanupInterval: NodeJS.Timer | undefined
     if (cleanupIntervalTimeInSec > 0) {
-        cleanupInterval = globals.clock.setInterval(() => {
-            const cutoffTime = globals.clock.Date.now() - cleanupIntervalTimeInSec * 1000
+        cleanupInterval = setInterval(() => {
+            const cutoffTime = Date.now() - cleanupIntervalTimeInSec * 1000
             const uris = Object.keys(languageModels)
             for (const uri of uris) {
                 const languageModelInfo = languageModels[uri]
@@ -50,12 +49,12 @@ export function getLanguageModelCache<T>(
                 languageModelInfo.version === version &&
                 languageModelInfo.languageId === languageId
             ) {
-                languageModelInfo.cTime = globals.clock.Date.now()
+                languageModelInfo.cTime = Date.now()
 
                 return languageModelInfo.languageModel
             }
             const languageModel = parse(document)
-            languageModels[document.uri] = { languageModel, version, languageId, cTime: globals.clock.Date.now() }
+            languageModels[document.uri] = { languageModel, version, languageId, cTime: Date.now() }
             if (!languageModelInfo) {
                 nModels++
             }
@@ -87,7 +86,7 @@ export function getLanguageModelCache<T>(
         },
         dispose() {
             if (typeof cleanupInterval !== 'undefined') {
-                globals.clock.clearInterval(cleanupInterval)
+                clearInterval(cleanupInterval)
                 cleanupInterval = undefined
                 languageModels = {}
                 nModels = 0

--- a/packages/core/src/stepFunctions/activation.ts
+++ b/packages/core/src/stepFunctions/activation.ts
@@ -11,7 +11,6 @@ const localize = nls.loadMessageBundle()
 import { join } from 'path'
 import * as vscode from 'vscode'
 import { AwsContext } from '../shared/awsContext'
-import { activate as activateASL } from './asl/client'
 import { createStateMachineFromTemplate } from './commands/createStateMachineFromTemplate'
 import { publishStateMachine } from './commands/publishStateMachine'
 import { AslVisualizationManager } from './commands/visualizeStateMachine/aslVisualizationManager'
@@ -23,6 +22,7 @@ import { renderCdkStateMachineGraph } from './commands/visualizeStateMachine/ren
 import { ToolkitError } from '../shared/errors'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { PerfLog } from '../shared/logger/logger'
+import { ASLLanguageClient } from './asl/client'
 
 /**
  * Activate Step Functions related functionality for the extension.
@@ -43,7 +43,7 @@ export async function activate(
     onDidOpenAslDoc = vscode.window.onDidChangeActiveTextEditor(async e => {
         if (e?.document && ASL_FORMATS.includes(e.document.languageId)) {
             const perflog = new PerfLog('stepFunctions: start LSP client/server')
-            await activateASL(extensionContext)
+            await ASLLanguageClient.create(extensionContext)
             perflog.done()
             onDidOpenAslDoc?.dispose() // Handler should only run once.
         }

--- a/packages/core/src/stepFunctions/asl/aslServer.ts
+++ b/packages/core/src/stepFunctions/asl/aslServer.ts
@@ -37,7 +37,6 @@ import * as URL from 'url'
 import { getLanguageModelCache } from '../../shared/languageServer/languageModelCache'
 import { formatError, runSafe, runSafeAsync } from '../../shared/languageServer/utils/runner'
 import { YAML_ASL, JSON_ASL } from '../constants/aslFormats'
-import globals from '../../shared/extensionGlobals'
 
 export const ResultLimitReached: NotificationType<string, any> = new NotificationType('asl/resultLimitReached')
 
@@ -159,7 +158,7 @@ class LimitExceededWarnings {
     public static cancel(uri: string) {
         const warning = LimitExceededWarnings.pendingWarnings[uri]
         if (warning && warning.timeout) {
-            globals.clock.clearTimeout(warning.timeout)
+            clearTimeout(warning.timeout)
             delete LimitExceededWarnings.pendingWarnings[uri]
         }
     }
@@ -176,7 +175,7 @@ class LimitExceededWarnings {
                 warning.timeout.refresh()
             } else {
                 warning = { features: { [name]: name } }
-                warning.timeout = globals.clock.setTimeout(() => {
+                warning.timeout = setTimeout(() => {
                     connection.sendNotification(
                         ResultLimitReached,
                         `${posix.basename(uri)}: For performance reasons, ${Object.keys(warning.features).join(
@@ -257,14 +256,14 @@ const validationDelayMs = 500
 function cleanPendingValidation(textDocument: TextDocument): void {
     const request = pendingValidationRequests[textDocument.uri]
     if (request) {
-        globals.clock.clearTimeout(request)
+        clearTimeout(request)
         delete pendingValidationRequests[textDocument.uri]
     }
 }
 
 function triggerValidation(textDocument: TextDocument): void {
     cleanPendingValidation(textDocument)
-    pendingValidationRequests[textDocument.uri] = globals.clock.setTimeout(() => {
+    pendingValidationRequests[textDocument.uri] = setTimeout(() => {
         delete pendingValidationRequests[textDocument.uri]
         validateTextDocument(textDocument)
     }, validationDelayMs)
@@ -299,7 +298,7 @@ function validateTextDocument(textDocument: TextDocument, callback?: (diagnostic
         .doValidation(textDocument, jsonDocument, documentSettings)
         .then(
             diagnostics => {
-                globals.clock.setTimeout(() => {
+                setTimeout(() => {
                     const currDocument = documents.get(textDocument.uri)
                     if (currDocument && currDocument.version === version) {
                         respond(diagnostics) // Send the computed diagnostics to VSCode.

--- a/packages/core/src/stepFunctions/asl/client.ts
+++ b/packages/core/src/stepFunctions/asl/client.ts
@@ -52,127 +52,130 @@ interface Settings {
     }
 }
 
-const ASLInit = new EventEmitter<void>()
-export const onASLInit = ASLInit.event
+export class ASLLanguageClient {
+    private static ASLInit = new EventEmitter<void>()
+    static onASLInit = this.ASLInit.event
 
-/**
- * Starts the ASL LSP client/server and creates related resources (vscode `OutputChannel`,
- * `registerDocumentRangeFormattingEditProvider`, …).
- */
-export async function activate(extensionContext: ExtensionContext) {
-    const config = new StepFunctionsSettings()
-    const toDispose = extensionContext.subscriptions
+    /**
+     * Starts the ASL LSP client/server and creates related resources (vscode `OutputChannel`,
+     * `registerDocumentRangeFormattingEditProvider`, …).
+     */
+    static async create(extensionContext: ExtensionContext) {
+        const config = new StepFunctionsSettings()
+        const toDispose = extensionContext.subscriptions
 
-    let rangeFormatting: Disposable | undefined
+        let rangeFormatting: Disposable | undefined
 
-    // The server is implemented in node
-    const serverModule = extensionContext.asAbsolutePath(path.join('dist/src/stepFunctions/asl/', 'aslServer.js'))
-    // The debug options for the server
-    // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-    const debugOptions = { execArgv: ['--nolazy', '--inspect=6009', '--preserve-symlinks'] }
+        // The server is implemented in node
+        const serverModule = extensionContext.asAbsolutePath(path.join('dist/src/stepFunctions/asl/', 'aslServer.js'))
+        // The debug options for the server
+        // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
+        const debugOptions = { execArgv: ['--nolazy', '--inspect=6009', '--preserve-symlinks'] }
 
-    // If the extension is launch in debug mode the debug server options are use
-    // Otherwise the run options are used
-    const serverOptions: ServerOptions = {
-        run: { module: serverModule, transport: TransportKind.ipc },
-        debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions },
-    }
-
-    const documentSelector = [
-        { schema: 'file', language: JSON_ASL },
-        { schema: 'untitled', language: JSON_ASL },
-        { schema: 'file', language: YAML_ASL },
-        { schema: 'untitled', language: YAML_ASL },
-    ]
-
-    // Options to control the language client
-    const clientOptions: LanguageClientOptions = {
-        // Register the server for json documents
-        documentSelector,
-        initializationOptions: {
-            handledSchemaProtocols: ['file', 'untitled'], // language server only loads file-URI. Fetching schemas with other protocols ('http'...) are made on the client.
-            provideFormatter: false, // tell the server to not provide formatting capability and ignore the `aws.stepfunctions.asl.format.enable` setting.
-        },
-        synchronize: {
-            // Synchronize the setting section 'json' to the server
-            configurationSection: ASL_FORMATS,
-            fileEvents: workspace.createFileSystemWatcher('**/*.{asl,asl.json,asl.yml,asl.yaml}'),
-        },
-        middleware: {
-            workspace: {
-                didChangeConfiguration: () =>
-                    client.sendNotification(DidChangeConfigurationNotification.type, { settings: getSettings(config) }),
-            },
-        },
-    }
-
-    // Create the language client and start the client.
-    const client = new LanguageClient(
-        'asl',
-        localize('asl.server.name', 'AWS: Amazon States Language Server'),
-        serverOptions,
-        clientOptions
-    )
-    client.registerProposedFeatures()
-
-    const disposable = client.start()
-    toDispose.push(disposable)
-
-    const languageConfiguration: LanguageConfiguration = {
-        wordPattern: /("(?:[^\\\"]*(?:\\.)?)*"?)|[^\s{}\[\],:]+/,
-        indentationRules: {
-            increaseIndentPattern: /({+(?=([^"]*"[^"]*")*[^"}]*$))|(\[+(?=([^"]*"[^"]*")*[^"\]]*$))/,
-            decreaseIndentPattern: /^\s*[}\]],?\s*$/,
-        },
-    }
-    languages.setLanguageConfiguration('asl', languageConfiguration)
-
-    function updateFormatterRegistration() {
-        const formatEnabled = config.get('format.enable', false)
-        if (!formatEnabled && rangeFormatting) {
-            rangeFormatting.dispose()
-            rangeFormatting = undefined
-        } else if (formatEnabled && !rangeFormatting) {
-            rangeFormatting = languages.registerDocumentRangeFormattingEditProvider(documentSelector, {
-                provideDocumentRangeFormattingEdits(
-                    document: TextDocument,
-                    range: Range,
-                    options: FormattingOptions,
-                    token: CancellationToken
-                ): ProviderResult<TextEdit[]> {
-                    const params: DocumentRangeFormattingParams = {
-                        textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
-                        range: client.code2ProtocolConverter.asRange(range),
-                        options: client.code2ProtocolConverter.asFormattingOptions(options),
-                    }
-
-                    return client.sendRequest(DocumentRangeFormattingRequest.type, params, token).then(
-                        response => client.protocol2CodeConverter.asTextEdits(response),
-                        async error => {
-                            client.logFailedRequest(DocumentRangeFormattingRequest.type, error)
-
-                            return Promise.resolve([])
-                        }
-                    )
-                },
-            })
+        // If the extension is launch in debug mode the debug server options are use
+        // Otherwise the run options are used
+        const serverOptions: ServerOptions = {
+            run: { module: serverModule, transport: TransportKind.ipc },
+            debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions },
         }
-    }
 
-    return client.onReady().then(() => {
-        updateFormatterRegistration()
-        const disposableFunc = { dispose: () => rangeFormatting?.dispose() as void }
-        toDispose.push(disposableFunc)
-        toDispose.push(config.onDidChange(({ key }) => key === 'format.enable' && updateFormatterRegistration()))
+        const documentSelector = [
+            { schema: 'file', language: JSON_ASL },
+            { schema: 'untitled', language: JSON_ASL },
+            { schema: 'file', language: YAML_ASL },
+            { schema: 'untitled', language: YAML_ASL },
+        ]
 
-        client.onNotification(ResultLimitReached, message => {
-            void window.showInformationMessage(
-                `${message}\nUse setting 'aws.stepfunctions.asl.maxItemsComputed' to configure the limit.`
-            )
+        // Options to control the language client
+        const clientOptions: LanguageClientOptions = {
+            // Register the server for json documents
+            documentSelector,
+            initializationOptions: {
+                handledSchemaProtocols: ['file', 'untitled'], // language server only loads file-URI. Fetching schemas with other protocols ('http'...) are made on the client.
+                provideFormatter: false, // tell the server to not provide formatting capability and ignore the `aws.stepfunctions.asl.format.enable` setting.
+            },
+            synchronize: {
+                // Synchronize the setting section 'json' to the server
+                configurationSection: ASL_FORMATS,
+                fileEvents: workspace.createFileSystemWatcher('**/*.{asl,asl.json,asl.yml,asl.yaml}'),
+            },
+            middleware: {
+                workspace: {
+                    didChangeConfiguration: () =>
+                        client.sendNotification(DidChangeConfigurationNotification.type, {
+                            settings: getSettings(config),
+                        }),
+                },
+            },
+        }
+
+        // Create the language client and start the client.
+        const client = new LanguageClient(
+            'asl',
+            localize('asl.server.name', 'AWS: Amazon States Language Server'),
+            serverOptions,
+            clientOptions
+        )
+        client.registerProposedFeatures()
+
+        const disposable = client.start()
+        toDispose.push(disposable)
+
+        const languageConfiguration: LanguageConfiguration = {
+            wordPattern: /("(?:[^\\\"]*(?:\\.)?)*"?)|[^\s{}\[\],:]+/,
+            indentationRules: {
+                increaseIndentPattern: /({+(?=([^"]*"[^"]*")*[^"}]*$))|(\[+(?=([^"]*"[^"]*")*[^"\]]*$))/,
+                decreaseIndentPattern: /^\s*[}\]],?\s*$/,
+            },
+        }
+        languages.setLanguageConfiguration('asl', languageConfiguration)
+
+        function updateFormatterRegistration() {
+            const formatEnabled = config.get('format.enable', false)
+            if (!formatEnabled && rangeFormatting) {
+                rangeFormatting.dispose()
+                rangeFormatting = undefined
+            } else if (formatEnabled && !rangeFormatting) {
+                rangeFormatting = languages.registerDocumentRangeFormattingEditProvider(documentSelector, {
+                    provideDocumentRangeFormattingEdits(
+                        document: TextDocument,
+                        range: Range,
+                        options: FormattingOptions,
+                        token: CancellationToken
+                    ): ProviderResult<TextEdit[]> {
+                        const params: DocumentRangeFormattingParams = {
+                            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
+                            range: client.code2ProtocolConverter.asRange(range),
+                            options: client.code2ProtocolConverter.asFormattingOptions(options),
+                        }
+
+                        return client.sendRequest(DocumentRangeFormattingRequest.type, params, token).then(
+                            response => client.protocol2CodeConverter.asTextEdits(response),
+                            async error => {
+                                client.logFailedRequest(DocumentRangeFormattingRequest.type, error)
+
+                                return Promise.resolve([])
+                            }
+                        )
+                    },
+                })
+            }
+        }
+
+        return client.onReady().then(() => {
+            updateFormatterRegistration()
+            const disposableFunc = { dispose: () => rangeFormatting?.dispose() as void }
+            toDispose.push(disposableFunc)
+            toDispose.push(config.onDidChange(({ key }) => key === 'format.enable' && updateFormatterRegistration()))
+
+            client.onNotification(ResultLimitReached, message => {
+                void window.showInformationMessage(
+                    `${message}\nUse setting 'aws.stepfunctions.asl.maxItemsComputed' to configure the limit.`
+                )
+            })
+            this.ASLInit.fire()
         })
-        ASLInit.fire()
-        ASLInit.dispose()
-    })
+    }
 }
 
 export async function deactivate(): Promise<any> {

--- a/packages/core/src/stepFunctions/asl/client.ts
+++ b/packages/core/src/stepFunctions/asl/client.ts
@@ -26,6 +26,7 @@ import {
     TextEdit,
     window,
     workspace,
+    EventEmitter,
 } from 'vscode'
 
 import {
@@ -50,6 +51,9 @@ interface Settings {
         resultLimit?: number
     }
 }
+
+const ASLInit = new EventEmitter<void>()
+export const onASLInit = ASLInit.event
 
 /**
  * Starts the ASL LSP client/server and creates related resources (vscode `OutputChannel`,
@@ -166,6 +170,8 @@ export async function activate(extensionContext: ExtensionContext) {
                 `${message}\nUse setting 'aws.stepfunctions.asl.maxItemsComputed' to configure the limit.`
             )
         })
+        ASLInit.fire()
+        ASLInit.dispose()
     })
 }
 

--- a/packages/core/src/testInteg/stepFunctions/init.test.ts
+++ b/packages/core/src/testInteg/stepFunctions/init.test.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { fsCommon } from '../../srcShared/fs'
+import { openATextEditorWithText } from '../../test/testUtil'
+import { makeTemporaryToolkitFolder } from '../../shared'
+import vscode from 'vscode'
+import { onASLInit } from '../../stepFunctions/asl/client'
+
+describe('initialization', async function () {
+    let tempFolder: string
+
+    beforeEach(async function () {
+        // Make a temp folder for all these tests
+        tempFolder = await makeTemporaryToolkitFolder()
+    })
+
+    afterEach(async function () {
+        await fsCommon.delete(tempFolder)
+    })
+
+    it('inits', async function () {
+        const stateMachineFileText = `{
+
+}`
+        const fileName = 'stepfunction.asl'
+        const editor = await openATextEditorWithText(stateMachineFileText, fileName, tempFolder)
+        await new Promise(resolve => {
+            onASLInit(() => {
+                resolve(undefined)
+            })
+        })
+        const result = (await vscode.commands.executeCommand(
+            'vscode.executeCompletionItemProvider',
+            editor.document.uri,
+            new vscode.Position(1, 4)
+        )) as vscode.CompletionList
+        assert.deepStrictEqual(
+            result.items.map(item => item.label),
+            ['Comment', 'StartAt', 'States', 'TimeoutSeconds', 'Version']
+        )
+    })
+})

--- a/packages/core/src/testInteg/stepFunctions/init.test.ts
+++ b/packages/core/src/testInteg/stepFunctions/init.test.ts
@@ -8,7 +8,7 @@ import { fsCommon } from '../../srcShared/fs'
 import { openATextEditorWithText } from '../../test/testUtil'
 import { makeTemporaryToolkitFolder } from '../../shared'
 import vscode from 'vscode'
-import { onASLInit } from '../../stepFunctions/asl/client'
+import { ASLLanguageClient } from '../../stepFunctions/asl/client'
 
 describe('initialization', async function () {
     let tempFolder: string
@@ -29,7 +29,7 @@ describe('initialization', async function () {
         const fileName = 'stepfunction.asl'
         const editor = await openATextEditorWithText(stateMachineFileText, fileName, tempFolder)
         await new Promise(resolve => {
-            onASLInit(() => {
+            ASLLanguageClient.onASLInit(() => {
                 resolve(undefined)
             })
         })

--- a/packages/toolkit/.changes/next-release/Bug Fix-dc4f03d3-e539-47c0-8313-317069ad6592.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-dc4f03d3-e539-47c0-8313-317069ad6592.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Step functions language server activation fails"
+}


### PR DESCRIPTION
## Problem
- step function language server failed to activate

## Solution
- remove globals from the language server

## Additional investigation
- Still investigating but it looks like something between version 2.20 and 3.0.0 broke the step functions language server activation. AFAICT the error occurs because the language server was starting in another process and that process doesn't have access to vscode which globals seems to be importing. It's not exactly clear why this is caused in 3.0.0 and not early though

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
