### PR TITLE
feat(amazonqFeatureDev): improve Error messages 

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b1dd8c2c-cc3d-4986-be5b-20be5ebc3925.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b1dd8c2c-cc3d-4986-be5b-20be5ebc3925.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Update client user error messages and refactor controller error handling"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-b1dd8c2c-cc3d-4986-be5b-20be5ebc3925.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b1dd8c2c-cc3d-4986-be5b-20be5ebc3925.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Update client user error messages and refactor controller error handling"
+	"description": "Amazon Q /dev command: improve user error messages"
 }

--- a/packages/core/src/amazonq/webview/ui/tabs/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/constants.ts
@@ -24,7 +24,7 @@ export const TabTypeDataMap: Record<TabType, TabTypeData> = {
     featuredev: {
         title: 'Q - Dev',
         placeholder: 'Describe your task or issue in as much detail as possible',
-        welcome: `Hi, I'm the Amazon Q Developer Agent for software development.
+        welcome: `Welcome to the agent for software development.
 
     I can generate code to implement new functionality across your workspace. We'll start by discussing an implementation plan, and then we can review and regenerate code based on your feedback.
 

--- a/packages/core/src/amazonq/webview/ui/tabs/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/constants.ts
@@ -24,7 +24,7 @@ export const TabTypeDataMap: Record<TabType, TabTypeData> = {
     featuredev: {
         title: 'Q - Dev',
         placeholder: 'Describe your task or issue in as much detail as possible',
-        welcome: `Welcome to the agent for software development.
+        welcome: `Hi, I'm the Amazon Q Developer Agent for software development.
 
     I can generate code to implement new functionality across your workspace. We'll start by discussing an implementation plan, and then we can review and regenerate code based on your feedback.
 

--- a/packages/core/src/amazonqFeatureDev/app.ts
+++ b/packages/core/src/amazonqFeatureDev/app.ts
@@ -52,7 +52,7 @@ export function init(appContext: AmazonQAppInitContext) {
             const tabID = params.get('tabID')
             if (!tabID) {
                 getLogger().error(`Unable to find tabID from ${uri.toString()}`)
-                throw new TabIdNotFoundError(uri.toString())
+                throw new TabIdNotFoundError()
             }
 
             const session = await sessionStorage.getSession(tabID)

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -49,6 +49,7 @@ import {
     messageWithConversationId,
 } from '../../userFacingText'
 import { getWorkspaceFoldersByPrefixes } from '../../../shared/utilities/workspaceUtils'
+import { ErrorMessages } from './messenger/constants'
 
 export interface ChatControllerEventEmitters {
     readonly processHumanChatMessage: EventEmitter<any>
@@ -297,17 +298,17 @@ export class FeatureDevController {
                 switch (session?.state.phase) {
                     case DevPhase.APPROACH:
                         if (isDenyListedError) {
-                            defaultMessage = `I'm sorry, I'm having trouble generating a plan. Please try again.`
+                            defaultMessage = ErrorMessages.approachPhase.denyListedError
                         } else {
-                            defaultMessage = `I'm sorry, I ran into an issue while trying to approach the problem. Please try again.`
+                            defaultMessage = ErrorMessages.approachPhase.default
                         }
                         break
                     case DevPhase.CODEGEN:
                         if (isDenyListedError) {
-                            defaultMessage = `I'm sorry, I'm having trouble generating your code and can't continue at the moment. Please try again later, and share feedback to help me improve.`
+                            defaultMessage = ErrorMessages.codeGen.denyListedError
                             noRetries = true
                         } else {
-                            defaultMessage = `I'm sorry, I ran into an issue while trying to generate your code. Please try again.`
+                            defaultMessage = ErrorMessages.codeGen.default
                         }
                         break
                 }

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -213,7 +213,7 @@ export class FeatureDevController {
         )
 
         let defaultMessage
-        const noRetries = false
+        let noRetries = false
         const isDenyListedError = denyListedErrors.some(err => errorMessage.includes(err))
 
         switch (err.code) {
@@ -305,6 +305,7 @@ export class FeatureDevController {
                     case DevPhase.CODEGEN:
                         if (isDenyListedError) {
                             defaultMessage = `I'm sorry, I'm having trouble generating your code and can't continue at the moment. Please try again later, and share feedback to help me improve.`
+                            noRetries = true
                         } else {
                             defaultMessage = `I'm sorry, I ran into an issue while trying to generate your code. Please try again.`
                         }

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -214,7 +214,6 @@ export class FeatureDevController {
         )
 
         let defaultMessage
-        let noRetries = false
         const isDenyListedError = denyListedErrors.some(err => errorMessage.includes(err))
 
         switch (err.code) {
@@ -304,9 +303,8 @@ export class FeatureDevController {
                         }
                         break
                     case DevPhase.CODEGEN:
-                        if (isDenyListedError) {
+                        if (this.retriesRemaining(session) === 0) {
                             defaultMessage = ErrorMessages.codeGen.denyListedError
-                            noRetries = true
                         } else {
                             defaultMessage = ErrorMessages.codeGen.default
                         }
@@ -316,7 +314,7 @@ export class FeatureDevController {
                 this.messenger.sendErrorMessage(
                     defaultMessage ? defaultMessage : errorMessage,
                     message.tabID,
-                    noRetries ? 0 : this.retriesRemaining(session),
+                    this.retriesRemaining(session),
                     session?.conversationIdUnsafe,
                     !!defaultMessage
                 )

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -212,7 +212,7 @@ export class FeatureDevController {
             `${featureName} request failed: ${err.cause?.message ?? err.message}`
         )
 
-        let sendErrorMessage = true
+        let isSendErrorMessage = true
         let defaultMessage = ''
         const isDenyListedError = denyListedErrors.some(err => errorMessage.includes(err))
 
@@ -315,7 +315,7 @@ export class FeatureDevController {
                     case DevPhase.CODEGEN:
                         if (isDenyListedError) {
                             defaultMessage = `I'm sorry, I'm having trouble generating your code and can't continue at the moment. Please try again later, and share feedback to help me improve.`
-                            sendErrorMessage = false
+                            isSendErrorMessage = false
                             this.messenger.sendAnswer({
                                 type: 'answer',
                                 tabID: message.tabID,
@@ -327,7 +327,7 @@ export class FeatureDevController {
                         break
                 }
 
-                if (sendErrorMessage) {
+                if (isSendErrorMessage) {
                     this.messenger.sendErrorMessage(
                         defaultMessage?.length ? defaultMessage : errorMessage,
                         message.tabID,

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/constants.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/constants.ts
@@ -7,7 +7,7 @@ export type MessengerTypes = 'answer' | 'answer-part' | 'answer-stream' | 'syste
 
 export const ErrorMessages = {
     technicalDifficulties: `I'm sorry, I'm having technical difficulties and can't continue at the moment. Please try again later, and share feedback to help me improve.`,
-    monthlyLimitReached: `Sorry, you have reached the monthly limit for feature development. You can try again next month.`,
+    monthlyLimitReached: `You've reached the monthly quota for the Amazon Q agent for software development. You can try again next month. For more information on usage limits, see the <a href="https://aws.amazon.com/q/developer/pricing/" target="_blank">Amazon Q Developer pricing page</a>.`,
     processingIssue: `Sorry, we encountered a problem when processing your request.`,
     tryAgain: `Sorry, we're experiencing an issue on our side. Would you like to try again?`,
 }

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/constants.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/constants.ts
@@ -9,6 +9,14 @@ export const ErrorMessages = {
     technicalDifficulties: `I'm sorry, I'm having technical difficulties and can't continue at the moment. Please try again later, and share feedback to help me improve.`,
     monthlyLimitReached: `You've reached the monthly quota for the Amazon Q agent for software development. You can try again next month. For more information on usage limits, see the <a href="https://aws.amazon.com/q/developer/pricing/" target="_blank">Amazon Q Developer pricing page</a>.`,
     processingIssue: `Sorry, we encountered a problem when processing your request.`,
+    approachPhase: {
+        denyListedError: `I'm sorry, I'm having trouble generating a plan. Please try again.`,
+        default: `I'm sorry, I ran into an issue while trying to approach the problem. Please try again.`,
+    },
+    codeGen: {
+        denyListedError: `I'm sorry, I'm having trouble generating your code and can't continue at the moment. Please try again later, and share feedback to help me improve.`,
+        default: `I'm sorry, I ran into an issue while trying to generate your code. Please try again.`,
+    },
     tryAgain: `We're experiencing an issue on our side. Try again?`,
 }
 

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/constants.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/constants.ts
@@ -9,7 +9,7 @@ export const ErrorMessages = {
     technicalDifficulties: `I'm sorry, I'm having technical difficulties and can't continue at the moment. Please try again later, and share feedback to help me improve.`,
     monthlyLimitReached: `You've reached the monthly quota for the Amazon Q agent for software development. You can try again next month. For more information on usage limits, see the <a href="https://aws.amazon.com/q/developer/pricing/" target="_blank">Amazon Q Developer pricing page</a>.`,
     processingIssue: `Sorry, we encountered a problem when processing your request.`,
-    tryAgain: `Sorry, we're experiencing an issue on our side. Would you like to try again?`,
+    tryAgain: `We're experiencing an issue on our side. Try again?`,
 }
 
 export const Placeholders = {

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DeletedFileInfo, DevPhase, FollowUpTypes, NewFileInfo, SessionStatePhase } from '../../../types'
+import { DeletedFileInfo, FollowUpTypes, NewFileInfo } from '../../../types'
 import { AuthFollowUpType, AuthMessageDataMap } from '../../../../amazonq/auth/model'
 import {
     ChatMessage,
     AsyncEventProgressMessage,
-    ErrorMessage,
     CodeResultMessage,
     UpdatePlaceholderMessage,
     ChatInputEnabledMessage,
@@ -77,67 +76,24 @@ export class Messenger {
         errorMessage: string,
         tabID: string,
         retries: number,
-        phase?: SessionStatePhase,
         conversationId?: string,
-        skipTitle?: boolean
+        showDefaultMessage?: boolean
     ) {
         if (retries === 0) {
             this.sendAnswer({
                 type: 'answer',
                 tabID: tabID,
-                message: ErrorMessages.technicalDifficulties,
+                message: showDefaultMessage ? errorMessage : ErrorMessages.technicalDifficulties,
             })
             this.sendFeedback(tabID)
             return
         }
-        switch (phase) {
-            case DevPhase.APPROACH:
-                if (skipTitle) {
-                    this.sendAnswer({
-                        type: 'answer',
-                        tabID: tabID,
-                        message: errorMessage + messageWithConversationId(conversationId),
-                    })
-                } else {
-                    this.dispatcher.sendErrorMessage(
-                        new ErrorMessage(
-                            ErrorMessages.tryAgain,
-                            errorMessage + messageWithConversationId(conversationId),
-                            tabID
-                        )
-                    )
-                }
 
-                break
-            case DevPhase.CODEGEN:
-                if (skipTitle) {
-                    this.sendAnswer({
-                        type: 'answer',
-                        tabID: tabID,
-                        message: errorMessage + messageWithConversationId(conversationId),
-                    })
-                } else {
-                    this.dispatcher.sendErrorMessage(
-                        new ErrorMessage(
-                            ErrorMessages.tryAgain,
-                            errorMessage + messageWithConversationId(conversationId),
-                            tabID
-                        )
-                    )
-                }
-
-                break
-            default:
-                // used to send generic error messages when we don't want to send the response as part of a phase
-                this.dispatcher.sendErrorMessage(
-                    new ErrorMessage(
-                        ErrorMessages.processingIssue,
-                        errorMessage + messageWithConversationId(conversationId),
-                        tabID
-                    )
-                )
-                break
-        }
+        this.sendAnswer({
+            type: 'answer',
+            tabID: tabID,
+            message: errorMessage + messageWithConversationId(conversationId),
+        })
 
         this.sendAnswer({
             message: undefined,

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -49,6 +49,21 @@ export class Messenger {
         )
     }
 
+    public sendFeedback(tabID: string) {
+        this.sendAnswer({
+            message: undefined,
+            type: 'system-prompt',
+            followUps: [
+                {
+                    pillText: 'Send feedback',
+                    type: FollowUpTypes.SendFeedback,
+                    status: 'info',
+                },
+            ],
+            tabID,
+        })
+    }
+
     public sendMonthlyLimitError(tabID: string) {
         this.sendAnswer({
             type: 'answer',
@@ -72,18 +87,7 @@ export class Messenger {
                 tabID: tabID,
                 message: ErrorMessages.technicalDifficulties,
             })
-            this.sendAnswer({
-                message: undefined,
-                type: 'system-prompt',
-                followUps: [
-                    {
-                        pillText: 'Send feedback',
-                        type: FollowUpTypes.SendFeedback,
-                        status: 'info',
-                    },
-                ],
-                tabID,
-            })
+            this.sendFeedback(tabID)
             return
         }
         switch (phase) {
@@ -92,7 +96,7 @@ export class Messenger {
                     this.sendAnswer({
                         type: 'answer',
                         tabID: tabID,
-                        message: errorMessage,
+                        message: errorMessage + messageWithConversationId(conversationId),
                     })
                 } else {
                     this.dispatcher.sendErrorMessage(
@@ -110,7 +114,7 @@ export class Messenger {
                     this.sendAnswer({
                         type: 'answer',
                         tabID: tabID,
-                        message: errorMessage,
+                        message: errorMessage + messageWithConversationId(conversationId),
                     })
                 } else {
                     this.dispatcher.sendErrorMessage(

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -97,7 +97,7 @@ export class Messenger {
                 } else {
                     this.dispatcher.sendErrorMessage(
                         new ErrorMessage(
-                            `Sorry, we're experiencing an issue on our side. Would you like to try again?`,
+                            ErrorMessages.tryAgain,
                             errorMessage + messageWithConversationId(conversationId),
                             tabID
                         )
@@ -115,7 +115,7 @@ export class Messenger {
                 } else {
                     this.dispatcher.sendErrorMessage(
                         new ErrorMessage(
-                            `Sorry, we're experiencing an issue on our side. Would you like to try again?`,
+                            ErrorMessages.tryAgain,
                             errorMessage + messageWithConversationId(conversationId),
                             tabID
                         )

--- a/packages/core/src/amazonqFeatureDev/errors.ts
+++ b/packages/core/src/amazonqFeatureDev/errors.ts
@@ -14,8 +14,10 @@ export class ConversationIdNotFoundError extends ToolkitError {
 }
 
 export class TabIdNotFoundError extends ToolkitError {
-    constructor(query: string) {
-        super(`Tab id was not found from ${query}`, { code: 'TabIdNotFound' })
+    constructor() {
+        super(`I'm sorry, I'm having technical difficulties at the moment. Please try again.`, {
+            code: 'TabIdNotFound',
+        })
     }
 }
 
@@ -38,14 +40,16 @@ export class WorkspaceFolderNotFoundError extends ToolkitError {
 
 export class UserMessageNotFoundError extends ToolkitError {
     constructor() {
-        super(`Message was not found`, { code: 'MessageNotFound' })
+        super(`It looks like you didn't provide an input. Please enter your message in the text bar.`, {
+            code: 'MessageNotFound',
+        })
     }
 }
 
 export class SelectedFolderNotInWorkspaceFolderError extends ToolkitError {
     constructor() {
         super(
-            `The selected folder is not in an opened workspace folder. Add the selected folder to the workspace or pick a new folder`,
+            `The folder you chose isn't in your open workspace folder. You can add this folder to your workspace, or choose a folder in your open workspace.`,
             {
                 code: 'SelectedFolderNotInWorkspaceFolder',
             }
@@ -55,7 +59,9 @@ export class SelectedFolderNotInWorkspaceFolderError extends ToolkitError {
 
 export class PrepareRepoFailedError extends ToolkitError {
     constructor() {
-        super('Unable to prepare repository for uploading', { code: 'PrepareRepoFailed' })
+        super('Sorry, I ran into an issue while trying to upload your code. Please try again.', {
+            code: 'PrepareRepoFailed',
+        })
     }
 }
 
@@ -74,7 +80,7 @@ export class IllegalStateTransition extends ToolkitError {
 export class ContentLengthError extends ToolkitError {
     constructor() {
         super(
-            'The project you have selected for source code is too large to use as context. Please select a different folder to use for this conversation',
+            'The folder you selected is too large for me to use as context. Please choose a smaller folder to work on. For more information on quotas, see the <a href="https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/software-dev.html#quotas" target="_blank">Amazon Q Developer documentation.</a>',
             { code: 'ContentLengthError' }
         )
     }
@@ -83,7 +89,7 @@ export class ContentLengthError extends ToolkitError {
 export class PlanIterationLimitError extends ToolkitError {
     constructor() {
         super(
-            'You have reached the free tier limit for number of iterations on an implementation plan. Please proceed to generating code or start to discuss a new plan.',
+            'Sorry, you\'ve reached the quota for number of iterations on an implementation plan. You can generate code for this task or discuss a new plan. For more information on quotas, see the <a href="https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/software-dev.html#quotas">Amazon Q Developer documentation</a>.',
             { code: 'PlanIterationLimitError' }
         )
     }
@@ -92,7 +98,7 @@ export class PlanIterationLimitError extends ToolkitError {
 export class CodeIterationLimitError extends ToolkitError {
     constructor() {
         super(
-            'You have reached the free tier limit for number of iterations on a code generation. Please proceed to accept the code or start a new conversation.',
+            'Sorry, you\'ve reached the quota for number of iterations on code generation. You can insert this code in your files or discuss a new plan. For more information on quotas, see the <a href="https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/software-dev.html#quotas" target="_blank">Amazon Q Developer documentation.</a>',
             { code: 'CodeIterationLimitError' }
         )
     }
@@ -116,7 +122,7 @@ export class ApiError extends ToolkitError {
     }
 }
 
-const denyListedErrors: string[] = ['Deserialization error', 'Inaccessible host']
+export const denyListedErrors: string[] = ['Deserialization error', 'Inaccessible host']
 
 export function createUserFacingErrorMessage(message: string) {
     if (denyListedErrors.some(err => message.includes(err))) {

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -6,7 +6,14 @@
 import * as path from 'path'
 
 import { ConversationNotStartedState, PrepareCodeGenState, PrepareRefinementState } from './sessionState'
-import type { DeletedFileInfo, Interaction, NewFileInfo, SessionState, SessionStateConfig } from '../types'
+import {
+    DevPhase,
+    type DeletedFileInfo,
+    type Interaction,
+    type NewFileInfo,
+    type SessionState,
+    type SessionStateConfig,
+} from '../types'
 import { ConversationIdNotFoundError } from '../errors'
 import { referenceLogText } from '../constants'
 import { FileSystemCommon } from '../../srcShared/fs'
@@ -215,9 +222,9 @@ export class Session {
 
     get retries() {
         switch (this.state.phase) {
-            case 'Approach':
+            case DevPhase.APPROACH:
                 return this.approachRetries
-            case 'Codegen':
+            case DevPhase.CODEGEN:
                 return this.codeGenRetries
             default:
                 return this.approachRetries
@@ -226,10 +233,10 @@ export class Session {
 
     decreaseRetries() {
         switch (this.state.phase) {
-            case 'Approach':
+            case DevPhase.APPROACH:
                 this.approachRetries -= 1
                 break
-            case 'Codegen':
+            case DevPhase.CODEGEN:
                 this.codeGenRetries -= 1
                 break
         }

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -41,7 +41,10 @@ export class ConversationNotStartedState implements Omit<SessionState, 'uploadId
     public tokenSource: vscode.CancellationTokenSource
     public readonly phase = DevPhase.INIT
 
-    constructor(public approach: string, public tabID: string) {
+    constructor(
+        public approach: string,
+        public tabID: string
+    ) {
         this.tokenSource = new vscode.CancellationTokenSource()
         this.approach = ''
     }
@@ -54,7 +57,11 @@ export class ConversationNotStartedState implements Omit<SessionState, 'uploadId
 export class PrepareRefinementState implements Omit<SessionState, 'uploadId'> {
     public tokenSource: vscode.CancellationTokenSource
     public readonly phase = DevPhase.APPROACH
-    constructor(private config: Omit<SessionStateConfig, 'uploadId'>, public approach: string, public tabID: string) {
+    constructor(
+        private config: Omit<SessionStateConfig, 'uploadId'>,
+        public approach: string,
+        public tabID: string
+    ) {
         this.tokenSource = new vscode.CancellationTokenSource()
     }
 
@@ -224,7 +231,10 @@ abstract class CodeGenBase {
     public readonly conversationId: string
     public readonly uploadId: string
 
-    constructor(protected config: SessionStateConfig, public tabID: string) {
+    constructor(
+        protected config: SessionStateConfig,
+        public tabID: string
+    ) {
         this.tokenSource = new vscode.CancellationTokenSource()
         this.conversationId = config.conversationId
         this.uploadId = config.uploadId
@@ -379,7 +389,11 @@ export class MockCodeGenState implements SessionState {
     public readonly conversationId: string
     public readonly uploadId: string
 
-    constructor(private config: SessionStateConfig, public approach: string, public tabID: string) {
+    constructor(
+        private config: SessionStateConfig,
+        public approach: string,
+        public tabID: string
+    ) {
         this.tokenSource = new vscode.CancellationTokenSource()
         this.filePaths = []
         this.deletedFiles = []

--- a/packages/core/src/amazonqFeatureDev/types.ts
+++ b/packages/core/src/amazonqFeatureDev/types.ts
@@ -44,8 +44,6 @@ export enum FollowUpTypes {
 
 export type SessionStatePhase = DevPhase.INIT | DevPhase.APPROACH | DevPhase.CODEGEN
 
-export type AnswerType = 'answer' | 'answer-part' | 'answer-stream' | 'system-prompt'
-
 export type CurrentWsFolders = [vscode.WorkspaceFolder, ...vscode.WorkspaceFolder[]]
 
 export interface SessionState {

--- a/packages/core/src/amazonqFeatureDev/types.ts
+++ b/packages/core/src/amazonqFeatureDev/types.ts
@@ -24,6 +24,12 @@ export interface SessionStateInteraction {
     interaction: Interaction
 }
 
+export enum DevPhase {
+    INIT = 'Init',
+    APPROACH = 'Approach',
+    CODEGEN = 'Codegen',
+}
+
 export enum FollowUpTypes {
     GenerateCode = 'GenerateCode',
     InsertCode = 'InsertCode',
@@ -36,7 +42,9 @@ export enum FollowUpTypes {
     SendFeedback = 'SendFeedback',
 }
 
-export type SessionStatePhase = 'Init' | 'Approach' | 'Codegen'
+export type SessionStatePhase = DevPhase.INIT | DevPhase.APPROACH | DevPhase.CODEGEN
+
+export type AnswerType = 'answer' | 'answer-part' | 'answer-stream' | 'system-prompt'
 
 export type CurrentWsFolders = [vscode.WorkspaceFolder, ...vscode.WorkspaceFolder[]]
 

--- a/packages/core/src/amazonqFeatureDev/userFacingText.ts
+++ b/packages/core/src/amazonqFeatureDev/userFacingText.ts
@@ -21,7 +21,7 @@ export const approachCreation = 'Ok, let me create a plan. This may take a few m
 export const updateCode = 'Code has been updated. Would you like to work on another task?'
 export const sessionClosed = 'Your session is now closed.'
 export const newTaskChanges = 'What change would you like to make?'
-export const uploadCodeError = `Amazon Q is unable to upload workspace artifacts to S3 for feature development. For more information, see the [Amazon Q documentation](${manageAccessGuideURL}) or contact your network or organization administrator.`
+export const uploadCodeError = `I'm sorry, I couldn’t upload your workspace artifacts to Amazon S3 to help you with this task. You might need to allow access to the S3 bucket. For more information, see the [Amazon Q documentation](${manageAccessGuideURL}) or contact your network or organization administrator.`
 
 // Utils for logging and showing customer facing conversation id text
 export const messageWithConversationId = (conversationId?: string) =>


### PR DESCRIPTION
## Problem
- Currently we don't have granular error handling for some specific scenarios shown by the technical writer.

## Solution
- This PR updates those messages.
- In addition:
   - Refactor the use of simple strings to describe the "phases" and use enum instead
   - Extract the error handling in controller state to a switch/case instead if/else

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
