### PR TITLE
fix: unreliable test "submitFeedbackListener"

### DIFF
--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -71,6 +71,12 @@ import DependencyVersions from '../../amazonqGumby/models/dependencies'
 import { dependencyNoAvailableVersions } from '../../amazonqGumby/models/constants'
 import { HumanInTheLoopManager } from '../service/transformByQ/humanInTheLoopManager'
 
+function getFeedbackCommentData() {
+    const jobId = transformByQState.getJobId()
+    const s = `Q CodeTransform jobId: ${jobId ? jobId : 'none'}`
+    return s
+}
+
 export async function processTransformFormInput(
     pathToProject: string,
     fromJDKVersion: JDKVersion,
@@ -666,7 +672,11 @@ export async function postTransformationJob() {
             )
             .then(choice => {
                 if (choice === CodeWhispererConstants.amazonQFeedbackText) {
-                    void submitFeedback(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
+                    void submitFeedback(
+                        placeholder,
+                        CodeWhispererConstants.amazonQFeedbackKey,
+                        getFeedbackCommentData()
+                    )
                 }
             })
     }
@@ -694,7 +704,11 @@ export async function transformationJobErrorHandler(error: any) {
             .showErrorMessage(displayedErrorMessage, CodeWhispererConstants.amazonQFeedbackText)
             .then(choice => {
                 if (choice === CodeWhispererConstants.amazonQFeedbackText) {
-                    void submitFeedback(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
+                    void submitFeedback(
+                        placeholder,
+                        CodeWhispererConstants.amazonQFeedbackKey,
+                        getFeedbackCommentData()
+                    )
                 }
             })
     } else {
@@ -746,7 +760,11 @@ export async function stopTransformByQ(
                 )
                 .then(choice => {
                     if (choice === CodeWhispererConstants.amazonQFeedbackText) {
-                        void submitFeedback(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
+                        void submitFeedback(
+                            placeholder,
+                            CodeWhispererConstants.amazonQFeedbackKey,
+                            getFeedbackCommentData()
+                        )
                     }
                 })
         } catch (err) {
@@ -757,7 +775,11 @@ export async function stopTransformByQ(
                 )
                 .then(choice => {
                     if (choice === CodeWhispererConstants.amazonQFeedbackText) {
-                        void submitFeedback(placeholder, CodeWhispererConstants.amazonQFeedbackKey)
+                        void submitFeedback(
+                            placeholder,
+                            CodeWhispererConstants.amazonQFeedbackKey,
+                            getFeedbackCommentData()
+                        )
                     }
                 })
             getLogger().error(`CodeTransformation: Error stopping transformation ${err}`)

--- a/packages/core/src/feedback/vue/submitFeedback.ts
+++ b/packages/core/src/feedback/vue/submitFeedback.ts
@@ -11,7 +11,6 @@ import { localize } from '../../shared/utilities/vsCodeUtils'
 import { VueWebview, VueWebviewPanel } from '../../webviews/main'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { Commands, RegisteredCommand, VsCodeCommandArg, placeholder } from '../../shared/vscode/commands2'
-import { transformByQState } from '../../codewhisperer/models/model'
 
 export interface FeedbackMessage {
     comment: string
@@ -22,7 +21,12 @@ export class FeedbackWebview extends VueWebview {
     public static readonly sourcePath: string = 'src/feedback/vue/index.js'
     public readonly id = 'submitFeedback'
 
-    public constructor(private readonly telemetry: TelemetryService, private readonly feedbackName: string) {
+    public constructor(
+        private readonly telemetry: TelemetryService,
+        private readonly feedbackName: string,
+        /** Arbitrary caller-defined data appended to comment when sending the feedback request. */
+        private commentData?: string
+    ) {
         super(FeedbackWebview.sourcePath)
     }
     public async getFeedbackName(): Promise<string | void> {
@@ -36,9 +40,8 @@ export class FeedbackWebview extends VueWebview {
             return 'Choose a reaction (smile/frown)'
         }
 
-        const jobId = transformByQState.getJobId()
-        if (jobId !== '') {
-            message.comment = `${message.comment}\n\nQ CodeTransform jobId: ${jobId}`
+        if (this.commentData) {
+            message.comment = `${message.comment}\n\n${this.commentData}`
         }
 
         try {
@@ -69,8 +72,16 @@ export class FeedbackWebview extends VueWebview {
 
 type FeedbackId = 'AWS Toolkit' | 'Amazon Q' | 'Application Composer' | 'Threat Composer'
 
-let _submitFeedback: RegisteredCommand<(_: VsCodeCommandArg, id: FeedbackId) => Promise<void>> | undefined
-export function submitFeedback(_: VsCodeCommandArg, id: FeedbackId) {
+let _submitFeedback:
+    | RegisteredCommand<(_: VsCodeCommandArg, id: FeedbackId, commentData?: string) => Promise<void>>
+    | undefined
+
+/**
+ * @param id Feedback name
+ * @param commentData Arbitrary caller-defined data appended to the comment when sending the
+ * feedback request.
+ */
+export function submitFeedback(_: VsCodeCommandArg, id: FeedbackId, commentData?: string) {
     if (_submitFeedback === undefined) {
         getLogger().error(
             'Attempted to access "submitFeedback" command, but it was never initialized.' +
@@ -78,18 +89,18 @@ export function submitFeedback(_: VsCodeCommandArg, id: FeedbackId) {
         )
         throw new Error("'submitFeedback' command was called programmitically, but its not registered.")
     }
-    return _submitFeedback.execute(_, id)
+    return _submitFeedback.execute(_, id, commentData)
 }
 
 export function registerSubmitFeedback(context: vscode.ExtensionContext, defaultId: FeedbackId, contextPrefix: string) {
     _submitFeedback = Commands.register(
         { id: `aws.${contextPrefix}.submitFeedback`, autoconnect: false },
-        async (_: VsCodeCommandArg, id: FeedbackId) => {
+        async (_: VsCodeCommandArg, id: FeedbackId, commentData?: string) => {
             if (_ !== placeholder) {
                 // No args exist, we must supply them
                 id = defaultId
             }
-            await showFeedbackView(context, id)
+            await showFeedbackView(context, id, commentData)
         }
     )
     getLogger().info(`initialized \'submitFeedback\' command with default feedback id: ${defaultId}`)
@@ -99,9 +110,9 @@ export function registerSubmitFeedback(context: vscode.ExtensionContext, default
 
 let activeWebview: VueWebviewPanel | undefined
 
-export async function showFeedbackView(context: vscode.ExtensionContext, feedbackName: string) {
+export async function showFeedbackView(context: vscode.ExtensionContext, feedbackName: string, commentData?: string) {
     const Panel = VueWebview.compilePanel(FeedbackWebview)
-    activeWebview ??= new Panel(context, globals.telemetry, feedbackName)
+    activeWebview ??= new Panel(context, globals.telemetry, feedbackName, commentData)
 
     const webviewPanel = await activeWebview.show({
         title: localize('AWS.submitFeedback.title', 'Send Feedback'),


### PR DESCRIPTION
## Problem:
unreliable test:

    submitFeedbackListener
      submits feedback for Amazon Q, disposes, and handles errors:

     AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
     assert.ok(postStub.calledOnceWithExactly({ comment: comment, sentiment: sentiment }))
     + expected - actual
     -false
     +true
     at Context.<anonymous> (src/test/feedback/commands/submitFeedbackListener.test.ts:33:20)

This is because of a race: CodeTransform sets a global "jobId", which may be used by the feedback form, which causes unexpected results in the feedback tests.

## Solution:

Remove random CodeTransform special-case from `FeedbackWebview`.




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
