### PR TITLE
StepFunctions LSP server activates when users re-open vscode with an ASL document from a previous editing session

### DIFF
--- a/packages/toolkit/.changes/next-release/Bug Fix-9d578109-b17a-40e9-a116-8c738b19e727.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-9d578109-b17a-40e9-a116-8c738b19e727.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Step functions language server activates when editing ASL documents from previous session"
+}


### PR DESCRIPTION
### Problem
Users who open vscode after previously editing an ASL document are not seeing error checking activate

- https://github.com/aws/aws-toolkit-vscode/issues/5163
- https://github.com/aws/aws-toolkit-vscode/issues/5110

### Solution
This fixes that behaviour where users will now see error checking activate when re-opening vscode and editing an ASL document from a previous session

### Testing
- I elected to keep the two new functions private as they only pertain to activation. Thus there are no unit tests with this particular change.

- I verified this fix by opening up a new vscode session from which I had previously been editing an ASL document. I've attached a video for proof.

- I wasn't sure if we can mock this behaviour somehow in integration tests or E2E tests so if anyone has any ideas or recommendations, I'm happy to implement them.

- [Demo](https://github.com/aws/aws-toolkit-vscode/assets/41310238/b2563bb1-8f27-4e69-9474-80a057c8bf1a)

## License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
