### PR TITLE
Amazon Q Code Transform: Link UI messages to troubleshooting document sections

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-82f3dfb6-c3d3-48e6-806f-ff006688d852.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-82f3dfb6-c3d3-48e6-806f-ff006688d852.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q Code Transform: Link UI messages to troubleshooting docs\""
+	"description": "Amazon Q Code Transform: Link UI messages to troubleshooting docs"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-82f3dfb6-c3d3-48e6-806f-ff006688d852.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-82f3dfb6-c3d3-48e6-806f-ff006688d852.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Code Transform: Link UI messages to troubleshooting docs\""
+}

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -393,25 +393,25 @@ export const amazonQFeedbackKey = 'Amazon Q'
 
 export const amazonQFeedbackText = 'Submit feedback'
 
-export const codeTransformTroubleshootDocProjectSize =
+export const codeTransformTroubleshootProjectSize =
     'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#reduce-project-size'
 
-export const codeTransformTroubleshootDocMvnFailure =
+export const codeTransformTroubleshootMvnFailure =
     'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#maven-commands-failing'
 
-export const codeTransformTroubleshootDocConfigureProxy =
-    "https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#configure-proxy"
+export const codeTransformTroubleshootConfigureProxy =
+    'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#configure-proxy'
 
-export const codeTransformTroubleshootDocDownloadExpired =
+export const codeTransformTroubleshootDownloadExpired =
     'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#download-24-hrs'
 
-export const codeTransformTroubleshootDocAllowS3Access =
-    "https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#allowlist-s3-bucket"
+export const codeTransformTroubleshootAllowS3Access =
+    'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#allowlist-s3-bucket'
 
-export const codeTransformTroubleshootDocUploadError =
+export const codeTransformTroubleshootUploadError =
     'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-upload-fail'
 
-export const codeTransformTroubleshootDocDownloadError =
+export const codeTransformTroubleshootDownloadError =
     'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#download-code-fail'
 
 export const codeTransformPrereqDoc =
@@ -471,17 +471,16 @@ export const buildSucceededChatMessage = 'I was able to build your project and w
 export const buildSucceededNotification =
     'Amazon Q was able to build your project and will start transforming your code soon.'
 
-export const unsupportedJavaVersionChatMessage =
-    `Sorry, currently I can only upgrade Java 8 or Java 11 projects. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
+export const unsupportedJavaVersionChatMessage = `Sorry, currently I can only upgrade Java 8 or Java 11 projects. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const failedToStartJobChatMessage =
-    'Sorry, I couldn\'t begin the transformation. Please try starting the transformation again.'
+    "Sorry, I couldn't begin the transformation. Please try starting the transformation again."
 
 export const failedToStartJobNotification =
     'Amazon Q could not begin the transformation. Please try starting the transformation again.'
 
 export const failedToStartJobTooManyJobsChatMessage =
-    'Sorry, I couldn\'t begin the transformation. You have too many active transformations running. Please try again after your other transformations have completed.'
+    "Sorry, I couldn't begin the transformation. You have too many active transformations running. Please try again after your other transformations have completed."
 
 export const failedToStartJobTooManyJobsNotification =
     'Amazon Q could not begin the transformation. You have too many active transformations running. Please try again after your other transformations have completed.'
@@ -499,24 +498,24 @@ export const failedToStartJobLinesLimitChatMessage =
     'I am sorry, your project exceeds the free tier limit of 1000 lines of code per transformation. You can try again with a smaller project.'
 
 export const failedToUploadProjectChatMessage =
-    'Sorry, I couldn\'t upload your project. Please try starting the transformation again.'
+    "Sorry, I couldn't upload your project. Please try starting the transformation again."
 
 export const failedToUploadProjectNotification =
     'Amazon Q could not upload your project. Please try starting the transformation again.'
 
 export const failedToGetPlanChatMessage =
-    'Sorry, I couldn\'t create the transformation plan to upgrade your project. Please try starting the transformation again.'
+    "Sorry, I couldn't create the transformation plan to upgrade your project. Please try starting the transformation again."
 
 export const failedToGetPlanNotification =
     'Amazon Q could not create the transformation plan to upgrade your project. Please try starting the transformation again.'
 
 export const failedToCompleteJobChatMessage =
-    'Sorry, I couldn\'t complete the transformation. Please try starting the transformation again.'
+    "Sorry, I couldn't complete the transformation. Please try starting the transformation again."
 
 export const failedToCompleteJobNotification =
     'Amazon Q could not complete the transformation. Please try starting the transformation again.'
 
-export const failedToCompleteJobGenericChatMessage = 'Sorry, I couldn\'t complete the transformation.'
+export const failedToCompleteJobGenericChatMessage = "Sorry, I couldn't complete the transformation."
 
 export const failedToCompleteJobGenericNotification = 'Amazon Q could not complete the transformation.'
 
@@ -540,42 +539,32 @@ export const jobPartiallyCompletedChatMessage =
 export const jobPartiallyCompletedNotification =
     'Amazon Q upgraded part of your code to Java 17. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the files I updated and the errors that prevented a complete transformation.'
 
-export const noPomXmlFoundChatMessage =
-    `Sorry, I couldn\'t find a project that I can upgrade. I couldn\'t find a pom.xml file in any of your open projects. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
+export const noPomXmlFoundChatMessage = `Sorry, I couldn\'t find a project that I can upgrade. I couldn\'t find a pom.xml file in any of your open projects. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
-export const noPomXmlFoundNotification =
-    `None of your open projects are supported by Amazon Q Code Transformation. Amazon Q could not find a pom.xml file in any of your open projects. Currently, Amazon Q can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
+export const noPomXmlFoundNotification = `None of your open projects are supported by Amazon Q Code Transformation. Amazon Q could not find a pom.xml file in any of your open projects. Currently, Amazon Q can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
-export const noJavaHomeFoundChatMessage =
-    `Sorry, I couldn\'t locate your Java installation. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
+export const noJavaHomeFoundChatMessage = `Sorry, I couldn\'t locate your Java installation. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
-export const errorUploadingWithExpiredUrl =
-    `The upload error may have been caused by the expiration of the S3 pre-signed URL that was used to upload code artifacts to Q Code Transformation. The S3 pre-signed URL expires in 30 minutes. This could be caused by any delays introduced by intermediate services in your network infrastructure. Please investigate your network configuration and consider allowlisting 'amazonq-code-transformation-us-east-1-c6160f047e0.s3.amazonaws.com' to skip any scanning that might delay the upload. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocAllowS3Access}).`
+export const errorUploadingWithExpiredUrl = `The upload error may have been caused by the expiration of the S3 pre-signed URL that was used to upload code artifacts to Q Code Transformation. The S3 pre-signed URL expires in 30 minutes. This could be caused by any delays introduced by intermediate services in your network infrastructure. Please investigate your network configuration and consider allowlisting 'amazonq-code-transformation-us-east-1-c6160f047e0.s3.amazonaws.com' to skip any scanning that might delay the upload. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootAllowS3Access}).`
 
 export const socketConnectionFailed =
     'Please check your network connectivity or firewall configuration, and then try again.'
 
-export const selfSignedCertificateError =
-    `This might have been caused by your IDE not trusting the certificate of your HTTP proxy. Ensure all certificates for your proxy client have been configured in your IDE, and then retry transformation. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocConfigureProxy}).`
+export const selfSignedCertificateError = `This might have been caused by your IDE not trusting the certificate of your HTTP proxy. Ensure all certificates for your proxy client have been configured in your IDE, and then retry transformation. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootConfigureProxy}).`
 
-export const errorStoppingJobChatMessage = 'Sorry, I couldn\'t stop the transformation.'
+export const errorStoppingJobChatMessage = "Sorry, I couldn't stop the transformation."
 
 export const errorStoppingJobNotification = 'Amazon Q could not stop the transformation.'
 
-export const errorDownloadingDiffChatMessage =
-    `Sorry, I couldn\'t download the diff with your upgraded code. Please try downloading it again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocDownloadError}).`
+export const errorDownloadingDiffChatMessage = `Sorry, I couldn\'t download the diff with your upgraded code. Please try downloading it again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDownloadError}).`
 
-export const errorDownloadingDiffNotification =
-    `Amazon Q could not download the diff with your upgraded code. Please try downloading it again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocDownloadError}).`
+export const errorDownloadingDiffNotification = `Amazon Q could not download the diff with your upgraded code. Please try downloading it again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDownloadError}).`
 
-export const errorDownloadingExpiredDiff =
-    `Your transformation is not available anymore. Your code and transformation summary are deleted 24 hours after the transformation completes. Please try starting the transformation again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocDownloadExpired}).`
+export const errorDownloadingExpiredDiff = `Your transformation is not available anymore. Your code and transformation summary are deleted 24 hours after the transformation completes. Please try starting the transformation again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDownloadExpired}).`
 
-export const errorDeserializingDiffChatMessage =
-    `Sorry, I couldn\'t parse the diff with your upgraded code. Please try starting the transformation again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocDownloadError}).`
+export const errorDeserializingDiffChatMessage = `Sorry, I couldn\'t parse the diff with your upgraded code. Please try starting the transformation again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDownloadError}).`
 
-export const errorDeserializingDiffNotification =
-    `Amazon Q could not parse the diff with your upgraded code. Please try starting the transformation again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocDownloadError}).`
+export const errorDeserializingDiffNotification = `Amazon Q could not parse the diff with your upgraded code. Please try starting the transformation again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDownloadError}).`
 
 export const viewProposedChangesChatMessage =
     'Download complete. You can view a summary of the transformation and accept or reject the proposed changes in the Transformation Hub.'
@@ -587,11 +576,9 @@ export const changesAppliedChatMessage = 'I applied the changes to your project.
 
 export const changesAppliedNotification = 'Amazon Q applied the changes to your project.'
 
-export const noOpenProjectsFoundChatMessage =
-    `Sorry, I couldn\'t find a project that I can upgrade. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
+export const noOpenProjectsFoundChatMessage = `Sorry, I couldn\'t find a project that I can upgrade. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
-export const noJavaProjectsFoundChatMessage =
-    `Sorry, I couldn\'t find a project that I can upgrade. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
+export const noJavaProjectsFoundChatMessage = `Sorry, I couldn\'t find a project that I can upgrade. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const linkToDocsHome = 'https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html'
 
@@ -606,11 +593,9 @@ export const linkToDownloadZipTooLarge = ''
 
 export const dependencyFolderName = 'transformation_dependencies_temp_'
 
-export const cleanInstallErrorChatMessage =
-    `Sorry, I couldn\'t run the Maven clean install command to build your project. For more information, see the [Amazon Q Code Transformation documentation](${codeTransformTroubleshootDocMvnFailure}).`
+export const cleanInstallErrorChatMessage = `Sorry, I couldn\'t run the Maven clean install command to build your project. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootMvnFailure}).`
 
-export const cleanInstallErrorNotification =
-    `Amazon Q could not run the Maven clean install command to build your project. For more information, see the [Amazon Q Code Transformation documentation](${codeTransformTroubleshootDocMvnFailure}).`
+export const cleanInstallErrorNotification = `Amazon Q could not run the Maven clean install command to build your project. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootMvnFailure}).`
 
 export const enterJavaHomeChatMessage = 'Enter the path to JDK '
 
@@ -626,11 +611,9 @@ export const nonWindowsJava8HomeHelpChatMessage =
 export const nonWindowsJava11HomeHelpChatMessage =
     'To find the JDK path, run the following command in a new IDE terminal:  `/usr/libexec/java_home -v 11`'
 
-export const projectSizeTooLargeChatMessage =
-    `Sorry, your project size exceeds the Amazon Q Code Transformation upload limit of 2GB. For more information, see the [Code Transformation documentation](${codeTransformTroubleshootDocProjectSize}).`
+export const projectSizeTooLargeChatMessage = `Sorry, your project size exceeds the Amazon Q Code Transformation upload limit of 2GB. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootProjectSize}).`
 
-export const projectSizeTooLargeNotification =
-    `Your project size exceeds the Amazon Q Code Transformation upload limit of 2GB. For more information, see the [Code Transformation documentation](${codeTransformTroubleshootDocProjectSize}).`
+export const projectSizeTooLargeNotification = `Your project size exceeds the Amazon Q Code Transformation upload limit of 2GB. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootProjectSize}).`
 
 export const JDK8VersionNumber = '52'
 

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -393,6 +393,30 @@ export const amazonQFeedbackKey = 'Amazon Q'
 
 export const amazonQFeedbackText = 'Submit feedback'
 
+export const codeTransformTroubleshootDocProjectSize =
+    'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#reduce-project-size'
+
+export const codeTransformTroubleshootDocMvnFailure =
+    'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#maven-commands-failing'
+
+export const codeTransformTroubleshootDocConfigureProxy =
+    "https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#configure-proxy"
+
+export const codeTransformTroubleshootDocDownloadExpired =
+    'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#download-24-hrs'
+
+export const codeTransformTroubleshootDocAllowS3Access =
+    "https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#allowlist-s3-bucket"
+
+export const codeTransformTroubleshootDocUploadError =
+    'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-upload-fail'
+
+export const codeTransformTroubleshootDocDownloadError =
+    'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#download-code-fail'
+
+export const codeTransformPrereqDoc =
+    'https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites'
+
 export const jobStartedChatMessage =
     'I am starting to transform your code. It can take 10 to 30 minutes to upgrade your code, depending on the size of your project. To monitor progress, go to the Transformation Hub. If I run into any issues, I might pause the transformation to get input from you on how to proceed.'
 
@@ -448,16 +472,16 @@ export const buildSucceededNotification =
     'Amazon Q was able to build your project and will start transforming your code soon.'
 
 export const unsupportedJavaVersionChatMessage =
-    'Sorry, currently I can only upgrade Java 8 or Java 11 projects. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites).'
+    `Sorry, currently I can only upgrade Java 8 or Java 11 projects. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const failedToStartJobChatMessage =
-    'Sorry, I could not begin the transformation. Please try starting the transformation again.'
+    'Sorry, I couldn\'t begin the transformation. Please try starting the transformation again.'
 
 export const failedToStartJobNotification =
     'Amazon Q could not begin the transformation. Please try starting the transformation again.'
 
 export const failedToStartJobTooManyJobsChatMessage =
-    'Sorry, I could not begin the transformation. You have too many active transformations running. Please try again after your other transformations have completed.'
+    'Sorry, I couldn\'t begin the transformation. You have too many active transformations running. Please try again after your other transformations have completed.'
 
 export const failedToStartJobTooManyJobsNotification =
     'Amazon Q could not begin the transformation. You have too many active transformations running. Please try again after your other transformations have completed.'
@@ -475,24 +499,24 @@ export const failedToStartJobLinesLimitChatMessage =
     'I am sorry, your project exceeds the free tier limit of 1000 lines of code per transformation. You can try again with a smaller project.'
 
 export const failedToUploadProjectChatMessage =
-    'Sorry, I could not upload your project. Please try starting the transformation again.'
+    'Sorry, I couldn\'t upload your project. Please try starting the transformation again.'
 
 export const failedToUploadProjectNotification =
     'Amazon Q could not upload your project. Please try starting the transformation again.'
 
 export const failedToGetPlanChatMessage =
-    'Sorry, I could not create the transformation plan to upgrade your project. Please try starting the transformation again.'
+    'Sorry, I couldn\'t create the transformation plan to upgrade your project. Please try starting the transformation again.'
 
 export const failedToGetPlanNotification =
     'Amazon Q could not create the transformation plan to upgrade your project. Please try starting the transformation again.'
 
 export const failedToCompleteJobChatMessage =
-    'Sorry, I could not complete the transformation. Please try starting the transformation again.'
+    'Sorry, I couldn\'t complete the transformation. Please try starting the transformation again.'
 
 export const failedToCompleteJobNotification =
     'Amazon Q could not complete the transformation. Please try starting the transformation again.'
 
-export const failedToCompleteJobGenericChatMessage = 'Sorry, I could not complete the transformation.'
+export const failedToCompleteJobGenericChatMessage = 'Sorry, I couldn\'t complete the transformation.'
 
 export const failedToCompleteJobGenericNotification = 'Amazon Q could not complete the transformation.'
 
@@ -517,41 +541,41 @@ export const jobPartiallyCompletedNotification =
     'Amazon Q upgraded part of your code to Java 17. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the files I updated and the errors that prevented a complete transformation.'
 
 export const noPomXmlFoundChatMessage =
-    'Sorry, I could not find a project that I can upgrade. I could not find a pom.xml file in any of your open projects. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites).'
+    `Sorry, I couldn\'t find a project that I can upgrade. I couldn\'t find a pom.xml file in any of your open projects. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const noPomXmlFoundNotification =
-    'None of your open projects are supported by Amazon Q Code Transformation. Amazon Q could not find a pom.xml file in any of your open projects. Currently, Amazon Q can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites).'
+    `None of your open projects are supported by Amazon Q Code Transformation. Amazon Q could not find a pom.xml file in any of your open projects. Currently, Amazon Q can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const noJavaHomeFoundChatMessage =
-    'Sorry, I could not locate your Java installation. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites).'
+    `Sorry, I couldn\'t locate your Java installation. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const errorUploadingWithExpiredUrl =
-    "The upload error may have been caused by the expiration of the S3 pre-signed URL that was used to upload code artifacts to Q Code Transformation. The S3 pre-signed URL expires in 30 minutes. This could be caused by any delays introduced by intermediate services in your network infrastructure. Please investigate your network configuration and consider allowlisting 'amazonq-code-transformation-us-east-1-c6160f047e0.s3.amazonaws.com' to skip any scanning that might delay the upload."
+    `The upload error may have been caused by the expiration of the S3 pre-signed URL that was used to upload code artifacts to Q Code Transformation. The S3 pre-signed URL expires in 30 minutes. This could be caused by any delays introduced by intermediate services in your network infrastructure. Please investigate your network configuration and consider allowlisting 'amazonq-code-transformation-us-east-1-c6160f047e0.s3.amazonaws.com' to skip any scanning that might delay the upload. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocAllowS3Access}).`
 
 export const socketConnectionFailed =
     'Please check your network connectivity or firewall configuration, and then try again.'
 
 export const selfSignedCertificateError =
-    'This might have been caused by your IDE not trusting the certificate of your HTTP proxy. Ensure all certificates for your proxy client have been configured in your IDE, and then retry transformation.'
+    `This might have been caused by your IDE not trusting the certificate of your HTTP proxy. Ensure all certificates for your proxy client have been configured in your IDE, and then retry transformation. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocConfigureProxy}).`
 
-export const errorStoppingJobChatMessage = 'Sorry, I could not stop the transformation.'
+export const errorStoppingJobChatMessage = 'Sorry, I couldn\'t stop the transformation.'
 
 export const errorStoppingJobNotification = 'Amazon Q could not stop the transformation.'
 
 export const errorDownloadingDiffChatMessage =
-    'Sorry, I could not download the diff with your upgraded code. Please try downloading it again. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/troubleshooting-code-transformation.html#output-artifact-size-limit).'
+    `Sorry, I couldn\'t download the diff with your upgraded code. Please try downloading it again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocDownloadError}).`
 
 export const errorDownloadingDiffNotification =
-    'Amazon Q could not download the diff with your upgraded code. Please try downloading it again. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/troubleshooting-code-transformation.html#output-artifact-size-limit).'
+    `Amazon Q could not download the diff with your upgraded code. Please try downloading it again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocDownloadError}).`
 
 export const errorDownloadingExpiredDiff =
-    'Your transformation is not available anymore. Your code and transformation summary are deleted 24 hours after the transformation completes. Please try starting the transformation again.'
+    `Your transformation is not available anymore. Your code and transformation summary are deleted 24 hours after the transformation completes. Please try starting the transformation again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocDownloadExpired}).`
 
 export const errorDeserializingDiffChatMessage =
-    'Sorry, I could not parse the diff with your upgraded code. Please try starting the transformation again. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/troubleshooting-code-transformation.html#output-artifact-size-limit).'
+    `Sorry, I couldn\'t parse the diff with your upgraded code. Please try starting the transformation again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocDownloadError}).`
 
 export const errorDeserializingDiffNotification =
-    'Amazon Q could not parse the diff with your upgraded code. Please try starting the transformation again. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/troubleshooting-code-transformation.html#output-artifact-size-limit).'
+    `Amazon Q could not parse the diff with your upgraded code. Please try starting the transformation again. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootDocDownloadError}).`
 
 export const viewProposedChangesChatMessage =
     'Download complete. You can view a summary of the transformation and accept or reject the proposed changes in the Transformation Hub.'
@@ -564,10 +588,10 @@ export const changesAppliedChatMessage = 'I applied the changes to your project.
 export const changesAppliedNotification = 'Amazon Q applied the changes to your project.'
 
 export const noOpenProjectsFoundChatMessage =
-    'Sorry, I could not find a project that I can upgrade. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites).'
+    `Sorry, I couldn\'t find a project that I can upgrade. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const noJavaProjectsFoundChatMessage =
-    'Sorry, I could not find a project that I can upgrade. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites).'
+    `Sorry, I couldn\'t find a project that I can upgrade. Currently, I can only upgrade Java 8 or Java 11 projects built on Maven. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const linkToDocsHome = 'https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html'
 
@@ -583,10 +607,10 @@ export const linkToDownloadZipTooLarge = ''
 export const dependencyFolderName = 'transformation_dependencies_temp_'
 
 export const cleanInstallErrorChatMessage =
-    'Sorry, I could not run the Maven clean install command to build your project. For more information, see the [Amazon Q Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/troubleshooting-code-transformation.html#maven-commands-failing).'
+    `Sorry, I couldn\'t run the Maven clean install command to build your project. For more information, see the [Amazon Q Code Transformation documentation](${codeTransformTroubleshootDocMvnFailure}).`
 
 export const cleanInstallErrorNotification =
-    'Amazon Q could not run the Maven clean install command to build your project. For more information, see the [Amazon Q Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/troubleshooting-code-transformation.html#maven-commands-failing).'
+    `Amazon Q could not run the Maven clean install command to build your project. For more information, see the [Amazon Q Code Transformation documentation](${codeTransformTroubleshootDocMvnFailure}).`
 
 export const enterJavaHomeChatMessage = 'Enter the path to JDK '
 
@@ -603,10 +627,10 @@ export const nonWindowsJava11HomeHelpChatMessage =
     'To find the JDK path, run the following command in a new IDE terminal:  `/usr/libexec/java_home -v 11`'
 
 export const projectSizeTooLargeChatMessage =
-    'Sorry, your project size exceeds the Amazon Q Code Transformation upload limit of 2GB. For more information, see the [Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-size-limit).'
+    `Sorry, your project size exceeds the Amazon Q Code Transformation upload limit of 2GB. For more information, see the [Code Transformation documentation](${codeTransformTroubleshootDocProjectSize}).`
 
 export const projectSizeTooLargeNotification =
-    'Your project size exceeds the Amazon Q Code Transformation upload limit of 2GB. For more information, see the [Code Transformation documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/troubleshooting-code-transformation.html#project-size-limit).'
+    `Your project size exceeds the Amazon Q Code Transformation upload limit of 2GB. For more information, see the [Code Transformation documentation](${codeTransformTroubleshootDocProjectSize}).`
 
 export const JDK8VersionNumber = '52'
 

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -133,7 +133,7 @@ export async function uploadArtifactToS3(
         })
         getLogger().info(`CodeTransformation: Status from S3 Upload = ${response.status}`)
     } catch (e: any) {
-        let errorMessage = `The upload failed due to: ${(e as Error).message}. For more information, see the [Amazon Q documentation](${CodeWhispererConstants.codeTransformTroubleshootDocUploadError})`
+        let errorMessage = `The upload failed due to: ${(e as Error).message}. For more information, see the [Amazon Q documentation](${CodeWhispererConstants.codeTransformTroubleshootUploadError})`
         if (errorMessage.includes('Request has expired')) {
             errorMessage = CodeWhispererConstants.errorUploadingWithExpiredUrl
         } else if (errorMessage.includes('Failed to establish a socket connection')) {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -111,7 +111,7 @@ export async function uploadArtifactToS3(
     try {
         const uploadFileByteSize = (await fs.promises.stat(fileName)).size
         getLogger().info(
-            `Uploading zip at %s with checksum %s using uploadId: %s and size %s kB`,
+            `Uploading project artifact at %s with checksum %s using uploadId: %s and size %s kB`,
             fileName,
             sha256,
             resp.uploadId,
@@ -133,7 +133,7 @@ export async function uploadArtifactToS3(
         })
         getLogger().info(`CodeTransformation: Status from S3 Upload = ${response.status}`)
     } catch (e: any) {
-        let errorMessage = `The upload failed due to: ${(e as Error).message}`
+        let errorMessage = `The upload failed due to: ${(e as Error).message}. For more information, see the [Amazon Q documentation](${CodeWhispererConstants.codeTransformTroubleshootDocUploadError})`
         if (errorMessage.includes('Request has expired')) {
             errorMessage = CodeWhispererConstants.errorUploadingWithExpiredUrl
         } else if (errorMessage.includes('Failed to establish a socket connection')) {
@@ -749,21 +749,6 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
 
             const errorMessage = response.transformationJob.reason
             if (errorMessage !== undefined) {
-                if (errorMessage.includes('Monthly aggregated Lines of Code limit breached')) {
-                    transformByQState.setJobFailureErrorNotification(
-                        CodeWhispererConstants.failedToStartJobMonthlyLimitNotification
-                    )
-                    transformByQState.setJobFailureErrorChatMessage(
-                        CodeWhispererConstants.failedToStartJobMonthlyLimitChatMessage
-                    )
-                } else if (errorMessage.includes('Lines of Code limit breached for job')) {
-                    transformByQState.setJobFailureErrorNotification(
-                        CodeWhispererConstants.failedToStartJobLinesLimitNotification
-                    )
-                    transformByQState.setJobFailureErrorChatMessage(
-                        CodeWhispererConstants.failedToStartJobLinesLimitChatMessage
-                    )
-                }
                 transformByQState.setJobFailureErrorChatMessage(
                     `${CodeWhispererConstants.failedToCompleteJobGenericChatMessage} ${errorMessage}`
                 )


### PR DESCRIPTION
## Problem
Minor adjustment to UI messages, including linking error messages to new troubleshooting document sections, removing unwanted UI messages, and minor renaming.

## Solution
<img width="280" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/36546476/0b69652f-6024-45c3-86c0-b808782493d7">

<img width="279" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/36546476/1521f006-3d9d-4499-a987-a12cf0d1c232">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
