### PR TITLE
auth: add telemetry for why the user needed to reauth

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -185,9 +185,9 @@ export class Auth implements AuthService, ConnectionManager {
 
             // We cannot easily set isReAuth inside the createToken() call,
             // so we need to set it here.
-            await telemetry.aws_loginWithBrowser.run(async (span) => {
-                span.record({ isReAuth: true, credentialStartUrl: profile.startUrl })
-                await this.authenticate(id, () => provider.createToken(), shouldInvalidate)
+            await telemetry.aws_loginWithBrowser.run(async span => {
+                span.record({ credentialStartUrl: profile.startUrl })
+                await this.authenticate(id, () => provider.createToken({isReAuth: true}), shouldInvalidate)
             })
 
             return this.getSsoConnection(id, profile)

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -182,13 +182,7 @@ export class Auth implements AuthService, ConnectionManager {
         const profile = this.store.getProfileOrThrow(id)
         if (profile.type === 'sso') {
             const provider = this.getSsoTokenProvider(id, profile)
-
-            // We cannot easily set reauth related fields inside the createToken() call,
-            // so we need to set it here.
-            await telemetry.aws_loginWithBrowser.run(async span => {
-                span.record({ credentialStartUrl: profile.startUrl })
-                await this.authenticate(id, () => provider.createToken({ isReAuth: true }), shouldInvalidate)
-            })
+            await this.authenticate(id, () => provider.createToken({ isReAuth: true }), shouldInvalidate)
 
             return this.getSsoConnection(id, profile)
         } else {

--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -217,7 +217,7 @@ export class SsoClient {
     private async handleError(error: unknown): Promise<never> {
         if (error instanceof SSOServiceException && isClientFault(error) && error.name !== 'ForbiddenException') {
             getLogger().warn(`credentials (sso): invalidating stored token: ${error.message}`)
-            await this.provider.invalidate()
+            await this.provider.invalidate(`ssoClient:${error.name}`)
         }
 
         throw error

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -204,7 +204,7 @@ export abstract class SsoAccessTokenProvider {
         func: T,
         args?: CreateTokenArgs
     ): ReturnType<T> {
-        return telemetry.aws_loginWithBrowser.run(span => {
+        return telemetry.aws_loginWithBrowser.run((span) => {
             span.record({
                 credentialStartUrl: this.profile.startUrl,
                 source: SsoAccessTokenProvider._authSource,

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -677,7 +677,7 @@ export class ReAuthState extends NestedMap<ReAuthStateKey, ReAuthStateValue> {
         super()
     }
 
-    protected override asKey(profile: ReAuthStateKey): string {
+    protected override hash(profile: ReAuthStateKey): string {
         return profile.identifier ?? profile.startUrl
     }
 

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -41,7 +41,7 @@ import { isRemoteWorkspace, isWebWorkspace } from '../../shared/vscode/env'
 import { showInputBox } from '../../shared/ui/inputPrompter'
 import { DevSettings } from '../../shared/settings'
 import { onceChanged } from '../../shared/utilities/functionUtils'
-import { MemoryMap } from '../../shared/utilities/map'
+import { NestedMap } from '../../shared/utilities/map'
 
 export const authenticationPath = 'sso/authenticated'
 
@@ -123,7 +123,7 @@ export abstract class SsoAccessTokenProvider {
             // Authentication in the browser is successfully done, so the reauth reason is now stale.
             // We don't clear the reason on failure since we want to keep reporting it as the reason until
             // reauth is a success.
-            this.reAuthState.clear(this.profile, 'reauth successful')
+            this.reAuthState.delete(this.profile, 'reauth successful')
 
             return result
         } catch (err) {
@@ -668,7 +668,7 @@ class WebAuthorization extends SsoAccessTokenProvider {
  * then upon the next reauth use `get()`. Finally, use `clear()` if the reauth is
  * successful.
  */
-export class ReAuthState extends MemoryMap<ReAuthStateKey, ReAuthStateValue> {
+export class ReAuthState extends NestedMap<ReAuthStateKey, ReAuthStateValue> {
     static #instance: ReAuthState
     static get instance() {
         return (this.#instance ??= new ReAuthState())

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -268,7 +268,7 @@ export abstract class SsoAccessTokenProvider {
  * Supplementary arguments for the create token flow. This data can be used
  * for things like telemetry.
  */
-type CreateTokenArgs = {
+export type CreateTokenArgs = {
     /** true if the create token flow is for reauthentication */
     isReAuth?: boolean
 }

--- a/packages/core/src/shared/utilities/cacheUtils.ts
+++ b/packages/core/src/shared/utilities/cacheUtils.ts
@@ -9,6 +9,7 @@ import { ToolkitError, isFileNotFoundError } from '../errors'
 import fs from '../../shared/fs/fs'
 import crypto from 'crypto'
 import { isWeb } from '../extensionGlobals'
+import type { MapSync } from './map'
 
 // TODO(sijaden): further generalize this concept over async references (maybe create a library?)
 // It's pretty clear that this interface (and VSC's `Memento`) reduce down to what is essentially
@@ -16,6 +17,8 @@ import { isWeb } from '../extensionGlobals'
 
 /**
  * A general, basic interface for a cache with key associativity.
+ *
+ * Look to use {@link MapSync} instead if you need atomicity.
  */
 export interface KeyedCache<T, K = string> {
     /**

--- a/packages/core/src/shared/utilities/map.ts
+++ b/packages/core/src/shared/utilities/map.ts
@@ -1,0 +1,100 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from "../logger"
+
+/**
+ * Simply maps a Key to an Object. Everything is done in memory, allowing for atomic updates.
+ * 
+ * There is a common use case for this class, so look to reuse this when possible.
+ * Benefits, instead of making your own:
+ * - A key does not have to be a string, {@link MemoryMap.asKey} enables this
+ * - Implements most of the boilerplate
+ */
+export abstract class MemoryMap<Key, Value = { [key: string]: any }>
+    implements MapSync<Key, Value>
+{
+    private readonly data: { [key: string]: Value | undefined } = {}
+
+    exists(key: Key): boolean {
+        return this.data[this.asKey(key)] !== undefined
+    }
+
+    /**
+     * IMPORTANT: If getting a key without having {@link set()} a value, the {@link default} will be returned.
+     * Use {@link exists()} to check for existence before calling get(), if necessary.
+     */
+    get(key: Key): Value {
+        const actualKey = this.asKey(key)
+        const result = this.data[actualKey]
+        return result ?? this.default
+    }
+
+    set(key: Key, data: Partial<Value>): void {
+        const currentData = this.get(key)
+        this.data[this.asKey(key)] = { ...currentData, ...data }
+    }
+
+    clear(key: Key, reason: string): void {
+        delete this.data[this.asKey(key)]
+        getLogger().debug(`${this.name}: cleared cache, key: ${JSON.stringify(key)}, reason: ${reason}`)
+    }
+
+    /**
+     * Converts the user-provided key to a string so that it can be used
+     * as an object key.
+     */
+    protected abstract asKey(key: Key): string
+
+    /**
+     * The name of the implementation, for logging purposes
+     */
+    protected abstract get name(): string
+
+    /**
+     * The default value returned from {@link get}() when {@link exists}() is false
+     */
+    protected abstract get default(): Value
+}
+
+/** 
+ * A synchronous version of a Map of Maps.
+ * - This allows for atomic updates as it is not async.
+ * - They Key does not need to be a string
+ */
+export interface MapSync<Key, ReturnObject = { [key: string]: any }> {
+    /**
+     * Attempts to read data stored at {@link key}.
+     *
+     * @param key Target key to read from.
+     * @returns `ReturnObject` regardless of cache hit or miss. Use {@link exists}() to verify existence,
+     *          otherwise a default object may be returned.
+     */
+    get(key: Key): ReturnObject
+
+    /**
+     * Writes {@link data} to {@link key}.
+     *
+     * @param key Target key to write to.
+     * @param data Data to write.
+     */
+    set(key: Key, data: ReturnObject): void
+
+    /**
+     * Returns true if the given key exists in the cache.
+     *
+     * @param key Target key to check.
+     * @returns True if the key exists, false otherwise.
+     */
+    exists(key: Key): boolean
+
+    /**
+     * Deletes data stored at {@link key}, if any.
+     *
+     * @param key Target key to clear.
+     * @param reason Partial log message explaining why the data is being deleted.
+     */
+    clear(key: Key, reason: string): void
+}

--- a/packages/core/src/shared/utilities/map.ts
+++ b/packages/core/src/shared/utilities/map.ts
@@ -11,7 +11,7 @@ import type { KeyedCache } from './cacheUtils'
  *
  * There is a common use case for this class, so look to reuse this when possible.
  * Benefits, instead of making your own:
- * - A key does not have to be a string, {@link NestedMap.asKey} enables this
+ * - A key does not have to be a string, {@link NestedMap.hash} enables this
  * - Implements most of the boilerplate
  * - Has a {@link NestedMap.default} property which is returned from {@link NestedMap.get()}
  *   in the case {@link NestedMap.has()} would return false.
@@ -20,7 +20,7 @@ export abstract class NestedMap<Key, Value = { [key: string]: any }> implements 
     private readonly data: { [key: string]: Value | undefined } = {}
 
     has(key: Key): boolean {
-        return this.data[this.asKey(key)] !== undefined
+        return this.data[this.hash(key)] !== undefined
     }
 
     /**
@@ -28,18 +28,18 @@ export abstract class NestedMap<Key, Value = { [key: string]: any }> implements 
      * Use {@link has()} to check for existence before calling {@link get()}, if necessary.
      */
     get(key: Key): Value {
-        const actualKey = this.asKey(key)
+        const actualKey = this.hash(key)
         const result = this.data[actualKey]
         return result ?? this.default
     }
 
     set(key: Key, data: Partial<Value>): void {
         const currentData = this.get(key)
-        this.data[this.asKey(key)] = { ...currentData, ...data }
+        this.data[this.hash(key)] = { ...currentData, ...data }
     }
 
     delete(key: Key, reason: string): void {
-        delete this.data[this.asKey(key)]
+        delete this.data[this.hash(key)]
         getLogger().debug(`${this.name}: cleared cache, key: ${JSON.stringify(key)}, reason: ${reason}`)
     }
 
@@ -47,7 +47,7 @@ export abstract class NestedMap<Key, Value = { [key: string]: any }> implements 
      * Converts the user-provided key to a string so that it can be used
      * as an object key.
      */
-    protected abstract asKey(key: Key): string
+    protected abstract hash(key: Key): string
 
     /**
      * The name of the implementation, for logging purposes

--- a/packages/core/src/shared/utilities/map.ts
+++ b/packages/core/src/shared/utilities/map.ts
@@ -3,19 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getLogger } from "../logger"
+import { getLogger } from '../logger'
 
 /**
  * Simply maps a Key to an Object. Everything is done in memory, allowing for atomic updates.
- * 
+ *
  * There is a common use case for this class, so look to reuse this when possible.
  * Benefits, instead of making your own:
  * - A key does not have to be a string, {@link MemoryMap.asKey} enables this
  * - Implements most of the boilerplate
  */
-export abstract class MemoryMap<Key, Value = { [key: string]: any }>
-    implements MapSync<Key, Value>
-{
+export abstract class MemoryMap<Key, Value = { [key: string]: any }> implements MapSync<Key, Value> {
     private readonly data: { [key: string]: Value | undefined } = {}
 
     exists(key: Key): boolean {
@@ -59,7 +57,7 @@ export abstract class MemoryMap<Key, Value = { [key: string]: any }>
     protected abstract get default(): Value
 }
 
-/** 
+/**
  * A synchronous version of a Map of Maps.
  * - This allows for atomic updates as it is not async.
  * - They Key does not need to be a string

--- a/packages/core/src/shared/utilities/map.ts
+++ b/packages/core/src/shared/utilities/map.ts
@@ -4,25 +4,28 @@
  */
 
 import { getLogger } from '../logger'
+import type { KeyedCache } from './cacheUtils'
 
 /**
  * Simply maps a Key to an Object. Everything is done in memory, allowing for atomic updates.
  *
  * There is a common use case for this class, so look to reuse this when possible.
  * Benefits, instead of making your own:
- * - A key does not have to be a string, {@link MemoryMap.asKey} enables this
+ * - A key does not have to be a string, {@link NestedMap.asKey} enables this
  * - Implements most of the boilerplate
+ * - Has a {@link NestedMap.default} property which is returned from {@link NestedMap.get()}
+ *   in the case {@link NestedMap.has()} would return false.
  */
-export abstract class MemoryMap<Key, Value = { [key: string]: any }> implements MapSync<Key, Value> {
+export abstract class NestedMap<Key, Value = { [key: string]: any }> implements MapSync<Key, Value> {
     private readonly data: { [key: string]: Value | undefined } = {}
 
-    exists(key: Key): boolean {
+    has(key: Key): boolean {
         return this.data[this.asKey(key)] !== undefined
     }
 
     /**
      * IMPORTANT: If getting a key without having {@link set()} a value, the {@link default} will be returned.
-     * Use {@link exists()} to check for existence before calling get(), if necessary.
+     * Use {@link has()} to check for existence before calling {@link get()}, if necessary.
      */
     get(key: Key): Value {
         const actualKey = this.asKey(key)
@@ -35,7 +38,7 @@ export abstract class MemoryMap<Key, Value = { [key: string]: any }> implements 
         this.data[this.asKey(key)] = { ...currentData, ...data }
     }
 
-    clear(key: Key, reason: string): void {
+    delete(key: Key, reason: string): void {
         delete this.data[this.asKey(key)]
         getLogger().debug(`${this.name}: cleared cache, key: ${JSON.stringify(key)}, reason: ${reason}`)
     }
@@ -52,7 +55,7 @@ export abstract class MemoryMap<Key, Value = { [key: string]: any }> implements 
     protected abstract get name(): string
 
     /**
-     * The default value returned from {@link get}() when {@link exists}() is false
+     * The default value returned from {@link get}() when {@link has}() is false
      */
     protected abstract get default(): Value
 }
@@ -61,13 +64,16 @@ export abstract class MemoryMap<Key, Value = { [key: string]: any }> implements 
  * A synchronous version of a Map of Maps.
  * - This allows for atomic updates as it is not async.
  * - They Key does not need to be a string
+ *
+ * There are similarities to {@link KeyedCache}, which is why this class' name
+ * explicitly has 'Sync'.
  */
 export interface MapSync<Key, ReturnObject = { [key: string]: any }> {
     /**
      * Attempts to read data stored at {@link key}.
      *
      * @param key Target key to read from.
-     * @returns `ReturnObject` regardless of cache hit or miss. Use {@link exists}() to verify existence,
+     * @returns `ReturnObject` regardless of cache hit or miss. Use {@link has()} to verify existence,
      *          otherwise a default object may be returned.
      */
     get(key: Key): ReturnObject
@@ -86,7 +92,7 @@ export interface MapSync<Key, ReturnObject = { [key: string]: any }> {
      * @param key Target key to check.
      * @returns True if the key exists, false otherwise.
      */
-    exists(key: Key): boolean
+    has(key: Key): boolean
 
     /**
      * Deletes data stored at {@link key}, if any.
@@ -94,5 +100,5 @@ export interface MapSync<Key, ReturnObject = { [key: string]: any }> {
      * @param key Target key to clear.
      * @param reason Partial log message explaining why the data is being deleted.
      */
-    clear(key: Key, reason: string): void
+    delete(key: Key, reason: string): void
 }

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -9,7 +9,7 @@ import fs from '../../shared/fs/fs'
 import { ToolkitError, isUserCancelledError } from '../../shared/errors'
 import { assertTreeItem } from '../shared/treeview/testUtil'
 import { getTestWindow } from '../shared/vscode/window'
-import { assertTelemetry, captureEventOnce, getMetrics } from '../testUtil'
+import { captureEventOnce } from '../testUtil'
 import { createBuilderIdProfile, createSsoProfile, createTestAuth } from './testUtil'
 import { toCollection } from '../../shared/utilities/asyncCollection'
 import globals from '../../shared/extensionGlobals'
@@ -256,15 +256,10 @@ describe('Auth', function () {
             assert.strictEqual(auth.getConnectionState(conn), 'valid')
         })
 
-        it('reauthentication is indicated in metric', async function () {
+        it('reauthentication flag is set at start of reauth process', async function () {
             const conn = await auth.createInvalidSsoConnection(ssoProfile)
             await auth.reauthenticate(conn)
-            assertTelemetry('aws_loginWithBrowser', {
-                result: 'Succeeded',
-                isReAuth: true,
-                credentialStartUrl: ssoProfile.startUrl,
-            })
-            assert.strictEqual(getMetrics('aws_loginWithBrowser').length, 1)
+            auth.getTestTokenProvider(conn).createToken.calledWith({ isReAuth: true })
         })
     })
 

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -265,7 +265,7 @@ describe('SsoAccessTokenProvider', function () {
                     isReAuth: true,
                     reAuthReason: 'myReAuthReason',
                 })
-                assert.deepStrictEqual(reAuthState.exists({ startUrl }), false)
+                assert.deepStrictEqual(reAuthState.has({ startUrl }), false)
             })
 
             it('no reAuthReason if isReAuth is false', async () => {
@@ -281,7 +281,7 @@ describe('SsoAccessTokenProvider', function () {
             })
 
             it('telemetry does not fail is reAuthReason does not exist', async () => {
-                assert.deepStrictEqual(reAuthState.exists({ startUrl }), false)
+                assert.deepStrictEqual(reAuthState.has({ startUrl }), false)
 
                 await sut.createToken({ isReAuth: true }) // function under test
 

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -433,8 +433,8 @@ describe('SsoAccessTokenProvider', function () {
             super()
         }
 
-        override asKey(profile: { readonly identifier?: string; readonly startUrl: string }): string {
-            return super.asKey(profile)
+        override hash(profile: { readonly identifier?: string; readonly startUrl: string }): string {
+            return super.hash(profile)
         }
 
         override get default(): { reAuthReason?: string } {
@@ -443,7 +443,7 @@ describe('SsoAccessTokenProvider', function () {
     }
 
     describe(ReAuthState.name, function () {
-        it(`asKey()`, async () => {
+        it(`hash()`, async () => {
             const profile1: Pick<SsoProfile, 'identifier' | 'startUrl'> = {
                 identifier: 'abc-123',
                 startUrl: 'https://sameUrl.com',
@@ -452,8 +452,8 @@ describe('SsoAccessTokenProvider', function () {
                 startUrl: 'https://sameUrl.com',
             }
 
-            assert.deepStrictEqual(reAuthState.asKey(profile1), profile1.identifier)
-            assert.deepStrictEqual(reAuthState.asKey(profile2), profile2.startUrl)
+            assert.deepStrictEqual(reAuthState.hash(profile1), profile1.identifier)
+            assert.deepStrictEqual(reAuthState.hash(profile2), profile2.startUrl)
         })
 
         it('default', () => {

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -246,7 +246,7 @@ describe('SsoAccessTokenProvider', function () {
                 oidcClient.createToken.rejects(new Error('random error')) // Forces failure during SSO flow
                 reAuthState.set({ startUrl }, { reAuthReason: 'thisReasonWillNotBeCleared' })
 
-                await assert.rejects(sut.createToken({isReAuth: true})) // function under test
+                await assert.rejects(sut.createToken({ isReAuth: true })) // function under test
 
                 assert.deepStrictEqual(reAuthState.get({ startUrl }), {
                     ...reAuthState.default,
@@ -257,13 +257,13 @@ describe('SsoAccessTokenProvider', function () {
             it('clears the reAuthReason on successful login', async () => {
                 reAuthState.set({ startUrl }, { reAuthReason: 'myReAuthReason' })
 
-                await sut.createToken({isReAuth: true}) // function under test
+                await sut.createToken({ isReAuth: true }) // function under test
 
                 assertTelemetry('aws_loginWithBrowser', {
                     result: 'Succeeded',
                     credentialStartUrl: startUrl,
                     isReAuth: true,
-                    reAuthReason: 'myReAuthReason'
+                    reAuthReason: 'myReAuthReason',
                 })
                 assert.deepStrictEqual(reAuthState.exists({ startUrl }), false)
             })
@@ -271,7 +271,7 @@ describe('SsoAccessTokenProvider', function () {
             it('no reAuthReason if isReAuth is false', async () => {
                 reAuthState.set({ startUrl }, { reAuthReason: 'thisReasonWontBeUsed' })
 
-                await sut.createToken({isReAuth: false}) // function under test
+                await sut.createToken({ isReAuth: false }) // function under test
 
                 assertTelemetry('aws_loginWithBrowser', {
                     result: 'Succeeded',
@@ -281,15 +281,15 @@ describe('SsoAccessTokenProvider', function () {
             })
 
             it('telemetry does not fail is reAuthReason does not exist', async () => {
-                assert.deepStrictEqual(reAuthState.exists({startUrl}), false)
+                assert.deepStrictEqual(reAuthState.exists({ startUrl }), false)
 
-                await sut.createToken({isReAuth: true}) // function under test
+                await sut.createToken({ isReAuth: true }) // function under test
 
                 assertTelemetry('aws_loginWithBrowser', {
                     result: 'Succeeded',
                     isReAuth: true,
                     credentialStartUrl: startUrl,
-                    reAuthReason: undefined // this does not exist, but it is fine.
+                    reAuthReason: undefined, // this does not exist, but it is fine.
                 })
             })
         })
@@ -469,11 +469,11 @@ describe('SsoAccessTokenProvider', function () {
             super()
         }
 
-        override asKey(profile: { readonly identifier?: string; readonly startUrl: string; }): string {
+        override asKey(profile: { readonly identifier?: string; readonly startUrl: string }): string {
             return super.asKey(profile)
         }
 
-        override get default(): { reAuthReason?: string; } {
+        override get default(): { reAuthReason?: string } {
             return super.default
         }
     }

--- a/packages/core/src/test/credentials/testUtil.ts
+++ b/packages/core/src/test/credentials/testUtil.ts
@@ -99,7 +99,7 @@ export function createTestAuth(): TestAuth {
     async function invalidateCachedCredentials(conn: Connection) {
         if (conn.type === 'sso') {
             const provider = tokenProviders.get(conn.id)
-            await provider?.invalidate()
+            await provider?.invalidate('test')
         } else {
             globals.loginManager.store.invalidateCredentials(fromString(conn.id))
         }

--- a/packages/core/src/test/shared/utilities/map.test.ts
+++ b/packages/core/src/test/shared/utilities/map.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import { NestedMap } from '../../../shared/utilities/map'
 
 class TestInMemoryMap extends NestedMap<string, { a?: string; b: number }> {
-    protected override asKey(key: string): string {
+    protected override hash(key: string): string {
         return key
     }
     protected override get name(): string {

--- a/packages/core/src/test/shared/utilities/map.test.ts
+++ b/packages/core/src/test/shared/utilities/map.test.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "assert";
+import { MemoryMap } from "../../../shared/utilities/map";
+
+class TestInMemoryMap extends MemoryMap<String, {a?: string, b: number}> {
+    protected override asKey(key: string): string {
+        return key
+    }
+    protected override get name(): string {
+        return TestInMemoryMap.name
+    }
+    override get default(): { a?: string, b: number } {
+        return {a: undefined, b: 0}
+    }
+
+}
+
+describe(MemoryMap.name, () => {
+    it('behaves as expected', () => {
+        const map = new TestInMemoryMap()
+        
+        // exist() returns false if the key does not exist
+        assert.deepStrictEqual(map.exists('key1'), false)
+
+        // get() returns the default value if the key does not exist
+        assert.deepStrictEqual(map.get('key1'), map.default)
+
+        // set() adds a new key
+        map.set('key1', {a: 'key1Value', b: 1})
+        assert.deepStrictEqual(map.exists('key1'), true)
+        assert.deepStrictEqual(map.get('key1'), {a: 'key1Value', b: 1})
+
+        // set() updates an existing key
+        map.set('key1', {a: 'key1ValueUpdated'})
+        assert.deepStrictEqual(map.exists('key1'), true)
+        assert.deepStrictEqual(map.get('key1'), { a: 'key1ValueUpdated', b: 1})
+
+        // set() another key
+        map.set('key2', {a: 'key2Value', b: 2})
+
+        // First key still exists and so does the new one
+        assert.deepStrictEqual(map.exists('key1'), true)
+        assert.deepStrictEqual(map.exists('key2'), true)
+        assert.deepStrictEqual(map.get('key1'), { a: 'key1ValueUpdated', b: 1})
+        assert.deepStrictEqual(map.get('key2'), { a: 'key2Value', b: 2})
+
+        // clear() removes first key
+        map.clear('key1', 'removing for test')
+        assert.deepStrictEqual(map.exists('key1'), false)
+        assert.deepStrictEqual(map.get('key1'), map.default)
+
+        // exist() is still true for the second key
+        assert.deepStrictEqual(map.exists('key2'), true)
+        assert.deepStrictEqual(map.get('key2'), { a: 'key2Value', b: 2})
+    })
+})

--- a/packages/core/src/test/shared/utilities/map.test.ts
+++ b/packages/core/src/test/shared/utilities/map.test.ts
@@ -4,9 +4,9 @@
  */
 
 import assert from 'assert'
-import { MemoryMap } from '../../../shared/utilities/map'
+import { NestedMap } from '../../../shared/utilities/map'
 
-class TestInMemoryMap extends MemoryMap<string, { a?: string; b: number }> {
+class TestInMemoryMap extends NestedMap<string, { a?: string; b: number }> {
     protected override asKey(key: string): string {
         return key
     }
@@ -18,42 +18,42 @@ class TestInMemoryMap extends MemoryMap<string, { a?: string; b: number }> {
     }
 }
 
-describe(MemoryMap.name, () => {
+describe(NestedMap.name, () => {
     it('behaves as expected', () => {
         const map = new TestInMemoryMap()
 
         // exist() returns false if the key does not exist
-        assert.deepStrictEqual(map.exists('key1'), false)
+        assert.deepStrictEqual(map.has('key1'), false)
 
         // get() returns the default value if the key does not exist
         assert.deepStrictEqual(map.get('key1'), map.default)
 
         // set() adds a new key
         map.set('key1', { a: 'key1Value', b: 1 })
-        assert.deepStrictEqual(map.exists('key1'), true)
+        assert.deepStrictEqual(map.has('key1'), true)
         assert.deepStrictEqual(map.get('key1'), { a: 'key1Value', b: 1 })
 
         // set() updates an existing key
         map.set('key1', { a: 'key1ValueUpdated' })
-        assert.deepStrictEqual(map.exists('key1'), true)
+        assert.deepStrictEqual(map.has('key1'), true)
         assert.deepStrictEqual(map.get('key1'), { a: 'key1ValueUpdated', b: 1 })
 
         // set() another key
         map.set('key2', { a: 'key2Value', b: 2 })
 
         // First key still exists and so does the new one
-        assert.deepStrictEqual(map.exists('key1'), true)
-        assert.deepStrictEqual(map.exists('key2'), true)
+        assert.deepStrictEqual(map.has('key1'), true)
+        assert.deepStrictEqual(map.has('key2'), true)
         assert.deepStrictEqual(map.get('key1'), { a: 'key1ValueUpdated', b: 1 })
         assert.deepStrictEqual(map.get('key2'), { a: 'key2Value', b: 2 })
 
         // clear() removes first key
-        map.clear('key1', 'removing for test')
-        assert.deepStrictEqual(map.exists('key1'), false)
+        map.delete('key1', 'removing for test')
+        assert.deepStrictEqual(map.has('key1'), false)
         assert.deepStrictEqual(map.get('key1'), map.default)
 
         // exist() is still true for the second key
-        assert.deepStrictEqual(map.exists('key2'), true)
+        assert.deepStrictEqual(map.has('key2'), true)
         assert.deepStrictEqual(map.get('key2'), { a: 'key2Value', b: 2 })
     })
 })

--- a/packages/core/src/test/shared/utilities/map.test.ts
+++ b/packages/core/src/test/shared/utilities/map.test.ts
@@ -3,26 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from "assert";
-import { MemoryMap } from "../../../shared/utilities/map";
+import assert from 'assert'
+import { MemoryMap } from '../../../shared/utilities/map'
 
-class TestInMemoryMap extends MemoryMap<String, {a?: string, b: number}> {
+class TestInMemoryMap extends MemoryMap<string, { a?: string; b: number }> {
     protected override asKey(key: string): string {
         return key
     }
     protected override get name(): string {
         return TestInMemoryMap.name
     }
-    override get default(): { a?: string, b: number } {
-        return {a: undefined, b: 0}
+    override get default(): { a?: string; b: number } {
+        return { a: undefined, b: 0 }
     }
-
 }
 
 describe(MemoryMap.name, () => {
     it('behaves as expected', () => {
         const map = new TestInMemoryMap()
-        
+
         // exist() returns false if the key does not exist
         assert.deepStrictEqual(map.exists('key1'), false)
 
@@ -30,23 +29,23 @@ describe(MemoryMap.name, () => {
         assert.deepStrictEqual(map.get('key1'), map.default)
 
         // set() adds a new key
-        map.set('key1', {a: 'key1Value', b: 1})
+        map.set('key1', { a: 'key1Value', b: 1 })
         assert.deepStrictEqual(map.exists('key1'), true)
-        assert.deepStrictEqual(map.get('key1'), {a: 'key1Value', b: 1})
+        assert.deepStrictEqual(map.get('key1'), { a: 'key1Value', b: 1 })
 
         // set() updates an existing key
-        map.set('key1', {a: 'key1ValueUpdated'})
+        map.set('key1', { a: 'key1ValueUpdated' })
         assert.deepStrictEqual(map.exists('key1'), true)
-        assert.deepStrictEqual(map.get('key1'), { a: 'key1ValueUpdated', b: 1})
+        assert.deepStrictEqual(map.get('key1'), { a: 'key1ValueUpdated', b: 1 })
 
         // set() another key
-        map.set('key2', {a: 'key2Value', b: 2})
+        map.set('key2', { a: 'key2Value', b: 2 })
 
         // First key still exists and so does the new one
         assert.deepStrictEqual(map.exists('key1'), true)
         assert.deepStrictEqual(map.exists('key2'), true)
-        assert.deepStrictEqual(map.get('key1'), { a: 'key1ValueUpdated', b: 1})
-        assert.deepStrictEqual(map.get('key2'), { a: 'key2Value', b: 2})
+        assert.deepStrictEqual(map.get('key1'), { a: 'key1ValueUpdated', b: 1 })
+        assert.deepStrictEqual(map.get('key2'), { a: 'key2Value', b: 2 })
 
         // clear() removes first key
         map.clear('key1', 'removing for test')
@@ -55,6 +54,6 @@ describe(MemoryMap.name, () => {
 
         // exist() is still true for the second key
         assert.deepStrictEqual(map.exists('key2'), true)
-        assert.deepStrictEqual(map.get('key2'), { a: 'key2Value', b: 2})
+        assert.deepStrictEqual(map.get('key2'), { a: 'key2Value', b: 2 })
     })
 })


### PR DESCRIPTION
## Problem:
    
In the reauth metric (`aws_loginWithBrowser` + `isReAuth: true`) we didn't know why
the user needed to reauth. It could have been due to regular expiration or some unexpected
error.

## Solution:

**See each commit for specific change**

Add a new field in `aws_loginWithBrowser` named `reAuthReason` which will have some sort
of identifier for why reauth was needed.

What was actually changed in this PR:
- `SsoAccessTokenProvider` has an object `ReAuthState` (name may change) which maps an SSO connection -> reason why we need to reauth
  - In certain flows such as SSO token refresh, if it fails we will update the `ReAuthState` with the reason why.
  - Later on the user may want to reauthenticate, and when they start the flow `SsoAccessTokenProvider` will know the reason and record it in `aws_loginWithBrowser`
- `isReAuth` is now an argument in `createToken()`
  - This allows us to get rid of some hacky telemetry code where we tried to essentially set `isReAuth: true` globally (through `record()`)
  - Now that it is an argument we pass `isReAuth` throughout the execution, this is more readable. 
- A generalized Map class was created
  - This maps a key to some data
  - We used this implementation with `ReAuthState`
  - It can probably be reused in other places of our code and reduce duplication of code

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
