### PR TITLE
fix: handling validation errors in approach/code generation

### DIFF
--- a/packages/core/src/amazonqFeatureDev/errors.ts
+++ b/packages/core/src/amazonqFeatureDev/errors.ts
@@ -80,6 +80,12 @@ export class ContentLengthError extends ToolkitError {
     }
 }
 
+export class ZipFileError extends ToolkitError {
+    constructor() {
+        super('The zip file is corrupted', { code: 'ZipFileError' })
+    }
+}
+
 export class PlanIterationLimitError extends ToolkitError {
     constructor() {
         super(


### PR DESCRIPTION

## Problem
When a validation errors(repo size exceeds limit or corrupted zip file) thrown from approach/code generation it will show generic internal error to the user
## Solution
Catch those errors and show proper errors

![Screenshot 2024-06-28 at 08 44 13](https://github.com/aws/aws-toolkit-vscode/assets/141347041/a6fd68ed-bf39-4894-ad0e-25041bc2cc82)
![Screenshot 2024-06-28 at 08 42 34](https://github.com/aws/aws-toolkit-vscode/assets/141347041/5c9cc919-fd7a-4971-b6a4-3446fb964026)

    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
