### PR TITLE
fix(gumby): Do not check auth when initializing transformation hub UX

### DIFF
--- a/packages/core/src/amazonqGumby/activation.ts
+++ b/packages/core/src/amazonqGumby/activation.ts
@@ -13,62 +13,59 @@ import { ProposedTransformationExplorer } from '../codewhisperer/service/transfo
 import { CodeTransformTelemetryState } from './telemetry/codeTransformTelemetryState'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { CancelActionPositions } from './telemetry/codeTransformTelemetry'
-import { AuthUtil } from '../codewhisperer/util/authUtil'
 
 export async function activate(context: ExtContext) {
     void vscode.commands.executeCommand('setContext', 'gumby.wasQCodeTransformationUsed', false)
-    // If the user is codewhisperer eligible, activate the plugin
-    if (AuthUtil.instance.isValidCodeTransformationAuthUser()) {
-        const transformationHubViewProvider = new TransformationHubViewProvider()
-        new ProposedTransformationExplorer(context.extensionContext)
-        // Register an activation event listener to determine when the IDE opens, closes or users
-        // select to open a new workspace
-        const workspaceChangeEvent = vscode.workspace.onDidChangeWorkspaceFolders(event => {
-            // A loophole to register the IDE closed. This is when no folders were added nor
-            // removed, but the event still fired. This assumes the user closed the workspace
-            if (event.added.length === 0 && event.removed.length === 0) {
-                // Only fire closed during running/active job status
-                if (transformByQState.isRunning()) {
-                    telemetry.codeTransform_jobIsClosedDuringIdeRun.emit({
-                        codeTransformJobId: transformByQState.getJobId(),
-                        codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                        codeTransformStatus: transformByQState.getStatus(),
-                    })
-                }
-            } else {
-                telemetry.codeTransform_jobIsResumedAfterIdeClose.emit({
+
+    const transformationHubViewProvider = new TransformationHubViewProvider()
+    new ProposedTransformationExplorer(context.extensionContext)
+    // Register an activation event listener to determine when the IDE opens, closes or users
+    // select to open a new workspace
+    const workspaceChangeEvent = vscode.workspace.onDidChangeWorkspaceFolders(event => {
+        // A loophole to register the IDE closed. This is when no folders were added nor
+        // removed, but the event still fired. This assumes the user closed the workspace
+        if (event.added.length === 0 && event.removed.length === 0) {
+            // Only fire closed during running/active job status
+            if (transformByQState.isRunning()) {
+                telemetry.codeTransform_jobIsClosedDuringIdeRun.emit({
                     codeTransformJobId: transformByQState.getJobId(),
                     codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
                     codeTransformStatus: transformByQState.getStatus(),
                 })
             }
-        })
+        } else {
+            telemetry.codeTransform_jobIsResumedAfterIdeClose.emit({
+                codeTransformJobId: transformByQState.getJobId(),
+                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                codeTransformStatus: transformByQState.getStatus(),
+            })
+        }
+    })
 
-        context.extensionContext.subscriptions.push(
-            vscode.window.registerWebviewViewProvider('aws.amazonq.transformationHub', transformationHubViewProvider),
+    context.extensionContext.subscriptions.push(
+        vscode.window.registerWebviewViewProvider('aws.amazonq.transformationHub', transformationHubViewProvider),
 
-            Commands.register('aws.amazonq.stopTransformationInHub', async (cancelSrc: CancelActionPositions) => {
-                if (transformByQState.isRunning()) {
-                    void stopTransformByQ(transformByQState.getJobId(), cancelSrc)
-                }
-            }),
+        Commands.register('aws.amazonq.stopTransformationInHub', async (cancelSrc: CancelActionPositions) => {
+            if (transformByQState.isRunning()) {
+                void stopTransformByQ(transformByQState.getJobId(), cancelSrc)
+            }
+        }),
 
-            Commands.register('aws.amazonq.showHistoryInHub', async () => {
-                await transformationHubViewProvider.updateContent('job history')
-            }),
+        Commands.register('aws.amazonq.showHistoryInHub', async () => {
+            await transformationHubViewProvider.updateContent('job history')
+        }),
 
-            Commands.register('aws.amazonq.showPlanProgressInHub', async (startTime: number) => {
-                await transformationHubViewProvider.updateContent('plan progress', startTime)
-            }),
+        Commands.register('aws.amazonq.showPlanProgressInHub', async (startTime: number) => {
+            await transformationHubViewProvider.updateContent('plan progress', startTime)
+        }),
 
-            Commands.register('aws.amazonq.showTransformationPlanInHub', async () => {
-                void vscode.commands.executeCommand(
-                    'markdown.showPreview',
-                    vscode.Uri.file(transformByQState.getPlanFilePath())
-                )
-            }),
+        Commands.register('aws.amazonq.showTransformationPlanInHub', async () => {
+            void vscode.commands.executeCommand(
+                'markdown.showPreview',
+                vscode.Uri.file(transformByQState.getPlanFilePath())
+            )
+        }),
 
-            workspaceChangeEvent
-        )
-    }
+        workspaceChangeEvent
+    )
 }


### PR DESCRIPTION
## Problem
There was a bug that happened when VSCode is opened without having first been signed into `Amazon Q` and the user attempts a code transformation. The Transformation Hub window would open, but would not update, and Code Transform would appear to hang.

## Solution

There is some initialization code that registers commands that other parts of Gumby uses to update the Transformation Hub, but this code was locked behind an auth check; if it fails, the commands are simply never registered, even if the user signs in again later.

This portion of the code is not necessary to lock behind an auth check (it doesn't save memory or make anything run faster to not have it run), so the check has been removed.

Testing:
1. User opens VSCode without already being signed in; the user signs in and then transforms a project successfully
2. User opens VSCode without already being signed in; the user signs in and then transforms a project unsuccessfully (partial success)
3. User opens VSCode without already being signed in; the user signs in and then is not able to submit a project to be transformed (fails to build locally)
4. User opens VSCode without already being signed in; the user signs in and then transforms a project that triggers HIL
5. User opens VSCode already having been signed in; the user transforms a project successfully

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
