### PR TITLE
telemetry: set more MetricBase fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "src.gen/@amzn/codewhisperer-streaming"
             ],
             "dependencies": {
-                "@aws-toolkits/telemetry": "^1.0.221",
+                "@aws-toolkits/telemetry": "^1.0.223",
                 "vscode-nls": "^5.2.0",
                 "vscode-nls-dev": "^4.0.4"
             },
@@ -3286,9 +3286,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.221",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.221.tgz",
-            "integrity": "sha512-mTWGvFPHTxEGGphVTGbYzPr6ebPCImYqB+6ZJHIzoVvKvnBPUJd/vMl9zQ04blq/kCV+ZfuxmG+bpOg2qmCLYg==",
+            "version": "1.0.223",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.223.tgz",
+            "integrity": "sha512-p2bINtiRQfNcvahgWfBMq0SoB1rum4kmtvMFpnFJo7ExUbHtXZyICFgIBGnGC+pihT6vHFXRcMD3vQhlZb3Krw==",
             "dependencies": {
                 "ajv": "^6.12.6",
                 "fs-extra": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "webpack-merge": "^5.10.0"
     },
     "dependencies": {
-        "@aws-toolkits/telemetry": "^1.0.221",
+        "@aws-toolkits/telemetry": "^1.0.223",
         "vscode-nls": "^5.2.0",
         "vscode-nls-dev": "^4.0.4"
     }

--- a/packages/core/src/amazonqFeatureDev/client/featureDev.ts
+++ b/packages/core/src/amazonqFeatureDev/client/featureDev.ts
@@ -21,7 +21,12 @@ import {
     PlanIterationLimitError,
     UnknownApiError,
 } from '../errors'
-import { ToolkitError, isAwsError, isCodeWhispererStreamingServiceException } from '../../shared/errors'
+import {
+    ToolkitError,
+    isAwsError,
+    isCodeWhispererStreamingServiceException,
+    getHttpStatusCode,
+} from '../../shared/errors'
 import { getCodewhispererConfig } from '../../codewhisperer/client/codewhisperer'
 import { LLMResponseType } from '../types'
 import { createCodeWhispererChatStreamingClient } from '../../shared/clients/codewhispererChatClient'
@@ -191,7 +196,7 @@ export class FeatureDevClient {
                     e.message,
                     'GeneratePlan',
                     e.name,
-                    e.$metadata?.httpStatusCode ?? streamResponseErrors[e.name] ?? 500
+                    getHttpStatusCode(e) ?? streamResponseErrors[e.name] ?? 500
                 )
             }
 

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -10,6 +10,7 @@ import {
     CodewhispererCompletionType,
     CodewhispererLanguage,
     CodewhispererTriggerType,
+    MetricBase,
     Result,
 } from '../../shared/telemetry/telemetry'
 import { References } from '../client/codewhisperer'
@@ -673,7 +674,7 @@ export class TransformByQStoppedError extends ToolkitError {
     }
 }
 
-export interface CodeScanTelemetryEntry {
+export interface CodeScanTelemetryEntry extends MetricBase {
     codewhispererCodeScanJobId?: string
     codewhispererLanguage: CodewhispererLanguage
     codewhispererCodeScanProjectBytes?: number

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -45,6 +45,7 @@ import { triggerPayloadToChatRequest } from './chatRequest/converter'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { openUrl } from '../../../shared/utilities/vsCodeUtils'
 import { randomUUID } from '../../../common/crypto'
+import { getHttpStatusCode } from '../../../shared/errors'
 
 export interface ChatControllerMessagePublishers {
     readonly processPromptChatMessage: MessagePublisher<PromptMessage>
@@ -590,7 +591,7 @@ export class ChatController {
             )
             await this.messenger.sendAIResponse(response, session, tabID, triggerID, triggerPayload)
         } catch (e: any) {
-            this.telemetryHelper.recordMessageResponseError(triggerPayload, tabID, e?.$metadata?.httpStatusCode ?? 0)
+            this.telemetryHelper.recordMessageResponseError(triggerPayload, tabID, getHttpStatusCode(e) ?? 0)
             // clears session, record telemetry before this call
             this.processException(e, tabID)
         }

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -22,7 +22,7 @@ import { ChatSession } from '../../../clients/chat/v0/chat'
 import { ChatException } from './model'
 import { CWCTelemetryHelper } from '../telemetryHelper'
 import { ChatPromptCommandType, TriggerPayload } from '../model'
-import { ToolkitError } from '../../../../shared/errors'
+import { getHttpStatusCode, getRequestId, ToolkitError } from '../../../../shared/errors'
 import { keys } from '../../../../shared/utilities/tsUtils'
 import { getLogger } from '../../../../shared/logger/logger'
 import { FeatureAuthState } from '../../../../codewhisperer/util/authUtil'
@@ -218,8 +218,8 @@ export class Messenger {
 
                 if (error instanceof CodeWhispererStreamingServiceException) {
                     errorMessage = error.message
-                    statusCode = error.$metadata?.httpStatusCode ?? 0
-                    requestID = error.$metadata.requestId
+                    statusCode = getHttpStatusCode(error) ?? 0
+                    requestID = getRequestId(error)
                 }
 
                 this.showChatExceptionMessage(

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -522,11 +522,15 @@ function hasFault<T>(error: T): error is T & { $fault: 'client' | 'server' } {
 }
 
 function hasMetadata<T>(error: T): error is T & Pick<CodeWhispererStreamingServiceException, '$metadata'> {
-    return typeof (error as { $metadata?: unknown }).$metadata === 'object'
+    return typeof (error as { $metadata?: unknown })?.$metadata === 'object'
+}
+
+function hasResponse<T>(error: T): error is T & Pick<ServiceException, '$response'> {
+    return typeof (error as { $response?: unknown })?.$response === 'object'
 }
 
 function hasName<T>(error: T): error is T & { name: string } {
-    return typeof (error as { name?: unknown }).name === 'string'
+    return typeof (error as { name?: unknown })?.name === 'string'
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -567,6 +571,17 @@ export function getRequestId(err: unknown): string | undefined {
     if (isAwsError(err)) {
         return err.requestId
     }
+}
+
+export function getHttpStatusCode(err: unknown): number | undefined {
+    if (hasResponse(err) && err?.$response?.statusCode !== undefined) {
+        return err?.$response?.statusCode
+    }
+    if (hasMetadata(err) && err.$metadata?.httpStatusCode !== undefined) {
+        return err.$metadata?.httpStatusCode
+    }
+
+    return undefined
 }
 
 export function isFilesystemError(err: unknown): boolean {

--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -15,7 +15,13 @@ import {
     MetricShapes,
     TelemetryBase,
 } from './telemetry.gen'
-import { getRequestId, getTelemetryReason, getTelemetryReasonDesc, getTelemetryResult } from '../errors'
+import {
+    getHttpStatusCode,
+    getRequestId,
+    getTelemetryReason,
+    getTelemetryReasonDesc,
+    getTelemetryResult,
+} from '../errors'
 import { entries, NumericKeys } from '../utilities/tsUtils'
 
 const AsyncLocalStorage: typeof AsyncLocalStorageClass =
@@ -151,14 +157,14 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
     public stop(err?: unknown): void {
         const duration = this.startTime !== undefined ? globals.clock.Date.now() - this.startTime.getTime() : undefined
 
-        // TODO: add reasonDesc/requestId to `MetricBase` so we can remove `as any` below.
         this.emit({
             duration,
             result: getTelemetryResult(err),
             reason: getTelemetryReason(err),
             reasonDesc: getTelemetryReasonDesc(err),
             requestId: getRequestId(err),
-        } as any as Partial<T>)
+            httpStatusCode: getHttpStatusCode(err),
+        } as Partial<T>)
 
         this.#startTime = undefined
     }

--- a/packages/core/src/test/shared/vscode/runCommand.test.ts
+++ b/packages/core/src/test/shared/vscode/runCommand.test.ts
@@ -6,20 +6,19 @@
 import globals from '../../../shared/extensionGlobals'
 
 import os from 'os'
-import vscode from 'vscode'
 import { promises as fsPromises } from 'fs'
 import * as sinon from 'sinon'
 import assert from 'assert'
-import { ToolkitError, UnknownError } from '../../../shared/errors'
+import { ToolkitError } from '../../../shared/errors'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import { Commands, defaultTelemetryThrottleMs } from '../../../shared/vscode/commands2'
-import { assertTelemetry, installFakeClock } from '../../testUtil'
+import { assertTelemetry, getMetrics, installFakeClock } from '../../testUtil'
 import { getTestWindow } from '../../shared/vscode/window'
 import { SystemUtilities } from '../../../shared/systemUtilities'
 import { makeTemporaryToolkitFolder } from '../../../shared'
 import path from 'path'
-import { SamCliError } from '../../../shared/sam/cli/samCliInvokerUtils'
 import * as env from '../../../shared/vscode/env'
+import { fakeErrorChain, getAwsServiceError } from '../errors.test'
 
 async function throwMe(errorOrFn?: Error | (() => Promise<never>)): Promise<void | never> {
     if (errorOrFn && !(errorOrFn instanceof Error)) {
@@ -28,40 +27,6 @@ async function throwMe(errorOrFn?: Error | (() => Promise<never>)): Promise<void
 
     if (errorOrFn) {
         throw errorOrFn
-    }
-}
-
-/** Creates a deep "cause chain", to test that error handler correctly gets the most relevant error. */
-export function fakeErrorChain(rootCause?: Error, toolkitErrors: boolean = true) {
-    try {
-        if (rootCause) {
-            throw rootCause
-        } else {
-            throw new Error('generic error 1')
-        }
-    } catch (e1) {
-        try {
-            const e = new UnknownError(e1)
-            throw e
-        } catch (e2) {
-            try {
-                const e = toolkitErrors ? new SamCliError('sam error', { cause: e2 as Error }) : new Error('error 3')
-                if (!toolkitErrors) {
-                    ;(e as any).cause = e2
-                }
-                throw e
-            } catch (e3) {
-                const e = toolkitErrors
-                    ? ToolkitError.chain(e3, 'ToolkitError message', {
-                          documentationUri: vscode.Uri.parse('https://docs.aws.amazon.com/toolkit-for-vscode/'),
-                      })
-                    : new Error('last error')
-                if (!toolkitErrors) {
-                    ;(e as any).cause = e3
-                }
-                throw e
-            }
-        }
     }
 }
 
@@ -191,7 +156,7 @@ describe('runCommand', function () {
                 viewLogsDialog.then(dialog => dialog.close()),
                 testCommand.execute(async () => {
                     const err = await SystemUtilities.writeFile(unwritableFile, 'bar').catch(e => e)
-                    throw fakeErrorChain(err, false)
+                    throw fakeErrorChain(err, new Error('error 3'))
                 }),
             ])
 
@@ -209,13 +174,33 @@ describe('runCommand', function () {
                 viewLogsDialog.then(dialog => dialog.close()),
                 testCommand.execute(async () => {
                     const err = await fsPromises.writeFile(unwritableFile, 'bar').catch(e => e)
-                    throw fakeErrorChain(err, false)
+                    throw fakeErrorChain(err, new Error('error 3'))
                 }),
             ])
 
             // TODO: commands.run() should use getBestError (if the top error is not ToolkitError)?
             // assertTelem('EACCES')
             assertTelem('Error')
+        })
+
+        it('AWS service error', async function () {
+            const expectedMsg = /Invalid client ID provided/
+            const viewLogsDialog = getTestWindow().waitForMessage(expectedMsg)
+            await Promise.all([
+                viewLogsDialog.then(dialog => dialog.close()),
+                testCommand.execute(async () => {
+                    const err = await getAwsServiceError()
+
+                    throw err
+                }),
+            ])
+
+            assertTelem('InvalidRequestException')
+            const metric = getMetrics('vscode_executeCommand')[0]
+            assert.match(metric.awsAccount ?? '', /not-set|n\/a|\d+/)
+            assert.match(metric.awsRegion ?? '', /not-set|\w+-\w+-\d+/)
+            assert.match(String(metric.duration) ?? '', /\d+/)
+            assert.match(metric.requestId ?? '', /[a-z0-9-]+/)
         })
     })
 


### PR DESCRIPTION
## Problem

`telemetry.run()` and `runCommand` do not set some "standard" fields on failure.


## Solution
Update `telemetry.run()` and `runCommand`.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
