### PR TITLE
fix: app composer generate suggestions unclickable when logged in

### DIFF
--- a/packages/amazonq/src/api.ts
+++ b/packages/amazonq/src/api.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GenerateAssistantResponseCommandOutput, GenerateAssistantResponseRequest } from '@amzn/codewhisperer-streaming'
+import { AuthUtil } from 'aws-core-vscode/codewhisperer'
+import { ChatSession } from 'aws-core-vscode/codewhispererChat'
+import { api } from 'aws-core-vscode/amazonq'
+
+export default {
+    chatApi: {
+        async chat(request: GenerateAssistantResponseRequest): Promise<GenerateAssistantResponseCommandOutput> {
+            const chatSession = new ChatSession()
+            return chatSession.chat(request)
+        },
+    },
+    authApi: {
+        async reauthIfNeeded() {
+            if (AuthUtil.instance.isConnectionExpired()) {
+                await AuthUtil.instance.showReauthenticatePrompt()
+            }
+        },
+        async getChatAuthState() {
+            return AuthUtil.instance.getChatAuthState()
+        },
+    },
+} satisfies api

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -14,11 +14,14 @@ import { isExtensionActive, VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
 import { registerSubmitFeedback } from 'aws-core-vscode/feedback'
 import { DevOptions } from 'aws-core-vscode/dev'
 import { Auth } from 'aws-core-vscode/auth'
+import api from './api'
 
 export async function activate(context: vscode.ExtensionContext) {
     // IMPORTANT: No other code should be added to this function. Place it in one of the following 2 functions where appropriate.
     await activateAmazonQCommon(context, false)
     await activateAmazonQNonCommon(context)
+
+    return api
 }
 
 /**

--- a/packages/core/src/amazonq/extApi.ts
+++ b/packages/core/src/amazonq/extApi.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode from 'vscode'
+import { VSCODE_EXTENSION_ID } from '../shared/utilities'
+import { GenerateAssistantResponseCommandOutput, GenerateAssistantResponseRequest } from '@amzn/codewhisperer-streaming'
+import { FeatureAuthState } from '../codewhisperer/util/authUtil'
+import { ToolkitError } from '../shared'
+
+/**
+ * This interface is used and exported by the amazon q extension. If you make a change here then
+ * update the corresponding api implementation in packages/amazonq/src/api.ts
+ */
+export interface api {
+    chatApi: {
+        chat(request: GenerateAssistantResponseRequest): Promise<GenerateAssistantResponseCommandOutput>
+    }
+    authApi: {
+        reauthIfNeeded(): Promise<void>
+        getChatAuthState(): Promise<FeatureAuthState>
+    }
+}
+
+export class AmazonqNotFoundError extends ToolkitError {
+    constructor() {
+        super(`${VSCODE_EXTENSION_ID.amazonq} is not installed`, { code: 'AmazonQNotInstalled' })
+    }
+}
+
+/**
+ * Get the extension API for Amazon q
+ *
+ * @returns The extension API for Amazon q, or undefined if the extension is not installed
+ */
+export async function getAmazonqApi(): Promise<api | undefined> {
+    const ext = vscode.extensions.getExtension(VSCODE_EXTENSION_ID.amazonq)
+    if (!ext) {
+        return undefined
+    }
+    return ext.activate()
+}

--- a/packages/core/src/amazonq/index.ts
+++ b/packages/core/src/amazonq/index.ts
@@ -13,6 +13,8 @@ export { showAmazonQWalkthroughOnce } from './onboardingPage/walkthrough'
 export { openAmazonQWalkthrough } from './onboardingPage/walkthrough'
 export { LspController, Content } from './lsp/lspController'
 export { LspClient } from './lsp/lspClient'
+export { api } from './extApi'
+
 /**
  * main from createMynahUI is a purely browser dependency. Due to this
  * we need to create a wrapper function that will dynamically execute it

--- a/packages/core/src/applicationcomposer/commands/openTemplateInComposer.ts
+++ b/packages/core/src/applicationcomposer/commands/openTemplateInComposer.ts
@@ -6,19 +6,25 @@
 import { Commands } from '../../shared/vscode/commands2'
 import { ApplicationComposerManager } from '../webviewManager'
 import vscode from 'vscode'
-import { AuthUtil } from '../../codewhisperer/util/authUtil'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { ToolkitError } from '../../shared/errors'
+import { getAmazonqApi } from '../../amazonq/extApi'
 
 export const openTemplateInComposerCommand = Commands.declare(
     'aws.openInApplicationComposer',
     (manager: ApplicationComposerManager) => async (arg?: vscode.TextEditor | vscode.Uri) => {
-        const authState = await AuthUtil.instance.getChatAuthState()
-
         let result: vscode.WebviewPanel | undefined
         await telemetry.appcomposer_openTemplate.run(async span => {
+            const amazonqApi = await getAmazonqApi()
+
+            let hasChatAuth = false
+            if (amazonqApi) {
+                const authState = await amazonqApi.authApi.getChatAuthState()
+                hasChatAuth = authState.codewhispererChat === 'connected' || authState.codewhispererChat === 'expired'
+            }
+
             span.record({
-                hasChatAuth: authState.codewhispererChat === 'connected' || authState.codewhispererChat === 'expired',
+                hasChatAuth,
             })
             arg ??= vscode.window.activeTextEditor
             const input = arg instanceof vscode.Uri ? arg : arg?.document

--- a/packages/core/src/applicationcomposer/messageHandlers/generateResourceHandler.ts
+++ b/packages/core/src/applicationcomposer/messageHandlers/generateResourceHandler.ts
@@ -11,10 +11,9 @@ import {
     Command,
     MessageType,
 } from '../types'
-import { ChatSession } from '../../codewhispererChat/clients/chat/v0/chat'
-import { AuthUtil } from '../../codewhisperer/util/authUtil'
 import globals from '../../shared/extensionGlobals'
 import { getLogger } from '../../shared/logger/logger'
+import { AmazonqNotFoundError, getAmazonqApi } from '../../amazonq/extApi'
 
 const TIMEOUT = 30_000
 
@@ -54,7 +53,10 @@ async function generateResource(prompt: string) {
     let startTime = globals.clock.Date.now()
 
     try {
-        const chatSession = new ChatSession()
+        const amazonqApi = await getAmazonqApi()
+        if (!amazonqApi) {
+            throw new AmazonqNotFoundError()
+        }
         const request: GenerateAssistantResponseRequest = {
             conversationState: {
                 currentMessage: {
@@ -72,13 +74,11 @@ async function generateResource(prompt: string) {
         let supplementaryWebLinks: SupplementaryWebLink[] = []
         let references: Reference[] = []
 
-        if (AuthUtil.instance.isConnectionExpired()) {
-            await AuthUtil.instance.showReauthenticatePrompt()
-        }
+        await amazonqApi.authApi.reauthIfNeeded()
 
         startTime = globals.clock.Date.now()
         // TODO-STARLING - Revisit to see if timeout still needed prior to launch
-        const data = await timeout(chatSession.chat(request), TIMEOUT)
+        const data = await timeout(amazonqApi.chatApi.chat(request), TIMEOUT)
         const initialResponseTime = globals.clock.Date.now() - startTime
         getLogger().debug(`CW Chat initial response: ${JSON.stringify(data, undefined, 2)}, ${initialResponseTime} ms`)
         if (data['$metadata']) {

--- a/packages/core/src/applicationcomposer/messageHandlers/initMessageHandler.ts
+++ b/packages/core/src/applicationcomposer/messageHandlers/initMessageHandler.ts
@@ -5,19 +5,24 @@
 
 import path from 'path'
 import { InitResponseMessage, MessageType, WebviewContext, Command } from '../types'
-import { AuthUtil } from '../../codewhisperer/util/authUtil'
+import { getAmazonqApi } from '../../amazonq/extApi'
 
 export async function initMessageHandler(context: WebviewContext) {
     const filePath = context.defaultTemplatePath
-    const authState = await AuthUtil.instance.getChatAuthState()
+    const amazonqApi = await getAmazonqApi()
+    let isConnectedToCodeWhisperer = false
+    if (amazonqApi) {
+        const authState = await amazonqApi.authApi.getChatAuthState()
+        isConnectedToCodeWhisperer =
+            authState.codewhispererChat === 'connected' || authState.codewhispererChat === 'expired'
+    }
 
     const responseMessage: InitResponseMessage = {
         messageType: MessageType.RESPONSE,
         command: Command.INIT,
         templateFileName: path.basename(filePath),
         templateFilePath: filePath,
-        isConnectedToCodeWhisperer:
-            authState.codewhispererChat === 'connected' || authState.codewhispererChat === 'expired',
+        isConnectedToCodeWhisperer,
     }
 
     await context.panel.webview.postMessage(responseMessage)

--- a/packages/core/src/codewhispererChat/index.ts
+++ b/packages/core/src/codewhispererChat/index.ts
@@ -6,3 +6,4 @@
 export { FocusAreaContextExtractor } from './editor/context/focusArea/focusAreaExtractor'
 export { TryChatCodeLensProvider, resolveModifierKey, tryChatCodeLensCommand } from './editor/codelens'
 export { focusAmazonQPanel } from './commands/registerCommands'
+export { ChatSession } from './clients/chat/v0/chat'

--- a/packages/core/src/test/applicationcomposer/messageHandlers/generateResourceHandler.test.ts
+++ b/packages/core/src/test/applicationcomposer/messageHandlers/generateResourceHandler.test.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import sinon from 'sinon'
+import { createTemplate, createWebviewContext } from '../utils'
+import { generateResourceHandler } from '../../../applicationcomposer/messageHandlers/generateResourceHandler'
+import { Command, MessageType } from '../../../applicationcomposer/types'
+
+describe('generateResourceHandler', function () {
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    it('amazon q is not installed', async () => {
+        const panel = await createTemplate()
+        const postMessageSpy = sinon.spy(panel.webview, 'postMessage')
+        const context = await createWebviewContext({
+            panel,
+        })
+        await generateResourceHandler(
+            {
+                command: Command.GENERATE_RESOURCE,
+                messageType: MessageType.REQUEST,
+                prompt: '',
+                traceId: '0',
+            },
+            context
+        )
+        assert.ok(postMessageSpy.calledOnce)
+        assert.deepStrictEqual(postMessageSpy.getCall(0).args[0].isSuccess, false)
+    })
+})

--- a/packages/core/src/test/applicationcomposer/messageHandlers/initMessageHandler.test.ts
+++ b/packages/core/src/test/applicationcomposer/messageHandlers/initMessageHandler.test.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import sinon from 'sinon'
+import { initMessageHandler } from '../../../applicationcomposer/messageHandlers/initMessageHandler'
+import { createTemplate, createWebviewContext } from '../utils'
+
+describe('initMessageHandler', function () {
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    it('not connected to codewhisperer', async () => {
+        const panel = await createTemplate()
+        const postMessageSpy = sinon.spy(panel.webview, 'postMessage')
+        const context = await createWebviewContext({
+            panel,
+        })
+        await initMessageHandler(context)
+        assert.ok(postMessageSpy.calledOnce)
+        assert.deepStrictEqual(postMessageSpy.getCall(0).args[0].isConnectedToCodeWhisperer, false)
+    })
+})

--- a/packages/core/src/test/applicationcomposer/utils.ts
+++ b/packages/core/src/test/applicationcomposer/utils.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { ApplicationComposerManager } from '../../applicationcomposer/webviewManager'
+import { globals } from '../../shared'
+import { WebviewContext } from '../../applicationcomposer/types'
+import { MockDocument } from '../fake/fakeDocument'
+
+export async function createTemplate() {
+    const manager = new ApplicationComposerManager(globals.context)
+    const panel = await manager.createTemplate()
+    assert.ok(panel)
+    return panel
+}
+
+export async function createWebviewContext({
+    defaultTemplateName,
+    defaultTemplatePath,
+    disposables,
+    panel,
+    fileWatches,
+    textDocument,
+    workSpacePath,
+}: Partial<WebviewContext>): Promise<WebviewContext> {
+    return {
+        defaultTemplateName: defaultTemplateName ?? '',
+        defaultTemplatePath: defaultTemplatePath ?? '',
+        disposables: disposables ?? [],
+        panel: panel ?? (await createTemplate()),
+        fileWatches: fileWatches ?? {},
+        textDocument: textDocument ?? new MockDocument('', 'foo', async () => true),
+        workSpacePath: workSpacePath ?? '',
+    }
+}

--- a/packages/toolkit/.changes/next-release/Bug Fix-2579c8e9-c8a2-45f8-bebf-228d7bd5796d.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-2579c8e9-c8a2-45f8-bebf-228d7bd5796d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "App composer generate suggestion unclickable when logged in"
+}


### PR DESCRIPTION
## Problem
- app composers generate suggestions became unclickable when we switched back to seperate auth since they were relying on auth session sharing

## Solution
- allow extensions to call into auth/chat for amazon q. This allows toolkit to have features that depend on q auth without exposing all of auth itself

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
