### PR TITLE
web: minor Timer/Timeout change for CW

### DIFF
--- a/packages/core/src/shared/utilities/timeoutUtils.ts
+++ b/packages/core/src/shared/utilities/timeoutUtils.ts
@@ -101,12 +101,14 @@ export class Timeout {
             globals.clock.clearTimeout(this._timerTimeout)
             this._timerTimeout = this.createTimeout()
         } else {
-            // These will not align, but we don't have visibility into a NodeJS.Timeout
-            // so remainingtime will be approximate. Timers are approximate anyway and are
-            // not highly accurate in when they fire.
-            this._endTime = globals.clock.Date.now() + this._timeoutLength
+            // This is a node timeout instance, which has refresh built in
             this._timerTimeout = this._timerTimeout.refresh()
         }
+
+        // These will not align, but we don't have visibility into a NodeJS.Timeout
+        // so remainingtime will be approximate. Timers are approximate anyway and are
+        // not highly accurate in when they fire.
+        this._endTime = globals.clock.Date.now() + this._timeoutLength
     }
 
     /**

--- a/packages/core/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/timeoutUtils.test.ts
@@ -9,7 +9,8 @@ import * as timeoutUtils from '../../../shared/utilities/timeoutUtils'
 import { installFakeClock, tickPromise } from '../../../test/testUtil'
 import { sleep } from '../../../shared/utilities/timeoutUtils'
 
-describe('timeoutUtils', async function () {
+// We export this describe() so it can be used in the web tests as well
+export const timeoutUtilsDescribe = describe('timeoutUtils', async function () {
     let clock: FakeTimers.InstalledClock
 
     before(function () {

--- a/packages/core/src/testWeb/shared/utilities/timeoutUtils.test.ts
+++ b/packages/core/src/testWeb/shared/utilities/timeoutUtils.test.ts
@@ -1,0 +1,13 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * IMPORTANT: We are importing the same test from the node timeoutUtils
+ * since the behavior should be the exact same.
+ *
+ * Any web specific tests should be made within their own `describe()`.
+ */
+import { timeoutUtilsDescribe } from '../../../test/shared/utilities/timeoutUtils.test'
+timeoutUtilsDescribe


### PR DESCRIPTION
## Problem

When in Web mode, we were using the Node.js Timeout `refresh()` method. This does not exist
in web mode.

## Solution

- Update the use with our environment agnostic `Timeout` class, which works in web or node.
- Copy the timeout unit tests from our regular `test/` in to the web mode tests. Fixed a minor bug when refreshing in web mode, and now they all pass without any modifications to the tests.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
