### PR TITLE
feat(telemetry): emit on opt-out and opt-in 

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/service/codewhisperer.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/codewhisperer.test.ts
@@ -36,9 +36,9 @@ describe('codewhisperer', async function () {
         telemetryEnabledDefault = globals.telemetry.telemetryEnabled
     })
 
-    afterEach(function () {
+    afterEach(async function () {
         sinon.restore()
-        globals.telemetry.telemetryEnabled = telemetryEnabledDefault
+        await globals.telemetry.setTelemetryEnabled(telemetryEnabledDefault)
     })
 
     it('sendTelemetryEvent for userTriggerDecision should respect telemetry optout status', async function () {
@@ -137,7 +137,7 @@ describe('codewhisperer', async function () {
         } as Request<SendTelemetryEventResponse, AWSError>)
 
         const authUtilStub = sinon.stub(AuthUtil.instance, 'isValidEnterpriseSsoInUse').returns(isSso)
-        globals.telemetry.telemetryEnabled = isTelemetryEnabled
+        await globals.telemetry.setTelemetryEnabled(isTelemetryEnabled)
         await codeWhispererClient.sendTelemetryEvent({ telemetryEvent: payload })
         const expectedOptOutPreference = isTelemetryEnabled ? 'OPTIN' : 'OPTOUT'
         if (isSso || isTelemetryEnabled) {

--- a/packages/amazonq/test/unit/codewhisperer/tracker/codewhispererTracker.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/tracker/codewhispererTracker.test.ts
@@ -34,13 +34,13 @@ describe('codewhispererTracker', function () {
             assert.ok(!pushSpy.neverCalledWith(suggestion))
         })
 
-        it('Should not enque when telemetry is disabled', function () {
-            globals.telemetry.telemetryEnabled = false
+        it('Should not enque when telemetry is disabled', async function () {
+            await globals.telemetry.setTelemetryEnabled(false)
             const suggestion = createAcceptedSuggestionEntry()
             const pushSpy = sinon.spy(Array.prototype, 'push')
             CodeWhispererTracker.getTracker().enqueue(suggestion)
             assert.ok(pushSpy.neverCalledWith(suggestion))
-            globals.telemetry.telemetryEnabled = true
+            await globals.telemetry.setTelemetryEnabled(true)
         })
     })
 
@@ -67,11 +67,11 @@ describe('codewhispererTracker', function () {
         })
 
         it('Should skip if telemetry is disabled', async function () {
-            globals.telemetry.telemetryEnabled = false
+            await globals.telemetry.setTelemetryEnabled(false)
             const getTimeSpy = sinon.spy(Date.prototype, 'getTime')
             await CodeWhispererTracker.getTracker().flush()
             assert.ok(!getTimeSpy.called)
-            globals.telemetry.telemetryEnabled = true
+            await globals.telemetry.setTelemetryEnabled(true)
         })
     })
 

--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -18,8 +18,8 @@ describe('editorContext', function () {
         telemetryEnabledDefault = globals.telemetry.telemetryEnabled
     })
 
-    afterEach(function () {
-        globals.telemetry.telemetryEnabled = telemetryEnabledDefault
+    afterEach(async function () {
+        await globals.telemetry.setTelemetryEnabled(telemetryEnabledDefault)
     })
 
     describe('extractContextForCodeWhisperer', function () {
@@ -136,7 +136,7 @@ describe('editorContext', function () {
         it('Should return expected fields for optOut, nextToken and reference config', async function () {
             const nextToken = 'testToken'
             const optOutPreference = false
-            globals.telemetry.telemetryEnabled = false
+            await globals.telemetry.setTelemetryEnabled(false)
             const editor = createMockTextEditor('import math\ndef two_sum(nums, target):\n', 'test.py', 'python', 1, 17)
             const actual = await EditorContext.buildListRecommendationRequest(editor, nextToken, optOutPreference)
 

--- a/packages/core/src/test/globalSetup.test.ts
+++ b/packages/core/src/test/globalSetup.test.ts
@@ -79,7 +79,7 @@ export const mochaHooks = {
         }
 
         // Enable telemetry features for tests. The metrics won't actually be posted.
-        globals.telemetry.telemetryEnabled = true
+        await globals.telemetry.setTelemetryEnabled(true)
         globals.telemetry.clearRecords()
         globals.telemetry.logger.clear()
         TelemetryDebounceInfo.instance.clear()

--- a/packages/core/src/testInteg/schema/schema.test.ts
+++ b/packages/core/src/testInteg/schema/schema.test.ts
@@ -73,7 +73,7 @@ describe('getDefaultSchemas()', () => {
 
     it('uses cache after initial fetch for CFN/SAM schema', async () => {
         fs.removeSync(GlobalStorage.samAndCfnSchemaDestinationUri().fsPath)
-        globals.telemetry.telemetryEnabled = true
+        await globals.telemetry.setTelemetryEnabled(true)
         globals.telemetry.clearRecords()
         globals.telemetry.logger.clear()
         await getDefaultSchemas()


### PR DESCRIPTION
- Emits 1 final metric on opt-out that will let us know the user opted out.
- Also, on opt out it will emit any telemetry that was previously recorded and not sent.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
