### PR TITLE
fix(codecatalyst): simplify InactivityMessage

### DIFF
--- a/packages/core/src/codecatalyst/devEnv.ts
+++ b/packages/core/src/codecatalyst/devEnv.ts
@@ -7,9 +7,7 @@ import { DevEnvironment } from '../shared/clients/codecatalystClient'
 import { DevEnvActivity, DevEnvClient } from '../shared/clients/devenvClient'
 import globals from '../shared/extensionGlobals'
 import * as vscode from 'vscode'
-import { Timeout, waitUntil } from '../shared/utilities/timeoutUtils'
-import { showMessageWithCancel } from '../shared/utilities/messages'
-import { isCloud9 } from '../shared/extensionUtilities'
+import { waitUntil } from '../shared/utilities/timeoutUtils'
 import { getLogger } from '../shared/logger'
 import { CodeCatalystAuthenticationProvider } from './auth'
 import { getThisDevEnv } from './model'
@@ -152,7 +150,6 @@ export function shouldSendActivity(inactivityTimeoutMin: DevEnvironment['inactiv
 /** Shows a "Dev env will shutdown in x minutes due to inactivity" warning. */
 export class InactivityMessage implements vscode.Disposable {
     #showMessageTimer: NodeJS.Timeout | undefined
-    private progressTimeout = new Timeout(1)
     /** Show a message this many minutes before auto-shutdown. */
     public readonly shutdownWarningThreshold = 5
 
@@ -200,12 +197,10 @@ export class InactivityMessage implements vscode.Disposable {
 
                 this.clear()
                 this.show(
-                    devEnvActivity,
                     Math.round(Math.max(0, minutesSinceActivity + minutesUntilMessage)),
                     Math.round(Math.max(0, minutesUntilShutdown - minutesUntilMessage)),
                     userIsActive,
-                    willRefreshOnStaleTimestamp,
-                    oneMin
+                    willRefreshOnStaleTimestamp
                 ).catch(e => {
                     getLogger().error('InactivityMessage.show failed: %s', (e as Error).message)
                 })
@@ -246,15 +241,12 @@ export class InactivityMessage implements vscode.Disposable {
      * @param willRefreshOnStaleTimestamp sanity checks with the dev env api that the latest activity timestamp
      *                                    is the same as what this client has locally. If stale, the warning message
      *                                    will be refreshed asynchronously. Returns true if the message will be refreshed.
-     * @param oneMin Milliseconds in a "minute". Used in tests.
      */
     async show(
-        devEnvActivity: DevEnvActivity,
         minutesUserWasInactive: number,
         minutesUntilShutdown: number,
         userIsActive: () => void,
-        willRefreshOnStaleTimestamp: () => Promise<boolean>,
-        oneMin: number
+        willRefreshOnStaleTimestamp: () => Promise<boolean>
     ) {
         getLogger().debug(
             'InactivityMessage.show: minutesUserWasInactive=%d minutesUntilShutdown=%d',
@@ -262,68 +254,26 @@ export class InactivityMessage implements vscode.Disposable {
             minutesUntilShutdown
         )
 
-        // Hide any current message.
-        this.progressTimeout.dispose()
-
         if (await willRefreshOnStaleTimestamp()) {
             return
         }
 
-        if (minutesUntilShutdown <= 1) {
-            const imHere = "I'm here!"
-            return vscode.window
-                .showWarningMessage(
-                    `Your CodeCatalyst Dev Environment has been inactive for ${minutesUserWasInactive} minutes, and will stop soon.`,
-                    { modal: true },
-                    imHere
-                )
-                .then(res => {
-                    if (res === imHere) {
-                        userIsActive()
-                    }
-                })
-        }
-
-        // Show a new message every minute
-        this.progressTimeout = new Timeout(oneMin)
-        this.progressTimeout.token.onCancellationRequested(c => {
-            getLogger().debug('InactivityMessage.show: CancelEvent.agent=%s', c.agent)
-            if (c.agent === 'user') {
-                // User clicked the 'Cancel' button, indicate they are active.
-                userIsActive()
-            } else {
-                // The message timed out, show the updated message.
-                void this.show(
-                    devEnvActivity,
-                    minutesUserWasInactive + 1,
-                    minutesUntilShutdown - 1,
-                    userIsActive,
-                    willRefreshOnStaleTimestamp,
-                    oneMin
-                )
-            }
-        })
-        if (isCloud9()) {
-            // C9 does not support message with progress, so just show a warning message.
-            return vscode.window
-                .showWarningMessage(this.getMessage(minutesUserWasInactive, minutesUntilShutdown), 'Cancel')
-                .then(() => {
-                    this.progressTimeout.cancel()
-                })
-        } else {
-            // Show cancellable "progress" message.
-            return void showMessageWithCancel(
-                this.getMessage(minutesUserWasInactive, minutesUntilShutdown),
-                this.progressTimeout
+        const imHere = "I'm here!"
+        return vscode.window
+            .showWarningMessage(
+                `Your CodeCatalyst Dev Environment has been inactive for ${minutesUserWasInactive} minutes, and will stop soon.`,
+                { modal: true },
+                imHere
             )
-        }
+            .then(res => {
+                if (res === imHere) {
+                    userIsActive()
+                }
+            })
     }
 
     /** Cancels or disposes the existing message and timer. */
     clear() {
-        // This also dismisses the message if it is currently displaying.
-        this.progressTimeout.cancel()
-
         if (this.#showMessageTimer) {
             clearTimeout(this.#showMessageTimer)
             this.#showMessageTimer = undefined
@@ -332,9 +282,5 @@ export class InactivityMessage implements vscode.Disposable {
 
     dispose() {
         this.clear()
-    }
-
-    private getMessage(inactiveMinutes: number, remainingMinutes: number) {
-        return `Your CodeCatalyst Dev Environment has been inactive for ${inactiveMinutes} minutes, and will stop in ${remainingMinutes} minutes.`
     }
 }

--- a/packages/core/src/testInteg/codecatalyst/devEnv.test.ts
+++ b/packages/core/src/testInteg/codecatalyst/devEnv.test.ts
@@ -22,27 +22,31 @@ describe('shouldSendActivity', function () {
     })
 })
 
-describe('InactivityMessages', function () {
+describe('InactivityMessage', function () {
     /** Actual minute in prod is this value instead so testing is faster. */
     let relativeMinuteMillis: number
     let testWindow: TestWindow
     let devEnvActivity: sinon.SinonStubbedInstance<DevEnvActivity>
     let actualMessages: { message: string; minute: number }[] = []
     let inactivityMsg: InactivityMessage
+    let userActivity: number
 
     beforeEach(function () {
-        relativeMinuteMillis = 200
+        relativeMinuteMillis = 100
         testWindow = getTestWindow()
         inactivityMsg = new InactivityMessage()
+        userActivity = 0
+        setInitialOffset(0)
 
         devEnvActivity = sinon.createStubInstance(DevEnvActivity)
-        // Setup for DevEnvClient stub to call the onUserActivity event callback code when sendActivityUpdate() is called
+        devEnvActivity.sendActivityUpdate.callsFake(async () => {
+            userActivity += 1
+            const timestamp = getLatestTimestamp()
+            return timestamp
+        })
         devEnvActivity.onActivityUpdate.callsFake(activityCallback => {
-            devEnvActivity.sendActivityUpdate.callsFake(async () => {
-                const timestamp = getLatestTimestamp()
-                activityCallback(timestamp)
-                return timestamp
-            })
+            const timestamp = getLatestTimestamp()
+            activityCallback(timestamp)
         })
         devEnvActivity.isLocalActivityStale.callsFake(async () => {
             return false
@@ -56,97 +60,47 @@ describe('InactivityMessages', function () {
         testWindow.dispose()
     })
 
-    it('shows expected messages 5 minutes before shutdown on a 15 minute inactivity timeout', async function () {
+    it('shows warning 5 minutes before shutdown for 15 minute timeout', async function () {
+        setInitialOffset(9)
         await inactivityMsg.init(15, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
 
         await assertMessagesShown([
-            ['Your CodeCatalyst Dev Environment has been inactive for 10 minutes, and will stop in 5 minutes.', 10],
-            ['Your CodeCatalyst Dev Environment has been inactive for 11 minutes, and will stop in 4 minutes.', 11],
-            ['Your CodeCatalyst Dev Environment has been inactive for 12 minutes, and will stop in 3 minutes.', 12],
-            ['Your CodeCatalyst Dev Environment has been inactive for 13 minutes, and will stop in 2 minutes.', 13],
-            ['Your CodeCatalyst Dev Environment has been inactive for 14 minutes, and will stop soon.', 14],
+            ['Your CodeCatalyst Dev Environment has been inactive for 10 minutes, and will stop soon.', 10],
         ])
     })
 
-    it('shows expected messages 5 minutes before shutdown on a 60 minute inactivity timeout', async function () {
+    it('shows warning 5 minutes before shutdown for 60 minute timeout', async function () {
+        setInitialOffset(54)
         await inactivityMsg.init(60, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
-        setInitialOffset(57)
-        await devEnvActivity.sendActivityUpdate()
-        await waitUntil(async () => actualMessages.length > 0, { interval: 10 })
-        setInitialOffset(58)
-        await devEnvActivity.sendActivityUpdate()
-        await waitUntil(async () => actualMessages.length > 2, { interval: 10 })
 
         await assertMessagesShown([
-            ['Your CodeCatalyst Dev Environment has been inactive for 57 minutes, and will stop in 3 minutes.', 0],
-            ['Your CodeCatalyst Dev Environment has been inactive for 58 minutes, and will stop in 2 minutes.', 0],
-            ['Your CodeCatalyst Dev Environment has been inactive for 59 minutes, and will stop soon.', 1],
+            ['Your CodeCatalyst Dev Environment has been inactive for 55 minutes, and will stop soon.', 55],
         ])
     })
 
-    it('resets the inactivity countdown when a user clicks on a button in any activity message', async function () {
-        let isFirstMessage = true
-        testWindow.onDidShowMessage(async message => {
-            if (message.message.endsWith('stop soon.')) {
-                // User hits the "I'm here!" button on the inactivity shutdown message
-                message.selectItem("I'm here!")
-                return
-            }
-
-            if (!isFirstMessage) {
-                return
-            }
-            isFirstMessage = false
-            // User hits the 'Cancel' button on the first inactivity warning message
-            message.selectItem('Cancel')
-        })
-
-        await inactivityMsg.init(7, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
+    it('resets inactivity countdown when a user confirms the message', async function () {
+        await inactivityMsg.init(10, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        const msg = await testWindow.waitForMessage(/Dev Environment has been inactive/)
+        assert.deepStrictEqual(userActivity, 1)
+        msg.selectItem("I'm here!")
+        await waitUntil(async () => userActivity > 1, { truthy: true, interval: 100, timeout: 5_000 })
+        assert.deepStrictEqual(userActivity, 2, 'confirming the message should trigger user activity')
 
         await assertMessagesShown([
-            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, and will stop in 5 minutes.', 2],
-            // User clicked 'Cancel' on the warning message so timer was reset
-            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, and will stop in 5 minutes.', 4],
-            ['Your CodeCatalyst Dev Environment has been inactive for 3 minutes, and will stop in 4 minutes.', 5],
-            ['Your CodeCatalyst Dev Environment has been inactive for 4 minutes, and will stop in 3 minutes.', 6],
-            ['Your CodeCatalyst Dev Environment has been inactive for 5 minutes, and will stop in 2 minutes.', 7],
-            ['Your CodeCatalyst Dev Environment has been inactive for 6 minutes, and will stop soon.', 8],
-            // User clicked "I'm here!" on the shutdown message so timer was reset
-            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, and will stop in 5 minutes.', 10],
+            ['Your CodeCatalyst Dev Environment has been inactive for 5 minutes, and will stop soon.', 5],
         ])
     })
 
-    it('takes in to consideration 2 1/2 minutes have already passed for an inactive external client.', async function () {
+    it('offsets when 2.5 minutes have already passed for an inactive external client', async function () {
         setInitialOffset(2.5)
         await inactivityMsg.init(9, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
-        await devEnvActivity.sendActivityUpdate()
 
         await assertMessagesShown([
-            ['Your CodeCatalyst Dev Environment has been inactive for 4 minutes, and will stop in 5 minutes.', 4],
-            ['Your CodeCatalyst Dev Environment has been inactive for 5 minutes, and will stop in 4 minutes.', 5],
-            ['Your CodeCatalyst Dev Environment has been inactive for 6 minutes, and will stop in 3 minutes.', 6],
-            ['Your CodeCatalyst Dev Environment has been inactive for 7 minutes, and will stop in 2 minutes.', 7],
-            ['Your CodeCatalyst Dev Environment has been inactive for 8 minutes, and will stop soon.', 8],
+            ['Your CodeCatalyst Dev Environment has been inactive for 4 minutes, and will stop soon.', 4],
         ])
     })
 
-    it('does not show any inactivity message if a newer user activity is found using the api', async function () {
+    it('does not show inactivity message if user activity is found using the API', async function () {
         // This gets checked each time before we decide to show the message.
         // If a new user activity exists then we abort showing the message.
         devEnvActivity.isLocalActivityStale.callsFake(async () => {
@@ -191,22 +145,6 @@ describe('InactivityMessages', function () {
         }
     }
 
-    /**
-     * Starts capturing all vscode messages shown and records them in {@link actualMessages}.
-     *
-     * The `minute` field in {@link actualMessages} records the minute the message was shown.
-     * This value is relative to {@link relativeMinuteMillis}.
-     */
-    function startCapturingMessages() {
-        const start = Date.now()
-        const messages: { message: string; minute: number }[] = []
-        testWindow.onDidShowMessage(async message => {
-            const now = Date.now()
-            messages.push({ message: message.message, minute: Math.floor((now - start) / relativeMinuteMillis) })
-        })
-        actualMessages = messages
-    }
-
     let _initialOffset = 0
     /**
      * This is used for the edge case where the MDE was previously updated with an activity
@@ -219,8 +157,26 @@ describe('InactivityMessages', function () {
     function getLatestTimestamp() {
         let timestamp = Date.now()
         timestamp -= _initialOffset
-        _initialOffset = 0
 
         return timestamp
+    }
+
+    /**
+     * Starts capturing all vscode messages shown and records them in {@link actualMessages}.
+     *
+     * The `minute` field in {@link actualMessages} records the minute the message was shown.
+     * This value is relative to {@link relativeMinuteMillis}.
+     */
+    function startCapturingMessages() {
+        const start = Date.now()
+        const messages: { message: string; minute: number }[] = []
+        testWindow.onDidShowMessage(async message => {
+            const now = Date.now()
+            messages.push({
+                message: message.message,
+                minute: Math.floor((now + _initialOffset - start) / relativeMinuteMillis),
+            })
+        })
+        actualMessages = messages
     }
 })

--- a/packages/toolkit/.changes/next-release/Feature-56b5e5bc-9891-421f-a352-bcc24f257e94.json
+++ b/packages/toolkit/.changes/next-release/Feature-56b5e5bc-9891-421f-a352-bcc24f257e94.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeCatalyst: always show Dev Environment timeout warning as modal prompt"
+}


### PR DESCRIPTION
## Problem


- The "progress" message tests are flaky because of the complex logic, and sometimes fail:
  ```
    1) InactivityMessages
         shows expected messages 5 minutes before shutdown on a 60 minute inactivity timeout:
       AssertionError [ERR_ASSERTION]: Expected 3 messages, but got 2
        at assertMessagesShown (src/testInteg/codecatalyst/devEnv.test.ts:182:20)
        at async Context.<anonymous> (src/testInteg/codecatalyst/devEnv.test.ts:85:9)
  ```
- Toolkit has complex logic for showing a "progress" message when the codecatalyst dev env timeout is approaching, followed by different logic for showing the "final" message. This isn't worth the complexity because if the user sees the message, clicking it is zero-cost and will happen immediately, otherwise the user isn't active and won't see any of the messages anyway.
- The non-modal progress message may be *hidden* if the user enabled vscode's "do not disturb" feature.

## Solution

- Remove the non-modal "progress" message. Only show the final, modal message **starting 5 min before shutdown**. Display it until user clicks it.

Followup to https://taskei.amazon.dev/tasks/IDE-13892

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
