### PR TITLE
fix: restorePackageJson failure after stopping toolkit extension

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -71,7 +71,8 @@
         "createRelease": "ts-node ../../scripts/createRelease.ts",
         "newChange": "ts-node ../../scripts/newChange.ts",
         "watch": "npm run clean && npm run buildScripts && tsc -watch -p ./",
-        "copyPackageJson": "ts-node ./scripts/build/handlePackageJson"
+        "copyPackageJson": "ts-node ./scripts/build/handlePackageJson",
+        "restorePackageJson": "ts-node ./scripts/build/handlePackageJson --restore"
     },
     "devDependencies": {},
     "dependencies": {

--- a/packages/toolkit/scripts/build/handlePackageJson.ts
+++ b/packages/toolkit/scripts/build/handlePackageJson.ts
@@ -13,7 +13,7 @@
  * TODO: IDE-12831 tracks work to eliminate this script.
  *
  * Args:
- *   --restore: (XXX: this mode was inlined into the package.ts script.)
+ *   --restore: reverts the package json changes to the original state
  *   --development: performs actions that should only be done during development and not production
  */
 
@@ -21,8 +21,7 @@ import * as fs from 'fs-extra'
 
 function main() {
     const args = process.argv.slice(2)
-    // XXX: --restore mode was inlined into the package.ts script.
-    const restoreMode = false
+    const restoreMode = args.includes('--restore')
 
     if (args.includes('--development')) {
         /** When we actually package the extension the null extension does not occur, so we will skip this hack */
@@ -34,14 +33,13 @@ function main() {
     const coreLibPackageJsonFile = '../core/package.json'
 
     if (restoreMode) {
-        // XXX: --restore mode was inlined into the package.ts script.
         // TODO: IDE-12831 will eliminate this entire script.
-        // try {
-        //     fs.copyFileSync(backupJsonFile, packageJsonFile)
-        //     fs.unlinkSync(backupJsonFile)
-        // } catch (err) {
-        //     console.log(`Could not restore package.json. Error: ${err}`)
-        // }
+        try {
+            fs.copyFileSync(backupJsonFile, packageJsonFile)
+            fs.unlinkSync(backupJsonFile)
+        } catch (err) {
+            console.log(`Could not restore package.json. Error: ${err}`)
+        }
     } else {
         fs.copyFileSync(packageJsonFile, backupJsonFile)
         const packageJson = JSON.parse(fs.readFileSync(packageJsonFile, { encoding: 'utf-8' }))


### PR DESCRIPTION
## Problem
- When debugging toolkit the tasks rely on the restorePackageJson script that was removed in https://github.com/aws/aws-toolkit-vscode/pull/5222

## Solution
- Re-add the restorePackageJson script

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
