### PR TITLE
fix(fs): FileSystemCommon lacks error handling

### DIFF
--- a/packages/core/src/codewhisperer/service/transformByQ/humanInTheLoopManager.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/humanInTheLoopManager.ts
@@ -77,23 +77,23 @@ export class HumanInTheLoopManager {
 
     public cleanUpArtifacts = async () => {
         try {
-            await fsCommon.delete(this.userDependencyUpdateDir)
+            await fsCommon.delete(this.userDependencyUpdateDir, { recursive: true })
         } catch (e: any) {
             this.logArtifactError(e)
         }
         try {
-            await fsCommon.delete(this.tmpDependencyListDir)
+            await fsCommon.delete(this.tmpDependencyListDir, { recursive: true })
         } catch (e: any) {
             this.logArtifactError(e)
         }
         try {
-            await fsCommon.delete(this.tmpDownloadsDir)
+            await fsCommon.delete(this.tmpDownloadsDir, { recursive: true })
         } catch (e: any) {
             this.logArtifactError(e)
         }
         for (let i = 0; i < this.tmpSessionFiles.length; i++) {
             try {
-                await fsCommon.delete(this.tmpSessionFiles[i])
+                await fsCommon.delete(this.tmpSessionFiles[i], { recursive: true })
             } catch (e: any) {
                 this.logArtifactError(e)
             }

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -246,8 +246,8 @@ export class ZipUtil {
     public async removeTmpFiles(zipMetadata: ZipMetadata, scope: CodeWhispererConstants.CodeAnalysisScope) {
         const logger = getLoggerForScope(scope)
         logger.verbose(`Cleaning up temporary files...`)
-        await fsCommon.delete(zipMetadata.zipFilePath)
-        await fsCommon.delete(zipMetadata.rootDir)
+        await fsCommon.delete(zipMetadata.zipFilePath, { force: true })
+        await fsCommon.delete(zipMetadata.rootDir, { recursive: true, force: true })
         logger.verbose(`Complete cleaning up temporary files.`)
     }
 }

--- a/packages/core/src/shared/filesystemUtilities.ts
+++ b/packages/core/src/shared/filesystemUtilities.ts
@@ -94,7 +94,7 @@ export async function tryRemoveFolder(folder?: string): Promise<boolean> {
             getLogger().warn('tryRemoveFolder: no folder given')
             return false
         }
-        await fsCommon.delete(folder)
+        await fsCommon.delete(folder, { recursive: true, force: true })
     } catch (err) {
         getLogger().warn('tryRemoveFolder: failed to delete directory "%s": %O', folder, err as Error)
         return false

--- a/packages/core/src/shared/systemUtilities.ts
+++ b/packages/core/src/shared/systemUtilities.ts
@@ -15,7 +15,7 @@ import { getLogger } from './logger/logger'
 import { GitExtension } from './extensions/git'
 import { isCloud9 } from './extensionUtilities'
 import { Settings } from './settings'
-import { PermissionsError, PermissionsTriplet, isFileNotFoundError } from './errors'
+import { PermissionsError, PermissionsTriplet } from './errors'
 import globals, { isWeb } from './extensionGlobals'
 
 export class SystemUtilities {
@@ -83,33 +83,11 @@ export class SystemUtilities {
     }
 
     public static async fileExists(file: string | vscode.Uri): Promise<boolean> {
-        const uri = this.toUri(file)
-
-        if (isCloud9()) {
-            return fsPromises.access(uri.fsPath, fs.constants.F_OK).then(
-                () => true,
-                () => false
-            )
-        }
-
-        return vscode.workspace.fs.stat(uri).then(
-            () => true,
-            err => !isFileNotFoundError(err)
-        )
+        return fs2.exists(file)
     }
 
     public static async createDirectory(file: string | vscode.Uri): Promise<void> {
-        const uri = this.toUri(file)
-        const errorHandler = createPermissionsErrorHandler(vscode.Uri.joinPath(uri, '..'), '*wx')
-
-        if (isCloud9()) {
-            return fsPromises
-                .mkdir(uri.fsPath, { recursive: true })
-                .then(() => {})
-                .catch(errorHandler)
-        }
-
-        return vscode.workspace.fs.createDirectory(uri).then(undefined, errorHandler)
+        return fs2.mkdir(file)
     }
 
     /** Converts the given path to a URI if necessary */

--- a/packages/core/src/shared/systemUtilities.ts
+++ b/packages/core/src/shared/systemUtilities.ts
@@ -8,39 +8,15 @@ import fs from 'fs'
 import * as vscode from 'vscode'
 import * as os from 'os'
 import * as path from 'path'
+import fs2, { createPermissionsErrorHandler } from '../srcShared/fs'
 import { EnvironmentVariables } from './environmentVariables'
 import { ChildProcess } from './utilities/childProcess'
 import { getLogger } from './logger/logger'
 import { GitExtension } from './extensions/git'
 import { isCloud9 } from './extensionUtilities'
 import { Settings } from './settings'
-import { PermissionsError, PermissionsTriplet, isFileNotFoundError, isNoPermissionsError } from './errors'
+import { PermissionsError, PermissionsTriplet, isFileNotFoundError } from './errors'
 import globals, { isWeb } from './extensionGlobals'
-
-export function createPermissionsErrorHandler(
-    uri: vscode.Uri,
-    perms: PermissionsTriplet
-): (err: unknown, depth?: number) => Promise<never> {
-    return async function (err: unknown, depth = 0) {
-        if (uri.scheme !== 'file' || process.platform === 'win32') {
-            throw err
-        }
-        if (!isNoPermissionsError(err) && !(isFileNotFoundError(err) && depth > 0)) {
-            throw err
-        }
-
-        const userInfo = os.userInfo({ encoding: 'utf-8' })
-        const stats = await fsPromises.stat(uri.fsPath).catch(async err2 => {
-            if (!isNoPermissionsError(err2) && !(isFileNotFoundError(err2) && perms[1] === 'w')) {
-                throw err
-            }
-
-            throw await createPermissionsErrorHandler(vscode.Uri.joinPath(uri, '..'), '*wx')(err2, depth + 1)
-        })
-
-        throw new PermissionsError(uri, stats, userInfo, perms, err)
-    }
-}
 
 export class SystemUtilities {
     /** Full path to VSCode CLI. */
@@ -103,45 +79,7 @@ export class SystemUtilities {
     }
 
     public static async delete(fileOrDir: string | vscode.Uri, opt?: { recursive: boolean }): Promise<void> {
-        const uri = this.toUri(fileOrDir)
-        const dirUri = vscode.Uri.joinPath(uri, '..')
-        const errorHandler = createPermissionsErrorHandler(dirUri, '*wx')
-
-        if (isCloud9()) {
-            const stat = await fsPromises.stat(uri.fsPath)
-            if (stat.isDirectory()) {
-                return fsPromises.rmdir(uri.fsPath).catch(errorHandler)
-            } else {
-                return fsPromises.unlink(uri.fsPath).catch(errorHandler)
-            }
-        }
-
-        if (opt?.recursive) {
-            // We shouldn't catch any errors if using the `recursive` option, otherwise the
-            // error messages may be misleading. Need to implement our own recursive delete
-            // if we want detailed info.
-            return vscode.workspace.fs.delete(uri, opt)
-        } else {
-            // Attempting to delete a file in a directory without `x` results in ENOENT.
-            // But this might not be true. The file could exist, we just don't know about it.
-            return vscode.workspace.fs.delete(uri, opt).then(undefined, async err => {
-                if (isNoPermissionsError(err)) {
-                    throw await errorHandler(err)
-                } else if (uri.scheme !== 'file' || !isFileNotFoundError(err) || process.platform === 'win32') {
-                    throw err
-                } else {
-                    const stats = await fsPromises.stat(dirUri.fsPath).catch(() => {
-                        throw err
-                    })
-                    if ((stats.mode & fs.constants.S_IXUSR) === 0) {
-                        const userInfo = os.userInfo({ encoding: 'utf-8' })
-                        throw new PermissionsError(dirUri, stats, userInfo, '*wx', err)
-                    }
-                }
-
-                throw err
-            })
-        }
+        await fs2.delete(fileOrDir, opt)
     }
 
     public static async fileExists(file: string | vscode.Uri): Promise<boolean> {

--- a/packages/core/src/shared/vscode/env.ts
+++ b/packages/core/src/shared/vscode/env.ts
@@ -102,6 +102,15 @@ export function isRemoteWorkspace(): boolean {
     return vscode.env.remoteName === 'ssh-remote'
 }
 
+/** Returns true if OS is Windows. */
+export function isWin(): boolean {
+    if (isWeb()) {
+        return false
+    }
+
+    return process.platform === 'win32'
+}
+
 export function isWebWorkspace(): boolean {
     return vscode.env.uiKind === vscode.UIKind.Web
 }
@@ -197,8 +206,23 @@ export function getUsername(): string | undefined {
         return username
     }
 
-    const userInfo = os.userInfo({ encoding: 'utf-8' })
+    const userInfo = getUserInfo()
     username = userInfo.username
 
     return userInfo.username
+}
+
+/** Gets platform-dependent user info, or (currently) a dummy object in web-mode. */
+export function getUserInfo(): os.UserInfo<string> {
+    if (isWeb()) {
+        return {
+            gid: 0,
+            uid: 0,
+            homedir: '',
+            shell: '',
+            username: 'webuser',
+        }
+    }
+
+    return os.userInfo({ encoding: 'utf-8' })
 }

--- a/packages/core/src/test/shared/systemUtilities.test.ts
+++ b/packages/core/src/test/shared/systemUtilities.test.ts
@@ -80,21 +80,6 @@ describe('SystemUtilities', function () {
         })
     })
 
-    describe('fileExists', function () {
-        it('returns true if file exists', async function () {
-            const filename: string = path.join(tempFolder, 'existing-file.txt')
-
-            fs.writeFileSync(filename, 'hello world', 'utf8')
-
-            assert.strictEqual(await SystemUtilities.fileExists(filename), true)
-        })
-
-        it('returns false if file does not exist', async function () {
-            const filename: string = path.join(tempFolder, 'non-existing-file.txt')
-            assert.strictEqual(await SystemUtilities.fileExists(filename), false)
-        })
-    })
-
     it('findTypescriptCompiler()', async function () {
         const iswin = process.platform === 'win32'
         const workspace = vscode.workspace.workspaceFolders![0]
@@ -126,6 +111,7 @@ describe('SystemUtilities', function () {
     })
 
     if (process.platform !== 'win32') {
+        // TODO: move these tests to fs.test.ts
         describe('permissions', function () {
             let runCounter = 0
 

--- a/packages/core/src/test/srcShared/fs.test.ts
+++ b/packages/core/src/test/srcShared/fs.test.ts
@@ -125,34 +125,45 @@ describe('FileSystem', function () {
     })
 
     describe('existsFile()', function () {
-        it('returns true for an existing file', async function () {
-            const filePath = await makeFile('test.txt')
-            const existantFile = await fsCommon.existsFile(filePath)
-            assert.strictEqual(existantFile, true)
+        it('true for existing file', async function () {
+            const file = await makeFile('test.txt')
+            assert.strictEqual(await fsCommon.existsFile(file), true)
         })
 
-        it('returns false for a non-existant file', async function () {
-            const nonExistantFile = await fsCommon.existsFile(createTestPath('thisDoesNotExist.txt'))
-            assert.strictEqual(nonExistantFile, false)
+        it('false for non-existent file', async function () {
+            const nonExistantFile = createTestPath('thisDoesNotExist.txt')
+            assert.strictEqual(await fsCommon.existsFile(nonExistantFile), false)
         })
 
-        it('returns false when directory with same name exists', async function () {
-            const directoryPath = mkTestDir('thisIsDirectory')
-            const existantFile = await fsCommon.existsFile(directoryPath)
-            assert.strictEqual(existantFile, false)
+        it('false for existing directory', async function () {
+            const dir = mkTestDir('thisIsDirectory')
+            assert.strictEqual(await fsCommon.existsFile(dir), false)
         })
     })
 
     describe('existsDir()', function () {
-        it('returns true for an existing directory', async function () {
-            const dirPath = mkTestDir('myDir')
-            const existantDirectory = await fsCommon.existsDir(dirPath)
-            assert.strictEqual(existantDirectory, true)
+        it('true for existing directory', async function () {
+            const dir = mkTestDir('myDir')
+            assert.strictEqual(await fsCommon.existsDir(dir), true)
         })
 
-        it('returns false for a non-existant directory', async function () {
-            const nonExistantDirectory = await fsCommon.existsDir(createTestPath('thisDirDoesNotExist'))
-            assert.strictEqual(nonExistantDirectory, false)
+        it('false for non-existent directory', async function () {
+            const noFile = createTestPath('non-existent')
+            assert.strictEqual(await fsCommon.existsDir(noFile), false)
+        })
+    })
+
+    describe('exists()', function () {
+        it('true for existing file/directory', async function () {
+            const dir = mkTestDir('myDir')
+            const file = await makeFile('test.txt')
+            assert.strictEqual(await fsCommon.exists(dir), true)
+            assert.strictEqual(await fsCommon.exists(file), true)
+        })
+
+        it('false for non-existent file/directory', async function () {
+            const noFile = createTestPath('non-existent')
+            assert.strictEqual(await fsCommon.exists(noFile), false)
         })
     })
 

--- a/packages/core/src/test/srcShared/fs.test.ts
+++ b/packages/core/src/test/srcShared/fs.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import * as vscode from 'vscode'
 import * as path from 'path'
-import { existsSync, mkdirSync, promises as fsPromises, readFileSync, rmSync } from 'fs'
+import { existsSync, mkdirSync, promises as nodefs, readFileSync, rmSync } from 'fs'
 import { FakeExtensionContext } from '../fakeExtensionContext'
 import { fsCommon } from '../../srcShared/fs'
 import * as os from 'os'
@@ -30,7 +30,7 @@ describe('FileSystem', function () {
     })
 
     beforeEach(async function () {
-        await makeTestRoot()
+        await mkTestRoot()
     })
 
     afterEach(async function () {
@@ -137,7 +137,7 @@ describe('FileSystem', function () {
         })
 
         it('returns false when directory with same name exists', async function () {
-            const directoryPath = await makeFolder('thisIsDirectory')
+            const directoryPath = mkTestDir('thisIsDirectory')
             const existantFile = await fsCommon.existsFile(directoryPath)
             assert.strictEqual(existantFile, false)
         })
@@ -145,7 +145,7 @@ describe('FileSystem', function () {
 
     describe('existsDir()', function () {
         it('returns true for an existing directory', async function () {
-            const dirPath = await makeFolder('myDir')
+            const dirPath = mkTestDir('myDir')
             const existantDirectory = await fsCommon.existsDir(dirPath)
             assert.strictEqual(existantDirectory, true)
         })
@@ -168,10 +168,10 @@ describe('FileSystem', function () {
         })
 
         paths.forEach(async function (p) {
-            it(`creates folder but uses the "fs" module if in C9: '${p}'`, async function () {
+            it(`creates folder but uses the "fs" module if in Cloud9: '${p}'`, async function () {
                 sandbox.stub(extensionUtilities, 'isCloud9').returns(true)
                 const dirPath = createTestPath(p)
-                const mkdirSpy = sandbox.spy(fsPromises, 'mkdir')
+                const mkdirSpy = sandbox.spy(nodefs, 'mkdir')
 
                 await fsCommon.mkdir(dirPath)
 
@@ -213,9 +213,9 @@ describe('FileSystem', function () {
             return i.sort((a, b) => a[0].localeCompare(b[0]))
         }
 
-        it('uses the "fs" readdir implementation if in C9', async function () {
+        it('uses the "fs" readdir implementation if in Cloud9', async function () {
             sandbox.stub(extensionUtilities, 'isCloud9').returns(true)
-            const readdirSpy = sandbox.spy(fsPromises, 'readdir')
+            const readdirSpy = sandbox.spy(nodefs, 'readdir')
 
             await makeFile('a.txt')
             await makeFile('b.txt')
@@ -236,13 +236,13 @@ describe('FileSystem', function () {
                     ['dirC', vscode.FileType.Directory],
                 ])
             )
-            assert.ok(readdirSpy.calledOnce)
+            assert(readdirSpy.calledOnce)
         })
     })
 
     describe('copy()', function () {
         it('copies files and folders from one dir to another', async function () {
-            const targetDir = await makeFolder('targetDir')
+            const targetDir = mkTestDir('targetDir')
             await makeFile('targetDir/a.txt', 'I am A')
             await makeFile('targetDir/dirB/b.txt', 'I am B')
 
@@ -255,39 +255,53 @@ describe('FileSystem', function () {
     })
 
     describe('delete()', function () {
-        it('deletes a file', async function () {
-            const filePath = await makeFile('test.txt', 'hello world')
-            await fsCommon.delete(filePath)
-            assert.ok(!existsSync(filePath))
+        it('deletes file', async function () {
+            const f = await makeFile('test.txt', 'hello world')
+            assert(existsSync(f))
+            await fsCommon.delete(f)
+            assert(!existsSync(f))
         })
 
-        it('deletes a directory', async function () {
-            const dirPath = createTestPath('dirToDelete')
-            mkdirSync(dirPath)
-
-            await fsCommon.delete(dirPath)
-
-            assert.ok(!existsSync(dirPath))
+        it('fails to delete non-empty directory with recursive:false (the default)', async function () {
+            const dir = mkTestDir()
+            const f = path.join(dir, 'testfile.txt')
+            await toFile('some content', f)
+            assert(existsSync(dir))
+            await assert.rejects(() => fsCommon.delete(dir), /not empty|non-empty/)
+            assert(existsSync(dir))
         })
 
-        it('does not error if the file to delete does not exist', async function () {
-            const nonExistantFilePath = 'does/not/exist'
-            await fsCommon.delete(nonExistantFilePath)
-            assert.ok(!existsSync(nonExistantFilePath))
+        it('deletes directory with recursive:true', async function () {
+            const dir = mkTestDir()
+            await fsCommon.delete(dir, { recursive: true })
+            assert(!existsSync(dir))
         })
 
-        it('uses the "fs" rm method if in C9', async function () {
+        it('no error if file not found (but parent exists)', async function () {
+            const dir = mkTestDir()
+            const f = path.join(dir, 'missingfile.txt')
+            assert(!existsSync(f))
+            await fsCommon.delete(f)
+        })
+
+        it('error if file *and* its parent dir not found', async function () {
+            const dir = mkTestDir()
+            const f = path.join(dir, 'missingdir/missingfile.txt')
+            assert(!existsSync(f))
+            await assert.rejects(() => fsCommon.delete(f))
+        })
+
+        it('uses "node:fs" rm() if in Cloud9', async function () {
             sandbox.stub(extensionUtilities, 'isCloud9').returns(true)
-            const rmdirSpy = sandbox.spy(fsPromises, 'rm')
+            const rmdirSpy = sandbox.spy(nodefs, 'rm')
             // Folder with subfolders
-            const dirPath = await makeFolder('a/b/deleteMe')
-
+            const dirPath = mkTestDir('a/b/deleteMe')
             mkdirSync(dirPath, { recursive: true })
 
-            await fsCommon.delete(dirPath)
+            await fsCommon.delete(dirPath, { recursive: true })
 
-            assert.ok(!existsSync(dirPath))
-            assert.ok(rmdirSpy.calledOnce)
+            assert(rmdirSpy.calledOnce)
+            assert(!existsSync(dirPath))
         })
     })
 
@@ -295,7 +309,7 @@ describe('FileSystem', function () {
         it('gets stat of a file', async function () {
             const filePath = await makeFile('test.txt', 'hello world')
             const stat = await fsCommon.stat(filePath)
-            assert.ok(stat)
+            assert(stat)
             assert.strictEqual(stat.type, vscode.FileType.File)
         })
 
@@ -311,16 +325,17 @@ describe('FileSystem', function () {
         await toFile(content ?? '', filePath)
 
         if (options?.mode !== undefined) {
-            await fsPromises.chmod(filePath, options.mode)
+            await nodefs.chmod(filePath, options.mode)
         }
 
         return filePath
     }
 
-    async function makeFolder(relativeFolderPath: string) {
-        const folderPath = path.join(testRootPath(), relativeFolderPath)
-        mkdirSync(folderPath, { recursive: true })
-        return folderPath
+    function mkTestDir(relativeDirPath?: string) {
+        const dir = createTestPath(relativeDirPath ?? 'testDir')
+        mkdirSync(dir, { recursive: true })
+        assert(existsSync(dir))
+        return dir
     }
 
     function createTestPath(relativePath: string): string {
@@ -331,7 +346,7 @@ describe('FileSystem', function () {
         return path.join(fakeContext.globalStorageUri.fsPath, 'fsTestDir')
     }
 
-    async function makeTestRoot() {
+    async function mkTestRoot() {
         return mkdirSync(testRootPath())
     }
 


### PR DESCRIPTION
Note: This commit is part of a series.

## Problem:
- Our `fs.ts` module does not have the advanced error-handling present in our `SystemUtilities` module.
- `fsCommon.delete()` defaults to `recursive:true`, which means directories may be unintentionally deleted when a file was expected, and related errors are not surfaced.

## Solution:
- Merge the features of `SystemUtilities` into `fs.ts`.
- Migrate `SystemUtilities.delete()`.
- Change `fsCommon.delete()` to default to `recursive:false`.
  - Update callers to explicitly pass `recursive:true`, where appropriate.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
