### PR TITLE
fix(ci): noisy lines in Linux CI output

### DIFF
--- a/buildspec/shared/common.sh
+++ b/buildspec/shared/common.sh
@@ -14,6 +14,10 @@ if [ "$VSCODE_TEST_VERSION" = 'minimum' ]; then
     _ignore_pat="$_ignore_pat"'\|Webview is disposed'
 fi
 
+# Do not print (noisy) lines matching these patterns.
+#   - "ERROR:bus… Failed to connect to the bus": noise related to "xvfb". https://github.com/cypress-io/cypress/issues/19299
+_discard_pat='ERROR:bus.cc\|ERROR:viz_main_impl.cc\|ERROR:command_buffer_proxy_impl.cc'
+
 # Expects stdin + two args:
 #   1: error code to return on failure
 #   2: grep pattern
@@ -27,7 +31,7 @@ run_and_report() {
     local msg="${3}"
     local r=0
     mkfifo testout
-    (cat testout &)
+    (grep -v "$_discard_pat" testout &)
     # Capture messages that we may want to fail (or report) later.
     tee testout \
         | { grep > testout-err --line-buffered -E "$pat" || true; }


### PR DESCRIPTION
## Problem:

    [3422:0705/221403.718606:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
    [3422:0705/221403.916070:ERROR:bus.cc(407)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
    [3449:0705/221404.002987:ERROR:viz_main_impl.cc(196)] Exiting GPU process due to errors during initialization
    [3519:0705/221404.270770:ERROR:command_buffer_proxy_impl.cc(131)] ContextResult::kTransientFailure: Failed to send GpuControl.CreateCommandBuffer.

## Solution:
- These lines are related to `xvfb` and are irrelevant. See https://github.com/cypress-io/cypress/issues/19299
- Drop the lines when printing output in Linux CI (AWS CodeBuild).


### Example before/after (no false positives)

![image](https://github.com/aws/aws-toolkit-vscode/assets/55561878/38988b53-75e2-4205-9d26-c91249c94990)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
