### PR TITLE
refactor(fs): FileSystem error handling, eliminate SystemUtilities

### DIFF
--- a/packages/core/src/shared/schemas.ts
+++ b/packages/core/src/shared/schemas.ts
@@ -16,7 +16,6 @@ import { once } from './utilities/functionUtils'
 import { Any, ArrayConstructor } from './utilities/typeConstructors'
 import { AWS_SCHEME } from './constants'
 import { fsCommon } from '../srcShared/fs'
-import { SystemUtilities } from './systemUtilities'
 import { normalizeVSCodeUri } from './utilities/vsCodeUtils'
 import { telemetry } from './telemetry/telemetry'
 
@@ -328,7 +327,7 @@ async function doCacheContent(
 ): Promise<void> {
     const parsedFile = { ...JSON.parse(content), title: params.title }
     const dir = vscode.Uri.joinPath(params.destination, '..')
-    await SystemUtilities.createDirectory(dir)
+    await fsCommon.mkdir(dir)
     await fsCommon.writeFile(params.destination.fsPath, JSON.stringify(parsedFile))
     await params.extensionContext.globalState.update(params.cacheKey, params.version).then(undefined, err => {
         getLogger().warn(`schemas: failed to update cache key for "${params.title}": ${err?.message}`)

--- a/packages/core/src/shared/systemUtilities.ts
+++ b/packages/core/src/shared/systemUtilities.ts
@@ -18,6 +18,11 @@ import { Settings } from './settings'
 import { PermissionsError, PermissionsTriplet } from './errors'
 import globals, { isWeb } from './extensionGlobals'
 
+/**
+ * Deprecated interface for filesystem operations.
+ *
+ * @deprecated Use `core/src/shared/fs.ts` instead
+ */
 export class SystemUtilities {
     /** Full path to VSCode CLI. */
     private static vscPath: string
@@ -52,14 +57,7 @@ export class SystemUtilities {
     }
 
     public static async readFile(file: string | vscode.Uri, decoder: TextDecoder = new TextDecoder()): Promise<string> {
-        const uri = this.toUri(file)
-        const errorHandler = createPermissionsErrorHandler(uri, 'r**')
-
-        if (isCloud9()) {
-            return decoder.decode(await fsPromises.readFile(uri.fsPath).catch(errorHandler))
-        }
-
-        return decoder.decode(await vscode.workspace.fs.readFile(uri).then(undefined, errorHandler))
+        return fs2.readFileAsString(file, decoder)
     }
 
     public static async writeFile(

--- a/packages/core/src/shared/systemUtilities.ts
+++ b/packages/core/src/shared/systemUtilities.ts
@@ -65,15 +65,7 @@ export class SystemUtilities {
         data: string | Buffer,
         opt?: fs.WriteFileOptions
     ): Promise<void> {
-        const uri = this.toUri(file)
-        const errorHandler = createPermissionsErrorHandler(uri, '*w*')
-        const content = typeof data === 'string' ? new TextEncoder().encode(data) : data
-
-        if (isCloud9()) {
-            return fsPromises.writeFile(uri.fsPath, content, opt).catch(errorHandler)
-        }
-
-        return vscode.workspace.fs.writeFile(uri, content).then(undefined, errorHandler)
+        return fs2.writeFile(file, data, opt)
     }
 
     public static async delete(fileOrDir: string | vscode.Uri, opt?: { recursive: boolean }): Promise<void> {

--- a/packages/core/src/shared/utilities/cacheUtils.ts
+++ b/packages/core/src/shared/utilities/cacheUtils.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import { dirname } from 'path'
 import { ToolkitError, isFileNotFoundError } from '../errors'
-import { SystemUtilities } from '../systemUtilities'
+import fs from '../../srcShared/fs'
 import { promises as fsPromises } from 'fs'
 import crypto from 'crypto'
 import { isWeb } from '../extensionGlobals'
@@ -107,7 +107,7 @@ export function createDiskCache<T, K>(
             const target = mapKey(key)
 
             try {
-                const result = JSON.parse(await SystemUtilities.readFile(target))
+                const result = JSON.parse(await fs.readFileAsString(target))
                 log('loaded', key)
                 return result
             } catch (error) {
@@ -126,16 +126,16 @@ export function createDiskCache<T, K>(
             const target = mapKey(key)
 
             try {
-                await SystemUtilities.createDirectory(dirname(target))
+                await fs.mkdir(dirname(target))
                 if (isWeb()) {
                     // There is no web-compatible rename() method. So do a regular write.
-                    await SystemUtilities.writeFile(target, JSON.stringify(data), { mode: 0o600 })
+                    await fs.writeFile(target, JSON.stringify(data), { mode: 0o600 })
                 } else {
                     // With SSO cache we noticed malformed JSON on read. A guess is that multiple writes
                     // are occuring at the same time. The following is a bandaid that ensures an all-or-nothing
                     // write, though there can still be race conditions with which version remains after overwrites.
                     const tempFile = `${target}.tmp-${crypto.randomBytes(4).toString('hex')}`
-                    await SystemUtilities.writeFile(tempFile, JSON.stringify(data), { mode: 0o600 })
+                    await fs.writeFile(tempFile, JSON.stringify(data), { mode: 0o600 })
                     await fsPromises.rename(tempFile, target)
                 }
             } catch (error) {
@@ -151,7 +151,7 @@ export function createDiskCache<T, K>(
             const target = mapKey(key)
 
             try {
-                await SystemUtilities.delete(target)
+                await fs.delete(target, { force: false })
             } catch (error) {
                 if (isFileNotFoundError(error)) {
                     return log('file not found', key)

--- a/packages/core/src/test/shared/systemUtilities.test.ts
+++ b/packages/core/src/test/shared/systemUtilities.test.ts
@@ -240,38 +240,4 @@ describe('SystemUtilities', function () {
             // Or potentially spawn new process with different uid...?
         })
     }
-
-    describe('toUri', function () {
-        it('uses existing scheme in final URI when input is string path', function () {
-            if (os.platform() === 'win32') {
-                this.skip()
-            }
-
-            assert.deepStrictEqual(
-                SystemUtilities.toUri('myScheme:/User/nikolas/file.txt'),
-                vscode.Uri.from({ scheme: 'myScheme', path: '/User/nikolas/file.txt' })
-            )
-        })
-
-        it('does not use existing scheme in final URI when input is string path AND is Windows', function () {
-            if (os.platform() !== 'win32') {
-                this.skip()
-            }
-
-            const myUri = 'c:\\hello\\there'
-            assert.deepStrictEqual(SystemUtilities.toUri(myUri), vscode.Uri.file(myUri))
-        })
-
-        it('string input, creates a file uri if no scheme', function () {
-            assert.deepStrictEqual(
-                SystemUtilities.toUri('/User/nikolas/file.txt'),
-                vscode.Uri.file('/User/nikolas/file.txt')
-            )
-        })
-
-        it('uri input, returns the given path if it is already a uri', function () {
-            const myUri = vscode.Uri.from({ scheme: 'myOtherScheme', path: '/User/john/otherFile.txt' })
-            assert.deepStrictEqual(SystemUtilities.toUri(myUri), myUri)
-        })
-    })
 })

--- a/packages/core/src/test/srcShared/fs.test.ts
+++ b/packages/core/src/test/srcShared/fs.test.ts
@@ -14,6 +14,7 @@ import { isMinVscode } from '../../shared/vscode/env'
 import Sinon from 'sinon'
 import * as extensionUtilities from '../../shared/extensionUtilities'
 import { toFile } from '../testUtil'
+import { PermissionsError } from '../../shared/errors'
 
 function isWin() {
     return os.platform() === 'win32'
@@ -57,8 +58,8 @@ describe('FileSystem', function () {
             const path = await makeFile(fileName, 'hello world', { mode: 0o000 })
 
             await assert.rejects(fsCommon.readFileAsString(path), err => {
-                assert(err instanceof vscode.FileSystemError)
-                assert.strictEqual(err.code, 'NoPermissions')
+                assert(err instanceof PermissionsError)
+                assert.strictEqual(err.code, 'InvalidPermissions')
                 assert(err.message.includes(fileName))
                 return true
             })

--- a/packages/core/src/test/srcShared/fs.test.ts
+++ b/packages/core/src/test/srcShared/fs.test.ts
@@ -103,8 +103,8 @@ describe('FileSystem', function () {
             const filePath = await makeFile(fileName, 'hello world', { mode: 0o000 })
 
             await assert.rejects(fsCommon.writeFile(filePath, 'MyContent'), err => {
-                assert(err instanceof vscode.FileSystemError)
-                assert.strictEqual(err.name, 'EntryWriteLocked (FileSystemError) (FileSystemError)')
+                assert(err instanceof PermissionsError)
+                assert.strictEqual(err.code, 'InvalidPermissions')
                 assert(err.message.includes(fileName))
                 return true
             })


### PR DESCRIPTION
Note: This commit is part of a series. Continued from https://github.com/aws/aws-toolkit-vscode/pull/5267

## Problem
- Error handling is inconsistent.
- `SystemUtilities` is redundant with `fs.ts`, and is not web-compatible.

## Solution
- Merge the features of `SystemUtilities` into `fs.ts`.
- Migrate tests.





<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
