### PR TITLE
fix: ReferenceError: Node is not defined in e2e tests

### DIFF
--- a/packages/amazonq/test/e2e/amazonq/framework/jsdomInjector.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/jsdomInjector.ts
@@ -18,6 +18,7 @@ export function injectJSDOM() {
     global.self = dom.window as unknown as Window & typeof globalThis
     global.Element = dom.window.Element
     global.HTMLElement = dom.window.HTMLElement
+    global.Node = dom.window.Node
 
     // jsdom doesn't have support for innerText: https://github.com/jsdom/jsdom/issues/1245 which mynah ui uses
     Object.defineProperty(global.Element.prototype, 'innerText', {


### PR DESCRIPTION
## Problem
- We are observing "ReferenceError: Node is not defined" in the e2e test logs

## Solution
- Add Node into the global object

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
