### PR TITLE
fix(appcomposer): add warning message to version 1.91.0 about drag an…

### DIFF
--- a/packages/core/src/applicationcomposer/webviewManager.ts
+++ b/packages/core/src/applicationcomposer/webviewManager.ts
@@ -79,6 +79,15 @@ export class ApplicationComposerManager {
             const newVisualization = new ApplicationComposer(document, this.extensionContext, this.getWebviewContent)
             this.handleNewVisualization(document.uri.fsPath, newVisualization)
 
+            if (vscode.version === '1.91.0') {
+                void vscode.window.showWarningMessage(
+                    localize(
+                        'AWS.applicationComposer.visualisation.warnings.draganddrop',
+                        'This version of Visual Studio Code has a bug preventing normal drag and drop. ' +
+                            'As a temporary workaround, you must hold "Shift" before releasing the mouse button.'
+                    )
+                )
+            }
             return newVisualization.getPanel()
         } catch (err) {
             this.handleErr(err as Error)

--- a/packages/core/src/applicationcomposer/webviewManager.ts
+++ b/packages/core/src/applicationcomposer/webviewManager.ts
@@ -84,7 +84,7 @@ export class ApplicationComposerManager {
                     localize(
                         'AWS.applicationComposer.visualisation.warnings.draganddrop',
                         'This version of Visual Studio Code has a bug preventing normal drag and drop. ' +
-                            'As a temporary workaround, you must hold "Shift" before releasing the mouse button.'
+                            'As a temporary workaround, hold "Shift" before releasing the mouse button when adding a resource.'
                     )
                 )
             }

--- a/packages/core/src/applicationcomposer/webviewManager.ts
+++ b/packages/core/src/applicationcomposer/webviewManager.ts
@@ -83,8 +83,8 @@ export class ApplicationComposerManager {
                 void vscode.window.showWarningMessage(
                     localize(
                         'AWS.applicationComposer.visualisation.warnings.draganddrop',
-                        'This version of Visual Studio Code has a bug preventing normal drag and drop. ' +
-                            'As a temporary workaround, hold "Shift" before releasing the mouse button when adding a resource.'
+                        'This version of Visual Studio Code has a bug preventing normal drag and drop functionality. ' +
+                            'As a temporary workaround, hold the Shift key before releasing a resource onto the visual canvas.'
                     )
                 )
             }

--- a/packages/toolkit/.changes/next-release/Bug Fix-49dc6b60-220e-4466-8e0b-a417265f370a.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-49dc6b60-220e-4466-8e0b-a417265f370a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Add warning message for drag and drop bug on VS Code 1.91.0"
+}


### PR DESCRIPTION
## Problem:
VS Code version 1.91.0 has a bug causing the dragEnd action to not trigger in WebViews unless Shift is held down. This breaks App Composer's ability to add new resources.

## Solution:
This has already been [reverted](https://github.com/microsoft/vscode/pull/219896) and should be fixed in the next VS Code version. In the meantime, this adds a warning message (upon opening Composer with version 1.91.0) informing users of the workaround.

<img width="482" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/65189184/01e4bfc0-e7c1-4ea7-afa5-63851ce82739">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
