### PR TITLE
fix(env): getUserInfo() may fail on AD/LDAP

### DIFF
--- a/packages/amazonq/src/extensionCommon.ts
+++ b/packages/amazonq/src/extensionCommon.ts
@@ -27,7 +27,7 @@ import {
     getMachineId,
     messages,
 } from 'aws-core-vscode/shared'
-import { fs } from 'aws-core-vscode/shared'
+import { fs, errors } from 'aws-core-vscode/shared'
 import { initializeAuth, CredentialsStore, LoginManager, AuthUtils, SsoConnection } from 'aws-core-vscode/auth'
 import { CommonAuthWebview } from 'aws-core-vscode/login'
 import { VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
@@ -42,9 +42,10 @@ export const amazonQContextPrefix = 'amazonq'
  */
 export async function activateAmazonQCommon(context: vscode.ExtensionContext, isWeb: boolean) {
     initialize(context, isWeb)
-    const homeDirLogs = await fs.initUserHomeDir(context, homeDir => {
+    const homeDirLogs = await fs.init(context, homeDir => {
         void messages.showViewLogsMessage(`Invalid home directory (check $HOME): "${homeDir}"`)
     })
+    errors.init(fs.getUsername())
     await initializeComputeRegion()
 
     globals.contextPrefix = 'amazonq.' //todo: disconnect from above line
@@ -97,7 +98,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
 
     if (homeDirLogs.length > 0) {
-        getLogger().error('initUserHomeDir: invalid env vars found: %O', homeDirLogs)
+        getLogger().error('fs.init: invalid env vars found: %O', homeDirLogs)
     }
 
     await activateTelemetry(context, globals.awsContext, Settings.instance, 'Amazon Q For VS Code')

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -5,7 +5,7 @@
  * This class is responsible for responding to UI events by calling
  * the Gumby extension.
  */
-import fs from 'fs'
+import nodefs from 'fs'
 import path from 'path'
 import * as vscode from 'vscode'
 import { GumbyNamedMessages, Messenger } from './messenger/messenger'
@@ -506,5 +506,5 @@ export class GumbyController {
  */
 function extractPath(text: string): string | undefined {
     const resolvedPath = path.resolve(text.trim())
-    return fs.existsSync(resolvedPath) && fs.lstatSync(resolvedPath).isDirectory() ? resolvedPath : undefined
+    return nodefs.existsSync(resolvedPath) && nodefs.lstatSync(resolvedPath).isDirectory() ? resolvedPath : undefined
 }

--- a/packages/core/src/extensionCommon.ts
+++ b/packages/core/src/extensionCommon.ts
@@ -23,6 +23,7 @@ import { AuthStatus, telemetry } from './shared/telemetry/telemetry'
 import { openUrl } from './shared/utilities/vsCodeUtils'
 import { activateViewsShared } from './awsexplorer/activationShared'
 import fs from './shared/fs/fs'
+import * as errors from './shared/errors'
 import { activate as activateLogger } from './shared/logger/activation'
 import { initializeComputeRegion } from './shared/extensionUtilities'
 import { activate as activateTelemetry } from './shared/telemetry/activation'
@@ -73,9 +74,10 @@ export async function activateCommon(
     localize = nls.loadMessageBundle()
 
     initialize(context, isWeb)
-    const homeDirLogs = await fs.initUserHomeDir(context, homeDir => {
+    const homeDirLogs = await fs.init(context, homeDir => {
         void showViewLogsMessage(`Invalid home directory (check $HOME): "${homeDir}"`)
     })
+    errors.init(fs.getUsername())
     await initializeComputeRegion()
 
     globals.contextPrefix = '' //todo: disconnect supplied argument
@@ -97,7 +99,7 @@ export async function activateCommon(
     globals.logOutputChannel = toolkitLogChannel
 
     if (homeDirLogs.length > 0) {
-        getLogger().error('initUserHomeDir: invalid home directory given by env vars: %O', homeDirLogs)
+        getLogger().error('fs.init: invalid home directory given by env vars: %O', homeDirLogs)
     }
 
     if (isCloud9()) {

--- a/packages/core/src/shared/vscode/env.ts
+++ b/packages/core/src/shared/vscode/env.ts
@@ -5,7 +5,6 @@
 
 import * as semver from 'semver'
 import * as vscode from 'vscode'
-import * as os from 'os'
 import * as packageJson from '../../../package.json'
 import { getLogger } from '../logger'
 import { onceChanged } from '../utilities/functionUtils'
@@ -104,9 +103,9 @@ export function isRemoteWorkspace(): boolean {
 
 /** Returns true if OS is Windows. */
 export function isWin(): boolean {
-    if (isWeb()) {
-        return false
-    }
+    // if (isWeb()) {
+    //     return false
+    // }
 
     return process.platform === 'win32'
 }
@@ -188,41 +187,10 @@ export function getServiceEnvVarConfig<T extends string[]>(service: string, conf
 
 export async function getMachineId(): Promise<string> {
     if (isWeb()) {
+        // TODO: use `vscode.env.machineId` instead?
         return 'browser'
     }
     const proc = new ChildProcess('hostname', [], { collect: true, logging: 'no' })
+    // TODO: check exit code.
     return (await proc.run()).stdout.trim() ?? 'unknown-host'
-}
-
-let username: string | undefined
-
-/** Gets the current system username, or undefined in web-mode. */
-export function getUsername(): string | undefined {
-    if (isWeb()) {
-        return undefined
-    }
-
-    if (username !== undefined) {
-        return username
-    }
-
-    const userInfo = getUserInfo()
-    username = userInfo.username
-
-    return userInfo.username
-}
-
-/** Gets platform-dependent user info, or (currently) a dummy object in web-mode. */
-export function getUserInfo(): os.UserInfo<string> {
-    if (isWeb()) {
-        return {
-            gid: 0,
-            uid: 0,
-            homedir: '',
-            shell: '',
-            username: 'webuser',
-        }
-    }
-
-    return os.userInfo({ encoding: 'utf-8' })
 }

--- a/packages/core/src/testWeb/shared/fs.test.ts
+++ b/packages/core/src/testWeb/shared/fs.test.ts
@@ -8,9 +8,15 @@ import globals from '../../shared/extensionGlobals'
 import fs from '../../shared/fs/fs'
 
 describe('FileSystem', function () {
-    it('getHomeDirectory() when in Browser', async () => {
+    it('getUserHomeDir()', async () => {
         // TODO: testWeb needs a `globalSetup.test.ts` ...
-        await fs.initUserHomeDir(globals.context, () => undefined)
+        await fs.init(globals.context, () => undefined)
         assert.strictEqual(fs.getUserHomeDir(), globals.context.globalStorageUri.toString())
+    })
+
+    it('getUsername()', async () => {
+        // TODO: testWeb needs a `globalSetup.test.ts` ...
+        await fs.init(globals.context, () => undefined)
+        assert.strictEqual(fs.getUsername(), 'webuser')
     })
 })


### PR DESCRIPTION
## Problem

Both AWS Toolkit and Amazon Q fail to start when the effective user account is defined externally (e.g. by AD/LDAP). #5277

    [error] SystemError: A system error occurred: uv_os_get_passwd returned ENOENT (no such file or directory)

Bisected to #5215 which calls os.userInfo in getUsername (env.ts).

When the effective user ID does not have a matching entry in /etc/passwd, userInfo throws an exception. Discussed in:
- https://github.com/microsoft/vscode-remote-release/issues/9649
- https://github.com/cyjake/ssh-config/issues/77

### Steps to reproduce

1. Login as a user that is synced to AD/LDAP.
2. Install AWS Toolkit and Amazon Q
3. Errors in `~/.config/Code/logs/<date and time>/window1/exthost/exthost.log`
   ```
   2024-07-08 12:09:54.179 [error] Activating extension amazonwebservices.amazon-q-vscode failed due to an error:
   2024-07-08 12:09:54.179 [error] SystemError: A system error occurred: uv_os_get_passwd returned ENOENT (no such file or directory)
           at new SystemError (node:internal/errors:257:5)
           at new NodeError (node:internal/errors:368:7)
           at Object.userInfo (node:os:365:11)
   ```

## Solution
- Move getUserInfo/getUsername into fs.ts since they depend on the filesystem.
- If userInfo fails, fallback to (in order of precedence):
  - process.env.USER
  - getUserHomeDir() directory name
  - "unknown-user"


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
