### PR TITLE
fix: eslint DeprecationWarning

### DIFF
--- a/plugins/eslint-plugin-aws-toolkits/lib/rules/no-incorrect-once-usage.ts
+++ b/plugins/eslint-plugin-aws-toolkits/lib/rules/no-incorrect-once-usage.ts
@@ -122,7 +122,7 @@ export default ESLintUtils.RuleCreator.withoutDocs({
                         declaration.init.callee?.type === AST_NODE_TYPES.Identifier &&
                         declaration.init.callee.name === 'once'
                     ) {
-                        const scope = context.getScope()
+                        const scope = context.sourceCode.getScope(declaration) // TODO: should this be `getScope(node)`?
                         const variable = scope.variables.find(
                             v => v.name === (declaration.id as TSESTree.Identifier).name
                         ) // we already confirmed the type in the if statement... why is TS mad?

--- a/plugins/eslint-plugin-aws-toolkits/lib/rules/no-incorrect-once-usage.ts
+++ b/plugins/eslint-plugin-aws-toolkits/lib/rules/no-incorrect-once-usage.ts
@@ -122,7 +122,7 @@ export default ESLintUtils.RuleCreator.withoutDocs({
                         declaration.init.callee?.type === AST_NODE_TYPES.Identifier &&
                         declaration.init.callee.name === 'once'
                     ) {
-                        const scope = context.sourceCode.getScope(declaration) // TODO: should this be `getScope(node)`?
+                        const scope = context.sourceCode.getScope(declaration)
                         const variable = scope.variables.find(
                             v => v.name === (declaration.id as TSESTree.Identifier).name
                         ) // we already confirmed the type in the if statement... why is TS mad?


### PR DESCRIPTION


## Problem

    (node:99880) DeprecationWarning: "no-incorrect-once-usage" rule is
    using `context.getScope()`, which is deprecated and will be removed
    in ESLint v9. Please use `sourceCode.getScope()` instead. (Use `node
    --trace-deprecation ...` to show where the warning was created)

## Solution

update rule

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
