### PR TITLE
feat(setContext): hoist setContext into a shared module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -156,6 +156,7 @@ module.exports = {
 
         'aws-toolkits/no-only-in-tests': 'error',
         'aws-toolkits/no-await-on-vscode-msg': 'error',
+        'aws-toolkits/no-banned-usages': 'error',
         'aws-toolkits/no-incorrect-once-usage': 'error',
         'aws-toolkits/no-string-exec-for-child-process': 'error',
 

--- a/docs/arch_runtime.md
+++ b/docs/arch_runtime.md
@@ -10,7 +10,8 @@ TODO: move from CONTRIBUTING.md
 ## VSCode context keys
 
 VScode extensions can use vscode 'setContext' command to set special context keys which are
-available in `package.json`.
+available in `package.json`. Use this only if there is no other alternative (it's shared, global,
+mutable state).
 
 ### Defining a new setContext key
 

--- a/packages/amazonq/src/extensionCommon.ts
+++ b/packages/amazonq/src/extensionCommon.ts
@@ -9,7 +9,6 @@ import { join } from 'path'
 import {
     activate as activateCodeWhisperer,
     shutdown as shutdownCodeWhisperer,
-    amazonQDismissedKey,
     AuthUtil,
 } from 'aws-core-vscode/codewhispererCommon'
 import {
@@ -27,7 +26,7 @@ import {
     getMachineId,
     messages,
 } from 'aws-core-vscode/shared'
-import { fs, errors } from 'aws-core-vscode/shared'
+import { fs, errors, setContext } from 'aws-core-vscode/shared'
 import { initializeAuth, CredentialsStore, LoginManager, AuthUtils, SsoConnection } from 'aws-core-vscode/auth'
 import { CommonAuthWebview } from 'aws-core-vscode/login'
 import { VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
@@ -117,7 +116,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     registerCommands(context)
 
     // Hide the Amazon Q tree in toolkit explorer
-    await vscode.commands.executeCommand('setContext', amazonQDismissedKey, true)
+    await setContext('aws.toolkit.amazonq.dismissed', true)
 
     // reload webviews
     await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction')

--- a/packages/amazonq/test/unit/codewhisperer/commands/onAcceptance.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/commands/onAcceptance.test.ts
@@ -8,7 +8,6 @@ import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import {
     onAcceptance,
-    userGroupKey,
     UserGroup,
     AcceptedSuggestionEntry,
     session,
@@ -80,7 +79,7 @@ describe('onAcceptance', function () {
         })
 
         it('Should report telemetry that records this user decision event', async function () {
-            await globals.context.globalState.update(userGroupKey, {
+            await globals.context.globalState.update('CODEWHISPERER_USER_GROUP', {
                 group: UserGroup.Control,
                 version: extensionVersion,
             })

--- a/packages/amazonq/test/unit/codewhisperer/commands/onInlineAcceptance.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/commands/onInlineAcceptance.test.ts
@@ -15,7 +15,6 @@ import {
     AuthUtil,
     session,
     CodeWhispererUserGroupSettings,
-    userGroupKey,
     UserGroup,
 } from 'aws-core-vscode/codewhisperer'
 import { globals } from 'aws-core-vscode/shared'
@@ -58,7 +57,7 @@ describe('onInlineAcceptance', function () {
         })
 
         it('Should report telemetry that records this user decision event', async function () {
-            await globals.context.globalState.update(userGroupKey, {
+            await globals.context.globalState.update('CODEWHISPERER_USER_GROUP', {
                 group: UserGroup.Classifier,
                 version: extensionVersion,
             })

--- a/packages/amazonq/test/unit/codewhisperer/service/recommendationHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/recommendationHandler.test.ts
@@ -16,7 +16,6 @@ import {
     ConfigurationEntry,
     RecommendationHandler,
     CodeWhispererCodeCoverageTracker,
-    userGroupKey,
     UserGroup,
     supplementalContextUtil,
 } from 'aws-core-vscode/codewhisperer'
@@ -115,7 +114,7 @@ describe('recommendationHandler', function () {
         })
 
         it('should call telemetry function that records a CodeWhisperer service invocation', async function () {
-            await globals.context.globalState.update(userGroupKey, {
+            await globals.context.globalState.update('CODEWHISPERER_USER_GROUP', {
                 group: UserGroup.CrossFile,
                 version: extensionVersion,
             })
@@ -167,7 +166,7 @@ describe('recommendationHandler', function () {
         })
 
         it('should call telemetry function that records a Empty userDecision event', async function () {
-            await globals.context.globalState.update(userGroupKey, {
+            await globals.context.globalState.update('CODEWHISPERER_USER_GROUP', {
                 group: UserGroup.CrossFile,
                 version: extensionVersion,
             })

--- a/packages/amazonq/test/unit/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -11,7 +11,6 @@ import {
     vsCodeState,
     TelemetryHelper,
     AuthUtil,
-    userGroupKey,
     UserGroup,
     CodeWhispererUserGroupSettings,
 } from 'aws-core-vscode/codewhisperer'
@@ -524,7 +523,7 @@ describe('codewhispererCodecoverageTracker', function () {
         })
 
         it('should emit correct code coverage telemetry in python file', async function () {
-            await globals.context.globalState.update(userGroupKey, {
+            await globals.globalState.update('CODEWHISPERER_USER_GROUP', {
                 group: UserGroup.Control,
                 version: extensionVersion,
             })
@@ -547,7 +546,7 @@ describe('codewhispererCodecoverageTracker', function () {
         })
 
         it('should emit correct code coverage telemetry when success count = 0', async function () {
-            await globals.context.globalState.update(userGroupKey, {
+            await globals.globalState.update('CODEWHISPERER_USER_GROUP', {
                 group: UserGroup.Control,
                 version: extensionVersion,
             })

--- a/packages/amazonq/test/unit/codewhisperer/tracker/codewhispererTracker.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/tracker/codewhispererTracker.test.ts
@@ -9,7 +9,6 @@ import { assertTelemetryCurried } from 'aws-core-vscode/test'
 import {
     AuthUtil,
     CodeWhispererTracker,
-    userGroupKey,
     UserGroup,
     CodeWhispererUserGroupSettings,
 } from 'aws-core-vscode/codewhisperer'
@@ -96,7 +95,7 @@ describe('codewhispererTracker', function () {
         })
 
         it('Should call recordCodewhispererUserModification with suggestion event', async function () {
-            await globals.context.globalState.update(userGroupKey, {
+            await globals.context.globalState.update('CODEWHISPERER_USER_GROUP', {
                 group: UserGroup.CrossFile,
                 version: extensionVersion,
             })

--- a/packages/amazonq/test/unit/codewhisperer/util/userGroupUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/userGroupUtil.test.ts
@@ -15,9 +15,9 @@ describe('getCodeWhispererUserGroup', function () {
     })
 
     it('getUserGroup should set the group and version if there is none', async function () {
-        await globals.context.globalState.update(CodeWhispererConstants.userGroupKey, undefined)
+        await globals.globalState.update('CODEWHISPERER_USER_GROUP', undefined)
 
-        assert.ok(!globals.context.globalState.get(CodeWhispererConstants.userGroupKey))
+        assert.ok(!globals.globalState.get('CODEWHISPERER_USER_GROUP'))
 
         assert.ok(CodeWhispererUserGroupSettings.getUserGroup())
         assert.ok(CodeWhispererUserGroupSettings.instance.version)
@@ -30,7 +30,7 @@ describe('getCodeWhispererUserGroup', function () {
     })
 
     it('should return the same result', async function () {
-        await globals.context.globalState.update(CodeWhispererConstants.userGroupKey, undefined)
+        await globals.globalState.update('CODEWHISPERER_USER_GROUP', undefined)
 
         const group0 = CodeWhispererUserGroupSettings.getUserGroup()
         const group1 = CodeWhispererUserGroupSettings.getUserGroup()
@@ -44,7 +44,7 @@ describe('getCodeWhispererUserGroup', function () {
     })
 
     it('should return result stored in the extension context if the plugin version remains the same', async function () {
-        await globals.context.globalState.update(CodeWhispererConstants.userGroupKey, {
+        await globals.globalState.update('CODEWHISPERER_USER_GROUP', {
             group: CodeWhispererConstants.UserGroup.Control,
             version: extensionVersion,
         })
@@ -56,7 +56,7 @@ describe('getCodeWhispererUserGroup', function () {
     })
 
     it('should return different result if the plugin version is not the same', async function () {
-        await globals.context.globalState.update(CodeWhispererConstants.userGroupKey, {
+        await globals.globalState.update('CODEWHISPERER_USER_GROUP', {
             group: CodeWhispererConstants.UserGroup.Control,
             version: 'fake-extension-version',
         })

--- a/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
+++ b/packages/core/src/amazonq/explorer/amazonQChildrenNodes.ts
@@ -11,8 +11,7 @@ import { installAmazonQExtension } from '../../codewhisperer/commands/basicComma
 import { amazonQHelpUrl } from '../../shared/constants'
 import { cwTreeNodeSource } from '../../codewhisperer/commands/types'
 import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
-import { globals } from '../../shared'
-import { amazonQDismissedKey } from '../../codewhisperer/models/constants'
+import { globals, setContext } from '../../shared'
 import { ExtStartUpSources, telemetry } from '../../shared/telemetry'
 import { ExtensionUse } from '../../auth/utils'
 
@@ -34,8 +33,8 @@ export const dismissQTree = Commands.declare(
                 source: ExtensionUse.instance.isFirstUse() ? ExtStartUpSources.firstStartUp : ExtStartUpSources.none,
             })
 
-            await globals.context.globalState.update(amazonQDismissedKey, true)
-            await vscode.commands.executeCommand('setContext', amazonQDismissedKey, true)
+            await globals.globalState.update('aws.toolkit.amazonq.dismissed', true)
+            await setContext('aws.toolkit.amazonq.dismissed', true)
 
             telemetry.record({ action: 'dismissQExplorerTree' })
         })

--- a/packages/core/src/amazonq/util/viewBadgeHandler.ts
+++ b/packages/core/src/amazonq/util/viewBadgeHandler.ts
@@ -10,7 +10,6 @@ import { AuthUtil } from '../../codewhisperer/util/authUtil'
 import { GlobalState } from '../../shared/globalState'
 
 let badgeHelperView: TreeView<void> | undefined
-const mementoKey = 'hasAlreadyOpenedAmazonQ'
 
 /**
  * invisible view meant exclusively to handle the view badge, note declaration has `"when": false`.
@@ -44,7 +43,7 @@ export function changeViewBadge(badge?: ViewBadge) {
  * Removes the view badge from the badge helper view and prevents it from showing up ever again
  */
 export function deactivateInitialViewBadge() {
-    GlobalState.instance.tryUpdate(mementoKey, true)
+    GlobalState.instance.tryUpdate('hasAlreadyOpenedAmazonQ', true)
     changeViewBadge()
 }
 
@@ -74,7 +73,7 @@ async function showInitialViewBadge() {
  */
 export async function shouldShowBadge(): Promise<boolean> {
     const memento = globals.context.globalState
-    const hasAlreadyShown = memento.get(mementoKey)
+    const hasAlreadyShown = memento.get('hasAlreadyOpenedAmazonQ')
     if (!hasAlreadyShown) {
         const state = await AuthUtil.instance.getChatAuthState()
         if (state.codewhispererCore === 'connected' && state.codewhispererChat !== 'connected') {

--- a/packages/core/src/amazonq/util/viewBadgeHandler.ts
+++ b/packages/core/src/amazonq/util/viewBadgeHandler.ts
@@ -7,7 +7,6 @@ import { window, TreeItem, TreeView, ViewBadge } from 'vscode'
 import { getLogger } from '../../shared/logger'
 import globals from '../../shared/extensionGlobals'
 import { AuthUtil } from '../../codewhisperer/util/authUtil'
-import { GlobalState } from '../../shared/globalState'
 
 let badgeHelperView: TreeView<void> | undefined
 
@@ -43,7 +42,7 @@ export function changeViewBadge(badge?: ViewBadge) {
  * Removes the view badge from the badge helper view and prevents it from showing up ever again
  */
 export function deactivateInitialViewBadge() {
-    GlobalState.instance.tryUpdate('hasAlreadyOpenedAmazonQ', true)
+    globals.globalState.tryUpdate('hasAlreadyOpenedAmazonQ', true)
     changeViewBadge()
 }
 

--- a/packages/core/src/amazonqGumby/activation.ts
+++ b/packages/core/src/amazonqGumby/activation.ts
@@ -13,9 +13,10 @@ import { ProposedTransformationExplorer } from '../codewhisperer/service/transfo
 import { CodeTransformTelemetryState } from './telemetry/codeTransformTelemetryState'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { CancelActionPositions } from './telemetry/codeTransformTelemetry'
+import { setContext } from '../shared'
 
 export async function activate(context: ExtContext) {
-    void vscode.commands.executeCommand('setContext', 'gumby.wasQCodeTransformationUsed', false)
+    void setContext('gumby.wasQCodeTransformationUsed', false)
 
     const transformationHubViewProvider = new TransformationHubViewProvider()
     new ProposedTransformationExplorer(context.extensionContext)

--- a/packages/core/src/auth/utils.ts
+++ b/packages/core/src/auth/utils.ts
@@ -51,6 +51,7 @@ import { extensionVersion } from '../shared/vscode/env'
 import { ExtStartUpSources } from '../shared/telemetry'
 import { CommonAuthWebview } from '../login/webview/vue/backend'
 import { AuthSource } from '../login/webview/util'
+import { setContext } from '../shared/vscode/setContext'
 
 // iam-only excludes Builder ID and IAM Identity Center from the list of valid connections
 // TODO: Understand if "iam" should include these from the list at all
@@ -480,11 +481,7 @@ export class AuthNode implements TreeNode<Auth> {
                 CommonAuthWebview.authSource = ExtensionUse.instance.isFirstUse()
                     ? ExtStartUpSources.firstStartUp
                     : ExtStartUpSources.reload
-                void vscode.commands.executeCommand(
-                    'setContext',
-                    'aws.explorer.showAuthView',
-                    !this.resource.hasConnections
-                )
+                void setContext('aws.explorer.showAuthView', !this.resource.hasConnections)
             })
             .catch(e => {
                 getLogger().error('tryAutoConnect failed: %s', (e as Error).message)

--- a/packages/core/src/awsService/s3/commands/uploadFile.ts
+++ b/packages/core/src/awsService/s3/commands/uploadFile.ts
@@ -24,7 +24,6 @@ import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import { progressReporter } from '../progressReporter'
 import globals from '../../../shared/extensionGlobals'
 import { telemetry } from '../../../shared/telemetry/telemetry'
-import { GlobalState } from '../../../shared/globalState'
 
 export interface FileSizeBytes {
     /**
@@ -102,7 +101,7 @@ export async function uploadFileCommand(
             })
         )
         if (node instanceof S3FolderNode) {
-            GlobalState.instance.tryUpdate('aws.lastUploadedToS3Folder', {
+            globals.globalState.tryUpdate('aws.lastUploadedToS3Folder', {
                 bucket: node.bucket,
                 folder: node.folder,
             })
@@ -166,7 +165,7 @@ export async function uploadFileCommand(
             )
 
             if (bucketResponse.folder) {
-                GlobalState.instance.tryUpdate('aws.lastUploadedToS3Folder', {
+                globals.globalState.tryUpdate('aws.lastUploadedToS3Folder', {
                     bucket: bucketResponse.bucket,
                     folder: bucketResponse.folder,
                 })

--- a/packages/core/src/awsexplorer/activation.ts
+++ b/packages/core/src/awsexplorer/activation.ts
@@ -28,7 +28,6 @@ import { CodeCatalystRootNode } from '../codecatalyst/explorer'
 import { CodeCatalystAuthenticationProvider } from '../codecatalyst/auth'
 import { S3FolderNode } from '../awsService/s3/explorer/s3FolderNode'
 import { AmazonQNode, refreshAmazonQ, refreshAmazonQRootNode } from '../amazonq/explorer/amazonQTreeNode'
-import { GlobalState } from '../shared/globalState'
 import { activateViewsShared, registerToolView } from './activationShared'
 import { isExtensionInstalled } from '../shared/utilities'
 import { CommonAuthViewProvider } from '../login/webview'
@@ -53,7 +52,7 @@ export async function activate(args: {
     })
     view.onDidExpandElement(element => {
         if (element.element instanceof S3FolderNode) {
-            GlobalState.instance.tryUpdate('aws.lastTouchedS3Folder', {
+            globals.globalState.tryUpdate('aws.lastTouchedS3Folder', {
                 bucket: element.element.bucket,
                 folder: element.element.folder,
             })

--- a/packages/core/src/awsexplorer/activation.ts
+++ b/packages/core/src/awsexplorer/activation.ts
@@ -31,8 +31,8 @@ import { AmazonQNode, refreshAmazonQ, refreshAmazonQRootNode } from '../amazonq/
 import { GlobalState } from '../shared/globalState'
 import { activateViewsShared, registerToolView } from './activationShared'
 import { isExtensionInstalled } from '../shared/utilities'
-import { amazonQDismissedKey } from '../codewhisperer/models/constants'
 import { CommonAuthViewProvider } from '../login/webview'
+import { setContext } from '../shared'
 
 /**
  * Activates the AWS Explorer UI and related functionality.
@@ -110,9 +110,9 @@ export async function activate(args: {
     if (!isCloud9()) {
         if (
             isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq) ||
-            globals.context.globalState.get<boolean>(amazonQDismissedKey)
+            globals.globalState.get<boolean>('aws.toolkit.amazonq.dismissed')
         ) {
-            await vscode.commands.executeCommand('setContext', amazonQDismissedKey, true)
+            await setContext('aws.toolkit.amazonq.dismissed', true)
         }
 
         // We should create the tree even if it's dismissed, in case the user installs Amazon Q later.

--- a/packages/core/src/codecatalyst/auth.ts
+++ b/packages/core/src/codecatalyst/auth.ts
@@ -28,6 +28,7 @@ import { createBuilderIdConnection } from '../auth/utils'
 import { builderIdStartUrl } from '../auth/sso/model'
 import { showReauthenticateMessage } from '../shared/utilities/messages'
 import { ToolkitPromptSettings } from '../shared/settings'
+import { setContext } from '../shared/vscode/setContext'
 
 // Secrets stored on the macOS keychain appear as individual entries for each key
 // This is fine so long as the user has only a few accounts. Otherwise this should
@@ -55,7 +56,7 @@ export const isUpgradeableConnection = (conn: Connection): conn is SsoConnection
     isSsoConnection(conn) && !isValidCodeCatalystConnection(conn)
 
 export function setCodeCatalystConnectedContext(isConnected: boolean) {
-    return vscode.commands.executeCommand('setContext', 'aws.codecatalyst.connected', isConnected)
+    return setContext('aws.codecatalyst.connected', isConnected)
 }
 
 type ConnectionState = {

--- a/packages/core/src/codecatalyst/model.ts
+++ b/packages/core/src/codecatalyst/model.ts
@@ -362,5 +362,3 @@ export interface DevEnvMemento {
     /** CodeCatalyst Alias */
     alias: string | undefined
 }
-
-export const codecatalystReconnectKey = 'CODECATALYST_RECONNECT'

--- a/packages/core/src/codecatalyst/reconnect.ts
+++ b/packages/core/src/codecatalyst/reconnect.ts
@@ -18,7 +18,6 @@ import globals from '../shared/extensionGlobals'
 import { isDevenvVscode } from './utils'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { SsoConnection } from '../auth/connection'
-import { GlobalState } from '../shared/globalState'
 
 const localize = nls.loadMessageBundle()
 
@@ -41,8 +40,7 @@ export function watchRestartingDevEnvs(ctx: ExtContext, authProvider: CodeCataly
 
 function handleRestart(conn: SsoConnection, ctx: ExtContext, envId: string | undefined) {
     if (envId !== undefined) {
-        const pendingReconnects =
-            GlobalState.instance.get<Record<string, DevEnvMemento>>('CODECATALYST_RECONNECT') ?? {}
+        const pendingReconnects = globals.globalState.get<Record<string, DevEnvMemento>>('CODECATALYST_RECONNECT') ?? {}
         if (envId in pendingReconnects) {
             const devenv = pendingReconnects[envId]
             const devenvName = getDevEnvName(devenv.alias, envId)
@@ -51,7 +49,7 @@ function handleRestart(conn: SsoConnection, ctx: ExtContext, envId: string | und
                 localize('AWS.codecatalyst.reconnect.success', 'Reconnected to Dev Environment: {0}', devenvName)
             )
             delete pendingReconnects[envId]
-            GlobalState.instance.tryUpdate('CODECATALYST_RECONNECT', pendingReconnects)
+            globals.globalState.tryUpdate('CODECATALYST_RECONNECT', pendingReconnects)
         }
     } else {
         getLogger().info('codecatalyst: attempting to poll dev environments')

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -43,6 +43,7 @@ import { isRemoteWorkspace } from '../../shared/vscode/env'
 import { isBuilderIdConnection } from '../../auth/connection'
 import globals from '../../shared/extensionGlobals'
 import { getVscodeCliPath, tryRun } from '../../shared/utilities/pathFind'
+import { setContext } from '../../shared/vscode/setContext'
 
 const MessageTimeOut = 5_000
 
@@ -78,8 +79,8 @@ export const enableCodeSuggestions = Commands.declare(
     (context: ExtContext) =>
         async (isAuto: boolean = true) => {
             await CodeSuggestionsState.instance.setSuggestionsEnabled(isAuto)
-            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.connected', true)
-            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.connectionExpired', false)
+            await setContext('aws.codewhisperer.connected', true)
+            await setContext('aws.codewhisperer.connectionExpired', false)
             vsCodeState.isFreeTierLimitReached = false
             if (!isCloud9()) {
                 await vscode.commands.executeCommand('aws.amazonq.refreshStatusBar')

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -70,6 +70,7 @@ import { sleep } from '../../shared/utilities/timeoutUtils'
 import DependencyVersions from '../../amazonqGumby/models/dependencies'
 import { dependencyNoAvailableVersions } from '../../amazonqGumby/models/constants'
 import { HumanInTheLoopManager } from '../service/transformByQ/humanInTheLoopManager'
+import { setContext } from '../../shared/vscode/setContext'
 
 function getFeedbackCommentData() {
     const jobId = transformByQState.getJobId()
@@ -553,7 +554,7 @@ export async function pollTransformationStatusUntilPlanReady(jobId: string) {
         fs.writeFileSync(planFilePath, plan)
         await vscode.commands.executeCommand('markdown.showPreview', vscode.Uri.file(planFilePath))
         transformByQState.setPlanFilePath(planFilePath)
-        await vscode.commands.executeCommand('setContext', 'gumby.isPlanAvailable', true)
+        await setContext('gumby.isPlanAvailable', true)
     }
     jobPlanProgress['generatePlan'] = StepProgress.Succeeded
     throwIfCancelled()
@@ -726,7 +727,7 @@ export async function transformationJobErrorHandler(error: any) {
 export async function cleanupTransformationJob() {
     clearInterval(transformByQState.getIntervalId())
     transformByQState.setJobDefaults()
-    await vscode.commands.executeCommand('setContext', 'gumby.isStopButtonAvailable', false)
+    await setContext('gumby.isStopButtonAvailable', false)
     await vscode.commands.executeCommand(
         'aws.amazonq.showPlanProgressInHub',
         CodeTransformTelemetryState.instance.getStartTime()
@@ -750,7 +751,7 @@ export async function stopTransformByQ(
         getLogger().info('CodeTransformation: User requested to stop transformation. Stopping transformation.')
         transformByQState.setToCancelled()
         transformByQState.setPolledJobStatus('CANCELLED')
-        await vscode.commands.executeCommand('setContext', 'gumby.isStopButtonAvailable', false)
+        await setContext('gumby.isStopButtonAvailable', false)
         try {
             await stopJob(jobId)
             void vscode.window
@@ -794,8 +795,8 @@ export async function stopTransformByQ(
 }
 
 async function setContextVariables() {
-    await vscode.commands.executeCommand('setContext', 'gumby.wasQCodeTransformationUsed', true)
-    await vscode.commands.executeCommand('setContext', 'gumby.isStopButtonAvailable', true)
-    await vscode.commands.executeCommand('setContext', 'gumby.isPlanAvailable', false)
-    await vscode.commands.executeCommand('setContext', 'gumby.isSummaryAvailable', false)
+    await setContext('gumby.wasQCodeTransformationUsed', true)
+    await setContext('gumby.isStopButtonAvailable', true)
+    await setContext('gumby.isPlanAvailable', false)
+    await setContext('gumby.isSummaryAvailable', false)
 }

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -146,8 +146,6 @@ export const selectedCustomizationKey = 'CODEWHISPERER_SELECTED_CUSTOMIZATION'
 
 export const inlinehintKey = 'CODEWHISPERER_HINT_DISPLAYED'
 
-export const inlinehintWipKey = 'aws.codewhisperer.tutorial.workInProgress'
-
 export type AnnotationChangeSource = 'codewhisperer' | 'selection' | 'editor' | 'content'
 
 export const learnMoreUriGeneral = 'https://aws.amazon.com/q/developer/'
@@ -327,8 +325,6 @@ export const stopScanMessage =
 
 export const showScannedFilesMessage = 'Show Scanned Files'
 
-export const userGroupKey = 'CODEWHISPERER_USER_GROUP'
-
 export const updateInlineLockKey = 'CODEWHISPERER_INLINE_UPDATE_LOCK_KEY'
 
 export const newCustomizationMessage = 'You have access to new Amazon Q customizations.'
@@ -385,9 +381,6 @@ export const validStatesForCheckingDownloadUrl = [
     'STOPPED',
     'REJECTED',
 ]
-
-export const amazonQDismissedKey = 'aws.toolkit.amazonq.dismissed'
-export const amazonQInstallDismissedKey = 'aws.toolkit.amazonqInstall.dismissed'
 
 export const amazonQFeedbackKey = 'Amazon Q'
 

--- a/packages/core/src/codewhisperer/tracker/lineTracker.ts
+++ b/packages/core/src/codewhisperer/tracker/lineTracker.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode'
 import { isTextEditor } from '../../shared/utilities/editorUtilities'
+import { setContext } from '../../shared'
 
 export interface LineSelection {
     anchor: number
@@ -85,7 +86,7 @@ export class LineTracker implements vscode.Disposable {
         this._selections = toLineSelections(editor?.selections)
         if (this._selections && this._selections[0]) {
             const s = this._selections.map(item => item.active + 1)
-            await vscode.commands.executeCommand('setContext', 'codewhisperer.activeLine', s)
+            await setContext('codewhisperer.activeLine', s)
         }
 
         this.notifyLinesChanged('editor')
@@ -107,7 +108,7 @@ export class LineTracker implements vscode.Disposable {
         this._selections = selections
         if (this._selections && this._selections[0]) {
             const s = this._selections.map(item => item.active + 1)
-            await vscode.commands.executeCommand('setContext', 'codewhisperer.activeLine', s)
+            await setContext('codewhisperer.activeLine', s)
         }
 
         this.notifyLinesChanged('selection')

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -33,7 +33,7 @@ import { onceChanged, once } from '../../shared/utilities/functionUtils'
 import { indent } from '../../shared/utilities/textUtilities'
 import { showReauthenticateMessage } from '../../shared/utilities/messages'
 import { showAmazonQWalkthroughOnce } from '../../amazonq/onboardingPage/walkthrough'
-import { setContext } from '../../shared'
+import { setContext } from '../../shared/vscode/setContext'
 
 /** Backwards compatibility for connections w pre-chat scopes */
 export const codeWhispererCoreScopes = [...scopesCodeWhispererCore]

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -33,6 +33,7 @@ import { onceChanged, once } from '../../shared/utilities/functionUtils'
 import { indent } from '../../shared/utilities/textUtilities'
 import { showReauthenticateMessage } from '../../shared/utilities/messages'
 import { showAmazonQWalkthroughOnce } from '../../amazonq/onboardingPage/walkthrough'
+import { setContext } from '../../shared'
 
 /** Backwards compatibility for connections w pre-chat scopes */
 export const codeWhispererCoreScopes = [...scopesCodeWhispererCore]
@@ -123,7 +124,7 @@ export class AuthUtil {
                 Commands.tryExecute('aws.amazonq.updateReferenceLog'),
             ])
 
-            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.connected', this.isConnected())
+            await setContext('aws.codewhisperer.connected', this.isConnected())
 
             // To check valid connection
             if (this.isValidEnterpriseSsoInUse() || (this.isBuilderIdInUse() && !this.isConnectionExpired())) {
@@ -140,14 +141,10 @@ export class AuthUtil {
             return
         }
 
-        await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.connected', this.isConnected())
+        await setContext('aws.codewhisperer.connected', this.isConnected())
         const doShowAmazonQLoginView = !this.isConnected() || this.isConnectionExpired()
-        await vscode.commands.executeCommand('setContext', 'aws.amazonq.showLoginView', doShowAmazonQLoginView)
-        await vscode.commands.executeCommand(
-            'setContext',
-            'aws.codewhisperer.connectionExpired',
-            this.isConnectionExpired()
-        )
+        await setContext('aws.amazonq.showLoginView', doShowAmazonQLoginView)
+        await setContext('aws.codewhisperer.connectionExpired', this.isConnectionExpired())
     }
 
     public reformatStartUrl(startUrl: string | undefined) {

--- a/packages/core/src/codewhisperer/util/userGroupUtil.ts
+++ b/packages/core/src/codewhisperer/util/userGroupUtil.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UserGroup, userGroupKey } from '../models/constants'
+import { UserGroup } from '../models/constants'
 import globals from '../../shared/extensionGlobals'
 import { extensionVersion } from '../../shared/vscode/env'
 import { GlobalState } from '../../shared/globalState'
@@ -36,7 +36,9 @@ export class CodeWhispererUserGroupSettings {
     }
 
     private determineUserGroupIfNeeded(): UserGroup {
-        const userGroupMetadata = globals.context.globalState.get<{ group: UserGroup; version: string }>(userGroupKey)
+        const userGroupMetadata = globals.globalState.get<{ group: UserGroup; version: string }>(
+            'CODEWHISPERER_USER_GROUP'
+        )
         // use the same userGroup setting if and only if they are the same version of plugin
         if (userGroupMetadata && userGroupMetadata.version && userGroupMetadata.version === extensionVersion) {
             this._userGroup = userGroupMetadata.group
@@ -48,7 +50,7 @@ export class CodeWhispererUserGroupSettings {
         this._version = extensionVersion
         this._userGroup = this.guessUserGroup()
 
-        GlobalState.instance.tryUpdate(userGroupKey, {
+        GlobalState.instance.tryUpdate('CODEWHISPERER_USER_GROUP', {
             group: this._userGroup,
             version: this._version,
         })

--- a/packages/core/src/codewhisperer/util/userGroupUtil.ts
+++ b/packages/core/src/codewhisperer/util/userGroupUtil.ts
@@ -6,7 +6,6 @@
 import { UserGroup } from '../models/constants'
 import globals from '../../shared/extensionGlobals'
 import { extensionVersion } from '../../shared/vscode/env'
-import { GlobalState } from '../../shared/globalState'
 
 export class CodeWhispererUserGroupSettings {
     private _userGroup: UserGroup | undefined
@@ -50,7 +49,7 @@ export class CodeWhispererUserGroupSettings {
         this._version = extensionVersion
         this._userGroup = this.guessUserGroup()
 
-        GlobalState.instance.tryUpdate('CODEWHISPERER_USER_GROUP', {
+        globals.globalState.tryUpdate('CODEWHISPERER_USER_GROUP', {
             group: this._userGroup,
             version: this._version,
         })

--- a/packages/core/src/codewhisperer/views/lineAnnotationController.ts
+++ b/packages/core/src/codewhisperer/views/lineAnnotationController.ts
@@ -11,7 +11,7 @@ import { cancellableDebounce } from '../../shared/utilities/functionUtils'
 import { subscribeOnce } from '../../shared/utilities/vsCodeUtils'
 import { RecommendationService } from '../service/recommendationService'
 import { set } from '../util/commonUtil'
-import { AnnotationChangeSource, autoTriggerEnabledKey, inlinehintKey, inlinehintWipKey } from '../models/constants'
+import { AnnotationChangeSource, autoTriggerEnabledKey, inlinehintKey } from '../models/constants'
 import globals from '../../shared/extensionGlobals'
 import { Container } from '../service/serviceContainer'
 import { telemetry } from '../../shared/telemetry/telemetry'
@@ -20,6 +20,7 @@ import { Commands } from '../../shared/vscode/commands2'
 import { session } from '../util/codeWhispererSession'
 import { RecommendationHandler } from '../service/recommendationHandler'
 import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
+import { setContext } from '../../shared'
 
 const case3TimeWindow = 30000 // 30 seconds
 
@@ -307,7 +308,7 @@ export class LineAnnotationController implements vscode.Disposable {
 
     async dismissTutorial() {
         this._currentState = new EndState()
-        await vscode.commands.executeCommand('setContext', inlinehintWipKey, false)
+        await setContext('aws.codewhisperer.tutorial.workInProgress', false)
         await set(inlinehintKey, this._currentState.id, globals.context.globalState)
     }
 
@@ -404,7 +405,7 @@ export class LineAnnotationController implements vscode.Disposable {
 
         if (decorationOptions === undefined) {
             this.clear()
-            await vscode.commands.executeCommand('setContext', inlinehintWipKey, false)
+            await setContext('aws.codewhisperer.tutorial.workInProgress', false)
             return
         } else if (this.isTutorialDone()) {
             // special case
@@ -423,7 +424,7 @@ export class LineAnnotationController implements vscode.Disposable {
         decorationOptions.range = range
 
         await set(inlinehintKey, this._currentState.id, globals.context.globalState)
-        await vscode.commands.executeCommand('setContext', inlinehintWipKey, true)
+        await setContext('aws.codewhisperer.tutorial.workInProgress', true)
         editor.setDecorations(this.cwLineHintDecoration, [decorationOptions])
     }
 

--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -46,6 +46,7 @@ import { Commands, VsCodeCommandArg, placeholder, vscodeComponent } from './shar
 import { isValidResponse } from './shared/wizards/wizard'
 import { CancellationError } from './shared/utilities/timeoutUtils'
 import { ToolkitError } from './shared/errors'
+import { setContext } from './shared'
 
 function switchConnections(auth: Auth | TreeNode | unknown) {
     if (!(auth instanceof Auth)) {
@@ -129,7 +130,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
 
             CommonAuthWebview.authSource = source
             await vscode.commands.executeCommand('aws.explorer.setLoginService', serviceToShow)
-            await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', true)
+            await setContext('aws.explorer.showAuthView', true)
             await vscode.commands.executeCommand('aws.toolkit.AmazonCommonAuth.focus')
         }
     )

--- a/packages/core/src/dev/activation.ts
+++ b/packages/core/src/dev/activation.ts
@@ -22,6 +22,7 @@ import { Auth } from '../auth/auth'
 import { getLogger } from '../shared/logger'
 import { entries } from '../shared/utilities/tsUtils'
 import { getEnvironmentSpecificMemento } from '../shared/utilities/mementos'
+import { setContext } from '../shared'
 
 interface MenuOption {
     readonly label: string
@@ -434,5 +435,5 @@ async function showState(path: string) {
 export const openStorageCommand = Commands.from(ObjectEditor).declareOpenStorage('_aws.dev.openStorage')
 
 export async function updateDevMode() {
-    await vscode.commands.executeCommand('setContext', 'aws.isDevMode', DevSettings.instance.isDevMode())
+    await setContext('aws.isDevMode', DevSettings.instance.isDevMode())
 }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -55,11 +55,11 @@ import { learnMoreAmazonQCommand, qExtensionPageCommand, dismissQTree } from './
 import { AuthUtil, codeWhispererCoreScopes, isPreviousQUser } from './codewhisperer/util/authUtil'
 import { installAmazonQExtension } from './codewhisperer/commands/basicCommands'
 import { isExtensionInstalled, VSCODE_EXTENSION_ID } from './shared/utilities'
-import { amazonQInstallDismissedKey } from './codewhisperer/models/constants'
 import { ExtensionUse } from './auth/utils'
 import { ExtStartUpSources } from './shared/telemetry'
 import { activate as activateThreatComposerEditor } from './threatComposer/activation'
 import { isSsoConnection, hasScopes } from './auth/connection'
+import { setContext } from './shared'
 
 let localize: nls.LocalizeFunc
 
@@ -116,10 +116,10 @@ export async function activate(context: vscode.ExtensionContext) {
         // do not enable codecatalyst for sagemaker
         // TODO: remove setContext if SageMaker adds the context to their IDE
         if (!isSageMaker()) {
-            await vscode.commands.executeCommand('setContext', 'aws.isSageMaker', false)
+            await setContext('aws.isSageMaker', false)
             await codecatalyst.activate(extContext)
         } else {
-            await vscode.commands.executeCommand('setContext', 'aws.isSageMaker', true)
+            await setContext('aws.isSageMaker', true)
         }
 
         // Clean up remaining logins after codecatalyst activated and ran its cleanup.
@@ -250,7 +250,7 @@ export async function deactivate() {
 }
 
 async function handleAmazonQInstall() {
-    const dismissedInstall = globals.context.globalState.get<boolean>(amazonQInstallDismissedKey)
+    const dismissedInstall = globals.globalState.get<boolean>('aws.toolkit.amazonqInstall.dismissed')
     if (isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq) || dismissedInstall) {
         return
     }
@@ -262,7 +262,7 @@ async function handleAmazonQInstall() {
             void vscode.window.showInformationMessage(
                 "Amazon Q is now its own extension.\n\nWe've auto-installed it for you with all the same features and settings from CodeWhisperer and Amazon Q chat."
             )
-            await globals.context.globalState.update(amazonQInstallDismissedKey, true)
+            await globals.globalState.update('aws.toolkit.amazonqInstall.dismissed', true)
         } else {
             telemetry.record({ id: 'amazonQStandaloneChange' })
             void vscode.window
@@ -293,7 +293,7 @@ async function handleAmazonQInstall() {
                         } else {
                             telemetry.record({ action: 'dismissQNotification' })
                         }
-                        await globals.context.globalState.update(amazonQInstallDismissedKey, true)
+                        await globals.globalState.update('aws.toolkit.amazonqInstall.dismissed', true)
                     })
                 })
         }

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -12,6 +12,7 @@ import { Auth } from '../../../../auth/auth'
 import { CodeCatalystAuthenticationProvider } from '../../../../codecatalyst/auth'
 import { AuthError, AuthFlowState, TelemetryMetadata } from '../types'
 import { builderIdStartUrl } from '../../../../auth/sso/model'
+import { setContext } from '../../../../shared'
 
 export class ToolkitLoginWebview extends CommonAuthWebview {
     public override id: string = 'aws.toolkit.AmazonCommonAuth'
@@ -45,7 +46,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
 
                 this.storeMetricMetadata({ authEnabledFeatures: this.getAuthEnabledFeatures(conn) })
 
-                await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', false)
+                await setContext('aws.explorer.showAuthView', false)
                 await this.showResourceExplorer()
             })
         }
@@ -59,7 +60,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
 
             this.storeMetricMetadata({ authEnabledFeatures: this.getAuthEnabledFeatures(conn) })
 
-            await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', false)
+            await setContext('aws.explorer.showAuthView', false)
             void vscode.window.showInformationMessage('Toolkit: Successfully connected to AWS IAM Identity Center')
             void this.showResourceExplorer()
         })
@@ -80,7 +81,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
             }
             try {
                 await tryAddCredentials(profileName, data, true)
-                await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', false)
+                await setContext('aws.explorer.showAuthView', false)
                 await this.showResourceExplorer()
             } catch (e) {
                 getLogger().error('Failed submitting credentials', e)
@@ -109,7 +110,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
             })
 
             await this.codeCatalystAuth.connectToAwsBuilderId()
-            await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', false)
+            await setContext('aws.explorer.showAuthView', false)
             await this.showResourceExplorer()
         })
     }
@@ -154,7 +155,7 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
     }
 
     async quitLoginScreen() {
-        await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', false)
+        await setContext('aws.explorer.showAuthView', false)
         await this.showResourceExplorer()
     }
 }

--- a/packages/core/src/shared/extensionGlobals.ts
+++ b/packages/core/src/shared/extensionGlobals.ts
@@ -146,7 +146,7 @@ export function initialize(context: ExtensionContext, isWeb: boolean = false): T
         context,
         clock: copyClock(),
         didReload: checkDidReload(context),
-        globalState: GlobalState.instance,
+        globalState: new GlobalState(context),
         manifestPaths: {} as ToolkitGlobals['manifestPaths'],
         visualizationResourcePaths: {} as ToolkitGlobals['visualizationResourcePaths'],
         isWeb,
@@ -170,6 +170,7 @@ export { globals as default }
  */
 interface ToolkitGlobals {
     readonly context: ExtensionContext
+    /** Global, shared, mutable, persisted state (survives IDE restart), namespaced to the extension (i.e. not shared with other vscode extensions). */
     readonly globalState: GlobalState
     /** Decides the prefix for package.json extension parameters, e.g. commands, 'setContext' values, etc. */
     contextPrefix: string

--- a/packages/core/src/shared/extensionGlobals.ts
+++ b/packages/core/src/shared/extensionGlobals.ts
@@ -16,7 +16,8 @@ import { SchemaService } from './schemas'
 import { TelemetryLogger } from './telemetry/telemetryLogger'
 import { TelemetryService } from './telemetry/telemetryService'
 import { UriHandler } from './vscode/uriHandler'
-import vscode from 'vscode'
+import { GlobalState } from './globalState'
+import { setContext } from './vscode/setContext'
 
 type Clock = Pick<
     typeof globalThis,
@@ -145,11 +146,12 @@ export function initialize(context: ExtensionContext, isWeb: boolean = false): T
         context,
         clock: copyClock(),
         didReload: checkDidReload(context),
+        globalState: GlobalState.instance,
         manifestPaths: {} as ToolkitGlobals['manifestPaths'],
         visualizationResourcePaths: {} as ToolkitGlobals['visualizationResourcePaths'],
         isWeb,
     })
-    void vscode.commands.executeCommand('setContext', 'aws.isWebExtHost', isWeb)
+    void setContext('aws.isWebExtHost', isWeb)
 
     initialized = true
 
@@ -168,6 +170,7 @@ export { globals as default }
  */
 interface ToolkitGlobals {
     readonly context: ExtensionContext
+    readonly globalState: GlobalState
     /** Decides the prefix for package.json extension parameters, e.g. commands, 'setContext' values, etc. */
     contextPrefix: string
     // TODO: make the rest of these readonly (or delete them)

--- a/packages/core/src/shared/filesystemUtilities.ts
+++ b/packages/core/src/shared/filesystemUtilities.ts
@@ -10,7 +10,6 @@ import * as vscode from 'vscode'
 import { getLogger } from './logger'
 import * as pathutils from './utilities/pathUtils'
 import globals from '../shared/extensionGlobals'
-import { GlobalState } from './globalState'
 import fs from '../shared/fs/fs'
 
 export const tempDirPath = path.join(
@@ -260,7 +259,7 @@ export async function cloud9Findfile(dir: string, fileName: string): Promise<vsc
  * @returns  A string path to the last locally stored download location. If none, returns the users 'Downloads' directory path.
  */
 export async function getDefaultDownloadPath(): Promise<string> {
-    const lastUsedPath = globals.context.globalState.get('aws.downloadPath')
+    const lastUsedPath = globals.globalState.get('aws.downloadPath')
     if (lastUsedPath) {
         if (typeof lastUsedPath === 'string') {
             return lastUsedPath
@@ -273,9 +272,9 @@ export async function getDefaultDownloadPath(): Promise<string> {
 export async function setDefaultDownloadPath(downloadPath: string) {
     try {
         if (await fs.existsDir(downloadPath)) {
-            GlobalState.instance.tryUpdate('aws.downloadPath', downloadPath)
+            globals.globalState.tryUpdate('aws.downloadPath', downloadPath)
         } else {
-            GlobalState.instance.tryUpdate('aws.downloadPath', path.dirname(downloadPath))
+            globals.globalState.tryUpdate('aws.downloadPath', path.dirname(downloadPath))
         }
     } catch (err) {
         getLogger().error('Error while setting "aws.downloadPath"', err as Error)

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -4,37 +4,44 @@
  */
 
 import * as vscode from 'vscode'
-import globals from './extensionGlobals'
 import { getLogger } from './logger/logger'
 
 type globalKey =
-    | 'gumby.wasQCodeTransformationUsed'
-    | 'aws.toolkit.amazonq.dismissed'
-    | 'aws.toolkit.amazonqInstall.dismissed'
-    | 'hasAlreadyOpenedAmazonQ'
+    | 'aws.downloadPath'
     | 'aws.lastTouchedS3Folder'
     | 'aws.lastUploadedToS3Folder'
-    | 'aws.downloadPath'
+    | 'aws.toolkit.amazonq.dismissed'
+    | 'aws.toolkit.amazonqInstall.dismissed'
+    // Deprecated/legacy names. New keys should start with "aws.".
     | 'CODECATALYST_RECONNECT'
     | 'CODEWHISPERER_USER_GROUP'
+    | 'gumby.wasQCodeTransformationUsed'
+    | 'hasAlreadyOpenedAmazonQ'
 
+/**
+ * Extension-local, shared state which persists after IDE restart. Shared with all instances (or
+ * tabs, in a web browser) of this extension for a given user, but not visible to other vscode
+ * extensions. Global state should be avoided, except when absolutely necessary.
+ *
+ * This wrapper adds structure and visibility to the vscode `globalState` interface. It also opens
+ * the door for:
+ * - validation
+ * - garbage collection
+ */
 export class GlobalState implements vscode.Memento {
-    static #instance: GlobalState
-    static get instance(): GlobalState {
-        return (this.#instance ??= new GlobalState())
-    }
+    public constructor(private readonly extContext: vscode.ExtensionContext) {}
 
     public keys(): readonly string[] {
-        return globals.context.globalState.keys()
+        return this.extContext.globalState.keys()
     }
 
     public get<T>(key: globalKey, defaultValue?: T): T | undefined {
-        return globals.context.globalState.get(key) ?? defaultValue
+        return this.extContext.globalState.get(key) ?? defaultValue
     }
 
     /** Asynchronously updates globalState, or logs an error on failure. */
     public tryUpdate(key: globalKey, value: any): void {
-        globals.context.globalState.update(key, value).then(
+        this.extContext.globalState.update(key, value).then(
             undefined, // TODO: log.debug() ?
             e => {
                 getLogger().error('GlobalState: failed to set "%s": %s', key, (e as Error).message)
@@ -43,13 +50,10 @@ export class GlobalState implements vscode.Memento {
     }
 
     public update(key: globalKey, value: any): Thenable<void> {
-        return globals.context.globalState.update(key, value)
+        return this.extContext.globalState.update(key, value)
     }
 
-    public static samAndCfnSchemaDestinationUri() {
-        return vscode.Uri.joinPath(globals.context.globalStorageUri, 'sam.schema.json')
+    public samAndCfnSchemaDestinationUri() {
+        return vscode.Uri.joinPath(this.extContext.globalStorageUri, 'sam.schema.json')
     }
 }
-
-export const globalState = GlobalState.instance
-export default globalState

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -7,6 +7,17 @@ import * as vscode from 'vscode'
 import globals from './extensionGlobals'
 import { getLogger } from './logger/logger'
 
+type globalKey =
+    | 'gumby.wasQCodeTransformationUsed'
+    | 'aws.toolkit.amazonq.dismissed'
+    | 'aws.toolkit.amazonqInstall.dismissed'
+    | 'hasAlreadyOpenedAmazonQ'
+    | 'aws.lastTouchedS3Folder'
+    | 'aws.lastUploadedToS3Folder'
+    | 'aws.downloadPath'
+    | 'CODECATALYST_RECONNECT'
+    | 'CODEWHISPERER_USER_GROUP'
+
 export class GlobalState implements vscode.Memento {
     static #instance: GlobalState
     static get instance(): GlobalState {
@@ -17,12 +28,12 @@ export class GlobalState implements vscode.Memento {
         return globals.context.globalState.keys()
     }
 
-    public get<T>(key: string, defaultValue?: T): T | undefined {
+    public get<T>(key: globalKey, defaultValue?: T): T | undefined {
         return globals.context.globalState.get(key) ?? defaultValue
     }
 
     /** Asynchronously updates globalState, or logs an error on failure. */
-    public tryUpdate(key: string, value: any): void {
+    public tryUpdate(key: globalKey, value: any): void {
         globals.context.globalState.update(key, value).then(
             undefined, // TODO: log.debug() ?
             e => {
@@ -31,7 +42,7 @@ export class GlobalState implements vscode.Memento {
         )
     }
 
-    public update(key: string, value: any): Thenable<void> {
+    public update(key: globalKey, value: any): Thenable<void> {
         return globals.context.globalState.update(key, value)
     }
 
@@ -39,3 +50,6 @@ export class GlobalState implements vscode.Memento {
         return vscode.Uri.joinPath(globals.context.globalStorageUri, 'sam.schema.json')
     }
 }
+
+export const globalState = GlobalState.instance
+export default globalState

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -24,6 +24,7 @@ export { VirtualMemoryFile } from './virtualMemoryFile'
 export { AmazonqCreateUpload, Metric } from './telemetry/telemetry'
 export { getClientId, getOperatingSystem } from './telemetry/util'
 export { extensionVersion } from './vscode/env'
+export * from './vscode/setContext'
 export { cast } from './utilities/typeConstructors'
 export {
     CodewhispererUserTriggerDecision,

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -4,7 +4,6 @@
  */
 
 import * as vscode from 'vscode'
-import globals from '../extensionGlobals'
 
 const toolkitLoggers: {
     main: Logger | undefined
@@ -202,11 +201,11 @@ export class PerfLog {
     public constructor(public readonly topic: string) {
         const log = getLogger()
         this.log = log
-        this.start = globals.clock.Date.now()
+        this.start = performance.now()
     }
 
     public elapsed(): number {
-        return globals.clock.Date.now() - this.start
+        return performance.now() - this.start
     }
 
     public done(): void {

--- a/packages/core/src/shared/vscode/setContext.ts
+++ b/packages/core/src/shared/vscode/setContext.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+
+/**
+ * Context keys used by the extension.
+ *
+ * New keys must start with "aws." or "amazonq.".
+ */
+type contextKey =
+    | 'aws.isDevMode'
+    | 'aws.isSageMaker'
+    | 'aws.isWebExtHost'
+    | 'aws.amazonq.showLoginView'
+    | 'aws.codecatalyst.connected'
+    | 'aws.codewhisperer.connected'
+    | 'aws.codewhisperer.connectionExpired'
+    | 'aws.codewhisperer.tutorial.workInProgress'
+    | 'aws.explorer.showAuthView'
+    | 'aws.toolkit.amazonq.dismissed'
+    | 'aws.toolkit.amazonqInstall.dismissed'
+    // Deprecated/legacy names. New keys should start with "aws.".
+    | 'codewhisperer.activeLine'
+    | 'gumby.isPlanAvailable'
+    | 'gumby.isStopButtonAvailable'
+    | 'gumby.isSummaryAvailable'
+    | 'gumby.reviewState'
+    | 'gumby.transformationProposalReviewInProgress'
+    | 'gumby.wasQCodeTransformationUsed'
+
+/**
+ * Calls the vscode "setContext" command.
+ *
+ * This wrapper adds structure and traceability to the vscode "setContext". It also opens the door
+ * for:
+ * - validation
+ * - getContext() (see also https://github.com/microsoft/vscode/issues/10471)
+ *
+ * Use "setContext" only as a last resort, to set flags that are detectable in package.json
+ * declarations. Do not use it as a general way to store global state (which should be avoided
+ * anyway).
+ */
+export async function setContext(key: contextKey, val: any): Promise<void> {
+    // eslint-disable-next-line aws-toolkits/no-banned-usages
+    await vscode.commands.executeCommand('setContext', key, val)
+}

--- a/packages/core/src/test/awsService/s3/commands/downloadFileAs.test.ts
+++ b/packages/core/src/test/awsService/s3/commands/downloadFileAs.test.ts
@@ -52,7 +52,7 @@ describe('downloadFileAsCommand', function () {
             dialog.accept()
         })
         const outputChannel = new MockOutputChannel()
-        await globals.context.globalState.update('aws.downloadPath', temp)
+        await globals.globalState.update('aws.downloadPath', temp)
 
         s3.downloadFileStream = sinon.stub().resolves(bufferToStream(Buffer.alloc(16)))
 

--- a/packages/core/src/test/globalSetup.test.ts
+++ b/packages/core/src/test/globalSetup.test.ts
@@ -23,6 +23,7 @@ import { getTestWindow, resetTestWindow } from './shared/vscode/window'
 import { mapTestErrors, normalizeError, setRunnableTimeout } from './setupUtil'
 import { TelemetryDebounceInfo } from '../shared/vscode/commands2'
 import { disableAwsSdkWarning } from '../shared/awsClientBuilder'
+import { GlobalState } from '../shared/globalState'
 
 disableAwsSdkWarning()
 
@@ -84,6 +85,7 @@ export const mochaHooks = {
         globals.telemetry.logger.clear()
         TelemetryDebounceInfo.instance.clear()
         ;(globals.context as FakeExtensionContext).globalState = new FakeMemento()
+        ;(globals as any).globalState = new GlobalState(globals.context)
 
         await testUtil.closeAllEditors()
     },

--- a/plugins/eslint-plugin-aws-toolkits/index.ts
+++ b/plugins/eslint-plugin-aws-toolkits/index.ts
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import NoOnlyInTests from './lib/rules/no-only-in-tests'
 import NoAwaitOnVscodeMsg from './lib/rules/no-await-on-vscode-msg'
+import NoBannedUsages from './lib/rules/no-banned-usages'
 import NoIncorrectOnceUsage from './lib/rules/no-incorrect-once-usage'
+import NoOnlyInTests from './lib/rules/no-only-in-tests'
 import NoStringExecForChildProcess from './lib/rules/no-string-exec-for-child-process'
 
 const rules = {
-    'no-only-in-tests': NoOnlyInTests,
     'no-await-on-vscode-msg': NoAwaitOnVscodeMsg,
+    'no-banned-usages': NoBannedUsages,
     'no-incorrect-once-usage': NoIncorrectOnceUsage,
+    'no-only-in-tests': NoOnlyInTests,
     'no-string-exec-for-child-process': NoStringExecForChildProcess,
 }
 

--- a/plugins/eslint-plugin-aws-toolkits/lib/rules/no-banned-usages.ts
+++ b/plugins/eslint-plugin-aws-toolkits/lib/rules/no-banned-usages.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ESLintUtils } from '@typescript-eslint/utils'
+import { AST_NODE_TYPES } from '@typescript-eslint/types'
+import { Rule } from 'eslint'
+// import * as util from 'util'
+
+export const errMsgs = {
+    setContext: 'Use shared/vscode/setContext.ts, do not use executeCommand("setContext") directly',
+}
+
+/**
+ * Prevents use of banned APIs:
+ *
+ * - vscode.commands.executeCommand('setContext', …)
+ */
+export default ESLintUtils.RuleCreator.withoutDocs({
+    meta: {
+        docs: {
+            description: 'disallow use of banned APIs',
+            recommended: 'recommended',
+        },
+        messages: errMsgs,
+        type: 'problem',
+        fixable: 'code',
+        schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+        return {
+            CallExpression(node) {
+                if (
+                    node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+                    node.callee.property.type !== AST_NODE_TYPES.Identifier ||
+                    node.callee.parent.type !== AST_NODE_TYPES.CallExpression
+                ) {
+                    return
+                }
+
+                const args = node.callee.parent.arguments
+
+                if (args[0]?.type !== AST_NODE_TYPES.Literal) {
+                    return
+                }
+
+                if (node.callee.property.name === 'executeCommand' && args[0].value === 'setContext') {
+                    return context.report({
+                        node,
+                        messageId: 'setContext',
+                    })
+                }
+            },
+        }
+    },
+}) as unknown as Rule.RuleModule

--- a/plugins/eslint-plugin-aws-toolkits/test/rules/no-banned-usages.test.ts
+++ b/plugins/eslint-plugin-aws-toolkits/test/rules/no-banned-usages.test.ts
@@ -1,0 +1,39 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { rules } from '../../index'
+import { errMsgs } from '../../lib/rules/no-banned-usages'
+import { getRuleTester } from '../testUtil'
+
+getRuleTester().run('no-banned-usages', rules['no-banned-usages'], {
+    valid: ["vscode.commands.executeCommand('foo', 'aws.foo', true, 42)"],
+
+    invalid: [
+        {
+            code: "async function test() { await vscode.commands.executeCommand('setContext', key, val) }",
+            errors: [errMsgs.setContext],
+        },
+        {
+            code: "const vsc = vscode; vsc.commands.executeCommand('setContext', key, val)",
+            errors: [errMsgs.setContext],
+        },
+        {
+            code: "const vsc = vscode; const cmds = vsc.commands; cmds.executeCommand('setContext', key, val)",
+            errors: [errMsgs.setContext],
+        },
+        {
+            code: "vscode.commands.executeCommand('setContext', 'aws.foo', true, 42)",
+            errors: [errMsgs.setContext],
+        },
+        {
+            code: "void vscode.commands.executeCommand('setContext', 'aws.foo', true, 42)",
+            errors: [errMsgs.setContext],
+        },
+        {
+            code: "const x = vscode.commands.executeCommand('setContext', key, val).catch(e => { return e })",
+            errors: [errMsgs.setContext],
+        },
+    ],
+})


### PR DESCRIPTION
## Problem

The vscode 'setContext' command:
- is not type-checked
- usages cannot be found programmatically (i.e. via "find references")
- keys are not centralized, so it's not clear which keys we are setting

## Solution
- Introduce a `setContext` module. Define keys as a `type`.
- Define a custom lint rule which prevents direct use of the vscode command.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
