### PR TITLE
fix(access analyzer): broken path

### DIFF
--- a/packages/core/src/awsService/accessanalyzer/vue/iamPolicyChecks.ts
+++ b/packages/core/src/awsService/accessanalyzer/vue/iamPolicyChecks.ts
@@ -53,7 +53,7 @@ type PolicyCommandOpts = {
 }
 
 export class IamPolicyChecksWebview extends VueWebview {
-    public static readonly sourcePath: string = 'src/accessanalyzer/vue/index.js'
+    public static readonly sourcePath: string = 'src/awsService/accessanalyzer/vue/index.js'
     public readonly id = 'iamPolicyChecks'
     private static editedDocumentUri: vscode.Uri
     private static editedDocumentFileName: string


### PR DESCRIPTION
## Problem
The refactor that moved AWS services to the `awsService` folder (https://github.com/aws/aws-toolkit-vscode/commit/198d2c9946adfd2a0f0c4ff567a8da2a985c72e6) broke the Access Analyzer integration, since `sourcePath` was hardcoded to `src/accessanalyzer/vue/index.js`. The integration UI is blank.

## Solution
Include `awsService` in `sourcePath`. The integration UI shows up after the fix.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
