### PR TITLE
feat: Add codecov to integ/e2e/linux tests

### DIFF
--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -41,6 +41,7 @@ phases:
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g')
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
+            - test -n "${CODE_COV_TOKEN}" && ./codecov --token=${CODE_COV_TOKEN} --branch=${CODEBUILD_RESOLVED_SOURCE_VERSION} --repository=${CODEBUILD_SOURCE_REPO_URL} --file=./coverage/lcov.info
         finally:
             - rm -rf ~/.aws/sso/cache || true
 reports:

--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -41,7 +41,7 @@ phases:
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g')
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
-            - test -n "${CODE_COV_TOKEN}" && ./codecov --token=${CODE_COV_TOKEN} --branch=${CODEBUILD_RESOLVED_SOURCE_VERSION} --repository=${CODEBUILD_SOURCE_REPO_URL} --file=./coverage/lcov.info
+            - test -n "${CODECOV_TOKEN}" && ./codecov --token=${CODECOV_TOKEN} --branch=${CODEBUILD_RESOLVED_SOURCE_VERSION} --repository=${CODEBUILD_SOURCE_REPO_URL} --file=./coverage/lcov.info
         finally:
             - rm -rf ~/.aws/sso/cache || true
 reports:

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -75,6 +75,7 @@ phases:
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g')
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
+            - test -n "${CODE_COV_TOKEN}" && ./codecov --token=${CODE_COV_TOKEN} --branch=${CODEBUILD_RESOLVED_SOURCE_VERSION} --repository=${CODEBUILD_SOURCE_REPO_URL} --file=./coverage/lcov.info
     post_build:
         commands:
             # Destroy .netrc to avoid leaking $GITHUB_READONLY_TOKEN.

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -75,7 +75,7 @@ phases:
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g')
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
-            - test -n "${CODE_COV_TOKEN}" && ./codecov --token=${CODE_COV_TOKEN} --branch=${CODEBUILD_RESOLVED_SOURCE_VERSION} --repository=${CODEBUILD_SOURCE_REPO_URL} --file=./coverage/lcov.info
+            - test -n "${CODECOV_TOKEN}" && ./codecov --token=${CODECOV_TOKEN} --branch=${CODEBUILD_RESOLVED_SOURCE_VERSION} --repository=${CODEBUILD_SOURCE_REPO_URL} --file=./coverage/lcov.info
     post_build:
         commands:
             # Destroy .netrc to avoid leaking $GITHUB_READONLY_TOKEN.

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -48,7 +48,7 @@ phases:
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
-            - test -n "${CODE_COV_TOKEN}" && ./codecov --token=${CODE_COV_TOKEN} --branch=${CODEBUILD_RESOLVED_SOURCE_VERSION} --repository=${CODEBUILD_SOURCE_REPO_URL} --file=./coverage/lcov.info
+            - test -n "${CODECOV_TOKEN}" && ./codecov --token=${CODECOV_TOKEN} --branch=${CODEBUILD_RESOLVED_SOURCE_VERSION} --repository=${CODEBUILD_SOURCE_REPO_URL} --file=./coverage/lcov.info
 
 reports:
     unit-test:

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -48,6 +48,7 @@ phases:
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
+            - test -n "${CODE_COV_TOKEN}" && ./codecov --token=${CODE_COV_TOKEN} --branch=${CODEBUILD_RESOLVED_SOURCE_VERSION} --repository=${CODEBUILD_SOURCE_REPO_URL} --file=./coverage/lcov.info
 
 reports:
     unit-test:

--- a/buildspec/shared/linux-install.sh
+++ b/buildspec/shared/linux-install.sh
@@ -24,3 +24,6 @@ mkdir -p ~codebuild-user
 chown -R codebuild-user:codebuild-user /tmp ~codebuild-user .
 chmod +x ~codebuild-user
 ls -ld ~codebuild-user
+
+curl -Os https://uploader.codecov.io/latest/linux/codecov 
+chmod +x codecov

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -8,7 +8,7 @@ phases:
             nodejs: 16
         commands:
             - |
-                if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
+                if(-Not($Env:CODECOV_TOKEN -eq $null)) {
                     choco install -y --no-progress codecov
                 }
 
@@ -34,11 +34,11 @@ phases:
             - npm run lint
             - $env:TEST_REPORT_DIR="$env:CODEBUILD_SRC_DIR/.test_reports"; npm run test
             - |
-                if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {
+                if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODECOV_TOKEN -eq $null)) {
                   $env:VCS_COMMIT_ID=$Env:CODEBUILD_RESOLVED_SOURCE_VERSION;
                   $env:CI_BUILD_URL=[uri]::EscapeUriString($Env:CODEBUILD_BUILD_URL);
                   $env:CI_BUILD_ID=$Env:CODEBUILD_BUILD_ID;
-                  codecov -t $Env:CODE_COV_TOKEN `
+                  codecov -t $Env:CODECOV_TOKEN `
                     --flag unittest `
                     -f "build/reports/jacoco/coverageReport/coverageReport.xml" `
                     -c $Env:CODEBUILD_RESOLVED_SOURCE_VERSION


### PR DESCRIPTION
## Problem
- We don't have code coverage reporting for our integ/e2e/linux tests

## Solution
- Add it

### Related issue: 
https://github.com/aws/aws-toolkit-vscode/issues/4232
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
