### PR TITLE
telemetry(feature dev): add ignore file metric while bundling repository

### DIFF
--- a/packages/amazonq/test/unit/amazonqFeatureDev/util/files.test.ts
+++ b/packages/amazonq/test/unit/amazonqFeatureDev/util/files.test.ts
@@ -10,7 +10,7 @@ import {
     ContentLengthError,
     maxRepoSizeBytes,
 } from 'aws-core-vscode/amazonqFeatureDev'
-import { createTestWorkspace } from 'aws-core-vscode/test'
+import { assertTelemetry, createTestWorkspace } from 'aws-core-vscode/test'
 import { fs, AmazonqCreateUpload, Metric } from 'aws-core-vscode/shared'
 import sinon from 'sinon'
 
@@ -52,6 +52,7 @@ describe('file utils', () => {
             // checksum is not the same across different test executions because some unique random folder names are generated
             assert.strictEqual(result.zipFileChecksum.length, 44)
             assert.strictEqual(telemetry.repositorySize, 0)
+            assertTelemetry('amazonq_bundleExtensionIgnored', { filenameExt: 'mp4', count: 1 })
         })
 
         // Test the logic that allows the customer to modify root source folder


### PR DESCRIPTION
## Problem

We (feature dev team) want to understand if there are any other relevant code file extension that should be added to the allowlist.

## Solution

To obtain such information, we want to emit telemetry event to see the most common file extensions being ignored while bundling.

Example log: 
```
2024-07-11 10:35:18.127 [info] Amazon Q Developer Agent for software development Conversation ID: dea452f8-e685-4285-b350-900a06a40d51
2024-07-11 10:35:19.146 [info] ignoring file extension name: graphql, count: 82
2024-07-11 10:35:19.146 [info] ignoring file extension name: eslintignore, count: 1
2024-07-11 10:35:19.146 [info] ignoring file extension name: nvmrc, count: 1
```

This is a follow up of this [pull request](https://github.com/aws/aws-toolkit-vscode/pull/5238)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
