### PR TITLE
fix: refactor broke webview paths

### DIFF
--- a/packages/core/src/awsService/apigateway/vue/invokeRemoteRestApi.ts
+++ b/packages/core/src/awsService/apigateway/vue/invokeRemoteRestApi.ts
@@ -42,7 +42,7 @@ export interface InvokeRemoteRestApiInitialData {
 }
 
 export class RemoteRestInvokeWebview extends VueWebview {
-    public static readonly sourcePath: string = 'src/apigateway/vue/index.js'
+    public static readonly sourcePath: string = 'src/awsService/apigateway/vue/index.js'
     public readonly id = 'remoteInvoke'
 
     private readonly logger = getLogger()


### PR DESCRIPTION
## Problem:

A recent refactor did not update certain static paths which prevent webviews from working.

## Solution:

Fix the incorrect paths.

## Testing it works

- Create a REST API Gateway on my AWS account
- In the AWS Explorer right click the REST API and select `Invoke on AWS`, this will open the webview.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
