### PR TITLE
ci: update accessanalyzer codeowners path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@ packages/core/src/codewhisperer/ @aws/codewhisperer-team
 packages/core/src/amazonqFeatureDev/ @aws/earlybird
 packages/core/src/codewhispererChat/ @aws/dexp
 packages/core/src/amazonq/ @aws/dexp
-packages/core/src/accessanalyzer/ @aws/access-analyzer
+packages/core/src/awsService/accessanalyzer/ @aws/access-analyzer


### PR DESCRIPTION
Due to a recent refactor we need to also update
the codeowners path for accessanalyzer

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
