### PR TITLE
fix(amazonq): fixing visual bugs in prompt input field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3321,9 +3321,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.15.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.1.tgz",
-            "integrity": "sha512-ATptfkyv7L1SirkYuUPWL5OtCJZLtnkfyPC4mzBSOl/2xNh0HQtwzdRMfFt/0Gvl1x5RELaqtxMEFvtvOKqqlA==",
+            "version": "4.15.2",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.2.tgz",
+            "integrity": "sha512-z2E8eDAMduM4+Pqpokj5ILyTbsXGV9TTtx9Flwi0JUzo04avZ5CbipIh2zTV6CxO5gmo5eq5u1t+cpFwSAdsag==",
             "hasInstallScript": true,
             "dependencies": {
                 "escape-html": "^1.0.3",
@@ -18762,7 +18762,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.15.1",
+                "@aws/mynah-ui": "^4.15.2",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-3025412d-2c04-4d84-9714-d2b067a2ba95.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-3025412d-2c04-4d84-9714-d2b067a2ba95.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Fixes a bug when the prompt input exceeds the width of the chat box it's not always wrapped correctly."
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-fbd79ad7-715d-40e6-b1ee-7388b5689995.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-fbd79ad7-715d-40e6-b1ee-7388b5689995.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Fixes a bug when user input contains 4 or more spaces at the beginning of the line for multiline inputs, that line appears like a code block instead of a paragraph"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4115,7 +4115,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.15.1",
+        "@aws/mynah-ui": "^4.15.2",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
There are 2 minor visual bugs in Amazon Q Chat UI:
* When the prompt input text exceeds the width of the chat box it's not always wrapped correctly.
* When user types empty spaces at the beginning of lines inside prompt, it appears like a code block instead of a paragraph.

## Solution
* Prompt input is properly sized and matches with the textarea underneath.
* Removed empty spaces for each line.

[MynahUI 4.15.2](https://github.com/aws/mynah-ui/releases/tag/v4.15.2)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
