### PR TITLE
fix(amazonq): always show latest build logs

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-acc20495-b700-47cd-b3fc-d73a34c7c720.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-acc20495-b700-47cd-b3fc-d73a34c7c720.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Code Transformation: always show build logs from last job run"
+}

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -270,6 +270,7 @@ export class GumbyController {
         const typedAction = MessengerUtils.stringToEnumValue(ButtonActions, message.action as any)
         switch (typedAction) {
             case ButtonActions.CONFIRM_TRANSFORMATION_FORM:
+                await resetDebugArtifacts()
                 await this.initiateTransformationOnProject(message)
                 break
             case ButtonActions.CANCEL_TRANSFORMATION_FORM:
@@ -473,6 +474,7 @@ export class GumbyController {
                 undefined,
                 GumbyNamedMessages.JOB_FAILED_IN_PRE_BUILD
             )
+            await openBuildLogFile()
             this.messenger.sendViewBuildLog(message.tabID)
         }
     }

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -24,7 +24,6 @@ import {
     openHilPomFile,
     postTransformationJob,
     processTransformFormInput,
-    resetDebugArtifacts,
     startTransformByQ,
     stopTransformByQ,
     validateCanCompileProject,
@@ -270,7 +269,6 @@ export class GumbyController {
         const typedAction = MessengerUtils.stringToEnumValue(ButtonActions, message.action as any)
         switch (typedAction) {
             case ButtonActions.CONFIRM_TRANSFORMATION_FORM:
-                await resetDebugArtifacts()
                 await this.initiateTransformationOnProject(message)
                 break
             case ButtonActions.CANCEL_TRANSFORMATION_FORM:
@@ -287,7 +285,6 @@ export class GumbyController {
                 break
             case ButtonActions.CONFIRM_START_TRANSFORMATION_FLOW:
                 this.resetTransformationChatFlow()
-                await resetDebugArtifacts()
                 this.messenger.sendCommandMessage({ ...message, command: GumbyCommands.CLEAR_CHAT })
                 await this.transformInitiated(message)
                 break

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -71,6 +71,7 @@ import DependencyVersions from '../../amazonqGumby/models/dependencies'
 import { dependencyNoAvailableVersions } from '../../amazonqGumby/models/constants'
 import { HumanInTheLoopManager } from '../service/transformByQ/humanInTheLoopManager'
 import { setContext } from '../../shared/vscode/setContext'
+import { makeTemporaryToolkitFolder } from '../../shared'
 
 function getFeedbackCommentData() {
     const jobId = transformByQState.getJobId()
@@ -527,14 +528,26 @@ export async function pollTransformationStatusUntilPlanReady(jobId: string) {
         // Since we don't yet have a good way of knowing what the error was,
         // we try to fetch any build failure artifacts that may exist so that we can optionally
         // show them to the user if they exist.
-        const tmpDir = path.join(os.tmpdir(), 'q-transformation-build-logs')
-        await downloadAndExtractResultArchive(jobId, undefined, tmpDir, 'Logs')
-        const pathToLog = path.join(tmpDir, 'buildCommandOutput.log')
-        transformByQState.setPreBuildLogFilePath(pathToLog)
+        let pathToLog = ''
+        try {
+            const tempToolkitFolder = await makeTemporaryToolkitFolder()
+            const tempBuildLogsDir = path.join(tempToolkitFolder, 'q-transformation-build-logs')
+            await downloadAndExtractResultArchive(jobId, undefined, tempBuildLogsDir, 'Logs')
+            pathToLog = path.join(tempBuildLogsDir, 'buildCommandOutput.log')
+            transformByQState.setPreBuildLogFilePath(pathToLog)
+        } catch (e) {
+            transformByQState.setPreBuildLogFilePath('')
+            getLogger().error(
+                'CodeTransformation: failed to download any possible build error logs: ' + (e as Error).message
+            )
+            throw e
+        }
 
         if (fs.existsSync(pathToLog) && !transformByQState.isCancelled()) {
             throw new TransformationPreBuildError()
         } else {
+            // not strictly needed to reset path here and above; doing it just to represent unavailable logs
+            transformByQState.setPreBuildLogFilePath('')
             throw new PollJobError()
         }
     }
@@ -733,14 +746,6 @@ export async function cleanupTransformationJob() {
         CodeTransformTelemetryState.instance.getStartTime()
     )
     CodeTransformTelemetryState.instance.resetCodeTransformMetaDataField()
-}
-
-export async function resetDebugArtifacts() {
-    const buildLogDir = path.join(os.tmpdir(), 'q-transformation-build-logs')
-    if (fs.existsSync(buildLogDir)) {
-        fs.rmSync(buildLogDir, { recursive: true, force: true })
-        transformByQState.setPreBuildLogFilePath('')
-    }
 }
 
 export async function stopTransformByQ(

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -532,7 +532,7 @@ export async function pollTransformationStatusUntilPlanReady(jobId: string) {
         const pathToLog = path.join(tmpDir, 'buildCommandOutput.log')
         transformByQState.setPreBuildLogFilePath(pathToLog)
 
-        if (fs.existsSync(pathToLog)) {
+        if (fs.existsSync(pathToLog) && !transformByQState.isCancelled()) {
             throw new TransformationPreBuildError()
         } else {
             throw new PollJobError()
@@ -736,11 +736,11 @@ export async function cleanupTransformationJob() {
 }
 
 export async function resetDebugArtifacts() {
-    const buildLogPath = transformByQState.getPreBuildLogFilePath()
-    if (buildLogPath && fs.existsSync(buildLogPath)) {
-        fs.rmSync(path.dirname(transformByQState.getPreBuildLogFilePath()), { recursive: true, force: true })
+    const buildLogDir = path.join(os.tmpdir(), 'q-transformation-build-logs')
+    if (fs.existsSync(buildLogDir)) {
+        fs.rmSync(buildLogDir, { recursive: true, force: true })
+        transformByQState.setPreBuildLogFilePath('')
     }
-    transformByQState.setPreBuildLogFilePath('')
 }
 
 export async function stopTransformByQ(

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -881,17 +881,16 @@ export async function downloadAndExtractResultArchive(
 
     const pathToArchive = path.join(pathToArchiveDir, 'ExportResultsArchive.zip')
 
-    await downloadResultArchive(jobId, downloadArtifactId, pathToArchive, downloadArtifactType)
-
     let downloadErrorMessage = undefined
     try {
         // Download and deserialize the zip
+        await downloadResultArchive(jobId, downloadArtifactId, pathToArchive, downloadArtifactType)
         const zip = new AdmZip(pathToArchive)
         zip.extractAllTo(pathToArchiveDir)
     } catch (e) {
         downloadErrorMessage = (e as Error).message
         getLogger().error(`CodeTransformation: ExportResultArchive error = ${downloadErrorMessage}`)
-        throw new Error('Error downloading transformation result artifacts')
+        throw new Error('Error downloading transformation result artifacts: ' + downloadErrorMessage)
     }
 }
 

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -310,21 +310,4 @@ describe('resetDebugArtifacts', () => {
         assert.strictEqual(fs.existsSync(preBuildLogFilePath), false)
         assert.strictEqual(transformByQState.getPreBuildLogFilePath(), '')
     })
-
-    it('should not remove any directory if the pre-build log file path is not set', async () => {
-        transformByQState.setPreBuildLogFilePath('')
-
-        await resetDebugArtifacts()
-
-        assert.strictEqual(transformByQState.getPreBuildLogFilePath(), '')
-    })
-
-    it('should not remove any directory if the pre-build log file does not exist', async () => {
-        const preBuildLogFilePath = 'non/existent/path/to/pre-build.log'
-        transformByQState.setPreBuildLogFilePath(preBuildLogFilePath)
-
-        await resetDebugArtifacts()
-
-        assert.strictEqual(transformByQState.getPreBuildLogFilePath(), '')
-    })
 })

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert'
 import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
+import * as os from 'os'
 import * as sinon from 'sinon'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { transformByQState, TransformByQStoppedError } from '../../../codewhisperer/models/model'
@@ -300,9 +301,9 @@ describe('transformByQ', function () {
 
 describe('resetDebugArtifacts', () => {
     it('should remove the directory containing the pre-build log file if it exists', async () => {
-        const dirPath = await createTestWorkspaceFolder()
-        const preBuildLogFilePath = path.join(dirPath.uri.fsPath, 'DummyLog.log')
-        await toFile('', preBuildLogFilePath)
+        const dirPath = path.join(os.tmpdir(), 'q-transformation-build-logs')
+        const preBuildLogFilePath = path.join(dirPath, 'DummyLog.log')
+        await toFile('<logs>', preBuildLogFilePath)
         transformByQState.setPreBuildLogFilePath(preBuildLogFilePath)
 
         await resetDebugArtifacts()

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -6,11 +6,10 @@
 import assert from 'assert'
 import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
-import * as os from 'os'
 import * as sinon from 'sinon'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { transformByQState, TransformByQStoppedError } from '../../../codewhisperer/models/model'
-import { resetDebugArtifacts, stopTransformByQ } from '../../../codewhisperer/commands/startTransformByQ'
+import { stopTransformByQ } from '../../../codewhisperer/commands/startTransformByQ'
 import { HttpResponse } from 'aws-sdk'
 import * as codeWhisperer from '../../../codewhisperer/client/codewhisperer'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
@@ -296,19 +295,5 @@ describe('transformByQ', function () {
             '-1': '{"columnNames":["relativePath","action"],"rows":[{"relativePath":"pom.xml","action":"Update"}, {"relativePath":"src/main/java/com/bhoruka/bloodbank/BloodbankApplication.java","action":"Update"}]}',
         }
         assert.deepStrictEqual(actual, expected)
-    })
-})
-
-describe('resetDebugArtifacts', () => {
-    it('should remove the directory containing the pre-build log file if it exists', async () => {
-        const dirPath = path.join(os.tmpdir(), 'q-transformation-build-logs')
-        const preBuildLogFilePath = path.join(dirPath, 'DummyLog.log')
-        await toFile('<logs>', preBuildLogFilePath)
-        transformByQState.setPreBuildLogFilePath(preBuildLogFilePath)
-
-        await resetDebugArtifacts()
-
-        assert.strictEqual(fs.existsSync(preBuildLogFilePath), false)
-        assert.strictEqual(transformByQState.getPreBuildLogFilePath(), '')
     })
 })


### PR DESCRIPTION
## Problem

When users download the pre-build error logs, then run another transformation without clicking the "Start a new transformation" button, if another pre-build error occurs, the **old** logs will show up. This could happen if they close the Q Chat tab and re-run a transformation, or if they close the IDE between job runs. If they do click the "Start a new transformation" button, everything works fine, but we need to handle these other situations.

## Solution

Use `makeTemporaryToolkitFolder()` which creates a new folder with a random name, so that the logs are downloaded there, meaning we don't have to deal with deleting the old logs that would otherwise be in the same folder as the new logs.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
