### PR TITLE
fix(amazonq): Update LSP version to 0.1.3

### DIFF
--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -67,7 +67,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.2']
+const supportedLspServerVersions = ['0.1.3']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 /*


### PR DESCRIPTION
## Problem

Upgrade the Amazon Q chat LSP to version 0.1.3. 

The version 0.1.3 has security improvements.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
