### PR TITLE
fix: EPERM error during SSO token refresh

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-e36701b2-54c6-4be5-9a9c-d82a91e00060.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-e36701b2-54c6-4be5-9a9c-d82a91e00060.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Unexpected SSO expiration on Windows due to EPERM"
+}

--- a/packages/core/src/shared/fs/fs.ts
+++ b/packages/core/src/shared/fs/fs.ts
@@ -202,6 +202,18 @@ export class FileSystem {
         return vfs.writeFile(uri, content).then(undefined, errHandler)
     }
 
+    async rename(oldPath: vscode.Uri | string, newPath: vscode.Uri | string) {
+        const oldUri = this.#toUri(oldPath)
+        const newUri = this.#toUri(newPath)
+        const errHandler = createPermissionsErrorHandler(this.isWeb, oldUri, 'rw*')
+
+        if (isCloud9()) {
+            return nodefs.rename(oldUri.fsPath, newUri.fsPath).catch(errHandler)
+        }
+
+        return vfs.rename(oldUri, newUri, { overwrite: true }).then(undefined, errHandler)
+    }
+
     /**
      * The stat of the file,  throws if the file does not exist or on any other error.
      */

--- a/packages/core/src/shared/utilities/cacheUtils.ts
+++ b/packages/core/src/shared/utilities/cacheUtils.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode'
 import { dirname } from 'path'
 import { ToolkitError, isFileNotFoundError } from '../errors'
 import fs from '../../shared/fs/fs'
-import { promises as fsPromises } from 'fs'
 import crypto from 'crypto'
 import { isWeb } from '../extensionGlobals'
 
@@ -136,7 +135,7 @@ export function createDiskCache<T, K>(
                     // write, though there can still be race conditions with which version remains after overwrites.
                     const tempFile = `${target}.tmp-${crypto.randomBytes(4).toString('hex')}`
                     await fs.writeFile(tempFile, JSON.stringify(data), { mode: 0o600 })
-                    await fsPromises.rename(tempFile, target)
+                    await fs.rename(tempFile, target)
                 }
             } catch (error) {
                 throw ToolkitError.chain(error, `Failed to save "${target}"`, {

--- a/packages/core/src/test/shared/fs/fs.test.ts
+++ b/packages/core/src/test/shared/fs/fs.test.ts
@@ -331,6 +331,40 @@ describe('FileSystem', function () {
         })
     })
 
+    describe('rename()', async () => {
+        it('renames a file', async () => {
+            const oldPath = await makeFile('oldFile.txt', 'hello world')
+            const newPath = path.join(path.dirname(oldPath), 'newFile.txt')
+
+            await fs.rename(oldPath, newPath)
+
+            assert.strictEqual(await fs.readFileAsString(newPath), 'hello world')
+            assert(!existsSync(oldPath))
+        })
+
+        it('renames a folder', async () => {
+            const oldPath = mkTestDir('test')
+            await fs.writeFile(path.join(oldPath, 'file.txt'), 'test text')
+            const newPath = path.join(path.dirname(oldPath), 'newName')
+
+            await fs.rename(oldPath, newPath)
+
+            assert(existsSync(newPath))
+            assert.deepStrictEqual(await fs.readFileAsString(path.join(newPath, 'file.txt')), 'test text')
+            assert(!existsSync(oldPath))
+        })
+
+        it('overwrites if destination exists', async () => {
+            const oldPath = await makeFile('oldFile.txt', 'hello world')
+            const newPath = await makeFile('newFile.txt', 'some content')
+
+            await fs.rename(oldPath, newPath)
+
+            assert.strictEqual(await fs.readFileAsString(newPath), 'hello world')
+            assert(!existsSync(oldPath))
+        })
+    })
+
     describe('getUserHomeDir()', function () {
         let fakeHome: string
         let saveEnv: EnvironmentVariables = {}

--- a/packages/toolkit/.changes/next-release/Bug Fix-19be4c1e-355d-428e-bc8a-b8aa3cc64b7a.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-19be4c1e-355d-428e-bc8a-b8aa3cc64b7a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Unexpected SSO expiration on Windows due to EPERM"
+}


### PR DESCRIPTION
## Problem:

During token refresh we were seeing unexpected EPERM errors in the `aws_refreshCredentials` metric, specifically in Windows.

## Solution:

A node filesystem rename() call can fail due to a racecondition on Windows. Looking in to the VS Code Filesystem implementation they account for this: https://github.com/microsoft/vscode/blob/09d5f4efc5089ce2fc5c8f6aeb51d728d7f4e758/src/vs/base/node/pfs.ts#L496
So we just need to use this rename instead.

Additional info here from graceful-fs which inspired the VSCode implementation: https://github.com/isaacs/node-graceful-fs/blob/234379906b7d2f4c9cfeb412d2516f42b0fb4953/polyfills.js#L87

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
