### PR TITLE
Remove Typo In ThreatComposer PopUp when Saving files

### DIFF
--- a/packages/core/src/threatComposer/handlers/saveFileMessageHandler.ts
+++ b/packages/core/src/threatComposer/handlers/saveFileMessageHandler.ts
@@ -57,7 +57,7 @@ export async function saveFileMessageHandler(request: SaveFileRequestMessage, co
                         throw new Error('Document has been modified externally')
                     }
 
-                    void vscode.window.showInformationMessage('Threat Composer JSON has bees saved')
+                    void vscode.window.showInformationMessage('Threat Composer JSON has been saved')
 
                     saveCompleteSubType = SaveCompleteSubType.SAVED
                 } else {

--- a/packages/toolkit/.changes/next-release/Bug Fix-b2643447-b3f1-441d-8473-c23b4ef649d8.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-b2643447-b3f1-441d-8473-c23b4ef649d8.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix Typo to correctly read \"Threat Composer JSON has been saved\""
+}

--- a/packages/toolkit/.changes/next-release/Bug Fix-b2643447-b3f1-441d-8473-c23b4ef649d8.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-b2643447-b3f1-441d-8473-c23b4ef649d8.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "Fix Typo to correctly read \"Threat Composer JSON has been saved\""
-}


### PR DESCRIPTION
## Problem
On saving a threat model, the window incorrectly displays "Threat Composer JSON has bees saved"

## Solution
Fix Typo to correctly read "Threat Composer JSON has been saved"

## License

✅ By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
