### PR TITLE
fix(codewhisperer): respect telemetryEnabled field

### DIFF
--- a/packages/core/src/codewhisperer/client/codewhisperer.ts
+++ b/packages/core/src/codewhisperer/client/codewhisperer.ts
@@ -260,7 +260,7 @@ export class DefaultCodeWhispererClient {
                 ideVersion: extensionVersion,
             },
         }
-        if (!AuthUtil.instance.isValidEnterpriseSsoInUse() && !globals.telemetry.telemetryEnabled) {
+        if (!globals.telemetry.telemetryEnabled) {
             return
         }
         const response = await (await this.createUserSdkClient()).sendTelemetryEvent(requestWithCommonFields).promise()


### PR DESCRIPTION
## Problem
- When enterprise sso is in use the telemetryEnabled field isn't properly respected

## Solution
- Gate codewhisperer telemetry only on the telemetryEnabled field

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
