### PR TITLE
amazonq: update default language coefficient for classifier

### DIFF
--- a/packages/core/src/codewhisperer/service/classifierTrigger.ts
+++ b/packages/core/src/codewhisperer/service/classifierTrigger.ts
@@ -525,7 +525,10 @@ export class ClassifierTrigger {
 
         const previousDecision = TelemetryHelper.instance.getLastTriggerDecisionForClassifier()
         const languageCoefficients = Object.values(this.languageCoefficientMap)
-        const avrgCoefficient = languageCoefficients.length > 0 ? (languageCoefficients.reduce((a, b) => a + b) / languageCoefficients.length) : 0
+        const avrgCoefficient =
+            languageCoefficients.length > 0
+                ? languageCoefficients.reduce((a, b) => a + b) / languageCoefficients.length
+                : 0
         const languageCoefficient = this.languageCoefficientMap[language.languageName] ?? avrgCoefficient
 
         let previousDecisionCoefficient = 0

--- a/packages/core/src/codewhisperer/service/classifierTrigger.ts
+++ b/packages/core/src/codewhisperer/service/classifierTrigger.ts
@@ -524,7 +524,9 @@ export class ClassifierTrigger {
         const ideCoefficient = this.ideVscode
 
         const previousDecision = TelemetryHelper.instance.getLastTriggerDecisionForClassifier()
-        const languageCoefficient = this.languageCoefficientMap[language.languageName] ?? 0
+        const languageCoefficients = Object.values(this.languageCoefficientMap)
+        const avrgCoefficient = languageCoefficients.reduce((a, b) => a + b) / languageCoefficients.length
+        const languageCoefficient = this.languageCoefficientMap[language.languageName] ?? avrgCoefficient
 
         let previousDecisionCoefficient = 0
         if (previousDecision === 'Accept') {

--- a/packages/core/src/codewhisperer/service/classifierTrigger.ts
+++ b/packages/core/src/codewhisperer/service/classifierTrigger.ts
@@ -525,7 +525,7 @@ export class ClassifierTrigger {
 
         const previousDecision = TelemetryHelper.instance.getLastTriggerDecisionForClassifier()
         const languageCoefficients = Object.values(this.languageCoefficientMap)
-        const avrgCoefficient = languageCoefficients.reduce((a, b) => a + b) / languageCoefficients.length
+        const avrgCoefficient = languageCoefficients.length > 0 ? (languageCoefficients.reduce((a, b) => a + b) / languageCoefficients.length) : 0
         const languageCoefficient = this.languageCoefficientMap[language.languageName] ?? avrgCoefficient
 
         let previousDecisionCoefficient = 0


### PR DESCRIPTION
## Problem
for new languages that we support which don't have a coefficient, we want to use average instead of 0 as default
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
