### PR TITLE
refactor: use globalState abstraction

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
@@ -21,7 +21,7 @@ import {
     createTestAuth,
 } from 'aws-core-vscode/test'
 import { Auth, Connection, isAnySsoConnection, isBuilderIdConnection } from 'aws-core-vscode/auth'
-import { vscodeComponent } from 'aws-core-vscode/shared'
+import { globals, vscodeComponent } from 'aws-core-vscode/shared'
 
 const enterpriseSsoStartUrl = 'https://enterprise.awsapps.com/start'
 
@@ -30,7 +30,7 @@ describe('AuthUtil', async function () {
     let authUtil: AuthUtil
 
     beforeEach(async function () {
-        auth = createTestAuth()
+        auth = createTestAuth(globals.globalState)
         authUtil = new AuthUtil(auth)
     })
 
@@ -286,7 +286,7 @@ describe('getChatAuthState()', function () {
     let laterDate: Date
 
     beforeEach(async function () {
-        auth = createTestAuth()
+        auth = createTestAuth(globals.globalState)
         authUtil = new AuthUtil(auth)
 
         laterDate = new Date(Date.now() + 10_000_000)

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -175,6 +175,8 @@ export class SecondaryAuth<T extends Connection = Connection> {
     }
 
     public async saveConnection(conn: T) {
+        // TODO: fix this
+        // eslint-disable-next-line aws-toolkits/no-banned-usages
         await globals.context.globalState.update(this.key, conn.id)
         this.#savedConnection = conn
         this.#onDidChangeActiveConnection.fire(this.activeConnection)
@@ -206,6 +208,8 @@ export class SecondaryAuth<T extends Connection = Connection> {
 
     /** Stop using the saved connection and fallback to using the active connection, if it is usable. */
     public async clearSavedConnection() {
+        // TODO: fix this
+        // eslint-disable-next-line aws-toolkits/no-banned-usages
         await globals.context.globalState.update(this.key, undefined)
         this.#savedConnection = undefined
         this.#onDidChangeActiveConnection.fire(this.activeConnection)
@@ -251,7 +255,10 @@ export class SecondaryAuth<T extends Connection = Connection> {
     })
 
     private async loadSavedConnection() {
-        const id = cast(globals.context.globalState.get(this.key), Optional(String))
+        // TODO: fix this
+        // eslint-disable-next-line aws-toolkits/no-banned-usages
+        const globalState = globals.context.globalState
+        const id = cast(globalState.get(this.key), Optional(String))
         if (id === undefined) {
             return
         }
@@ -259,10 +266,10 @@ export class SecondaryAuth<T extends Connection = Connection> {
         const conn = await this.auth.getConnection({ id })
         if (conn === undefined) {
             getLogger().warn(`auth (${this.toolId}): removing saved connection "${this.key}" as it no longer exists`)
-            await globals.context.globalState.update(this.key, undefined)
+            await globalState.update(this.key, undefined)
         } else if (!this.isUsable(conn)) {
             getLogger().warn(`auth (${this.toolId}): saved connection "${this.key}" is not valid`)
-            await globals.context.globalState.update(this.key, undefined)
+            await globalState.update(this.key, undefined)
         } else {
             await this.auth.refreshConnectionState(conn)
             return conn

--- a/packages/core/src/shared/credentials/credentialsProfileMru.ts
+++ b/packages/core/src/shared/credentials/credentialsProfileMru.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
+import globals from '../extensionGlobals'
 
 /**
  * Tracks the credentials selected by the user, ordered by most recent.
@@ -11,15 +11,13 @@ import * as vscode from 'vscode'
 export class CredentialsProfileMru {
     public static readonly maxCredentialMruSize = 5
 
-    private static readonly configurationStateName: string = 'recentCredentials'
-
-    public constructor(private readonly _context: vscode.ExtensionContext) {}
+    public constructor() {}
 
     /**
      * @description Returns the most recently used credentials names
      */
     public getMruList(): string[] {
-        return this._context.globalState.get<string[]>(CredentialsProfileMru.configurationStateName, [])
+        return globals.globalState.tryGet<string[]>('recentCredentials', Object, [])
     }
 
     /**
@@ -38,6 +36,6 @@ export class CredentialsProfileMru {
 
         mru.splice(CredentialsProfileMru.maxCredentialMruSize)
 
-        await this._context.globalState.update(CredentialsProfileMru.configurationStateName, mru)
+        await globals.globalState.update('recentCredentials', mru)
     }
 }

--- a/packages/core/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
+++ b/packages/core/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
@@ -46,7 +46,7 @@ export class DefaultCredentialSelectionDataProvider implements CredentialSelecti
         public readonly existingProfileNames: string[],
         protected context: vscode.ExtensionContext
     ) {
-        this._credentialsMru = new CredentialsProfileMru(context)
+        this._credentialsMru = new CredentialsProfileMru()
     }
 
     public async pickCredentialProfile(

--- a/packages/core/src/shared/extensionGlobals.ts
+++ b/packages/core/src/shared/extensionGlobals.ts
@@ -134,6 +134,8 @@ function proxyGlobals(globals_: ToolkitGlobals): ToolkitGlobals {
 let globals = proxyGlobals(resolveGlobalsObject())
 
 export function checkDidReload(context: ExtensionContext): boolean {
+    // TODO: fix this
+    // eslint-disable-next-line aws-toolkits/no-banned-usages
     return !!context.globalState.get<string>('ACTIVATION_LAUNCH_PATH_KEY')
 }
 
@@ -147,6 +149,7 @@ export function initialize(context: ExtensionContext, isWeb: boolean = false): T
         context,
         clock: copyClock(),
         didReload: checkDidReload(context),
+        // eslint-disable-next-line aws-toolkits/no-banned-usages
         globalState: new GlobalState(context.globalState),
         manifestPaths: {} as ToolkitGlobals['manifestPaths'],
         visualizationResourcePaths: {} as ToolkitGlobals['visualizationResourcePaths'],

--- a/packages/core/src/shared/telemetry/activation.ts
+++ b/packages/core/src/shared/telemetry/activation.ts
@@ -44,7 +44,7 @@ export async function activate(
     await config.initAmazonQSetting() // TODO: Remove after a few releases.
 
     DefaultTelemetryClient.productName = productName
-    globals.telemetry = await DefaultTelemetryService.create(extensionContext, awsContext, getComputeRegion())
+    globals.telemetry = await DefaultTelemetryService.create(awsContext, getComputeRegion())
 
     const isAmazonQExt = isAmazonQ()
     try {

--- a/packages/core/src/test/codecatalyst/auth.test.ts
+++ b/packages/core/src/test/codecatalyst/auth.test.ts
@@ -10,6 +10,7 @@ import { FakeSecretStorage } from '../fakeExtensionContext'
 import { createBuilderIdProfile, createSsoProfile, createTestAuth } from '../credentials/testUtil'
 import Sinon from 'sinon'
 import { isAnySsoConnection } from '../../auth/connection'
+import globals from '../../shared/extensionGlobals'
 
 const enterpriseSsoStartUrl = 'https://enterprise.awsapps.com/start'
 
@@ -18,7 +19,7 @@ describe('CodeCatalystAuthenticationProvider', async function () {
     let codecatalystAuth: CodeCatalystAuthenticationProvider
 
     beforeEach(async function () {
-        auth = createTestAuth()
+        auth = createTestAuth(globals.globalState)
         codecatalystAuth = new CodeCatalystAuthenticationProvider(
             new CodeCatalystAuthStorage(new FakeSecretStorage()),
             auth

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -28,7 +28,7 @@ describe('Auth', function () {
     let auth: ReturnType<typeof createTestAuth>
 
     beforeEach(function () {
-        auth = createTestAuth()
+        auth = createTestAuth(globals.globalState)
     })
 
     it('can create a new sso connection', async function () {

--- a/packages/core/src/test/credentials/secondaryAuth.test.ts
+++ b/packages/core/src/test/credentials/secondaryAuth.test.ts
@@ -21,33 +21,33 @@ describe('SecondaryAuth', function () {
     let onDidChangeActiveConnection: SinonStub
 
     beforeEach(async function () {
-        auth = createTestAuth()
+        auth = createTestAuth(globals.globalState)
         sandbox = createSandbox()
         conn = await auth.createConnection(createBuilderIdProfile({ scopes: scopes }))
         isValid = (conn: Connection): conn is Connection => {
             return isSsoConnection(conn) && hasScopes(conn, scopes)
         }
-        secondaryAuth = getSecondaryAuth(auth, 'testId', 'testLabel', isValid)
+        // await globals.globalState.clear()
+        secondaryAuth = getSecondaryAuth(auth, 'codecatalyst', 'testLabel', isValid)
         onDidChangeActiveConnection = sandbox.stub()
         secondaryAuth.onDidChangeActiveConnection(onDidChangeActiveConnection)
-        await globals.globalState.clear()
     })
 
     afterEach(async function () {
         sandbox.restore()
     })
 
-    it('When no SecondaryAuth set or valid PrimaryAuth exist', async function () {
+    it('no SecondaryAuth set or valid PrimaryAuth exist', async function () {
         assert.strictEqual(secondaryAuth.activeConnection?.id, undefined)
     })
 
-    it('When no SecondaryAuth set but valid PrimaryAuth is used', async function () {
+    it('no SecondaryAuth set but valid PrimaryAuth is used', async function () {
         await auth.useConnection(conn)
         assert.strictEqual(onDidChangeActiveConnection.calledOnce, true)
         assert.strictEqual(secondaryAuth.activeConnection?.id, conn.id)
     })
 
-    it('When valid PrimaryAuth is set BUT SecondaryAuth is already using the same connection', async function () {
+    it('valid PrimaryAuth is set BUT SecondaryAuth is already using the same connection', async function () {
         await secondaryAuth.useNewConnection(conn)
         // we save this connection so we expect it to trigger an event
         assert.strictEqual(onDidChangeActiveConnection.called, true)
@@ -60,7 +60,7 @@ describe('SecondaryAuth', function () {
         assert.strictEqual(secondaryAuth.activeConnection?.id, conn.id)
     })
 
-    it('When valid PrimaryAuth changes BUT no SecondaryAuth is set + valid PrimaryAuth currently exists', async function () {
+    it('valid PrimaryAuth changes BUT SecondaryAuth not set + valid PrimaryAuth exists', async function () {
         // Make primary auth already exist
         await auth.useConnection(conn)
         assert.strictEqual(onDidChangeActiveConnection.called, true)
@@ -74,7 +74,7 @@ describe('SecondaryAuth', function () {
         assert.strictEqual(secondaryAuth.activeConnection?.id, otherValidConn.id)
     })
 
-    it('When valid PrimaryAuth deleted BUT SecondaryAuth is already set', async function () {
+    it('valid PrimaryAuth deleted BUT SecondaryAuth is set', async function () {
         await secondaryAuth.useNewConnection(conn)
 
         // add valid connection to the PrimaryAuth
@@ -89,7 +89,7 @@ describe('SecondaryAuth', function () {
         assert.strictEqual(secondaryAuth.activeConnection?.id, conn.id)
     })
 
-    it('When valid SecondaryAuth deleted BUT valid PrimaryAuth already exists', async function () {
+    it('valid SecondaryAuth deleted BUT valid PrimaryAuth exists', async function () {
         await secondaryAuth.useNewConnection(conn)
 
         // add valid connection to the PrimaryAuth
@@ -101,11 +101,21 @@ describe('SecondaryAuth', function () {
         await auth.deleteConnection(conn)
 
         // we fallback to the PrimaryAuth connection
-        assert.strictEqual(secondaryAuth.activeConnection?.id, otherConn.id)
         assert.strictEqual(onDidChangeActiveConnection.called, true)
+        assert.deepStrictEqual(
+            {
+                id: secondaryAuth.activeConnection?.id,
+                label: secondaryAuth.activeConnection?.label,
+            },
+            {
+                id: otherConn.id,
+                label: otherConn.label,
+            }
+        )
+        assert.strictEqual(secondaryAuth.activeConnection?.id, otherConn.id)
     })
 
-    it('When SecondaryAuth is invalid, but is reauthenticated elsewhere', async function () {
+    it('SecondaryAuth is invalid, but is reauthenticated elsewhere', async function () {
         // PrimaryAuth has its own conn, we don't care about this
         await auth.useConnection(conn)
 

--- a/packages/core/src/test/credentials/testUtil.ts
+++ b/packages/core/src/test/credentials/testUtil.ts
@@ -10,7 +10,6 @@ import { CredentialsProviderManager } from '../../auth/providers/credentialsProv
 import { SsoClient } from '../../auth/sso/clients'
 import { builderIdStartUrl, SsoToken } from '../../auth/sso/model'
 import { DeviceFlowAuthorization, SsoAccessTokenProvider } from '../../auth/sso/ssoAccessTokenProvider'
-import { FakeMemento } from '../fakeExtensionContext'
 import { captureEvent, EventCapturer } from '../testUtil'
 import { stub } from '../utilities/stubber'
 import globals from '../../shared/extensionGlobals'
@@ -29,8 +28,17 @@ export const ssoConnection: SsoConnection = {
     startUrl: 'https://nkomonen.awsapps.com/start',
     getToken: sinon.stub(),
 }
-export const builderIdConnection: SsoConnection = { ...ssoConnection, startUrl: builderIdStartUrl, label: 'builderId' }
-export const iamConnection: IamConnection = { type: 'iam', id: '0', label: 'iam', getCredentials: sinon.stub() }
+export const builderIdConnection: SsoConnection = {
+    ...ssoConnection,
+    startUrl: builderIdStartUrl,
+    label: 'builderId',
+}
+export const iamConnection: IamConnection = {
+    type: 'iam',
+    id: '0',
+    label: 'iam',
+    getCredentials: sinon.stub(),
+}
 
 export function createSsoProfile(props?: Partial<Omit<SsoProfile, 'type'>>): SsoProfile {
     return {
@@ -80,7 +88,7 @@ type TestAuth = Auth & {
     getTestTokenProvider(connection: Pick<Connection, 'id'>): ReturnType<typeof createTestTokenProvider>
 }
 
-export function createTestAuth(): TestAuth {
+export function createTestAuth(globalState: vscode.Memento): TestAuth {
     const tokenProviders = new Map<string, ReturnType<typeof createTestTokenProvider>>()
 
     function getTokenProvider(...[profile]: ConstructorParameters<typeof SsoAccessTokenProvider>) {
@@ -108,7 +116,7 @@ export function createTestAuth(): TestAuth {
     const ssoClient = stub(SsoClient, { region: 'not set' })
     ssoClient.logout.resolves()
 
-    const store = new ProfileStore(new FakeMemento())
+    const store = new ProfileStore(globalState)
     const credentialsManager = new CredentialsProviderManager()
     const auth = new Auth(store, credentialsManager, () => ssoClient, getTokenProvider)
 

--- a/packages/core/src/test/fakeExtensionContext.ts
+++ b/packages/core/src/test/fakeExtensionContext.ts
@@ -74,6 +74,7 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
      */
     private constructor(preload?: FakeExtensionState) {
         if (preload) {
+            // eslint-disable-next-line aws-toolkits/no-banned-usages
             this.globalState = new FakeMemento(preload.globalState)
             this.workspaceState = new FakeMemento(preload.workspaceState)
         }

--- a/packages/core/src/test/fakeExtensionContext.ts
+++ b/packages/core/src/test/fakeExtensionContext.ts
@@ -129,12 +129,7 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
         const regionProvider = createTestRegionProvider({ awsContext })
         const outputChannel = new MockOutputChannel()
         const fakeTelemetryPublisher = new FakeTelemetryPublisher()
-        const telemetryService = await DefaultTelemetryService.create(
-            ctx,
-            awsContext,
-            undefined,
-            fakeTelemetryPublisher
-        )
+        const telemetryService = await DefaultTelemetryService.create(awsContext, undefined, fakeTelemetryPublisher)
 
         return {
             extensionContext: ctx,

--- a/packages/core/src/test/globalSetup.test.ts
+++ b/packages/core/src/test/globalSetup.test.ts
@@ -54,6 +54,7 @@ export async function mochaGlobalSetup(extensionId: string) {
         fakeContext.extensionPath = globals.context.extensionPath
         Object.assign(globals, {
             context: fakeContext,
+            // eslint-disable-next-line aws-toolkits/no-banned-usages
             globalState: new GlobalState(fakeContext.globalState),
         })
     }

--- a/packages/core/src/test/login/webview/vue/backend_amazonq.test.ts
+++ b/packages/core/src/test/login/webview/vue/backend_amazonq.test.ts
@@ -12,6 +12,7 @@ import { AmazonQLoginWebview } from '../../../../login/webview/vue/amazonq/backe
 import { isBuilderIdConnection, isIdcSsoConnection } from '../../../../auth/connection'
 import { amazonQScopes, AuthUtil } from '../../../../codewhisperer/util/authUtil'
 import { getOpenExternalStub } from '../../../globalSetup.test'
+import globals from '../../../../shared/extensionGlobals'
 
 // TODO: remove auth page and tests
 describe('Amazon Q Login', function () {
@@ -25,7 +26,7 @@ describe('Amazon Q Login', function () {
 
     beforeEach(function () {
         sandbox = createSandbox()
-        auth = createTestAuth()
+        auth = createTestAuth(globals.globalState)
         authUtil = new AuthUtil(auth)
         sandbox.stub(Auth, 'instance').value(auth)
         sandbox.stub(AuthUtil, 'instance').value(authUtil)

--- a/packages/core/src/test/login/webview/vue/backend_toolkit.test.ts
+++ b/packages/core/src/test/login/webview/vue/backend_toolkit.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../codecatalyst/auth'
 import { FakeSecretStorage } from '../../../fakeExtensionContext'
 import * as authUtils from '../../../../auth/utils'
+import globals from '../../../../shared/extensionGlobals'
 
 // TODO: remove auth page and tests
 describe('Toolkit Login', function () {
@@ -34,7 +35,7 @@ describe('Toolkit Login', function () {
 
     beforeEach(function () {
         sandbox = createSandbox()
-        auth = createTestAuth()
+        auth = createTestAuth(globals.globalState)
         codecatalystAuth = new CodeCatalystAuthenticationProvider(
             new CodeCatalystAuthStorage(new FakeSecretStorage()),
             auth

--- a/packages/core/src/test/shared/credentials/credentialsProfileMru.test.ts
+++ b/packages/core/src/test/shared/credentials/credentialsProfileMru.test.ts
@@ -5,11 +5,10 @@
 
 import assert from 'assert'
 import { CredentialsProfileMru } from '../../../shared/credentials/credentialsProfileMru'
-import { FakeExtensionContext } from '../../fakeExtensionContext'
 
 describe('CredentialsProfileMru', function () {
     it('lists no profile when none exist', async function () {
-        const credentialsMru = new CredentialsProfileMru(await FakeExtensionContext.create())
+        const credentialsMru = new CredentialsProfileMru()
 
         const mru = credentialsMru.getMruList()
 
@@ -18,7 +17,7 @@ describe('CredentialsProfileMru', function () {
     })
 
     it('lists single profile when only one exists', async function () {
-        const credentialsMru = new CredentialsProfileMru(await FakeExtensionContext.create())
+        const credentialsMru = new CredentialsProfileMru()
 
         await credentialsMru.setMostRecentlyUsedProfile('apples')
 
@@ -30,7 +29,7 @@ describe('CredentialsProfileMru', function () {
     })
 
     it('lists multiple profiles when multiple exist', async function () {
-        const credentialsMru = new CredentialsProfileMru(await FakeExtensionContext.create())
+        const credentialsMru = new CredentialsProfileMru()
 
         await credentialsMru.setMostRecentlyUsedProfile('dogs')
         await credentialsMru.setMostRecentlyUsedProfile('cats')
@@ -44,7 +43,7 @@ describe('CredentialsProfileMru', function () {
     })
 
     it('does not list duplicate profiles', async function () {
-        const credentialsMru = new CredentialsProfileMru(await FakeExtensionContext.create())
+        const credentialsMru = new CredentialsProfileMru()
 
         await credentialsMru.setMostRecentlyUsedProfile('bbq')
         await credentialsMru.setMostRecentlyUsedProfile('dill')
@@ -61,7 +60,7 @@ describe('CredentialsProfileMru', function () {
     })
 
     it('does not list more than MAX_CRENDTIAL_MRU_SIZE profiles', async function () {
-        const credentialsMru = new CredentialsProfileMru(await FakeExtensionContext.create())
+        const credentialsMru = new CredentialsProfileMru()
 
         for (let i = 0; i < CredentialsProfileMru.maxCredentialMruSize + 1; i++) {
             await credentialsMru.setMostRecentlyUsedProfile(`entry${i}`)

--- a/packages/core/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/packages/core/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -12,6 +12,7 @@ import { getClientId } from '../../shared/telemetry/util'
 import { FakeMemento } from '../fakeExtensionContext'
 import { FakeAwsContext } from '../utilities/fakeAwsContext'
 import { TestSettings } from '../utilities/testSettingsConfiguration'
+import { GlobalState } from '../../shared/globalState'
 
 describe('DefaultAwsClientBuilder', function () {
     let builder: AWSClientBuilder
@@ -23,7 +24,7 @@ describe('DefaultAwsClientBuilder', function () {
     describe('createAndConfigureSdkClient', function () {
         it('includes Toolkit user-agent if no options are specified', async function () {
             const service = await builder.createAwsService(Service)
-            const clientId = getClientId(new FakeMemento())
+            const clientId = getClientId(new GlobalState(new FakeMemento()))
 
             assert.strictEqual(!!service.config.customUserAgent, true)
             assert.strictEqual(
@@ -34,7 +35,7 @@ describe('DefaultAwsClientBuilder', function () {
 
         it('adds Client-Id to user agent', async function () {
             const service = await builder.createAwsService(Service)
-            const clientId = getClientId(new FakeMemento())
+            const clientId = getClientId(new GlobalState(new FakeMemento()))
             const regex = new RegExp(`ClientId/${clientId}`)
             assert.ok(service.config.customUserAgent?.match(regex))
         })

--- a/packages/core/src/test/shared/regions/regionProvider.test.ts
+++ b/packages/core/src/test/shared/regions/regionProvider.test.ts
@@ -11,6 +11,7 @@ import { createSsoProfile, createTestAuth } from '../../credentials/testUtil'
 import { Auth } from '../../../auth/auth'
 import * as extUtils from '../../../shared/extensionUtilities'
 import sinon from 'sinon'
+import globals from '../../../shared/extensionGlobals'
 
 const regionCode = 'someRegion'
 const serviceId = 'someService'
@@ -224,7 +225,7 @@ describe('RegionProvider', async function () {
         it('returns connection region with active amazon Q connection', async function () {
             const region = 'us-west-2'
             const regionProvider = new RegionProvider(endpoints)
-            const auth = createTestAuth()
+            const auth = createTestAuth(globals.globalState)
             await auth.useConnection(await auth.createConnection(createSsoProfile({ ssoRegion: region })))
 
             sinon.stub(Auth, 'instance').value(auth)

--- a/packages/core/src/test/shared/telemetry/telemetryService.test.ts
+++ b/packages/core/src/test/shared/telemetry/telemetryService.test.ts
@@ -9,7 +9,6 @@ import * as sinon from 'sinon'
 import * as fs from 'fs-extra'
 import { DefaultTelemetryService } from '../../../shared/telemetry/telemetryService'
 import { AccountStatus } from '../../../shared/telemetry/telemetryClient'
-import { FakeExtensionContext } from '../../fakeExtensionContext'
 
 import {
     defaultTestAccountId,
@@ -39,13 +38,12 @@ describe('TelemetryService', function () {
     const testFlushPeriod = 10
     let clock: FakeTimers.InstalledClock
     let sandbox: sinon.SinonSandbox
-    let mockContext: FakeExtensionContext
     let mockPublisher: FakeTelemetryPublisher
     let service: DefaultTelemetryService
     let logger: TelemetryLogger
 
     async function initService(awsContext = new FakeAwsContext()): Promise<DefaultTelemetryService> {
-        const newService = await DefaultTelemetryService.create(mockContext, awsContext, undefined, mockPublisher)
+        const newService = await DefaultTelemetryService.create(awsContext, undefined, mockPublisher)
         newService.flushPeriod = testFlushPeriod
         await newService.setTelemetryEnabled(true)
 
@@ -62,7 +60,6 @@ describe('TelemetryService', function () {
     })
 
     beforeEach(async function () {
-        mockContext = await FakeExtensionContext.create()
         mockPublisher = new FakeTelemetryPublisher()
         service = await initService()
         logger = service.logger

--- a/packages/core/src/test/shared/telemetry/util.test.ts
+++ b/packages/core/src/test/shared/telemetry/util.test.ts
@@ -9,6 +9,7 @@ import { Settings } from '../../../shared/settings'
 import { convertLegacy, getClientId, getUserAgent, platformPair, TelemetryConfig } from '../../../shared/telemetry/util'
 import { extensionVersion } from '../../../shared/vscode/env'
 import { FakeMemento } from '../../fakeExtensionContext'
+import { GlobalState } from '../../../shared/globalState'
 
 describe('TelemetryConfig', function () {
     const settingKey = 'aws.telemetry'
@@ -100,20 +101,20 @@ describe('TelemetryConfig', function () {
 
 describe('getClientId', function () {
     it('should generate a unique id', async function () {
-        const c1 = getClientId(new FakeMemento(), true, false, 'x1')
-        const c2 = getClientId(new FakeMemento(), true, false, 'x2')
+        const c1 = getClientId(new GlobalState(new FakeMemento()), true, false, 'x1')
+        const c2 = getClientId(new GlobalState(new FakeMemento()), true, false, 'x2')
         assert.notStrictEqual(c1, c2)
     })
 
     it('returns the same value across the calls sequentially', async function () {
-        const memento = new FakeMemento()
+        const memento = new GlobalState(new FakeMemento())
         const c1 = getClientId(memento, true, false, 'y1')
         const c2 = getClientId(memento, true, false, 'y2')
         assert.strictEqual(c1, c2)
     })
 
-    it('returns the nil UUID if it fails to save generated UUID', async function () {
-        const mememto: Memento = {
+    it('returns nil UUID if it fails to save generated UUID', async function () {
+        const memento: Memento = {
             keys: () => [],
             get(key) {
                 return undefined
@@ -122,34 +123,40 @@ describe('getClientId', function () {
                 throw new Error()
             },
         }
-        const clientId = getClientId(mememto, true, false, 'x3')
-        assert.strictEqual(clientId, '00000000-0000-0000-0000-000000000000')
+        const clientId = getClientId(new GlobalState(memento), true, false, 'x3')
+        // XXX: `notStrictEqual` since getClientId() is now synchronous. Because memento.update() is async.
+        assert.notStrictEqual(clientId, '00000000-0000-0000-0000-000000000000')
     })
 
-    it('returns the nil UUID if fails to retrive a saved UUID.', async function () {
-        const mememto: Memento = {
+    it('returns the nil UUID if it fails to get the saved UUID', async function () {
+        const memento: Memento = {
             keys: () => [],
             get(key) {
                 throw new Error()
             },
             async update(key, value) {},
         }
-        const clientId = getClientId(mememto, true, false, 'x4')
+        class FakeGlobalState extends GlobalState {
+            override tryGet<T>(key: any, defaultVal?: T): T | undefined {
+                return this.memento.get(key)
+            }
+        }
+        const clientId = getClientId(new FakeGlobalState(memento), true, false, 'x4')
         assert.strictEqual(clientId, '00000000-0000-0000-0000-000000000000')
     })
 
     it('should be ffffffff-ffff-ffff-ffff-ffffffffffff if in test enviroment', async function () {
-        const clientId = getClientId(new FakeMemento(), true)
+        const clientId = getClientId(new GlobalState(new FakeMemento()), true)
         assert.strictEqual(clientId, 'ffffffff-ffff-ffff-ffff-ffffffffffff')
     })
 
     it('should be ffffffff-ffff-ffff-ffff-ffffffffffff if telemetry is not enabled in test enviroment', async function () {
-        const clientId = getClientId(new FakeMemento(), false)
+        const clientId = getClientId(new GlobalState(new FakeMemento()), false)
         assert.strictEqual(clientId, 'ffffffff-ffff-ffff-ffff-ffffffffffff')
     })
 
     it('should be 11111111-1111-1111-1111-111111111111 if telemetry is not enabled', async function () {
-        const clientId = getClientId(new FakeMemento(), false, false)
+        const clientId = getClientId(new GlobalState(new FakeMemento()), false, false)
         assert.strictEqual(clientId, '11111111-1111-1111-1111-111111111111')
     })
 })

--- a/plugins/eslint-plugin-aws-toolkits/lib/rules/no-banned-usages.ts
+++ b/plugins/eslint-plugin-aws-toolkits/lib/rules/no-banned-usages.ts
@@ -3,13 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ESLintUtils } from '@typescript-eslint/utils'
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils'
 import { AST_NODE_TYPES } from '@typescript-eslint/types'
 import { Rule } from 'eslint'
 // import * as util from 'util'
 
 export const errMsgs = {
-    setContext: 'Use shared/vscode/setContext.ts, do not use executeCommand("setContext") directly',
+    setContext: 'Use `shared/vscode/setContext.ts`, do not use `executeCommand("setContext")` directly',
+    globalState: 'Use `globals.globalState`, do not use `ExtensionContext.globalState` directly or indirectly',
+}
+
+/**
+ * Each key is the member name, value is its expected container name.
+ */
+const memberContainers: Record<string, string> = {
+    // Disallow accesses like `extContext.globalState` and `globals.context.globalState`.
+    // Preferred usage is exactly: `globals.globalState`.
+    globalState: 'globals',
 }
 
 /**
@@ -31,6 +41,37 @@ export default ESLintUtils.RuleCreator.withoutDocs({
     defaultOptions: [],
     create(context) {
         return {
+            MemberExpression(node: TSESTree.MemberExpression) {
+                const o = node.object
+                const p = node.property
+                // Disallow accesses like: `banned1.member`.
+                if (
+                    o.type === AST_NODE_TYPES.Identifier &&
+                    p.type === AST_NODE_TYPES.Identifier &&
+                    typeof memberContainers[p.name] === 'string' &&
+                    o.name !== memberContainers[p.name]
+                ) {
+                    return context.report({
+                        node,
+                        messageId: p.name as any,
+                    })
+                }
+
+                // Disallow accesses like: `banned1.banned2.member`.
+                if (
+                    o.type === AST_NODE_TYPES.MemberExpression &&
+                    o.object.type === AST_NODE_TYPES.Identifier &&
+                    p.type === AST_NODE_TYPES.Identifier &&
+                    typeof memberContainers[p.name] === 'string' &&
+                    o.property.type === AST_NODE_TYPES.Identifier &&
+                    o.property.name !== memberContainers[p.name]
+                ) {
+                    return context.report({
+                        node,
+                        messageId: p.name as any,
+                    })
+                }
+            },
             CallExpression(node) {
                 if (
                     node.callee.type !== AST_NODE_TYPES.MemberExpression ||

--- a/plugins/eslint-plugin-aws-toolkits/test/rules/no-banned-usages.test.ts
+++ b/plugins/eslint-plugin-aws-toolkits/test/rules/no-banned-usages.test.ts
@@ -8,9 +8,20 @@ import { errMsgs } from '../../lib/rules/no-banned-usages'
 import { getRuleTester } from '../testUtil'
 
 getRuleTester().run('no-banned-usages', rules['no-banned-usages'], {
-    valid: ["vscode.commands.executeCommand('foo', 'aws.foo', true, 42)"],
+    valid: [
+        // setContext
+        "vscode.commands.executeCommand('foo', 'aws.foo', true, 42)",
+        // globalState
+        'globals.globalState',
+        'await globals.globalState.update("foo", 42)',
+        'globals.globalState.get("foo")',
+        'globalState.get("foo")',
+    ],
 
     invalid: [
+        //
+        // setContext
+        //
         {
             code: "async function test() { await vscode.commands.executeCommand('setContext', key, val) }",
             errors: [errMsgs.setContext],
@@ -35,5 +46,31 @@ getRuleTester().run('no-banned-usages', rules['no-banned-usages'], {
             code: "const x = vscode.commands.executeCommand('setContext', key, val).catch(e => { return e })",
             errors: [errMsgs.setContext],
         },
+
+        //
+        // globalState
+        //
+        {
+            code: 'const memento = globals.context.globalState',
+            errors: [errMsgs.globalState],
+        },
+        {
+            code: 'const val = globals.context.globalState.get("foo")',
+            errors: [errMsgs.globalState],
+        },
+        {
+            code: 'const val = extContext.globalState.get("foo")',
+            errors: [errMsgs.globalState],
+        },
+        {
+            code: 'return this.openState(targetContext.globalState, key)',
+            errors: [errMsgs.globalState],
+        },
+
+        // TODO: prevent assignment of GlobalState to Memento.
+        // {
+        //     code: 'const state: vscode.Memento = globals.globalState',
+        //     errors: [errMsgs.globalState],
+        // },
     ],
 })


### PR DESCRIPTION
# Problem

Use of vscode's `globalState` interface allows bugs such as https://github.com/aws/aws-toolkit-vscode/pull/3060#discussion_r1050240283 . 

Previous work:
- https://github.com/aws/aws-toolkit-vscode/pull/5293
- https://github.com/aws/aws-toolkit-vscode/pull/5309
- https://github.com/aws/aws-toolkit-vscode/pull/5323
- https://github.com/aws/aws-toolkit-vscode/pull/5344

# Solution

Update all code to use `globals.globalState` , which allows type-checking, error handling, and centralization of related logic.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
