### PR TITLE
fix(accessanalyzer): Update cfn-policy-validator version

### DIFF
--- a/packages/core/src/awsService/accessanalyzer/vue/iamPolicyChecks.vue
+++ b/packages/core/src/awsService/accessanalyzer/vue/iamPolicyChecks.vue
@@ -15,7 +15,7 @@
                         <p>Install Python 3.6+</p>
                     </li>
                     <li>
-                        <code> pip install cfn-policy-validator==0.0.33 </code>
+                        <code> pip install cfn-policy-validator==0.0.34 </code>
                     </li>
                     <li>
                         <code> pip install tf-policy-validator==0.0.8 </code>

--- a/packages/toolkit/.changes/next-release/Bug Fix-ba5dce72-56eb-42a5-92f7-f3b894c43e76.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-ba5dce72-56eb-42a5-92f7-f3b894c43e76.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "AccessAnalyzer: error when running CheckNoPublicAccess with only role trust policy in template"
+}


### PR DESCRIPTION
## Problem

`cfn-policy-validator` dependency was updated with a bugfix (https://github.com/awslabs/aws-cloudformation-iam-policy-validator/releases/tag/v0.0.34)

## Solution

Update the dependency version to 0.0.34 from 0.0.33 in the accessanalyzer integration.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
