### PR TITLE
refactor(amazonqFeatureDev): refactor error message and include backfill for error name

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-4b44becd-f933-48b3-9e77-62da8504969a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-4b44becd-f933-48b3-9e77-62da8504969a.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "refactor error message and include backfill for error name"
+	"description": "Amazon Q /dev: update error message for code gen timeout and include backfill for error name"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-4b44becd-f933-48b3-9e77-62da8504969a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-4b44becd-f933-48b3-9e77-62da8504969a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "refactor error message and include backfill for error name"
+}

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -220,7 +220,7 @@ export class FeatureDevController {
         const isDenyListedError = denyListedErrors.some((err) => errorMessage.includes(err))
 
         switch (err.code) {
-            case ContentLengthError.name:
+            case ContentLengthError.errorName:
                 this.messenger.sendAnswer({
                     type: 'answer',
                     tabID: message.tabID,
@@ -238,11 +238,11 @@ export class FeatureDevController {
                     ],
                 })
                 break
-            case MonthlyConversationLimitError.name:
+            case MonthlyConversationLimitError.errorName:
                 this.messenger.sendMonthlyLimitError(message.tabID)
                 break
 
-            case PlanIterationLimitError.name:
+            case PlanIterationLimitError.errorName:
                 this.messenger.sendAnswer({
                     type: 'answer',
                     tabID: message.tabID,
@@ -266,11 +266,11 @@ export class FeatureDevController {
                 })
                 break
 
-            case FeatureDevServiceError.name:
-            case UploadCodeError.name:
-            case UserMessageNotFoundError.name:
-            case TabIdNotFoundError.name:
-            case PrepareRepoFailedError.name:
+            case FeatureDevServiceError.errorName:
+            case UploadCodeError.errorName:
+            case UserMessageNotFoundError.errorName:
+            case TabIdNotFoundError.errorName:
+            case PrepareRepoFailedError.errorName:
                 this.messenger.sendErrorMessage(
                     errorMessage,
                     message.tabID,
@@ -278,11 +278,11 @@ export class FeatureDevController {
                     session?.conversationIdUnsafe
                 )
                 break
-            case PromptRefusalException.name:
-            case ZipFileError.name:
+            case PromptRefusalException.errorName:
+            case ZipFileError.errorName:
                 this.messenger.sendErrorMessage(errorMessage, message.tabID, 0, session?.conversationIdUnsafe, true)
                 break
-            case CodeIterationLimitError.name:
+            case CodeIterationLimitError.errorName:
                 this.messenger.sendAnswer({
                     type: 'answer',
                     tabID: message.tabID,

--- a/packages/core/src/amazonqFeatureDev/errors.ts
+++ b/packages/core/src/amazonqFeatureDev/errors.ts
@@ -16,6 +16,8 @@ export class ConversationIdNotFoundError extends ToolkitError {
 }
 
 export class TabIdNotFoundError extends ToolkitError {
+    static errorName = 'TabIdNotFoundError'
+
     constructor() {
         super(`I'm sorry, I'm having technical difficulties at the moment. Please try again.`, {
             code: 'TabIdNotFound',
@@ -41,6 +43,7 @@ export class WorkspaceFolderNotFoundError extends ToolkitError {
 }
 
 export class UserMessageNotFoundError extends ToolkitError {
+    static errorName = 'UserMessageNotFoundError'
     constructor() {
         super(`It looks like you didn't provide an input. Please enter your message in the text bar.`, {
             code: 'MessageNotFound',
@@ -60,6 +63,7 @@ export class SelectedFolderNotInWorkspaceFolderError extends ToolkitError {
 }
 
 export class PromptRefusalException extends ToolkitError {
+    static errorName = 'PromptRefusalException'
     constructor() {
         super(
             'I\'m sorry, I can\'t generate code for your request. Please make sure your message and code files comply with the <a href="https://aws.amazon.com/machine-learning/responsible-ai/policy/">AWS Responsible AI Policy.</a>',
@@ -71,12 +75,14 @@ export class PromptRefusalException extends ToolkitError {
 }
 
 export class FeatureDevServiceError extends ToolkitError {
+    static errorName = 'FeatureDevServiceError'
     constructor(message: string, code: string) {
         super(message, { code })
     }
 }
 
 export class PrepareRepoFailedError extends ToolkitError {
+    static errorName = 'PrepareRepoFailedError'
     constructor() {
         super('Sorry, I ran into an issue while trying to upload your code. Please try again.', {
             code: 'PrepareRepoFailed',
@@ -85,6 +91,7 @@ export class PrepareRepoFailedError extends ToolkitError {
 }
 
 export class UploadCodeError extends ToolkitError {
+    static errorName = 'UploadCodeError'
     constructor(statusCode: string) {
         super(uploadCodeError, { code: `UploadCode-${statusCode}` })
     }
@@ -97,41 +104,46 @@ export class IllegalStateTransition extends ToolkitError {
 }
 
 export class ContentLengthError extends ToolkitError {
+    static errorName = 'ContentLengthError'
     constructor() {
         super(
             'The folder you selected is too large for me to use as context. Please choose a smaller folder to work on. For more information on quotas, see the <a href="https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/software-dev.html#quotas" target="_blank">Amazon Q Developer documentation.</a>',
-            { code: 'ContentLengthError' }
+            { code: ContentLengthError.errorName }
         )
     }
 }
 
 export class ZipFileError extends ToolkitError {
+    static errorName = 'ZipFileError'
     constructor() {
-        super('The zip file is corrupted', { code: 'ZipFileError' })
+        super('The zip file is corrupted', { code: ZipFileError.errorName })
     }
 }
 
 export class PlanIterationLimitError extends ToolkitError {
+    static errorName = 'PlanIterationLimitError'
     constructor() {
         super(
             'Sorry, you\'ve reached the quota for number of iterations on an implementation plan. You can generate code for this task or discuss a new plan. For more information on quotas, see the <a href="https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/software-dev.html#quotas">Amazon Q Developer documentation</a>.',
-            { code: 'PlanIterationLimitError' }
+            { code: PlanIterationLimitError.errorName }
         )
     }
 }
 
 export class CodeIterationLimitError extends ToolkitError {
+    static errorName = 'CodeIterationLimitError'
     constructor() {
         super(
             'Sorry, you\'ve reached the quota for number of iterations on code generation. You can insert this code in your files or discuss a new plan. For more information on quotas, see the <a href="https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/software-dev.html#quotas" target="_blank">Amazon Q Developer documentation.</a>',
-            { code: 'CodeIterationLimitError' }
+            { code: CodeIterationLimitError.errorName }
         )
     }
 }
 
 export class MonthlyConversationLimitError extends ToolkitError {
+    static errorName = 'MonthlyConversationLimitError'
     constructor(message: string) {
-        super(message, { code: 'MonthlyConversationLimitError' })
+        super(message, { code: MonthlyConversationLimitError.errorName })
     }
 }
 

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -326,7 +326,7 @@ abstract class CodeGenBase {
         }
         if (!this.tokenSource.token.isCancellationRequested) {
             // still in progress
-            const errorMessage = 'Code generation did not finish withing the expected time'
+            const errorMessage = 'Code generation did not finish within the expected time'
             throw new ToolkitError(errorMessage, { code: 'CodeGenTimeout' })
         }
         return {


### PR DESCRIPTION
## Problem

When cancellation is requested, the error message includes a typo ("within"). By the way, since ```class.name``` or ```someClassInstance.constructor.name``` can be impacted by transpilers when bundled, some explicit name might be required and adding here.

## Solution

This PR fixes:

- Typo
- Add a safe static field check for error name which doesn't depend on transpiler / prototype / es polyfill

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
