### PR TITLE
fix: VSCode is downloaded for every test package

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,6 +21,8 @@ jobs:
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
+            AWS_TOOLKIT_TEST_CACHE_DIR: '/tmp/.vscode-test/'
+            AWS_TOOLKIT_TEST_USER_DIR: '/tmp/.vscode-test/user-data/'
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
@@ -88,6 +90,8 @@ jobs:
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
+            AWS_TOOLKIT_TEST_CACHE_DIR: '/tmp/.vscode-test/'
+            AWS_TOOLKIT_TEST_USER_DIR: '/tmp/.vscode-test/user-data/'
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
@@ -111,6 +115,8 @@ jobs:
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
+            AWS_TOOLKIT_TEST_CACHE_DIR: '/tmp/.vscode-test/'
+            AWS_TOOLKIT_TEST_USER_DIR: '/tmp/.vscode-test/user-data/'
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -115,8 +115,6 @@ jobs:
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
-            AWS_TOOLKIT_TEST_CACHE_DIR: '/tmp/.vscode-test/'
-            AWS_TOOLKIT_TEST_USER_DIR: '/tmp/.vscode-test/user-data/'
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}

--- a/packages/core/scripts/test/launchTestUtilities.ts
+++ b/packages/core/scripts/test/launchTestUtilities.ts
@@ -10,7 +10,6 @@ import { join, resolve } from 'path'
 import { runTests } from '@vscode/test-electron'
 import { VSCODE_EXTENSION_ID } from '../../src/shared/extensions'
 import { TestOptions } from '@vscode/test-electron/out/runTest'
-import { defaultCachePath } from '@vscode/test-electron/out/download'
 
 const envvarVscodeTestVersion = 'VSCODE_TEST_VERSION'
 
@@ -146,7 +145,7 @@ async function setupVSCodeTestInstance(suite: SuiteName): Promise<string> {
     const downloadOptions = {
         platform,
         version: vsCodeVersion,
-        cachePath: process.env.AWS_TOOLKIT_TEST_CACHE_DIR ?? defaultCachePath,
+        cachePath: process.env.AWS_TOOLKIT_TEST_CACHE_DIR ?? '../../.vscode-test',
     }
 
     const vsCodeExecutablePath = await downloadAndUnzipVSCode(downloadOptions)


### PR DESCRIPTION
## Problem
- In github ci vscode is downloaded for every test package (core/q)

## Solution
- Use AWS_TOOLKIT_TEST_CACHE_DIR and AWS_TOOLKIT_TEST_USER_DIR to cache the test and user directories
- By default use `../../.vscode-test` directory

Related issue: https://github.com/aws/aws-toolkit-vscode/issues/5311
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
