### PR TITLE
fix: Amazon Q Dev and Transform introduction text formatted incorrectly

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-32f3fd29-6924-4e09-a94d-f8e249542c1b.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-32f3fd29-6924-4e09-a94d-f8e249542c1b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Dev and Transform introduction text formatted incorrectly"
+}

--- a/packages/core/src/amazonq/webview/ui/tabs/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/constants.ts
@@ -26,15 +26,15 @@ export const TabTypeDataMap: Record<TabType, TabTypeData> = {
         placeholder: 'Describe your task or issue in as much detail as possible',
         welcome: `Hi, I'm the Amazon Q Developer Agent for software development.
 
-    I can generate code to implement new functionality across your workspace. We'll start by discussing an implementation plan, and then we can review and regenerate code based on your feedback.
+I can generate code to implement new functionality across your workspace. We'll start by discussing an implementation plan, and then we can review and regenerate code based on your feedback.
 
-    To get started, describe the task you are trying to accomplish.`,
+To get started, describe the task you are trying to accomplish.`,
     },
     gumby: {
         title: 'Q - Code Transformation',
         placeholder: 'Open a new tab to chat with Q',
         welcome: `Welcome to Code Transformation!
 
-    I can help you upgrade your Java 8 and 11 codebases to Java 17.`,
+I can help you upgrade your Java 8 and 11 codebases to Java 17.`,
     },
 }


### PR DESCRIPTION
## Problem
- dev/transform intro text shows as markdown

## Solution
- it should show as regular text

### /dev
Before:
![Screenshot 2024-07-23 at 2 54 26 PM](https://github.com/user-attachments/assets/da555d39-ca04-4724-9750-0a175e9b5424)

After:
![Screenshot 2024-07-23 at 2 57 04 PM](https://github.com/user-attachments/assets/98f88646-10ad-45bf-bf00-ac060f68ac12)

### /transform
Before:
![Screenshot 2024-07-23 at 2 54 17 PM](https://github.com/user-attachments/assets/a44baa6c-92c5-493b-ba42-d911bcc6f6af)

After:
![Screenshot 2024-07-23 at 2 57 16 PM](https://github.com/user-attachments/assets/b5ed966c-09e4-442f-b39f-34b418b89391)
<!---



    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
