### PR TITLE
fix(amazonq): sign-in page may not render in rare scenarios

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-a2ce509a-e62b-45a6-95d1-2e5e1fe4587d.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-a2ce509a-e62b-45a6-95d1-2e5e1fe4587d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Sign-in page may fail to render in rare circumstances."
+}

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -28,6 +28,7 @@ import {
     initialize,
     initializeComputeRegion,
     messages,
+    placeholder,
     setContext,
 } from 'aws-core-vscode/shared'
 import { ExtStartUpSources, telemetry } from 'aws-core-vscode/telemetry'
@@ -36,6 +37,7 @@ import { join } from 'path'
 import * as semver from 'semver'
 import * as vscode from 'vscode'
 import { registerCommands } from './commands'
+import { focusAmazonQPanel } from 'aws-core-vscode/codewhispererChat'
 
 export const amazonQContextPrefix = 'amazonq'
 
@@ -125,8 +127,11 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction')
 
     if (AuthUtils.ExtensionUse.instance.isFirstUse()) {
-        CommonAuthWebview.authSource = ExtStartUpSources.firstStartUp
-        await vscode.commands.executeCommand('workbench.view.extension.amazonq')
+        // Give time for the extension to finish initializing.
+        globals.clock.setTimeout(async () => {
+            CommonAuthWebview.authSource = ExtStartUpSources.firstStartUp
+            void focusAmazonQPanel.execute(placeholder, 'firstStartUp')
+        }, 1000)
     }
 
     await telemetry.auth_userState.run(async () => {


### PR DESCRIPTION
Problem: VSC workbench can throw an error sometimes if we try to focus the panel too quickly. `Error: View already awaiting revival`

Solution: Use our command to focus the panel and give time for the ext to load by sending this to the back of the queue after 1 second.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
