### PR TITLE
telemetry: include chained error message in reasonDesc

### DIFF
--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -243,9 +243,22 @@ export class ToolkitError extends Error implements ErrorInformation {
     }
 }
 
-export function getErrorMsg(err: Error | undefined): string | undefined {
+/**
+ * Derives an error message from the given error object.
+ * Depending on the Error, the property used to derive the message can vary.
+ *
+ * @param withCause If the error is a ToolkitError, the message of the cause will
+ *                  be appended and delimited by a '::'. Eg: msg1::causeMsg1:causeMsg2
+ */
+export function getErrorMsg(err: Error | undefined, withCause = false): string | undefined {
     if (err === undefined) {
         return undefined
+    }
+
+    if (withCause && err instanceof ToolkitError) {
+        // append the message of the cause, recursively
+        // output eg: "ToolkitError Message::Cause Message::Nested Cause Message::Nested Nested Cause Message"
+        return `${err.message}${err.cause ? '::' + getErrorMsg(err.cause, true) : ''}`
     }
 
     // Non-standard SDK fields added by the OIDC service, to conform to the OAuth spec
@@ -404,7 +417,7 @@ export function scrubNames(s: string, username?: string) {
  * @param err Error object, or message text
  */
 export function getTelemetryReasonDesc(err: unknown | undefined): string | undefined {
-    const m = typeof err === 'string' ? err : getErrorMsg(err as Error) ?? ''
+    const m = typeof err === 'string' ? err : getErrorMsg(err as Error, true) ?? ''
     const msg = scrubNames(m, _username)
 
     // Truncate to 200 chars.

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -247,18 +247,17 @@ export class ToolkitError extends Error implements ErrorInformation {
  * Derives an error message from the given error object.
  * Depending on the Error, the property used to derive the message can vary.
  *
- * @param withCause If the error is a ToolkitError, the message of the cause will
- *                  be appended and delimited by a '::'. Eg: msg1::causeMsg1:causeMsg2
+ * @param withCause Append the message(s) from the cause chain, recursively.
+ *                  The message(s) are delimited by ' | '. Eg: msg1 | causeMsg1 | causeMsg2
  */
 export function getErrorMsg(err: Error | undefined, withCause = false): string | undefined {
     if (err === undefined) {
         return undefined
     }
 
-    if (withCause && err instanceof ToolkitError) {
-        // append the message of the cause, recursively
-        // output eg: "ToolkitError Message::Cause Message::Nested Cause Message::Nested Nested Cause Message"
-        return `${err.message}${err.cause ? '::' + getErrorMsg(err.cause, true) : ''}`
+    const cause = (err as any).cause
+    if (withCause && cause) {
+        return `${err.message}${cause ? ' | ' + getErrorMsg(cause, true) : ''}`
     }
 
     // Non-standard SDK fields added by the OIDC service, to conform to the OAuth spec

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -452,7 +452,7 @@ describe('util', function () {
             'unauthorized message'
         )
         assert.deepStrictEqual(getErrorMsg(undefined), undefined)
-        const awsErr = new TestAwsError('ValidationException', 'aws validation msg 1', new Date())
+        let awsErr = new TestAwsError('ValidationException', 'aws validation msg 1', new Date())
         assert.deepStrictEqual(getErrorMsg(awsErr), 'aws validation msg 1')
         ;(awsErr as any).error_description = ''
         assert.deepStrictEqual(getErrorMsg(awsErr), 'aws validation msg 1')
@@ -461,24 +461,24 @@ describe('util', function () {
         ;(awsErr as any).error_description = 'aws error desc 1'
         assert.deepStrictEqual(getErrorMsg(awsErr), 'aws error desc 1')
 
-        // -- start -- With 'composite' arg as as true
+        // Arg withCause=true
+        awsErr = new TestAwsError('ValidationException', 'aws validation msg 1', new Date())
         let toolkitError = new ToolkitError('ToolkitError Message')
         assert.deepStrictEqual(getErrorMsg(toolkitError, true), 'ToolkitError Message')
 
         toolkitError = new ToolkitError('ToolkitError Message', { cause: awsErr })
-        assert.deepStrictEqual(getErrorMsg(toolkitError, true), `ToolkitError Message::aws validation msg 1`)
+        assert.deepStrictEqual(getErrorMsg(toolkitError, true), `ToolkitError Message | aws validation msg 1`)
 
         const nestedNestedToolkitError = new ToolkitError('C')
         const nestedToolkitError = new ToolkitError('B', { cause: nestedNestedToolkitError })
         toolkitError = new ToolkitError('A', { cause: nestedToolkitError })
-        assert.deepStrictEqual(getErrorMsg(toolkitError, true), `A::B::C`)
-        // -- end -- With 'composite' arg as as true
+        assert.deepStrictEqual(getErrorMsg(toolkitError, true), `A | B | C`)
     })
 
     it('getTelemetryReasonDesc()', () => {
         const err = new Error('Cause Message a/b/c/d.txt')
         const toolkitError = new ToolkitError('ToolkitError Message', { cause: err })
-        assert.deepStrictEqual(getTelemetryReasonDesc(toolkitError), 'ToolkitError Message::Cause Message x/x/x/x.txt')
+        assert.deepStrictEqual(getTelemetryReasonDesc(toolkitError), 'ToolkitError Message | Cause Message x/x/x/x.txt')
     })
 
     it('isNetworkError()', function () {

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -10,6 +10,7 @@ import {
     formatError,
     getErrorMsg,
     getTelemetryReason,
+    getTelemetryReasonDesc,
     getTelemetryResult,
     isNetworkError,
     resolveErrorMessageToDisplay,
@@ -451,14 +452,33 @@ describe('util', function () {
             'unauthorized message'
         )
         assert.deepStrictEqual(getErrorMsg(undefined), undefined)
-        const err = new TestAwsError('ValidationException', 'aws validation msg 1', new Date())
-        assert.deepStrictEqual(getErrorMsg(err), 'aws validation msg 1')
-        ;(err as any).error_description = ''
-        assert.deepStrictEqual(getErrorMsg(err), 'aws validation msg 1')
-        ;(err as any).error_description = {}
-        assert.deepStrictEqual(getErrorMsg(err), 'aws validation msg 1')
-        ;(err as any).error_description = 'aws error desc 1'
-        assert.deepStrictEqual(getErrorMsg(err), 'aws error desc 1')
+        const awsErr = new TestAwsError('ValidationException', 'aws validation msg 1', new Date())
+        assert.deepStrictEqual(getErrorMsg(awsErr), 'aws validation msg 1')
+        ;(awsErr as any).error_description = ''
+        assert.deepStrictEqual(getErrorMsg(awsErr), 'aws validation msg 1')
+        ;(awsErr as any).error_description = {}
+        assert.deepStrictEqual(getErrorMsg(awsErr), 'aws validation msg 1')
+        ;(awsErr as any).error_description = 'aws error desc 1'
+        assert.deepStrictEqual(getErrorMsg(awsErr), 'aws error desc 1')
+
+        // -- start -- With 'composite' arg as as true
+        let toolkitError = new ToolkitError('ToolkitError Message')
+        assert.deepStrictEqual(getErrorMsg(toolkitError, true), 'ToolkitError Message')
+
+        toolkitError = new ToolkitError('ToolkitError Message', { cause: awsErr })
+        assert.deepStrictEqual(getErrorMsg(toolkitError, true), `ToolkitError Message::aws validation msg 1`)
+
+        const nestedNestedToolkitError = new ToolkitError('C')
+        const nestedToolkitError = new ToolkitError('B', { cause: nestedNestedToolkitError })
+        toolkitError = new ToolkitError('A', { cause: nestedToolkitError })
+        assert.deepStrictEqual(getErrorMsg(toolkitError, true), `A::B::C`)
+        // -- end -- With 'composite' arg as as true
+    })
+
+    it('getTelemetryReasonDesc()', () => {
+        const err = new Error('Cause Message a/b/c/d.txt')
+        const toolkitError = new ToolkitError('ToolkitError Message', { cause: err })
+        assert.deepStrictEqual(getTelemetryReasonDesc(toolkitError), 'ToolkitError Message::Cause Message x/x/x/x.txt')
     })
 
     it('isNetworkError()', function () {


### PR DESCRIPTION
## Problem:

When we use the function getTelemetryReasonDesc() we would lose information about the underlying error in the case the error was a ToolkitError with an underlying chained error. Only the message of the ToolkitError was used.

So in telemetry we would be missing some information about the real cause of the error.

## Solution:

getTelemetryReasonDesc() will return a  message which consists of all messages in the chain. It recursively calls in to the next chained error of a ToolkitError and appends it to the final output.

This will give us some context about the higher level call as well as the root of the issue.

The final message could look something like:
"Message A::Message B::Message C"

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
