### PR TITLE
feature: added pick string to enable running without any other extensions

### DIFF
--- a/packages/amazonq/.vscode/launch.json
+++ b/packages/amazonq/.vscode/launch.json
@@ -15,7 +15,7 @@
                 "webRoot": "${workspaceFolder}"
             },
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}", "${input:disableExtensions}"],
             "env": {
                 "SSMDOCUMENT_LANGUAGESERVER_PORT": "6010",
                 "WEBPACK_DEVELOPER_SERVER": "http://localhost:8080"
@@ -101,6 +101,24 @@
             },
             "outFiles": ["${workspaceFolder}/dist/**/*.js", "${workspaceFolder}/../core/dist/**/*.js"],
             "preLaunchTask": "watch"
+        }
+    ],
+    "inputs": [
+        {
+            "id": "disableExtensions",
+            "type": "pickString",
+            "description": "Disable extensions when running tests",
+            "options": [
+                {
+                    "value": "--disable-extensions",
+                    "label": "Yes"
+                },
+                {
+                    "value": "",
+                    "label": "No"
+                }
+            ],
+            "default": "No"
         }
     ]
 }


### PR DESCRIPTION
## Problem

When constantly restarting the debugger in watch mode, the  [Extension Development Host] sometimes takes an unruly time to load Amazon Q since i might have dozens of other extensions, themes, plugins running.

## Solution

Option
<img width="605" alt="Screenshot 2024-07-24 at 11 45 37 AM" src="https://github.com/user-attachments/assets/b6c02723-d4ea-4041-95fb-91a126a3ff0a">

Results
<img width="465" alt="Screenshot 2024-07-24 at 12 14 24 PM" src="https://github.com/user-attachments/assets/efbdad97-9a27-47a4-a1d1-e63ca3a4dff7">


When either restarting of `F5` in the primary window with [Extension Development Host]  already open i am presented with a select option of wether or not i want to run it with other extensions

>[!NOTE]
> Why is it in `launch.json`?

Attempted to solution by placing the "inputs" "pickString" in the `tasks.json` file, this will cause issues and ammend the argument to the end of the command string

ex: `'npm run compileOnly -- --watch' --disable-extensions` 

`tasks.json` is really meant for all the `preLaunchTask` mechanisms anyway

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
