### PR TITLE
fix: Auth Server is not found when user closes webview before finishing browser auth

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-f0e62bbc-f4bb-40c0-931a-e96f0b139efa.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-f0e62bbc-f4bb-40c0-931a-e96f0b139efa.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth Server is not found when user closes webview before finishing auth"
+}

--- a/packages/core/src/extensionNode.ts
+++ b/packages/core/src/extensionNode.ts
@@ -60,6 +60,7 @@ import { ExtStartUpSources } from './shared/telemetry'
 import { activate as activateThreatComposerEditor } from './threatComposer/activation'
 import { isSsoConnection, hasScopes } from './auth/connection'
 import { setContext } from './shared'
+import { AuthSSOServer } from './auth/sso/server'
 
 let localize: nls.LocalizeFunc
 
@@ -145,6 +146,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         // MUST restore CW/Q auth so that we can see if this user is already a Q user.
         await AuthUtil.instance.restore()
+        await AuthSSOServer.instance.start()
 
         await activateAwsExplorer({
             context: extContext,
@@ -247,6 +249,7 @@ export async function activate(context: vscode.ExtensionContext) {
 export async function deactivate() {
     await deactivateCommon()
     await globals.resourceManager.dispose()
+    await AuthSSOServer.instance.close()
 }
 
 async function handleAmazonQInstall() {

--- a/packages/core/src/login/webview/commonAuthViewProvider.ts
+++ b/packages/core/src/login/webview/commonAuthViewProvider.ts
@@ -104,7 +104,6 @@ export class CommonAuthViewProvider implements WebviewViewProvider {
                     this.webView!.server.storeMetricMetadata({ isReAuth: false })
                 }
                 this.webView!.server.emitAuthMetric()
-                this.webView!.server.cancelAuthFlow()
 
                 // Set after emitting. If users use side bar to return to login, this source is correct
                 // for the next iteration. Otherwise, other sources will be set accordingly by whatever

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -33,7 +33,6 @@ import { AuthSources } from '../util'
 import { AuthEnabledFeatures, AuthError, AuthFlowState, AuthUiClick, TelemetryMetadata, userCancelled } from './types'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { DevSettings } from '../../../shared/settings'
-import { AuthSSOServer } from '../../../auth/sso/server'
 import { getLogger } from '../../../shared/logger/logger'
 
 export abstract class CommonAuthWebview extends VueWebview {
@@ -296,9 +295,5 @@ export abstract class CommonAuthWebview extends VueWebview {
 
     getDefaultStartUrl() {
         return DevSettings.instance.get('autofillStartUrl', '')
-    }
-
-    cancelAuthFlow() {
-        AuthSSOServer.lastInstance?.cancelCurrentFlow()
     }
 }

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -484,7 +484,7 @@ export default defineComponent({
             if (this.startUrl && !validateSsoUrlFormat(this.startUrl)) {
                 this.startUrlError =
                     'URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start'
-            } else if (this.startUrl && this.existingStartUrls.some(url => url === this.startUrl)) {
+            } else if (this.startUrl && this.existingStartUrls.some((url) => url === this.startUrl)) {
                 this.startUrlError =
                     'A connection for this start URL already exists. Sign out before creating a new one.'
             } else {
@@ -501,8 +501,6 @@ export default defineComponent({
             void client.emitUiClick('auth_regionSelection')
         },
         async handleCancelButton() {
-            void client.cancelAuthFlow()
-
             await client.storeMetricMetadata({ isReAuth: false, result: 'Cancelled' })
             void client.emitAuthMetric()
             void client.emitUiClick('auth_cancelButton')
@@ -520,7 +518,7 @@ export default defineComponent({
             // to reuse connections in AWS Toolkit & Amazon Q
             const sharedConnections = await client.fetchConnections()
             sharedConnections
-                ?.filter(c => !this.existingStartUrls.includes(c.startUrl))
+                ?.filter((c) => !this.existingStartUrls.includes(c.startUrl))
                 .forEach((connection, index) => {
                     this.importedLogins.push({
                         id: LoginOption.IMPORTED_LOGINS + index,
@@ -535,7 +533,7 @@ export default defineComponent({
             this.$forceUpdate()
         },
         async updateExistingStartUrls() {
-            this.existingStartUrls = (await client.listSsoConnections()).map(conn => conn.startUrl)
+            this.existingStartUrls = (await client.listSsoConnections()).map((conn) => conn.startUrl)
         },
         async getDefaultStartUrl() {
             return await client.getDefaultStartUrl()

--- a/packages/core/src/login/webview/vue/reauthenticate.vue
+++ b/packages/core/src/login/webview/vue/reauthenticate.vue
@@ -141,7 +141,6 @@ export default defineComponent({
         },
         async cancel() {
             void client.emitUiClick('auth_reauthCancelButton')
-            await client.cancelAuthFlow()
         },
     },
 })

--- a/packages/core/src/test/credentials/sso/server.test.ts
+++ b/packages/core/src/test/credentials/sso/server.test.ts
@@ -13,8 +13,7 @@ import {
 } from '../../../auth/sso/server'
 import request from '../../../shared/request'
 import { URLSearchParams } from 'url'
-import { isUserCancelledError, ToolkitError } from '../../../shared/errors'
-import { sleep } from '../../../shared/utilities/timeoutUtils'
+import { ToolkitError } from '../../../shared/errors'
 
 describe('AuthSSOServer', function () {
     const code = 'zfhgaiufgsbdfigsdfg'
@@ -25,7 +24,7 @@ describe('AuthSSOServer', function () {
     let server: AuthSSOServer
 
     beforeEach(async function () {
-        server = AuthSSOServer.init(state)
+        server = AuthSSOServer.instance
         await server.start()
     })
 
@@ -122,22 +121,5 @@ describe('AuthSSOServer', function () {
             return
         }
         assert.fail('Expected address 127.0.0.1')
-    })
-
-    it('can be cancelled while waiting for auth', async function () {
-        const promise = server.waitForAuthorization().catch((e) => {
-            return e
-        })
-        server.cancelCurrentFlow()
-
-        const err = await promise
-        assert.ok(isUserCancelledError(err.inner), 'CancellationError not thrown.')
-    })
-
-    it('initializes and closes instances', async function () {
-        const newServer = AuthSSOServer.init('1234')
-        assert.equal(AuthSSOServer.lastInstance, newServer)
-        await sleep(100)
-        assert.ok(server.closed)
     })
 })

--- a/packages/toolkit/.changes/next-release/Bug Fix-0caa251e-a9e0-4fe8-9b74-c350c42c0f34.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-0caa251e-a9e0-4fe8-9b74-c350c42c0f34.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth Server is not found when user closes webview before finishing auth"
+}


### PR DESCRIPTION
## Problem
- If a user opens the authorization url and then before authentication is finished closes the amazonq/toolkit webview the auth server shuts down, giving them a 400 once they try to complete login

## Solution
- Have one auth server per extension that stays open until the extension is deactivated. This simplifies starting/stopping the auth server and sidesteps any of these issues

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
