### PR TITLE
fix(telemetry): toolkit replacing amazon q clientId

### DIFF
--- a/packages/core/src/shared/telemetry/activation.ts
+++ b/packages/core/src/shared/telemetry/activation.ts
@@ -14,12 +14,11 @@ import { DefaultTelemetryService } from './telemetryService'
 import { getLogger } from '../logger'
 import { getComputeRegion, isAmazonQ, isCloud9, productName } from '../extensionUtilities'
 import { openSettingsId, Settings } from '../settings'
-import { TelemetryConfig, setupTelemetryId } from './util'
+import { TelemetryConfig } from './util'
 import { isAutomation, isReleaseVersion } from '../vscode/env'
 import { AWSProduct } from './clienttelemetry'
 import { DefaultTelemetryClient } from './telemetryClient'
 import { telemetry } from './telemetry'
-import { Commands } from '../vscode/commands2'
 
 export const noticeResponseViewSettings = localize('AWS.telemetry.notificationViewSettings', 'Settings')
 export const noticeResponseOk = localize('AWS.telemetry.notificationOk', 'OK')
@@ -71,19 +70,11 @@ export async function activate(
             })
         )
 
-        if (isAmazonQExt) {
-            extensionContext.subscriptions.push(
-                Commands.register('aws.amazonq.setupTelemetryId', async () => {
-                    await setupTelemetryId(extensionContext)
-                })
-            )
-        }
-
         // Prompt user about telemetry if they haven't been
         if (!isCloud9() && !hasUserSeenTelemetryNotice()) {
             showTelemetryNotice()
         }
-        await setupTelemetryId(extensionContext)
+
         await globals.telemetry.start()
     } catch (e) {
         // Only throw in a production build because:


### PR DESCRIPTION
Problem: There is a function called `setupTelemetryId` which syncs the client Id between the two extensions when both are installed. However, there is a race condition that causes toolkit to generate the client ID before calling this setup function. The result is that amazon q is signalled to update its client id with a fresh one from toolkit. This results in telemetry showing we have a new user even though that is not the case. 

Solution: Bypass this race condition by putting the logic in the client id generation function. We will also change how we compute the client ID so that extensions more intuitively  converge to the same client id. See code for computation docs.

Cases:
1. New user installs an extension -> client id is generated once and stored in global state
2. Existing extension user installs another extension -> new extension will fetch the client id from the first extension via env variables, and store it itself
3. Existing users of both extensions update to the newer versions -> client ids were already synced between extensions, so they will store their identical client ids to themselves and env variables

There is an edge case that will still result in a failure:

4. Existing extension user installs another extension manually while vscode is closed -> the new extension loads first and stores its fresh client id in environment variables. The first extension will see this and update its client id to the new one, resulting in the original issue.

This is unavoidable because:
- Extensions can load in arbitrary orders
  - There is no way to know which extension's client ID is the one to use unless we check which one has something stored in its global state already.
  - This requires the new extension to ask the old extension, so it must be initialized already.
  - While waiting for this request, either extension could already start emitting telemetry. It has also already initialized a bunch of internal memory states with the other client id (fixable via large refactors).
  - Storing to a local file will only help if the file pre-exists. Users updating to this version will have no file to determine from.
- We want to preserve current client IDs

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
