### PR TITLE
fix(feature dev): Session occasionally does not start when /dev is prompted

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-de56ac50-9c87-4da2-bf45-87485813478c.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-de56ac50-9c87-4da2-bf45-87485813478c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Q feature dev: session will start robustly when /dev is prompted"
+}

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -373,6 +373,18 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
                 return
             }
 
+            // If feature dev is not started correctly, force trigger /dev session
+            if (prompt.escapedPrompt?.startsWith('/dev')) {
+                const featureDevPrompt: ChatPrompt = {
+                    ...prompt,
+                    escapedPrompt: prompt.escapedPrompt.replace('/dev', ''),
+                    command: '/dev',
+                }
+
+                quickActionHandler.handle(featureDevPrompt, tabID, eventId)
+                return
+            }
+
             textMessageHandler.handle(prompt, tabID)
         },
         onVote: connector.onChatItemVoted,


### PR DESCRIPTION
## Problem

Feature dev session does not start occasionally when it is being prompted, this can happen in a couple ways:
- User focuses on other area of the IDE and come back to complete the Q chat prompt
- When copy pasting `/dev some prompt`, the quick action handler does not recognize it being a quick action

## Solution

Add a logic where if the prompt is started with `/dev`, the feature dev session will be initiated. 

Not sure if other quick actions should also have the same functionality.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

Before

https://github.com/user-attachments/assets/e46e7e07-b58a-4799-8e09-776fa0b3fc50

After

https://github.com/user-attachments/assets/5ee6325e-2802-46c4-ac9c-d6625714f73e






