### PR TITLE
Add codecoverage for partner teams

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -42,3 +42,15 @@ flags:
     amazonqFeatureDev:
         paths:
             - packages/core/src/amazonqFeatureDev/
+    amazonqGumby:
+        paths:
+            - packages/core/src/amazonqGumby/
+    codewhispererChat:
+        paths:
+            - packages/core/src/codewhispererChat/
+    applicationcomposer:
+        paths:
+            - packages/core/src/applicationcomposer/
+    stepFunctions:
+        paths:
+            - packages/core/src/stepFunctions/

--- a/codecov.yml
+++ b/codecov.yml
@@ -27,6 +27,21 @@ coverage:
                     - packages/core/src/amazonqFeatureDev/*
                 flags:
                     - 'amazonqFeatureDev'
+            amazonqGumby:
+                paths:
+                    - packages/core/src/amazonqGumby/*
+            codewhispererChat:
+                paths:
+                    - packages/core/src/codewhispererChat/*
+            applicationcomposer:
+                paths:
+                    - packages/core/src/applicationcomposer/*
+            stepFunctions:
+                paths:
+                    - packages/core/src/stepFunctions/*
+            threatComposer:
+                paths:
+                    - packages/core/src/threatComposer/*
         patch: no
         changes: no
 
@@ -42,18 +57,3 @@ flags:
     amazonqFeatureDev:
         paths:
             - packages/core/src/amazonqFeatureDev/
-    amazonqGumby:
-        paths:
-            - packages/core/src/amazonqGumby/
-    codewhispererChat:
-        paths:
-            - packages/core/src/codewhispererChat/
-    applicationcomposer:
-        paths:
-            - packages/core/src/applicationcomposer/
-    stepFunctions:
-        paths:
-            - packages/core/src/stepFunctions/
-    threatComposer:
-        paths:
-            - packages/core/src/threatComposer/

--- a/codecov.yml
+++ b/codecov.yml
@@ -54,3 +54,6 @@ flags:
     stepFunctions:
         paths:
             - packages/core/src/stepFunctions/
+    threatComposer:
+        paths:
+            - packages/core/src/threatComposer/


### PR DESCRIPTION
## Problem
We have no idea what % of codecoverage partner teams have

## Solution
Add flags to see


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
