### PR TITLE
fix: add class files from local file

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-3caf33d6-2e1f-4013-92e3-365c77ac9378.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-3caf33d6-2e1f-4013-92e3-365c77ac9378.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Security Scan: Fixed an issue scans were not able to succeed on Java projects with .class files"
+}


### PR DESCRIPTION
## Problem

When zipping the project workspace, binary files are getting decoded/added to the zip artifacts as a utf-8 string which results in .class files being invalid and causing scans to fail.

## Solution

Process binary files by adding them to the zip using the local file path instead of a buffer.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
