### PR TITLE
fix: FileNotFound error during SSO token refresh

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-ceb237af-1d58-4560-9939-c07074eb3eee.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-ceb237af-1d58-4560-9939-c07074eb3eee.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "FileNotFound error causing early SSO expiration"
+}

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -345,7 +345,7 @@ export function getTelemetryResult(error: unknown | undefined): Result {
  */
 export function scrubNames(s: string, username?: string) {
     let r = ''
-    const fileExtRe = /\.[^.\/]{1,4}$/
+    const fileExtRe = /\.[^.\/]+$/
     const slashdot = /^[~.]*[\/\\]*/
 
     /** Allowlisted filepath segments. */

--- a/packages/core/src/shared/fs/fs.ts
+++ b/packages/core/src/shared/fs/fs.ts
@@ -22,6 +22,7 @@ import { resolvePath } from '../utilities/pathUtils'
 import crypto from 'crypto'
 import { waitUntil } from '../utilities/timeoutUtils'
 import { telemetry } from '../telemetry/telemetry'
+import { getLogger } from '../logger/logger'
 
 const vfs = vscode.workspace.fs
 type Uri = vscode.Uri
@@ -260,6 +261,7 @@ export class FileSystem {
                     reason: 'writeFileAtomicVscRename',
                     reasonDesc: getTelemetryReasonDesc(e),
                 })
+                getLogger().warn(`writeFile atomic VSC failed for, ${uri.fsPath}, with %O`, e)
                 // Atomic write with VSC rename() failed, so try with Node rename()
                 try {
                     await write(tempFile)
@@ -272,6 +274,7 @@ export class FileSystem {
                         reason: 'writeFileAtomicNodeRename',
                         reasonDesc: getTelemetryReasonDesc(e),
                     })
+                    getLogger().warn(`writeFile atomic Node failed for, ${uri.fsPath}, with %O`, e)
                     // The atomic rename techniques were not successful, so we will
                     // just resort to regular a non-atomic write
                 }

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -518,12 +518,17 @@ describe('util', function () {
             scrubNames('user: jdoe123 file: C:/Users/user1/.aws/sso/cache/abc123.json (regex: /foo/)', fakeUser),
             'user: x file: C:/Users/x/.aws/sso/cache/x.json (regex: /x/)'
         )
-        assert.deepStrictEqual(scrubNames('/Users/user1/foo.jso (?)', fakeUser), '/Users/x/x.jso (?)')
-        assert.deepStrictEqual(scrubNames('/Users/user1/foo.js (?)', fakeUser), '/Users/x/x.js (?)')
-        assert.deepStrictEqual(scrubNames('/Users/user1/foo.longextension (?)', fakeUser), '/Users/x/x (?)')
-        assert.deepStrictEqual(scrubNames('/Users/user1/foo.ext1.ext2.ext3', fakeUser), '/Users/x/x.ext3')
-        assert.deepStrictEqual(scrubNames('/Users/user1/extMaxLength.1234', fakeUser), '/Users/x/x.1234')
-        assert.deepStrictEqual(scrubNames('/Users/user1/extExceedsMaxLength.12345', fakeUser), '/Users/x/x')
+        assert.deepStrictEqual(scrubNames('/Users/user1/foo.jso', fakeUser), '/Users/x/x.jso')
+        assert.deepStrictEqual(scrubNames('/Users/user1/foo.js', fakeUser), '/Users/x/x.js')
+        assert.deepStrictEqual(scrubNames('/Users/user1/noFileExtension', fakeUser), '/Users/x/x')
+        assert.deepStrictEqual(scrubNames('/Users/user1/minExtLength.a', fakeUser), '/Users/x/x.a')
+        assert.deepStrictEqual(scrubNames('/Users/user1/extIsNum.123456', fakeUser), '/Users/x/x.123456')
+        assert.deepStrictEqual(
+            scrubNames('/Users/user1/foo.looooooooongextension', fakeUser),
+            '/Users/x/x.looooooooongextension'
+        )
+        assert.deepStrictEqual(scrubNames('/Users/user1/multipleExts.ext1.ext2.ext3', fakeUser), '/Users/x/x.ext3')
+
         assert.deepStrictEqual(scrubNames('c:\\fooß\\bar\\baz.txt', fakeUser), 'c:/xß/x/x.txt')
         assert.deepStrictEqual(
             scrubNames('uhh c:\\path with\\ spaces \\baz.. hmm...', fakeUser),

--- a/packages/core/src/test/shared/fs/fs.test.ts
+++ b/packages/core/src/test/shared/fs/fs.test.ts
@@ -4,10 +4,11 @@
  */
 
 import assert from 'assert'
-import * as vscode from 'vscode'
+import vscode from 'vscode'
 import * as path from 'path'
 import * as utils from 'util'
 import { existsSync, mkdirSync, promises as nodefs, readFileSync, rmSync } from 'fs'
+import nodeFs from 'fs'
 import { FakeExtensionContext } from '../../fakeExtensionContext'
 import fs, { FileSystem } from '../../../shared/fs/fs'
 import * as os from 'os'
@@ -91,6 +92,28 @@ describe('FileSystem', function () {
             const filePath = createTestPath('dirA/dirB/myFileName.txt')
             await fs.writeFile(filePath, 'MyContent')
             assert.strictEqual(readFileSync(filePath, 'utf-8'), 'MyContent')
+        })
+
+        // We try multiple methods to do an atomic write, but if one fails we want to fallback
+        // to the next method. The following are the different combinations of this when a method throws.
+        const throwCombinations = [
+            { vsc: false, node: false },
+            { vsc: true, node: false },
+            { vsc: true, node: true },
+        ]
+        throwCombinations.forEach((throws) => {
+            it(`still writes a file if one of the atomic write methods fails: ${JSON.stringify(throws)}`, async function () {
+                if (throws.vsc) {
+                    sandbox.stub(fs, 'rename').throws()
+                }
+                if (throws.node) {
+                    sandbox.stub(nodeFs.promises, 'rename').throws()
+                }
+
+                const filePath = createTestPath('myFileName')
+                await fs.writeFile(filePath, 'MyContent', { atomic: true })
+                assert.strictEqual(readFileSync(filePath, 'utf-8'), 'MyContent')
+            })
         })
 
         it('throws when existing file + no permission', async function () {

--- a/packages/toolkit/.changes/next-release/Bug Fix-04a6bfcb-9d56-4388-aadd-50e6c7db9670.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-04a6bfcb-9d56-4388-aadd-50e6c7db9670.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "FileNotFound error causing early SSO expiration"
+}


### PR DESCRIPTION
## Problem:

In our `aws_refreshCredentials` telemetry we saw a spike in `FileNotFound`
errors when writing the refreshed token to our filesystem.
This is caused by something in the `vscode.workspace.fs.rename()`
implementation that is not obvious and does not seem like an obvious error
on our end. Most of the time things work, so most users are not running
in to this problem.

Originally, to fix some errors happening during writing to the filesystem
we created an "atomic" write, but there are edge cases where this did
not work. So there are different implementations of writing a file that we used
to rememdy this.

## Solution:

Try the next write file method as a fallback when one fails.
See the comment in the code for the explanation of the implementation.

We also report telemetry on the specific failed cases to hopefully get a better understanding
of the specific failures. We can use this

## Additional

- A change was made to `scrubNames()` since the telemetry we were looking at for `aws_refreshCredentials` was missing the file extension. A guess is that the length of the file extension was exceeding 4 chars. So we instead do not factor in the length of the file ext anymore.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
