### PR TITLE
fix tech debt tests

### DIFF
--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -223,20 +223,6 @@ export class AuthUtil {
         return this.secondaryAuth.useNewConnection(conn)
     }
 
-    /**
-     * HACK: Use the connection, but then mark it as expired.
-     * We currently only need this to handle an edge case with the transition
-     * from the old to new standalone extension. This should eventually be removed.
-     */
-    public async useConnectionButExpire(conn: Connection) {
-        await this.secondaryAuth.useNewConnection(conn)
-        if (conn.type !== 'sso') {
-            return
-        }
-        await this.auth.expireConnection(conn)
-        await this.notifyReauthenticate()
-    }
-
     public static get instance() {
         if (this.#instance !== undefined) {
             return this.#instance

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -47,6 +47,6 @@ describe('tech debt', function () {
     it('remove separate sessions login edge cases', async function () {
         // src/auth/auth.ts:SessionSeparationPrompt
         // forgetConnection() function and calls
-        fixByDate('2024-07-30', 'Remove the edge case code from the commit that this test is a part of.')
+        fixByDate('2024-08-30', 'Remove the edge case code from the commit that this test is a part of.')
     })
 })

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -40,10 +40,6 @@ describe('tech debt', function () {
         )
     })
 
-    it('remove missing Amazon Q scopes edge case handling', async function () {
-        fixByDate('2024-07-30', 'Remove the edge case code from the commit that this test is a part of.')
-    })
-
     it('remove separate sessions login edge cases', async function () {
         // src/auth/auth.ts:SessionSeparationPrompt
         // forgetConnection() function and calls


### PR DESCRIPTION
[fix(tests): snooze split session tech debt](https://github.com/aws/aws-toolkit-vscode/commit/a71d1e9b2601e082ae2f5841c3e53b92a3a8b29f) 

- Split sessions is just over a month old, let's snooze it a little longer.

[fix(tests): remove Q 3 -> 5 scope migration tech debt](https://github.com/aws/aws-toolkit-vscode/commit/62238939beafdbf72925f7d09b5ae2f2a270960e) 

- Cleans up remainder of https://github.com/aws/aws-toolkit-vscode/commit/9525cdfab8a40cb88f361c522d6bc7dadf794f81

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
