### PR TITLE
Fix Q chat's cursor positioning, scroll bars, max tabs notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3322,10 +3322,11 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.15.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.2.tgz",
-            "integrity": "sha512-z2E8eDAMduM4+Pqpokj5ILyTbsXGV9TTtx9Flwi0JUzo04avZ5CbipIh2zTV6CxO5gmo5eq5u1t+cpFwSAdsag==",
+            "version": "4.15.4",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.4.tgz",
+            "integrity": "sha512-aXKM6l4SSGcCgFjmioyqVX71dlgPqdiQbGaq4pyVR+zv6wTcpkMqSs2pcr+3NKTLO6RWenJVRgdMPB3NVNdTMA==",
             "hasInstallScript": true,
+            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
@@ -18839,7 +18840,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.15.2",
+                "@aws/mynah-ui": "^4.15.4",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-1215af20-b5fb-451a-b118-deb6a462fb32.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-1215af20-b5fb-451a-b118-deb6a462fb32.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Fixing issue with an incorrect input cursor position in the prompt text box"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-4885c18d-bf4f-4b58-b318-407d1c2bcbec.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-4885c18d-bf4f-4b58-b318-407d1c2bcbec.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Fixing issue with the max tabs notification not being dismissible."
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-58eb1af1-78e7-44ba-b62f-7ebb6751f774.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-58eb1af1-78e7-44ba-b62f-7ebb6751f774.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Showing/hiding the scrollbars is now controlled by the OS settings"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4111,7 +4111,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.15.2",
+        "@aws/mynah-ui": "^4.15.4",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
Q Chat UI:
- Prompt Text box does not accurately display cursor position
![QChatIssueWindows](https://github.com/user-attachments/assets/6a72a7a7-aa5c-428e-8ca3-3e1907a6d100)
- The scrollbars were disabled/invisible
- The max tabs notification couldn't be dismissed
![350022198-c736e164-f232-43d8-8291-c4d9b9e3e118](https://github.com/user-attachments/assets/4af48af8-7006-41cc-94ec-7f1dbe51b127)

## Solution
Updating @aws/mynah-ui to 4.15.4
https://github.com/aws/mynah-ui/releases/tag/v4.15.4

- Fixing issue with an incorrect input cursor position in the prompt text box
- Showing/hiding the scrollbars is now controlled by the OS settings
![image](https://github.com/user-attachments/assets/13b0f4d4-fc8f-4474-8833-bf39b0f5e4a2)
- Fixing issue with the max tabs notification not being dismissible


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
