### PR TITLE
fix(amazonq): skip symlinks when zipping

### DIFF
--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -365,7 +365,7 @@ export async function zipCode({ dependenciesFolder, humanInTheLoopFlag, modulePa
             let sourceFilesSize = 0
             for (const file of sourceFiles) {
                 if ((await fs.stat(file)).isDirectory()) {
-                    getLogger().info(`CodeTransformation: Skipping directory, likely a symlink`)
+                    getLogger().info('CodeTransformation: Skipping directory, likely a symlink')
                     continue
                 }
                 const relativePath = path.relative(modulePath, file)

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -364,6 +364,10 @@ export async function zipCode({ dependenciesFolder, humanInTheLoopFlag, modulePa
             const sourceFiles = getFilesRecursively(modulePath, false)
             let sourceFilesSize = 0
             for (const file of sourceFiles) {
+                if ((await fs.stat(file)).isDirectory()) {
+                    getLogger().info(`CodeTransformation: Skipping directory, likely a symlink`)
+                    continue
+                }
                 const relativePath = path.relative(modulePath, file)
                 const paddedPath = path.join('sources', relativePath)
                 zip.addLocalFile(file, path.dirname(paddedPath))


### PR DESCRIPTION
## Problem

Some users have broken symlinks within their projects, which cause the zipping process to fail.

## Solution

Skip these so that the zipping still succeeds.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
