### PR TITLE
feat(amazonq): emit ide_editCodeFile

### DIFF
--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -7,7 +7,8 @@ import * as vscode from 'vscode'
 import { activateAmazonQCommon, amazonQContextPrefix, deactivateCommon } from './extension'
 import { DefaultAmazonQAppInitContext } from 'aws-core-vscode/amazonq'
 import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
-import { ExtContext } from 'aws-core-vscode/shared'
+import { ExtContext, globals } from 'aws-core-vscode/shared'
+import { filetypes, SchemaService } from 'aws-core-vscode/sharedNode'
 import { updateDevMode } from 'aws-core-vscode/dev'
 import { CommonAuthViewProvider } from 'aws-core-vscode/login'
 import { isExtensionActive, VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
@@ -50,6 +51,9 @@ async function activateAmazonQNode(context: vscode.ExtensionContext) {
         }),
         registerSubmitFeedback(context, 'Amazon Q', amazonQContextPrefix)
     )
+
+    globals.schemaService = new SchemaService()
+    filetypes.activate()
 
     await setupDevMode(context)
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
         "./codewhisperer": "./dist/src/codewhisperer/index.js",
         "./codewhisperer/node": "./dist/src/codewhisperer/indexNode.js",
         "./shared": "./dist/src/shared/index.js",
+        "./sharedNode": "./dist/src/shared/indexNode.js",
         "./auth": "./dist/src/auth/index.js",
         "./amazonqGumby": "./dist/src/amazonqGumby/index.js",
         "./amazonqFeatureDev": "./dist/src/amazonqFeatureDev/index.js",

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * Contains exports that work in both node and web.
+ */
+
 export { ExtContext } from './extensions'
 export { initialize, default as globals } from './extensionGlobals'
 export { activate as activateLogger } from './logger/activation'
@@ -14,7 +18,6 @@ export { initializeComputeRegion } from './extensionUtilities'
 export { RegionProvider } from './regions/regionProvider'
 export { Commands } from './vscode/commands2'
 export { getMachineId } from './vscode/env'
-export * from './environmentVariables'
 export { getLogger } from './logger/logger'
 export { activateExtension } from './utilities/vsCodeUtils'
 export { waitUntil, sleep } from './utilities/timeoutUtils'
@@ -24,7 +27,6 @@ export { VirtualMemoryFile } from './virtualMemoryFile'
 export { AmazonqCreateUpload, Metric } from './telemetry/telemetry'
 export { getClientId, getOperatingSystem } from './telemetry/util'
 export { extensionVersion } from './vscode/env'
-export * from './vscode/setContext'
 export { cast } from './utilities/typeConstructors'
 export {
     CodewhispererUserTriggerDecision,
@@ -34,6 +36,8 @@ export {
     CodewhispererUserDecision,
     CodewhispererSecurityScan,
 } from './telemetry/telemetry.gen'
+export * from './environmentVariables'
+export * from './vscode/setContext'
 export * from './utilities/textUtilities'
 export * from './filesystemUtilities'
 export * from './localizedText'

--- a/packages/core/src/shared/indexNode.ts
+++ b/packages/core/src/shared/indexNode.ts
@@ -1,0 +1,13 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Contains exports that only work for node, NOT web.
+ * Attempting to import from this file in web will throw an error,
+ * likely `TypeError: Cannot read properties of undefined (reading 'native')`
+ */
+
+export * as filetypes from './filetypes'
+export { SchemaService } from './schemas'


### PR DESCRIPTION
4294f8d1522511308651d3f82992c1489f7c2e4c only emits for toolkit. This adds to amazon q as well.

This will mean telemetry events are duplicated if both extensions are installed. With some additional complexity and over-engineering, we can avoid this. But de-duplication should not be a big deal across products.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
