### PR TITLE
fix(amazonq): AmazonQ Chat window became unresponsive after prompt

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b1798202-f20e-42b4-a730-04ee77572ee7.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b1798202-f20e-42b4-a730-04ee77572ee7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Q chat may stop responding after processing Python/Java code"
+}

--- a/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
+++ b/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
@@ -3,29 +3,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Java, Python } from '@aws/fully-qualified-names'
+// import { Java, Python } from '@aws/fully-qualified-names'
 import { extractContextFromJavaImports } from './javaImportReader'
 
 export async function readImports(text: string, languageId: string): Promise<string[]> {
-    let names: any = {}
-    switch (languageId) {
-        case 'java':
-            names = await Java.findNames(text)
-            break
-        case 'javascript':
-        case 'javascriptreact':
-        case 'typescriptreact':
-            // Disable Tsx.findNames because promise Tsx.findNames
-            // may not resolve and can cause chat to hang
-            //names = await Tsx.findNames(text)
-            return []
-        case 'python':
-            names = await Python.findNames(text)
-            break
-        case 'typescript':
-            //names = await TypeScript.findNames(text)
-            return []
-    }
+    const names: any = {}
+    //  Disable findNames calls temporarily because
+    //  the promise may not resolve and can cause chat to hang
+    //  TODO: enable it back after root-cause and fix in the dependency
+
+    // switch (languageId) {
+    //     case 'java':
+    //         names = await Java.findNames(text)
+    //         break
+    //     case 'javascript':
+    //     case 'javascriptreact':
+    //     case 'typescriptreact':
+    //         //names = await Tsx.findNames(text)
+    //         return []
+    //     case 'python':
+    //         names = await Python.findNames(text)
+    //         break
+    //     case 'typescript':
+    //         //names = await TypeScript.findNames(text)
+    //         return []
+    // }
     if (names.fullyQualified === undefined) {
         return []
     }

--- a/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
+++ b/packages/core/src/codewhispererChat/editor/context/file/importReader.ts
@@ -2,32 +2,13 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-// import { Java, Python } from '@aws/fully-qualified-names'
 import { extractContextFromJavaImports } from './javaImportReader'
 
 export async function readImports(text: string, languageId: string): Promise<string[]> {
     const names: any = {}
-    //  Disable findNames calls temporarily because
-    //  the promise may not resolve and can cause chat to hang
-    //  TODO: enable it back after root-cause and fix in the dependency
+    //  TODO: call findNames from @aws/fully-qualified-names for imports
+    //  after promise not resolving issue is fixed
 
-    // switch (languageId) {
-    //     case 'java':
-    //         names = await Java.findNames(text)
-    //         break
-    //     case 'javascript':
-    //     case 'javascriptreact':
-    //     case 'typescriptreact':
-    //         //names = await Tsx.findNames(text)
-    //         return []
-    //     case 'python':
-    //         names = await Python.findNames(text)
-    //         break
-    //     case 'typescript':
-    //         //names = await TypeScript.findNames(text)
-    //         return []
-    // }
     if (names.fullyQualified === undefined) {
         return []
     }

--- a/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
+++ b/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
@@ -40,9 +40,8 @@ export class FocusAreaContextExtractor {
             importantRange = editor.document.lineAt(importantRange.start.line).range
         }
 
-        // Temporarily disable findNamesWithInExtent because the promise
-        // may not resolve and can cause chat to hang
-        // const names = await this.findNamesInRange(editor.document.getText(), importantRange, editor.document.languageId)
+        //  TODO: call findNamesWithInExtent from @aws/fully-qualified-names
+        //  after promise not resolving issue is fixed
         const names = {}
         const [simpleNames] = this.prepareSimpleNames(names)
         const [usedFullyQualifiedNames] = this.prepareFqns(names)
@@ -223,37 +222,6 @@ export class FocusAreaContextExtractor {
     private getRangeText(document: TextDocument, range: Range): string {
         return document.getText(range)
     }
-
-    // private async findNamesInRange(fileText: string, selection: Range, languageId: string) {
-    //     fileText.replace(/([\uE000-\uF8FF]|\uD83C[\uDF00-\uDFFF]|\uD83D[\uDC00-\uDDFF])/g, '')
-    //     const startLocation: Location = new Location(selection.start.line, selection.start.character)
-    //     const endLocation: Location = new Location(selection.end.line, selection.end.character)
-    //     const extent: Extent = new Extent(startLocation, endLocation)
-
-    //     let names: any = {}
-    //     switch (languageId) {
-    //         case 'java':
-    //             names = await Java.findNamesWithInExtent(fileText, extent)
-    //             break
-    //         case 'javascript':
-    //         case 'javascriptreact':
-    //         case 'typescriptreact':
-    //             // Disable Tsx.findNamesWithInExtent because promise Tsx.findNamesWithInExtent
-    //             // may not resolve and can cause chat to hang
-    //             //names = await Tsx.findNamesWithInExtent(fileText, extent)
-    //             names = undefined
-    //             break
-    //         case 'python':
-    //             names = await Python.findNamesWithInExtent(fileText, extent)
-    //             break
-    //         case 'typescript':
-    //             //names = await TypeScript.findNamesWithInExtent(fileText, extent)
-    //             names = undefined
-    //             break
-    //     }
-
-    //     return names
-    // }
 
     private prepareFqns(names: any): [FullyQualifiedName[], boolean] {
         if (names === undefined || !names.fullyQualified) {

--- a/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
+++ b/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
@@ -5,7 +5,7 @@
 
 import { TextEditor, Selection, TextDocument, Range } from 'vscode'
 
-import { Extent, Java, Python, Location } from '@aws/fully-qualified-names'
+// import { Extent, Java, Python, Location } from '@aws/fully-qualified-names'
 import { FocusAreaContext, FullyQualifiedName } from './model'
 
 const focusAreaCharLimit = 9_000
@@ -40,8 +40,10 @@ export class FocusAreaContextExtractor {
             importantRange = editor.document.lineAt(importantRange.start.line).range
         }
 
-        const names = await this.findNamesInRange(editor.document.getText(), importantRange, editor.document.languageId)
-
+        // Temporarily disable findNamesWithInExtent because the promise
+        // may not resolve and can cause chat to hang
+        // const names = await this.findNamesInRange(editor.document.getText(), importantRange, editor.document.languageId)
+        const names = {}
         const [simpleNames] = this.prepareSimpleNames(names)
         const [usedFullyQualifiedNames] = this.prepareFqns(names)
 
@@ -222,36 +224,36 @@ export class FocusAreaContextExtractor {
         return document.getText(range)
     }
 
-    private async findNamesInRange(fileText: string, selection: Range, languageId: string) {
-        fileText.replace(/([\uE000-\uF8FF]|\uD83C[\uDF00-\uDFFF]|\uD83D[\uDC00-\uDDFF])/g, '')
-        const startLocation: Location = new Location(selection.start.line, selection.start.character)
-        const endLocation: Location = new Location(selection.end.line, selection.end.character)
-        const extent: Extent = new Extent(startLocation, endLocation)
+    // private async findNamesInRange(fileText: string, selection: Range, languageId: string) {
+    //     fileText.replace(/([\uE000-\uF8FF]|\uD83C[\uDF00-\uDFFF]|\uD83D[\uDC00-\uDDFF])/g, '')
+    //     const startLocation: Location = new Location(selection.start.line, selection.start.character)
+    //     const endLocation: Location = new Location(selection.end.line, selection.end.character)
+    //     const extent: Extent = new Extent(startLocation, endLocation)
 
-        let names: any = {}
-        switch (languageId) {
-            case 'java':
-                names = await Java.findNamesWithInExtent(fileText, extent)
-                break
-            case 'javascript':
-            case 'javascriptreact':
-            case 'typescriptreact':
-                // Disable Tsx.findNamesWithInExtent because promise Tsx.findNamesWithInExtent
-                // may not resolve and can cause chat to hang
-                //names = await Tsx.findNamesWithInExtent(fileText, extent)
-                names = undefined
-                break
-            case 'python':
-                names = await Python.findNamesWithInExtent(fileText, extent)
-                break
-            case 'typescript':
-                //names = await TypeScript.findNamesWithInExtent(fileText, extent)
-                names = undefined
-                break
-        }
+    //     let names: any = {}
+    //     switch (languageId) {
+    //         case 'java':
+    //             names = await Java.findNamesWithInExtent(fileText, extent)
+    //             break
+    //         case 'javascript':
+    //         case 'javascriptreact':
+    //         case 'typescriptreact':
+    //             // Disable Tsx.findNamesWithInExtent because promise Tsx.findNamesWithInExtent
+    //             // may not resolve and can cause chat to hang
+    //             //names = await Tsx.findNamesWithInExtent(fileText, extent)
+    //             names = undefined
+    //             break
+    //         case 'python':
+    //             names = await Python.findNamesWithInExtent(fileText, extent)
+    //             break
+    //         case 'typescript':
+    //             //names = await TypeScript.findNamesWithInExtent(fileText, extent)
+    //             names = undefined
+    //             break
+    //     }
 
-        return names
-    }
+    //     return names
+    // }
 
     private prepareFqns(names: any): [FullyQualifiedName[], boolean] {
         if (names === undefined || !names.fullyQualified) {

--- a/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
+++ b/packages/core/src/codewhispererChat/editor/context/focusArea/focusAreaExtractor.ts
@@ -5,7 +5,6 @@
 
 import { TextEditor, Selection, TextDocument, Range } from 'vscode'
 
-// import { Extent, Java, Python, Location } from '@aws/fully-qualified-names'
 import { FocusAreaContext, FullyQualifiedName } from './model'
 
 const focusAreaCharLimit = 9_000


### PR DESCRIPTION
## Problem
the `Python.findNames` and `findNamesWithInExtent` promises never resolves and causing chat to hang
related: https://github.com/aws/aws-toolkit-vscode/pull/4954
## Solution
temporarily remove the findNames & findNamesWithInExtent calls for all languages as a mitigation until the rootcause is fixed
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
