### PR TITLE
fix(amazonq): reverted table styles in mynah-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3322,9 +3322,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.15.4",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.4.tgz",
-            "integrity": "sha512-aXKM6l4SSGcCgFjmioyqVX71dlgPqdiQbGaq4pyVR+zv6wTcpkMqSs2pcr+3NKTLO6RWenJVRgdMPB3NVNdTMA==",
+            "version": "4.15.5",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.5.tgz",
+            "integrity": "sha512-qLeeyzaHgI9V4zet9AarHR1kL0XhHr23wWvucPfl8DcEi4gpnvL5cAUpYWgdMHv3Pmt1aajVyDjNkEGRpezgmA==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {
@@ -18840,7 +18840,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.15.4",
+                "@aws/mynah-ui": "^4.15.5",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4112,7 +4112,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.15.4",
+        "@aws/mynah-ui": "^4.15.5",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
Before the latest v4.15.4 release, the markdown table's UI was:
![image](https://github.com/user-attachments/assets/aebcd668-aadd-4cd2-a09e-90833ad27031)
But with v14.5.4 the new style was inadvertently introduced:
![image](https://github.com/user-attachments/assets/cd002d64-e35e-44ec-bc12-13833290e386)

## Solution
Updating @aws/mynah-ui to v4.15.5. 
https://github.com/aws/mynah-ui/releases/tag/v4.15.5
Table styles are reverted back
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
