### PR TITLE
fix(amazonqFeatureDev): add retry step after user change workspace folder

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-4ca70db9-154a-4c5d-a311-07e08e7bd56c.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-4ca70db9-154a-4c5d-a311-07e08e7bd56c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /dev: include a retry option for the same prompt after folder reselection"
+}

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -300,7 +300,7 @@
     "AWS.amazonq.featureDev.pillText.sendFeedback": "Send feedback",
     "AWS.amazonq.featureDev.pillText.selectFiles": "Select files for context",
     "AWS.amazonq.featureDev.pillText.retry": "Retry",
-    "AWS.amazonq.featureDev.pillText.retryOrAddNewPrompt": "Retry or write a new prompt",
+    "AWS.amazonq.featureDev.pillText.writeNewPrompt": "Write a new prompt",
     "AWS.amazonq.featureDev.pillText.reauthenticate": "Follow instructions to re-authenticate ...",
     "AWS.amazonq.featureDev.pillText.closeSession": "Close session",
     "AWS.amazonq.featureDev.pillText.selectOption": "Select an option above to proceed",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -300,6 +300,7 @@
     "AWS.amazonq.featureDev.pillText.sendFeedback": "Send feedback",
     "AWS.amazonq.featureDev.pillText.selectFiles": "Select files for context",
     "AWS.amazonq.featureDev.pillText.retry": "Retry",
+    "AWS.amazonq.featureDev.pillText.retryOrAddNewPrompt": "Retry or write a new prompt",
     "AWS.amazonq.featureDev.pillText.reauthenticate": "Follow instructions to re-authenticate ...",
     "AWS.amazonq.featureDev.pillText.closeSession": "Close session",
     "AWS.amazonq.featureDev.pillText.selectOption": "Select an option above to proceed",

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -730,10 +730,7 @@ export class FeatureDevController {
                 tabID: message.tabID,
             })
             this.messenger.sendChatInputEnabled(message.tabID, true)
-            this.messenger.sendUpdatePlaceholder(
-                message.tabID,
-                i18n('AWS.amazonq.featureDev.pillText.retryOrAddNewPrompt')
-            )
+            this.messenger.sendUpdatePlaceholder(message.tabID, i18n('AWS.amazonq.featureDev.pillText.writeNewPrompt'))
         }
 
         telemetry.amazonq_modifySourceFolder.emit({

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -729,6 +729,11 @@ export class FeatureDevController {
                 ],
                 tabID: message.tabID,
             })
+            this.messenger.sendChatInputEnabled(message.tabID, true)
+            this.messenger.sendUpdatePlaceholder(
+                message.tabID,
+                i18n('AWS.amazonq.featureDev.pillText.retryOrAddNewPrompt')
+            )
         }
 
         telemetry.amazonq_modifySourceFolder.emit({

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -717,6 +717,18 @@ export class FeatureDevController {
                 type: 'answer',
                 tabID: message.tabID,
             })
+            this.messenger.sendAnswer({
+                message: undefined,
+                type: 'system-prompt',
+                followUps: [
+                    {
+                        pillText: i18n('AWS.amazonq.featureDev.pillText.retry'),
+                        type: FollowUpTypes.Retry,
+                        status: 'warning',
+                    },
+                ],
+                tabID: message.tabID,
+            })
         }
 
         telemetry.amazonq_modifySourceFolder.emit({


### PR DESCRIPTION
## Problem

When selected folder/workspace size its too large, we prompt to select a smaller one. However, after selected, user describe that doesn't retry again forcing to rewrite the prompt again. 

![Screenshot 2024-08-01 at 1 27 43 PM](https://github.com/user-attachments/assets/cd589e74-e2f7-4775-806e-f7a85eadff68)

## Solution

This PR adds a retry button option after it changes the workspace folder and update the placeholder, allowing user choose rewrite the prompt or retry the previous one.

https://github.com/user-attachments/assets/3281cbf3-afed-4293-887a-5346df0b4afe




## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
