### PR TITLE
fix(telemetry): try to handle SyntaxError for createToken requests

### DIFF
--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -28,7 +28,7 @@ import { pageableToCollection, partialClone } from '../../shared/utilities/colle
 import { assertHasProps, isNonNullable, RequiredProps, selectFrom } from '../../shared/utilities/tsUtils'
 import { getLogger } from '../../shared/logger'
 import { SsoAccessTokenProvider } from './ssoAccessTokenProvider'
-import { isClientFault } from '../../shared/errors'
+import { ToolkitError, getHttpStatusCode, getReasonFromSyntaxError, isClientFault } from '../../shared/errors'
 import { DevSettings } from '../../shared/settings'
 import { SdkError } from '@aws-sdk/types'
 import { HttpRequest, HttpResponse } from '@smithy/protocol-http'
@@ -86,7 +86,25 @@ export class OidcClient {
     }
 
     public async createToken(request: CreateTokenRequest) {
-        const response = await this.client.createToken(request as CreateTokenRequest)
+        let response
+        try {
+            response = await this.client.createToken(request as CreateTokenRequest)
+        } catch (err) {
+            // In rare cases the SDK client may get unexpected data from its API call.
+            // This will throw a SyntaxError that contains the returned data.
+            if (err instanceof SyntaxError) {
+                getLogger().error(`createToken: SSOIDC Client received an unexpected non-JSON response: %O`, err)
+                throw new ToolkitError(
+                    `SDK Client unexpected error response: data response code: ${getHttpStatusCode(err)}, data reason: ${getReasonFromSyntaxError(err)}`,
+                    {
+                        code: `${getHttpStatusCode(err)}`,
+                        cause: err,
+                    }
+                )
+            } else {
+                throw err
+            }
+        }
         assertHasProps(response, 'accessToken', 'expiresIn')
 
         return {

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -47,7 +47,7 @@ import { randomUUID } from '../../../shared/crypto'
 import { LspController } from '../../../amazonq/lsp/lspController'
 import { CodeWhispererSettings } from '../../../codewhisperer/util/codewhispererSettings'
 import { getSelectedCustomization } from '../../../codewhisperer/util/customizationUtil'
-import { getHttpStatusCode } from '../../../shared/errors'
+import { getHttpStatusCode, getReasonFromSyntaxError } from '../../../shared/errors'
 
 export interface ChatControllerMessagePublishers {
     readonly processPromptChatMessage: MessagePublisher<PromptMessage>
@@ -298,24 +298,7 @@ export class ChatController {
             errorMessage = e.toUpperCase()
         } else if (e instanceof SyntaxError) {
             // Workaround to handle case when LB returns web-page with error and our client doesn't return proper exception
-            // eslint-disable-next-line no-prototype-builtins
-            if (e.hasOwnProperty('$response')) {
-                type exceptionKeyType = keyof typeof e
-                const responseKey = '$response' as exceptionKeyType
-                const response = e[responseKey]
-
-                let reason
-
-                if (response) {
-                    type responseKeyType = keyof typeof response
-                    const reasonKey = 'reason' as responseKeyType
-                    reason = response[reasonKey]
-                }
-
-                errorMessage = reason ? (reason as string) : defaultMessage
-            } else {
-                errorMessage = defaultMessage
-            }
+            errorMessage = getReasonFromSyntaxError(e) ?? defaultMessage
         } else if (e instanceof CodeWhispererStreamingServiceException) {
             errorMessage = e.message
             requestID = e.$metadata.requestId


### PR DESCRIPTION
Problem: Rare and unreproducible case where SDK client calls to create an SSO token return an html page instead of JSON data. It is probably some error page indicating an interference with the request.
Solution: Try to extract the reason and status code from the page if possible, and report it in telemetry.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
