### PR TITLE
Fix: incorrect chatSession import

### DIFF
--- a/packages/core/src/amazonqGumby/app.ts
+++ b/packages/core/src/amazonqGumby/app.ts
@@ -15,6 +15,7 @@ import { debounce } from 'lodash'
 import { AuthUtil } from '../codewhisperer/util/authUtil'
 import { showTransformationHub } from './commands'
 import { transformByQState } from '../codewhisperer/models/model'
+import { ChatSessionManager } from './chat/storages/chatSession'
 
 export function init(appContext: AmazonQAppInitContext) {
     const gumbyChatControllerEventEmitters: ChatControllerEventEmitters = {
@@ -55,7 +56,7 @@ export function init(appContext: AmazonQAppInitContext) {
         let authenticatingSessionID = ''
 
         if (authenticated) {
-            const session = sessionStorage.getSession()
+            const session = ChatSessionManager.Instance.getSession()
 
             if (session.isTabOpen() && session.isAuthenticating) {
                 authenticatingSessionID = session.tabID!


### PR DESCRIPTION
## Problem
We were incorrectly importing the wrong `sessionStorage` api, causing a runtime error to be reported under `Features -> Runtime Status`.

## Solution
This change imports the correct already-existing sessionStorage.

### Testing
Tested:
1. Launched VSCode while not authenticated through Q, authenticated and ran `/transform` workflow on a project expected to succeed in transforming
2. Repeated above test case, but was authenticated at launch
3. Closed `/transform` tab, re-opened, confirmed tab saved session state
4. While a `/transform` tab was already open, tried to open a new `/transform` tab from the Q Chat tab and was redirected to the already existing tab

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
