### PR TITLE
Misc small changes (allow trailing slash in start url, updating log level)

### DIFF
--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -286,7 +286,7 @@ type Stage = 'START' | 'SSO_FORM' | 'CONNECTED' | 'AUTHENTICATING' | 'AWS_PROFIL
 
 function validateSsoUrlFormat(url: string) {
     const regex =
-        /^(https?:\/\/(.+)\.awsapps\.com\/start|https?:\/\/identitycenter\.amazonaws\.com\/ssoins-[\da-zA-Z]{16})$/
+        /^(https?:\/\/(.+)\.awsapps\.com\/start|https?:\/\/identitycenter\.amazonaws\.com\/ssoins-[\da-zA-Z]{16})\/?$/
     return regex.test(url)
 }
 
@@ -484,7 +484,7 @@ export default defineComponent({
             if (this.startUrl && !validateSsoUrlFormat(this.startUrl)) {
                 this.startUrlError =
                     'URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start'
-            } else if (this.startUrl && this.existingStartUrls.some(url => url === this.startUrl)) {
+            } else if (this.startUrl && this.existingStartUrls.some((url) => url === this.startUrl)) {
                 this.startUrlError =
                     'A connection for this start URL already exists. Sign out before creating a new one.'
             } else {
@@ -520,7 +520,7 @@ export default defineComponent({
             // to reuse connections in AWS Toolkit & Amazon Q
             const sharedConnections = await client.fetchConnections()
             sharedConnections
-                ?.filter(c => !this.existingStartUrls.includes(c.startUrl))
+                ?.filter((c) => !this.existingStartUrls.includes(c.startUrl))
                 .forEach((connection, index) => {
                     this.importedLogins.push({
                         id: LoginOption.IMPORTED_LOGINS + index,
@@ -535,7 +535,7 @@ export default defineComponent({
             this.$forceUpdate()
         },
         async updateExistingStartUrls() {
-            this.existingStartUrls = (await client.listSsoConnections()).map(conn => conn.startUrl)
+            this.existingStartUrls = (await client.listSsoConnections()).map((conn) => conn.startUrl)
         },
         async getDefaultStartUrl() {
             return await client.getDefaultStartUrl()

--- a/packages/core/src/shared/clients/ec2MetadataClient.ts
+++ b/packages/core/src/shared/clients/ec2MetadataClient.ts
@@ -40,7 +40,10 @@ export class DefaultEc2MetadataClient {
             ;(this.metadata as any).fetchMetadataToken((tokenErr: AWSError, token: string) => {
                 let options
                 if (tokenErr) {
-                    getLogger().error('Ec2MetadataClient failed to fetch token: %s', tokenErr)
+                    getLogger().warn(
+                        'Ec2MetadataClient failed to fetch token. If this is an EC2 environment, then Toolkit will fall back to IMDSv1: %s',
+                        tokenErr
+                    )
 
                     // Fall back to IMDSv1 for legacy instances.
                     options = {}


### PR DESCRIPTION
Contains 2 commits (don't squash merge)

[chore: change ec2 token fetch error to warn instead](https://github.com/aws/aws-toolkit-vscode/commit/f247601818a5949aab279c44242d60d1dc115b8c) 

It isn't really an error unless you are using the ext in EC2. It's just cluttering the logs.
`warn` may even be a stretch.

[fix(auth): allow trailing slash for start urls](https://github.com/aws/aws-toolkit-vscode/commit/717062f91cb98ae5346b49c12744b5caebd6b525) 

Might fix cases for some users reporting that the auth screen is not accepting their start url. ~~May or may not~~ Does fix https://github.com/aws/aws-toolkit-vscode/issues/5412

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
