### PR TITLE
auth: Add more network errors

### DIFF
--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -785,7 +785,7 @@ export function isNetworkError(err?: unknown): err is Error & { code: string } {
         return false
     }
 
-    if (isVSCodeProxyError(err) || isSocketTimeoutError(err) || isNonJsonHttpResponse(err)) {
+    if (isVSCodeProxyError(err) || isSocketTimeoutError(err) || isNonJsonHttpResponse(err) || isEnoentError(err)) {
         return true
     }
 
@@ -839,6 +839,14 @@ function isSocketTimeoutError(err: Error): boolean {
  */
 function isNonJsonHttpResponse(err: Error): boolean {
     return (err.name === 'SyntaxError' || err.name === 'SyntaxError') && err.message.includes('Unexpected token')
+}
+
+/**
+ * We were seeing errors of ENOENT for the oidc FQDN (eg: oidc.us-east-1.amazonaws.com) during the SSO flow.
+ * Our assumption is that this is an intermittent error.
+ */
+function isEnoentError(err: Error): boolean {
+    return (err.name === 'ENOENT' || (err as any).code === 'ENOENT') && err.message.includes('getaddrinfo ENOENT')
 }
 
 /**

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -785,7 +785,7 @@ export function isNetworkError(err?: unknown): err is Error & { code: string } {
         return false
     }
 
-    if (isVSCodeProxyError(err) || isSocketTimeoutError(err)) {
+    if (isVSCodeProxyError(err) || isSocketTimeoutError(err) || isNonJsonHttpResponse(err)) {
         return true
     }
 
@@ -829,6 +829,16 @@ function isVSCodeProxyError(err: Error): boolean {
  */
 function isSocketTimeoutError(err: Error): boolean {
     return err.name === 'TimeoutError' && err.message.includes('Connection timed out after')
+}
+
+/**
+ * Expected JSON response from HTTP request, but got an error HTML error page instead.
+ *
+ * Example error message:
+ * "Unexpected token '<', "<html><bod"... is not valid JSON Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object."
+ */
+function isNonJsonHttpResponse(err: Error): boolean {
+    return (err.name === 'SyntaxError' || err.name === 'SyntaxError') && err.message.includes('Unexpected token')
 }
 
 /**

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -790,7 +790,9 @@ export function isNetworkError(err?: unknown): err is Error & { code: string } {
         isSocketTimeoutError(err) ||
         isNonJsonHttpResponse(err) ||
         isEnoentError(err) ||
-        isEaccesError(err)
+        isEaccesError(err) ||
+        isEbadfError(err) ||
+        isEconnRefusedError(err)
     ) {
         return true
     }
@@ -811,7 +813,14 @@ export function isNetworkError(err?: unknown): err is Error & { code: string } {
         'EHOSTUNREACH',
         'EADDRINUSE',
         'ENOBUFS', // client side memory issue during http request?
-        'EADDRNOTAVAIL', // port not available/allowed?
+        'EADDRNOTAVAIL', // port not available/allowed?,
+        'SELF_SIGNED_CERT_IN_CHAIN',
+        'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+        'HPE_INVALID_VERSION',
+        'DEPTH_ZERO_SELF_SIGNED_CERT',
+        'ENOTCONN',
+        '502',
+        'InternalServerException',
     ].includes(err.code)
 }
 
@@ -859,8 +868,16 @@ function isEaccesError(err: Error): boolean {
     return isError(err, 'EACCES', 'connect EACCES')
 }
 
+function isEbadfError(err: Error): boolean {
+    return isError(err, 'EBADF', 'connect EBADF')
+}
+
+function isEconnRefusedError(err: Error): boolean {
+    return isError(err, 'Error', 'connect ECONNREFUSED')
+}
+
 /** Helper function to assert given error has the expected properties */
-function isError(err: Error, id: string, messageIncludes: string) {
+function isError(err: Error, id: string, messageIncludes: string = '') {
     // It is not always clear if the error has the expected value in the `name` or `code` field
     // so this checks both.
     return (err.name === id || (err as any).code === id) && err.message.includes(messageIncludes)

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -492,6 +492,9 @@ describe('util', function () {
             false,
             'Incorrectly indicated as network error'
         )
+        const err = new Error("Unexpected token '<'")
+        err.name = 'SyntaxError'
+        assert.deepStrictEqual(isNetworkError(err), false, 'Incorrectly indicated as network error')
     })
 
     it('scrubNames()', async function () {

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -485,7 +485,7 @@ describe('util', function () {
         assert.deepStrictEqual(
             isNetworkError(new Error('Failed to establish a socket connection to proxies BLAH BLAH BLAH')),
             true,
-            'Did not return "true" on a VS Code Proxy error'
+            'Did not VS Code Proxy error as network error'
         )
         assert.deepStrictEqual(
             isNetworkError(new Error('I am NOT a network error')),
@@ -494,7 +494,7 @@ describe('util', function () {
         )
         let err = new Error("Unexpected token '<'")
         err.name = 'SyntaxError'
-        assert.deepStrictEqual(isNetworkError(err), false, 'Incorrectly indicated as network error')
+        assert.deepStrictEqual(isNetworkError(err), true, 'Did not indicate SyntaxError as network error')
 
         err = new Error('getaddrinfo ENOENT oidc.us-east-1.amazonaws.com')
         ;(err as any).code = 'ENOENT'

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -492,9 +492,13 @@ describe('util', function () {
             false,
             'Incorrectly indicated as network error'
         )
-        const err = new Error("Unexpected token '<'")
+        let err = new Error("Unexpected token '<'")
         err.name = 'SyntaxError'
         assert.deepStrictEqual(isNetworkError(err), false, 'Incorrectly indicated as network error')
+
+        err = new Error('getaddrinfo ENOENT oidc.us-east-1.amazonaws.com')
+        ;(err as any).code = 'ENOENT'
+        assert.deepStrictEqual(isNetworkError(err), true, 'Did not indicate ENOENT error as network error')
     })
 
     it('scrubNames()', async function () {


### PR DESCRIPTION
## Problem

During SSO token refresh (`aws_refreshCredentials`) we were seeing certain transitive Network specific errors causing the refresh to fail and the connection to show as expired.

## Solution

Add the specific errors to the `isNetworkError()` function.

What this ends up doing:
- when these errors appear during token refresh the SSO connection remains valid, but the `getToken()` call will throw


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
