### PR TITLE
fix(amazonq): ignore venv when local indexing

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-7299b780-d965-4bed-9302-0ed726c8e2ee.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-7299b780-d965-4bed-9302-0ed726c8e2ee.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Ignore virtual environment when indexing workspace"
+}

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -552,7 +552,7 @@ export async function collectFilesForIndex(
     }
 
     const isBuildOrBin = (filePath: string) => {
-        const k = /[/\\](bin|build|node_modules|env|\.idea)[/\\]/i
+        const k = /[/\\](bin|build|node_modules|env|\.idea|\.venv|venv)[/\\]/i
         return k.test(filePath)
     }
 


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/issues/5431

## Solution

Ignore .venv and venv at local indexing. We will build more robust ignore mechanism in the LSP soon. This is a stopgap for now.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
