### PR TITLE
fix(amazonq): avoid refresh suggestion for paginated response

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b3b09219-b76c-4892-90b4-45fada4a5e60.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b3b09219-b76c-4892-90b4-45fada4a5e60.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Avoid refreshing code suggestion for paginated response"
+}

--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -656,9 +656,9 @@ export class RecommendationHandler {
             return
         }
         if (this.isSuggestionVisible()) {
-            // to force refresh the visual cue so that the total recommendation count can be updated
+            // do not force refresh the tooltip to avoid suggestion "flashing"
             // const index = this.inlineCompletionProvider?.getActiveItemIndex
-            await this.showRecommendation(0, false)
+            // await this.showRecommendation(0, false)
             return
         }
         if (

--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -657,7 +657,6 @@ export class RecommendationHandler {
         }
         if (this.isSuggestionVisible()) {
             // do not force refresh the tooltip to avoid suggestion "flashing"
-            // const index = this.inlineCompletionProvider?.getActiveItemIndex
             // await this.showRecommendation(0, false)
             return
         }

--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -657,7 +657,6 @@ export class RecommendationHandler {
         }
         if (this.isSuggestionVisible()) {
             // do not force refresh the tooltip to avoid suggestion "flashing"
-            // await this.showRecommendation(0, false)
             return
         }
         if (


### PR DESCRIPTION
## Problem


https://github.com/user-attachments/assets/40cf2d0f-2c25-469d-a7e4-3895766a3fbf


The flash exists because after each pagination call we refresh the max number of suggestions in the tooltip.(1/1 to 1/5, then 1/6) Since we refresh the max count, we also refresh the suggestion itself. VSC do not have API to let us just refresh the max count.(we fresh it by re-creating the inline completion object)

## Solution


https://github.com/user-attachments/assets/f88d7cb0-a717-4b06-a208-957ee19993bb

Remove the refresh of index. This solution has been approved by product.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
