### PR TITLE
feat: telemetry stack trace - runWithCallEntry()

### DIFF
--- a/packages/core/src/shared/telemetry/telemetry.ts
+++ b/packages/core/src/shared/telemetry/telemetry.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { TelemetryTracer } from './spans'
+import { SpanOptions, TelemetryTracer } from './spans'
 import { NumericKeys } from '../utilities/tsUtils'
 
 // This file makes it so you can import 'telemetry' and not 'telemetry.gen'
@@ -15,9 +15,15 @@ export function millisecondsSince(date: Date): number {
 
 export const telemetry = new TelemetryTracer()
 
-// TODO: move this into `Metric` by updating the codegen
+/**
+ * The following are overrides or additions to the actual './telemetry.gen'
+ *
+ * This is not a permanent solution, but a temporary override.
+ * Look to add any permanent solutions to: https://github.com/aws/aws-toolkit-common/tree/main/telemetry/vscode
+ */
 declare module './telemetry.gen' {
     interface Metric<T extends MetricBase = MetricBase> {
         increment(data: { [P in NumericKeys<T>]+?: number }): void
+        run<U>(fn: (span: this) => U, options?: SpanOptions): U
     }
 }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1078,6 +1078,11 @@
                     "required": false
                 }
             ]
+        },
+        {
+            "name": "function_call",
+            "description": "Represents a function call",
+            "metadata": []
         }
     ]
 }

--- a/packages/core/src/shared/vscode/commands2.ts
+++ b/packages/core/src/shared/vscode/commands2.ts
@@ -489,7 +489,7 @@ function getInstrumenter(
     }
 
     // Throttling occurs regardless of whether or not the instrumenter is invoked
-    const span = telemetryName ? telemetry[telemetryName] : telemetry.vscode_executeCommand
+    const span: Metric = telemetryName ? telemetry[telemetryName] : telemetry.vscode_executeCommand
     const debounceCount = info?.debounceCount !== 0 ? info?.debounceCount : undefined
     TelemetryDebounceInfo.instance.set(id, { startTime: currentTime, debounceCount: 0 })
 

--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -5,11 +5,12 @@
 
 import assert from 'assert'
 import { ToolkitError } from '../../../shared/errors'
-import { TelemetrySpan, TelemetryTracer } from '../../../shared/telemetry/spans'
-import { MetricName, MetricShapes } from '../../../shared/telemetry/telemetry'
+import { asStringifiedStack, FunctionEntry, TelemetrySpan, TelemetryTracer } from '../../../shared/telemetry/spans'
+import { MetricName, MetricShapes, telemetry } from '../../../shared/telemetry/telemetry'
 import { assertTelemetry, getMetrics, installFakeClock } from '../../testUtil'
 import { selectFrom } from '../../../shared/utilities/tsUtils'
 import { getAwsServiceError } from '../errors.test'
+import { sleep } from '../../../shared'
 
 describe('TelemetrySpan', function () {
     let clock: ReturnType<typeof installFakeClock>
@@ -285,6 +286,184 @@ describe('TelemetryTracer', function () {
                 tracer.run(metricName, () => tracer.run(nestedName, () => {}))
                 assertTelemetry(metricName, { result: 'Succeeded' })
                 assertTelemetry(nestedName, { result: 'Succeeded', parentMetric: metricName } as any)
+            })
+        })
+
+        describe(`run() with emit false`, function () {
+            it('emits by default when not set', function () {
+                telemetry.run(metricName, (span) => {
+                    span.record({ awsRegion: 'us-east-1' })
+                })
+                assertTelemetry(metricName, [{ awsRegion: 'us-east-1' }])
+            })
+
+            it('emits when set to true', function () {
+                telemetry.run(
+                    metricName,
+                    (span) => {
+                        span.record({ awsRegion: 'us-east-1' })
+                    },
+                    { emit: true }
+                )
+                assertTelemetry(metricName, [{ awsRegion: 'us-east-1' }])
+            })
+
+            it('emits nothing when set to false', function () {
+                telemetry.run(
+                    metricName,
+                    (span) => {
+                        span.record({ awsRegion: 'us-east-1' })
+                    },
+                    { emit: false }
+                )
+                assertTelemetry(metricName, [])
+            })
+        })
+
+        describe('run() with function entry', function () {
+            /**
+             * A class that uses execution context in its methods calls
+             */
+            class TestClassA1 {
+                constructor(readonly a2: TestClassA2) {}
+
+                methodA(): Promise<FunctionEntry[]> {
+                    return telemetry.function_call.run(() => this.methodB(), {
+                        functionId: { name: 'methodA', class: 'TestClassA1' },
+                    })
+                }
+
+                /**
+                 * IMPORTANT: this does not set a context, so it will not be included. But
+                 * any nested calls that set their own execution context will.
+                 */
+                methodB() {
+                    return this.a2.methodX()
+                }
+            }
+
+            /**
+             * Another class that uses execution context in its calls
+             */
+            class TestClassA2 {
+                methodX(): Promise<FunctionEntry[]> {
+                    return telemetry.function_call.run(
+                        async () => {
+                            // sleep to hand over execution to the other class
+                            await sleep(100)
+                            return this.methodY()
+                        },
+                        {
+                            functionId: { name: 'methodX', class: 'TestClassA2' },
+                        }
+                    )
+                }
+
+                methodY() {
+                    return telemetry.function_call.run(() => this.methodZ(), {
+                        functionId: { name: 'methodY', class: 'TestClassA2' },
+                    })
+                }
+
+                methodZ() {
+                    return telemetry.function_call.run(() => functionWithExecutionContext(), {
+                        functionId: { name: 'thisIsAlsoZ', class: 'TestClassA2' },
+                    })
+                }
+            }
+
+            /**
+             * Another class that uses execution context in its calls
+             */
+            class TestClassB1 {
+                async methodJ(): Promise<FunctionEntry[]> {
+                    return telemetry.function_call.run(() => this.methodK(), {
+                        functionId: { name: 'methodJ', class: 'TestClassB1' },
+                    })
+                }
+
+                methodK() {
+                    return telemetry.function_call.run(
+                        async () => {
+                            // sleep to hand over execution to the other class
+                            await sleep(100)
+                            return this.methodL()
+                        },
+                        {
+                            functionId: { name: 'methodK', class: 'TestClassB1' },
+                        }
+                    )
+                }
+
+                methodL() {
+                    return telemetry.accessanalyzer_iamPolicyChecksCustomChecks.run(
+                        () => {
+                            return functionWithExecutionContext()
+                        },
+                        {
+                            functionId: { name: 'methodL', class: 'TestClassB1' },
+                        }
+                    )
+                }
+            }
+
+            function functionWithExecutionContext() {
+                return telemetry.function_call.run(() => telemetry.getFunctionStack(), {
+                    functionId: { name: 'functionWithExecutionContext' },
+                })
+            }
+
+            it(`returns the correct call stack when the context switches`, async function () {
+                // This test runs multiple functions that use the context asynchronously. They sleep() part way through their entire flow,
+                // which allows the other to execute. We expect the async local storage to maintain the correct context for each execution.
+                // The final nested function call in each stack returns the final stringified source stack.
+
+                const a1 = new TestClassA1(new TestClassA2())
+                const b1 = new TestClassB1()
+
+                const [resA1, resB1] = await Promise.all([a1.methodA(), b1.methodJ()])
+
+                assert.deepStrictEqual(resA1, [
+                    { name: 'methodA', class: 'TestClassA1' },
+                    { name: 'methodX', class: 'TestClassA2' },
+                    { name: 'methodY', class: 'TestClassA2' },
+                    { name: 'thisIsAlsoZ', class: 'TestClassA2' },
+                    { name: 'functionWithExecutionContext' },
+                ])
+                assert.deepStrictEqual(
+                    asStringifiedStack(resA1),
+                    'TestClassA1#methodA:TestClassA2#methodX,methodY,thisIsAlsoZ:functionWithExecutionContext'
+                )
+
+                assert.deepStrictEqual(resB1, [
+                    { name: 'methodJ', class: 'TestClassB1' },
+                    { name: 'methodK', class: 'TestClassB1' },
+                    { name: 'methodL', class: 'TestClassB1' },
+                    { name: 'functionWithExecutionContext' },
+                ])
+                assert.deepStrictEqual(
+                    asStringifiedStack(resB1),
+                    'TestClassB1#methodJ,methodK,methodL:functionWithExecutionContext'
+                )
+            })
+
+            it(`${asStringifiedStack.name}() works as expected`, function () {
+                assert.deepStrictEqual(asStringifiedStack([]), '')
+                assert.deepStrictEqual(asStringifiedStack([{ name: 'a' }]), 'a')
+                assert.deepStrictEqual(asStringifiedStack([{ name: 'a' }, { name: 'b' }]), 'a:b')
+                assert.deepStrictEqual(
+                    asStringifiedStack([{ name: 'a' }, { name: 'b' }, { name: 'c', class: 'C' }]),
+                    'a:b:C#c'
+                )
+                assert.deepStrictEqual(
+                    asStringifiedStack([
+                        { name: 'a1', class: 'A' },
+                        { name: 'a2', class: 'A' },
+                        { name: 'b1', class: 'B' },
+                        { name: 'b2', class: 'B' },
+                    ]),
+                    'A#a1,a2:B#b1,b2'
+                )
             })
         })
     })

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -247,6 +247,12 @@ export function assertTelemetry<K extends MetricName>(
     const expectedList = Array.isArray(expected) ? expected : [expected]
     const query = { metricName: name }
     const metadata = globals.telemetry.logger.query(query)
+
+    // succeeds if no results found, but none were expected
+    if (Array.isArray(expected) && expected.length === 0 && metadata.length === 0) {
+        return
+    }
+
     assert.ok(metadata.length > 0, `telemetry metric not found: "${name}"`)
 
     for (let i = 0; i < expectedList.length; i++) {


### PR DESCRIPTION
See the doc added in this PR for explanation on Problem + Solution

The gist is that you can now add "options" to a `run()`, allowing configurations.
In our case:
- we can signal for run() to not emit, but it will still emit by default.
- Add a `FunctionEntry` which will add to the function execution stack that is derived from the span stack

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
