### PR TITLE
performance: Create a starter set of tools for measuring the CPU/memory impact of code

### DIFF
--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -1,0 +1,118 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { getLogger } from '../logger'
+import { isWeb } from '../extensionGlobals'
+
+interface PerformanceMetrics {
+    cpuUsage: number
+    heapTotal: number
+    duration: number
+}
+
+interface TestOptions {
+    darwin?: Partial<PerformanceMetrics>
+    win32?: Partial<PerformanceMetrics>
+    linux?: Partial<PerformanceMetrics>
+}
+
+export interface PerformanceSpan<T> {
+    value: T
+    performance: PerformanceMetrics
+}
+
+export class PerformanceTracker {
+    #startPerformance:
+        | {
+              cpuUsage: NodeJS.CpuUsage
+              memory: number
+              duration: [number, number]
+          }
+        | undefined
+
+    constructor(private readonly name: string) {}
+
+    static enabled(name: string, trackPerformance?: boolean): boolean {
+        return name === 'function_call' && (trackPerformance ?? false) && !isWeb()
+    }
+
+    start() {
+        this.#startPerformance = {
+            cpuUsage: process.cpuUsage(),
+            memory: process.memoryUsage().heapTotal,
+            duration: process.hrtime(),
+        }
+    }
+
+    stop(): PerformanceMetrics | undefined {
+        if (this.#startPerformance) {
+            const endCpuUsage = process.cpuUsage(this.#startPerformance?.cpuUsage)
+            const userCpuUsage = endCpuUsage.user / 1000000
+            const systemCpuUsage = endCpuUsage.system / 1000000
+
+            const elapsedTime = process.hrtime(this.#startPerformance.duration)
+            const duration = elapsedTime[0] + elapsedTime[1] / 1e9 // convert microseconds to seconds
+            const usage = ((userCpuUsage + systemCpuUsage) / duration) * 100 // convert to percentage
+
+            const endMemoryUsage = process.memoryUsage().heapTotal - this.#startPerformance?.memory
+            const endMemoryUsageInMB = endMemoryUsage / (1024 * 1024) // converting bytes to MB
+
+            return {
+                cpuUsage: usage,
+                heapTotal: endMemoryUsageInMB,
+                duration,
+            }
+        } else {
+            getLogger().debug(`PerformanceTracker: start performance not defined for ${this.name}`)
+        }
+    }
+}
+
+export function performanceTest(options: TestOptions, name: string, fn: () => Promise<void>): Mocha.Test
+export function performanceTest(options: TestOptions, name: string, fn: () => void): Mocha.Test
+export function performanceTest(options: TestOptions, name: string, fn: () => void | Promise<void>) {
+    const testOption = options[process.platform as 'linux' | 'darwin' | 'win32']
+
+    const performanceTracker = new PerformanceTracker(name)
+
+    return it(name, async () => {
+        performanceTracker.start()
+        await fn()
+        const metrics = performanceTracker.stop()
+        if (!metrics) {
+            assert.fail('Performance metrics not found')
+        }
+        assertPerformanceMetrics(metrics, name, testOption)
+    })
+}
+
+function assertPerformanceMetrics(
+    performanceMetrics: PerformanceMetrics,
+    name: string,
+    testOption?: Partial<PerformanceMetrics>
+) {
+    const expectedCPUUsage = testOption?.cpuUsage ?? 50
+    const foundCPUUsage = performanceMetrics.cpuUsage
+
+    assert(
+        foundCPUUsage < expectedCPUUsage,
+        `Expected total CPU usage for ${name} to be less than ${expectedCPUUsage}. Actual CPU usage was ${foundCPUUsage}`
+    )
+
+    const expectedMemoryUsage = testOption?.heapTotal ?? 400
+    const foundMemoryUsage = performanceMetrics.heapTotal
+    assert(
+        foundMemoryUsage < expectedMemoryUsage,
+        `Expected total memory usage for ${name} to be less than ${expectedMemoryUsage}. Actual memory usage was ${foundMemoryUsage}`
+    )
+
+    const expectedDuration = testOption?.duration ?? 5
+    const foundDuration = performanceMetrics.duration
+    assert(
+        foundDuration < expectedDuration,
+        `Expected total duration for ${name} to be less than ${expectedDuration}. Actual duration was ${foundDuration}`
+    )
+}

--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -23,6 +23,7 @@ import {
     getTelemetryResult,
 } from '../errors'
 import { entries, NumericKeys } from '../utilities/tsUtils'
+import { PerformanceTracker } from '../performance/performance'
 
 const AsyncLocalStorage: typeof AsyncLocalStorageClass =
     require('async_hooks').AsyncLocalStorage ??
@@ -97,6 +98,9 @@ export type SpanOptions = {
     /** True if this span should emit its telemetry events. Defaults to true if undefined. */
     emit?: boolean
 
+    /** True if this span should emit performance metrics acquired when running the function. Defaults to false if undefined */
+    trackPerformance?: boolean
+
     /**
      * Adds a function entry to the span stack.
      *
@@ -134,6 +138,7 @@ export type SpanOptions = {
 export class TelemetrySpan<T extends MetricBase = MetricBase> {
     #startTime?: Date
     #options: SpanOptions
+    #performance?: PerformanceTracker
 
     private readonly state: Partial<T> = {}
     private readonly definition = definitions[this.name] ?? {
@@ -157,6 +162,7 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
             // do emit by default
             emit: options?.emit === undefined ? true : options.emit,
             functionId: options?.functionId,
+            trackPerformance: PerformanceTracker.enabled(this.name, options?.trackPerformance),
         }
     }
 
@@ -195,6 +201,10 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
      */
     public start(): this {
         this.#startTime = new globals.clock.Date()
+        if (this.#options.trackPerformance) {
+            ;(this.#performance ??= new PerformanceTracker(this.name)).start()
+        }
+
         return this
     }
 
@@ -205,6 +215,19 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
      */
     public stop(err?: unknown): void {
         const duration = this.startTime !== undefined ? globals.clock.Date.now() - this.startTime.getTime() : undefined
+
+        if (this.#options.trackPerformance) {
+            // TODO add these to the global metrics, right now it just forces them in the telemetry and ignores the type
+            // if someone enables this action
+            const performanceMetrics = this.#performance?.stop()
+            if (performanceMetrics) {
+                this.record({
+                    cpuUsage: performanceMetrics.cpuUsage,
+                    heapTotal: performanceMetrics.heapTotal,
+                    functionName: this.#options.functionId?.name ?? this.name,
+                } as any)
+            }
+        }
 
         if (this.#options.emit) {
             this.emit({
@@ -307,11 +330,7 @@ export class TelemetryTracer extends TelemetryBase {
      * All changes made to {@link attributes} (via {@link record}) during the execution are
      * reverted after the execution completes.
      */
-    public run<T, U extends MetricName>(
-        name: U,
-        fn: (span: Metric<MetricShapes[U]>) => T,
-        options?: SpanOptions | undefined
-    ): T {
+    public run<T, U extends MetricName>(name: U, fn: (span: Metric<MetricShapes[U]>) => T, options?: SpanOptions): T {
         const span = this.createSpan(name, options).start()
         const frame = this.switchContext(span)
 

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -8,13 +8,18 @@
         {
             "name": "documentFormat",
             "type": "string",
-            "allowedValues": ["JSON, YAML"],
+            "allowedValues": [
+                "JSON, YAML"
+            ],
             "description": "SSM Create document format selection"
         },
         {
             "name": "ssmOperation",
             "type": "string",
-            "allowedValues": ["Create", "Update"],
+            "allowedValues": [
+                "Create",
+                "Update"
+            ],
             "description": "SSM Publish Document operation type"
         },
         {
@@ -40,7 +45,11 @@
         {
             "name": "cwsprChatTriggerInteraction",
             "type": "string",
-            "allowedValues": ["hotkeys", "click", "contextMenu"],
+            "allowedValues": [
+                "hotkeys",
+                "click",
+                "contextMenu"
+            ],
             "description": "Identifies the specific interaction that opens the chat panel"
         },
         {
@@ -105,7 +114,11 @@
         {
             "name": "cwsprChatConversationType",
             "type": "string",
-            "allowedValues": ["Chat", "Assign", "Transform"],
+            "allowedValues": [
+                "Chat",
+                "Assign",
+                "Transform"
+            ],
             "description": "Identifies the type of conversation"
         },
         {
@@ -232,7 +245,12 @@
         {
             "name": "cwsprChatCommandType",
             "type": "string",
-            "allowedValues": ["clear", "help", "transform", "auth"],
+            "allowedValues": [
+                "clear",
+                "help",
+                "transform",
+                "auth"
+            ],
             "description": "Type of chat command (/command) executed"
         },
         {
@@ -248,7 +266,11 @@
         {
             "name": "authStatus",
             "type": "string",
-            "allowedValues": ["connected", "notConnected", "expired"],
+            "allowedValues": [
+                "connected",
+                "notConnected",
+                "expired"
+            ],
             "description": "Status of the an auth connection."
         },
         {
@@ -275,6 +297,21 @@
             "name": "connectionState",
             "type": "string",
             "description": "A detailed state of a specific auth connection. Use `authStatus` for a higher level view of an extension's general connection."
+        },
+        {
+            "name": "cpuUsage",
+            "type": "int",
+            "description": "Percentage of cpu usage"
+        },
+        {
+            "name": "heapTotal",
+            "type": "int",
+            "description": "Memory heap usage in MB"
+        },
+        {
+            "name": "functionName",
+            "type": "string",
+            "description": "The name of the function"
         }
     ],
     "metrics": [
@@ -876,7 +913,9 @@
             "description": "User clicked on the thumbs up button to say that they are unsatisfied",
             "unit": "Count",
             "metadata": [
-                { "type": "amazonqConversationId" },
+                {
+                    "type": "amazonqConversationId"
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
@@ -888,7 +927,9 @@
             "description": "User clicked on the thumbs down button to say that they are unsatisfied",
             "unit": "Count",
             "metadata": [
-                { "type": "amazonqConversationId" },
+                {
+                    "type": "amazonqConversationId"
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
@@ -900,7 +941,9 @@
             "description": "User clicked on the thumbs up button, to mention that they are satisfied",
             "unit": "Count",
             "metadata": [
-                { "type": "amazonqConversationId" },
+                {
+                    "type": "amazonqConversationId"
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
@@ -912,7 +955,9 @@
             "description": "User clicked on the thumbs down button to say that they are unsatisfied",
             "unit": "Count",
             "metadata": [
-                { "type": "amazonqConversationId" },
+                {
+                    "type": "amazonqConversationId"
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
@@ -924,21 +969,26 @@
             "description": "User reviewed changes",
             "passive": true,
             "metadata": [
-                { "type": "enabled" },
-                { "type": "amazonqConversationId" },
+                {
+                    "type": "enabled"
+                },
+                {
+                    "type": "amazonqConversationId"
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
                 }
             ]
         },
-
         {
             "name": "amazonq_startChat",
             "description": "Number of times the user have triggered /dev and started the chat",
             "unit": "Count",
             "metadata": [
-                { "type": "amazonqConversationId" },
+                {
+                    "type": "amazonqConversationId"
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
@@ -949,8 +999,13 @@
             "name": "amazonq_endChat",
             "description": "Captures end of the conversation with amazonq /dev",
             "metadata": [
-                { "type": "amazonqConversationId" },
-                { "type": "amazonqEndOfTheConversationLatency", "required": false },
+                {
+                    "type": "amazonqConversationId"
+                },
+                {
+                    "type": "amazonqEndOfTheConversationLatency",
+                    "required": false
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
@@ -961,9 +1016,15 @@
             "name": "amazonq_approachInvoke",
             "description": "Captures Approach generation process",
             "metadata": [
-                { "type": "amazonqConversationId" },
-                { "type": "amazonqGenerateApproachIteration" },
-                { "type": "amazonqGenerateApproachLatency" },
+                {
+                    "type": "amazonqConversationId"
+                },
+                {
+                    "type": "amazonqGenerateApproachIteration"
+                },
+                {
+                    "type": "amazonqGenerateApproachLatency"
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
@@ -974,7 +1035,10 @@
             "name": "amazonq_startConversationInvoke",
             "description": "Captures startConversation invocation process",
             "metadata": [
-                { "type": "amazonqConversationId", "required": false },
+                {
+                    "type": "amazonqConversationId",
+                    "required": false
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
@@ -985,8 +1049,13 @@
             "name": "amazonq_createUpload",
             "description": "Captures createUploadUrl invocation process",
             "metadata": [
-                { "type": "amazonqConversationId" },
-                { "type": "amazonqRepositorySize", "required": false },
+                {
+                    "type": "amazonqConversationId"
+                },
+                {
+                    "type": "amazonqRepositorySize",
+                    "required": false
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
@@ -1087,7 +1156,20 @@
         {
             "name": "function_call",
             "description": "Represents a function call. In most cases this should wrap code with a run(), then you can add context.",
-            "metadata": [],
+            "metadata": [
+                {
+                    "type": "cpuUsage",
+                    "required": true
+                },
+                {
+                    "type": "heapTotal",
+                    "required": true
+                },
+                {
+                    "type": "functionName",
+                    "required": true
+                }
+            ],
             "passive": true
         }
     ]

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -17,6 +17,7 @@ import { sanitizeFilename } from './textUtilities'
 import { GitIgnoreAcceptor } from '@gerhobbelt/gitignore-parser'
 import * as parser from '@gerhobbelt/gitignore-parser'
 import fs from '../fs/fs'
+import { telemetry } from '../telemetry'
 
 type GitIgnoreRelativeAcceptor = {
     folderPath: string
@@ -317,69 +318,80 @@ export async function collectFiles(
         zipFilePath: string
     }[]
 > {
-    const storage: Awaited<ReturnType<typeof collectFiles>> = []
+    return telemetry.function_call.run(
+        async () => {
+            const storage: Awaited<ReturnType<typeof collectFiles>> = []
 
-    const workspaceFoldersMapping = getWorkspaceFoldersByPrefixes(workspaceFolders)
-    const workspaceToPrefix = new Map<vscode.WorkspaceFolder, string>(
-        workspaceFoldersMapping === undefined
-            ? [[workspaceFolders[0], '']]
-            : Object.entries(workspaceFoldersMapping).map((value) => [value[1], value[0]])
-    )
-    const prefixWithFolderPrefix = (folder: vscode.WorkspaceFolder, path: string) => {
-        const prefix = workspaceToPrefix.get(folder)
-        /**
-         * collects all files that are marked as source
-         * @param sourcePaths the paths where collection starts
-         * @param workspaceFolders the current workspace folders opened
-         * @param respectGitIgnore whether to respect gitignore file
-         * @returns all matched files
-         */
-        if (prefix === undefined) {
-            throw new ToolkitError(`Failed to find prefix for workspace folder ${folder.name}`)
-        }
-        return prefix === '' ? path : `${prefix}/${path}`
-    }
-
-    let totalSizeBytes = 0
-    for (const rootPath of sourcePaths) {
-        const allFiles = await vscode.workspace.findFiles(
-            new vscode.RelativePattern(rootPath, '**'),
-            getExcludePattern()
-        )
-        const files = respectGitIgnore ? await filterOutGitignoredFiles(rootPath, allFiles) : allFiles
-
-        for (const file of files) {
-            const relativePath = getWorkspaceRelativePath(file.fsPath, { workspaceFolders })
-            if (!relativePath) {
-                continue
+            const workspaceFoldersMapping = getWorkspaceFoldersByPrefixes(workspaceFolders)
+            const workspaceToPrefix = new Map<vscode.WorkspaceFolder, string>(
+                workspaceFoldersMapping === undefined
+                    ? [[workspaceFolders[0], '']]
+                    : Object.entries(workspaceFoldersMapping).map((value) => [value[1], value[0]])
+            )
+            const prefixWithFolderPrefix = (folder: vscode.WorkspaceFolder, path: string) => {
+                const prefix = workspaceToPrefix.get(folder)
+                /**
+                 * collects all files that are marked as source
+                 * @param sourcePaths the paths where collection starts
+                 * @param workspaceFolders the current workspace folders opened
+                 * @param respectGitIgnore whether to respect gitignore file
+                 * @returns all matched files
+                 */
+                if (prefix === undefined) {
+                    throw new ToolkitError(`Failed to find prefix for workspace folder ${folder.name}`)
+                }
+                return prefix === '' ? path : `${prefix}/${path}`
             }
 
-            const fileStat = await fs.stat(file)
-            if (totalSizeBytes + fileStat.size > maxSize) {
-                throw new ToolkitError(
-                    'The project you have selected for source code is too large to use as context. Please select a different folder to use',
-                    { code: 'ContentLengthError' }
+            let totalSizeBytes = 0
+            for (const rootPath of sourcePaths) {
+                const allFiles = await vscode.workspace.findFiles(
+                    new vscode.RelativePattern(rootPath, '**'),
+                    getExcludePattern()
                 )
+                const files = respectGitIgnore ? await filterOutGitignoredFiles(rootPath, allFiles) : allFiles
+
+                for (const file of files) {
+                    const relativePath = getWorkspaceRelativePath(file.fsPath, { workspaceFolders })
+                    if (!relativePath) {
+                        continue
+                    }
+
+                    const fileStat = await fs.stat(file)
+                    if (totalSizeBytes + fileStat.size > maxSize) {
+                        throw new ToolkitError(
+                            'The project you have selected for source code is too large to use as context. Please select a different folder to use',
+                            { code: 'ContentLengthError' }
+                        )
+                    }
+
+                    const fileContent = await readFile(file)
+
+                    if (fileContent === undefined) {
+                        continue
+                    }
+
+                    // Now that we've read the file, increase our usage
+                    totalSizeBytes += fileStat.size
+                    storage.push({
+                        workspaceFolder: relativePath.workspaceFolder,
+                        relativeFilePath: relativePath.relativePath,
+                        fileUri: file,
+                        fileContent: fileContent,
+                        zipFilePath: prefixWithFolderPrefix(relativePath.workspaceFolder, relativePath.relativePath),
+                    })
+                }
             }
-
-            const fileContent = await readFile(file)
-
-            if (fileContent === undefined) {
-                continue
-            }
-
-            // Now that we've read the file, increase our usage
-            totalSizeBytes += fileStat.size
-            storage.push({
-                workspaceFolder: relativePath.workspaceFolder,
-                relativeFilePath: relativePath.relativePath,
-                fileUri: file,
-                fileContent: fileContent,
-                zipFilePath: prefixWithFolderPrefix(relativePath.workspaceFolder, relativePath.relativePath),
-            })
+            return storage
+        },
+        {
+            emit: true,
+            trackPerformance: true,
+            functionId: {
+                name: 'collectFiles',
+            },
         }
-    }
-    return storage
+    )
 }
 
 const readFile = async (file: vscode.Uri) => {

--- a/packages/core/src/test/shared/performance/performance.test.ts
+++ b/packages/core/src/test/shared/performance/performance.test.ts
@@ -1,0 +1,34 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import { PerformanceTracker } from '../../../shared/performance/performance'
+import { stubPerformance } from '../../utilities/performance'
+
+describe('performance tooling', () => {
+    let sandbox: sinon.SinonSandbox
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    describe('PerformanceTracker', () => {
+        it('gets performance metrics', () => {
+            const { expectedCpuUsage, expectedHeapTotal, expectedTotalSeconds } = stubPerformance(sandbox)
+            const perf = new PerformanceTracker('foo')
+            perf.start()
+            const metrics = perf.stop()
+
+            assert.deepStrictEqual(metrics?.cpuUsage, expectedCpuUsage)
+            assert.deepStrictEqual(metrics?.heapTotal, expectedHeapTotal)
+            assert.deepStrictEqual(metrics?.duration, expectedTotalSeconds)
+        })
+    })
+})

--- a/packages/core/src/test/utilities/performance.ts
+++ b/packages/core/src/test/utilities/performance.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Sinon from 'sinon'
+
+export function stubPerformance(sandbox: Sinon.SinonSandbox) {
+    const expectedCpuUsage = { user: 10000, system: 2000 }
+    const initialHeapTotal = 1
+    const totalNanoseconds = 30000000 // 0.03 seconds
+
+    sandbox.stub(process, 'cpuUsage').returns(expectedCpuUsage)
+
+    const memoryUsageStub = sandbox.stub(process, 'memoryUsage')
+    memoryUsageStub
+        .onCall(0)
+        .returns({ heapTotal: initialHeapTotal, arrayBuffers: 0, external: 0, rss: 0, heapUsed: 0 })
+    memoryUsageStub.onCall(1).returns({ heapTotal: 10485761, arrayBuffers: 0, external: 0, rss: 0, heapUsed: 0 })
+
+    sandbox.stub(process, 'hrtime').onCall(0).returns([0, 0]).onCall(1).returns([0, totalNanoseconds])
+
+    return {
+        expectedCpuUsage: 40,
+        expectedHeapTotal: 10,
+        expectedTotalSeconds: totalNanoseconds / 1e9,
+    }
+}


### PR DESCRIPTION
## Problem
- We are sometimes running into problems where functions are using a ton of memory/cpu but we have no way to figure that out ahead of time without manually debugging

## Solution
- Create a starter set of tools that allows us to measure the impact of different parts of code. These tools should be used as needed and surround heavy computational parts of the code i.e. collecting all files in the workspace, reading them in and putting them in a zip

See:
- [Security Scans] Adding performance test for auto scans: https://github.com/aws/aws-toolkit-vscode/pull/5420
- [Amazon Q Security Scans] Refactoring code to improve the performance: https://github.com/aws/aws-toolkit-vscode/pull/5346#

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
