### PR TITLE
feat(amazonq): add session configuration notification

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-273f3647-0ce0-48ad-874a-a9614447a18d.json
+++ b/packages/amazonq/.changes/next-release/Feature-273f3647-0ce0-48ad-874a-a9614447a18d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Add notification for extended session to IdC users"
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -106,6 +106,10 @@
                         "amazonQWelcomePage": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "amazonQSessionConfigurationMessage": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -302,6 +302,9 @@ export async function activate(context: ExtContext): Promise<void> {
             const defaulMsg = localize('AWS.generic.message.error', 'Failed to reauth:')
             void logAndShowError(localize, e, 'showReauthenticatePrompt', defaulMsg)
         })
+        if (auth.isEnterpriseSsoInUse()) {
+            await auth.notifySessionConfiguration()
+        }
     }
     if (auth.isValidEnterpriseSsoInUse()) {
         await notifyNewCustomizations()

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -349,7 +349,7 @@ export class AuthUtil {
     public async notifySessionConfiguration() {
         const suppressId = 'amazonQSessionConfigurationMessage'
         const settings = AmazonQPromptSettings.instance
-        const shouldShow = await settings.isPromptEnabled(suppressId as any)
+        const shouldShow = await settings.isPromptEnabled(suppressId)
         if (!shouldShow) {
             return
         }
@@ -367,7 +367,7 @@ export class AuthUtil {
                 await openUrl(learnMoreUrl)
             }
         })
-        await settings.disablePrompt(suppressId as any)
+        await settings.disablePrompt(suppressId)
     }
 
     public async notifyReauthenticate(isAutoTrigger?: boolean) {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -364,12 +364,20 @@ export class AuthUtil {
         const learnMoreUrl = vscode.Uri.parse(
             'https://docs.aws.amazon.com/singlesignon/latest/userguide/configure-user-session.html#90-day-extended-session-duration'
         )
-        await vscode.window.showInformationMessage(message, localizedText.learnMore).then(async (resp) => {
-            if (resp === localizedText.learnMore) {
-                await openUrl(learnMoreUrl)
-            }
+        await telemetry.toolkit_showNotification.run(async () => {
+            telemetry.record({ id: 'sessionExtension' })
+            void vscode.window.showInformationMessage(message, localizedText.learnMore).then(async (resp) => {
+                await telemetry.toolkit_invokeAction.run(async () => {
+                    if (resp === localizedText.learnMore) {
+                        telemetry.record({ action: 'learnMore' })
+                        await openUrl(learnMoreUrl)
+                    } else {
+                        telemetry.record({ action: 'dismissSessionExtensionNotification' })
+                    }
+                    await settings.disablePrompt(suppressId)
+                })
+            })
         })
-        await settings.disablePrompt(suppressId)
     }
 
     public async notifyReauthenticate(isAutoTrigger?: boolean) {

--- a/packages/core/src/shared/settings-amazonq.gen.ts
+++ b/packages/core/src/shared/settings-amazonq.gen.ts
@@ -15,7 +15,8 @@ export const amazonqSettings = {
         "createCredentialsProfile": {},
         "codeWhispererNewWelcomeMessage": {},
         "codeWhispererConnectionExpired": {},
-        "amazonQWelcomePage": {}
+        "amazonQWelcomePage": {},
+        "amazonQSessionConfigurationMessage": {}
     },
     "amazonQ.showInlineCodeSuggestionsWithCodeReferences": {},
     "amazonQ.importRecommendationForInlineCodeSuggestions": {},


### PR DESCRIPTION
## Problem
need to add a notification to IdC users to contact their admin to configure extended session
## Solution
show the notification once to IdC users when their connection expired
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
