### PR TITLE
fix(telemetry): update to 1.0.239 and mitigate discrepancies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "src.gen/@amzn/codewhisperer-streaming"
             ],
             "dependencies": {
-                "@aws-toolkits/telemetry": "^1.0.232",
+                "@aws-toolkits/telemetry": "^1.0.239",
                 "vscode-nls": "^5.2.0",
                 "vscode-nls-dev": "^4.0.4"
             },
@@ -3287,9 +3287,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.232",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.232.tgz",
-            "integrity": "sha512-JZ4m24rv+LTQW4FBXcy7Jyf3m2K78e5vV1ehgHM2nr5AianZREOlC3EMZYfkTyjUBriG10UY9ET9PZjcvYl3XA==",
+            "version": "1.0.239",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.239.tgz",
+            "integrity": "sha512-vnx4mzVbE63zUvXzcA3gju4784X43W1C8xE/znkZYXjFrNVz8QEWXSpKRt3idQptpyaB/xIU1bQUIM3c9n61SA==",
             "dependencies": {
                 "ajv": "^6.12.6",
                 "fs-extra": "^11.1.0",
@@ -18890,7 +18890,6 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
-                "@aws-toolkits/telemetry": "^1.0.216",
                 "@aws/fully-qualified-names": "^2.1.4",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "webpack-merge": "^5.10.0"
     },
     "dependencies": {
-        "@aws-toolkits/telemetry": "^1.0.232",
+        "@aws-toolkits/telemetry": "^1.0.239",
         "vscode-nls": "^5.2.0",
         "vscode-nls-dev": "^4.0.4"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4044,7 +4044,6 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws-toolkits/telemetry": "^1.0.216",
         "@aws/fully-qualified-names": "^2.1.4",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",

--- a/packages/core/src/codewhisperer/service/transformByQ/humanInTheLoopManager.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/humanInTheLoopManager.ts
@@ -110,7 +110,6 @@ export class HumanInTheLoopManager {
             codeTransformJobId: transformByQState.getJobId(),
             result: MetadataResult.Fail,
             reason: errorMessage,
-            codeTransformApiErrorMessage: errorMessage,
         })
     }
 

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -407,9 +407,9 @@ export async function zipCode({ dependenciesFolder, humanInTheLoopFlag, modulePa
     } catch (e: any) {
         telemetry.codeTransform_logGeneralError.emit({
             codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-            codeTransformApiErrorMessage: 'Failed to zip project',
             result: MetadataResult.Fail,
             reason: 'ZipCreationFailed',
+            reasonDesc: 'Failed to zip project',
         })
         throw Error('Failed to zip project')
     } finally {


### PR DESCRIPTION
**Blocked until changes from https://github.com/aws/aws-toolkit-common/pull/807 are addressed**

Problem:
Updates to @aws-toolkits/telemetry were not done in parallel with VSC updates. Trying to upgrade the dependency causes build failures due to telemetry validation errors.

Solution:
- Align transform metrics with latest commons telemetry. This means deleting redundant error filds and falling back to built in `reason` and `reasonDesc` fields, which is consistent with the upstream telemetry changes.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
