### PR TITLE
fix: center login logo

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b5a20120-ce65-48ef-a256-62d0c48f4c95.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b5a20120-ce65-48ef-a256-62d0c48f4c95.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Update login logo styling"
+}

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -569,7 +569,7 @@ export default defineComponent({
 .logoIcon {
     display: flex;
     flex-direction: row;
-    justify-content: left;
+    justify-content: center;
     align-items: flex-start;
     height: auto;
 }


### PR DESCRIPTION
## Problem

Q logo is aligned left for some reason

![image](https://github.com/user-attachments/assets/a78f192f-1285-447a-973a-cebc80902a3a)

## Solution

Change styling to align center, see screenshot

![image](https://github.com/user-attachments/assets/282b4a7b-6326-410b-a4fd-f25d970a99e4)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
