### PR TITLE
ci: conventional commits

### DIFF
--- a/.github/workflows/lintcommit.js
+++ b/.github/workflows/lintcommit.js
@@ -1,0 +1,200 @@
+// Checks that a PR title conforms to our custom flavor of "conventional commits"
+// (https://www.conventionalcommits.org/).
+//
+// To run self-tests, simply run this script:
+//
+//     node lintcommit.js test
+//
+// TODO: "PR must describe Problem in a concise way, and Solution".
+// TODO: this script intentionally avoids github APIs so that it is locally-debuggable, but if those
+// are needed, use actions/github-script as described in: https://github.com/actions/github-script?tab=readme-ov-file#run-a-separate-file
+//
+
+const fs = require('fs')
+// This script intentionally avoids github APIs so that:
+//   1. it is locally-debuggable
+//   2. the CI job is fast ("npm install" is slow)
+// But if we still want to use github API, we can keep it fast by using `actions/github-script` as
+// described in: https://github.com/actions/github-script?tab=readme-ov-file#run-a-separate-file
+//
+// const core = require('@actions/core')
+// const github = require('@actions/github')
+
+const topics = new Set([
+    'build',
+    // Don't allow "chore" because it's over-used.
+    // Instead, add a new topic if absolutely needed (if the existing ones can't possibly apply).
+    // 'chore',
+    'ci',
+    'config',
+    'docs',
+    'feat',
+    'fix',
+    'perf',
+    'refactor',
+    'style',
+    'telemetry',
+    'test',
+    'types',
+])
+
+// TODO: Validate against this once we are satisfied with this list.
+const scopes = new Set([
+    'amazonq',
+    'core',
+    'lambda',
+    'logs',
+    'redshift',
+    'q-chat',
+    'q-featuredev',
+    'q-inlinechat',
+    'q-transform',
+    's3',
+    'telemetry',
+    'ui',
+])
+void scopes
+
+/**
+ * Checks that a pull request title, or commit message subject, follows the expected format:
+ *
+ *      topic(scope): message
+ *
+ * Returns undefined if `title` is valid, else an error message.
+ */
+function validateTitle(title) {
+    const parts = title.split(':')
+    const subject = parts.slice(1).join(':').trim()
+
+    if (parts.length < 2) {
+        return 'missing colon (:) char'
+    }
+
+    const topicScope = parts[0]
+
+    if (topicScope.startsWith('revert')) {
+        return validateTitle(subject)
+    }
+
+    const [topic, scope] = topicScope.split(/\(([^)]+)\)$/)
+
+    if (/\s+/.test(topic)) {
+        return `topic contains whitespace: "${topic}"`
+    } else if (topic === 'chore') {
+        return 'do not use "chore" as a topic. If the existing valid topics are insufficent, add a new topic to the `lintcommit.js` script.'
+    } else if (!topics.has(topic)) {
+        return `invalid topic "${topic}"`
+    } else if (!scope && topicScope.includes('(')) {
+        return `must be formatted like topic(scope):`
+    } else if (scope && scope.length > 30) {
+        return 'invalid scope (must be <=30 chars)'
+    } else if (scope && /[^- a-z0-9]+/.test(scope)) {
+        return `invalid scope (must be lowercase, ascii only): "${scope}"`
+    } else if (subject.length === 0) {
+        return 'empty subject'
+    } else if (subject.length > 100) {
+        return 'invalid subject (must be <=100 chars)'
+    }
+
+    return undefined
+}
+
+function run() {
+    const eventData = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'))
+    const pullRequest = eventData.pull_request
+
+    // console.log(eventData)
+
+    if (!pullRequest) {
+        console.info('No pull request found in the context')
+        return
+    }
+
+    const title = pullRequest.title
+
+    const failReason = validateTitle(title)
+    const msg = failReason
+        ? `
+Pull request title does not match the [expected format](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#pull-request-title):
+
+* Title: \`${title}\`
+* Reason: ${failReason}
+* Expected format: \`topic(scope): subject...\`
+    * topic: one of (${Array.from(topics).join(', ')})
+    * scope: lowercase, <30 chars
+    * subject: must be <100 chars
+`
+        : `Pull request title matches the [expected format](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#pull-request-title).`
+
+    if (process.env.GITHUB_STEP_SUMMARY) {
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, msg)
+    }
+
+    if (failReason) {
+        console.error(msg)
+        process.exit(1)
+    } else {
+        console.info(msg)
+    }
+}
+
+function _test() {
+    const tests = {
+        ' foo(scope): bar': 'topic contains whitespace: " foo"',
+        'build: update build process': undefined,
+        'chore: update dependencies':
+            'do not use "chore" as a topic. If the existing valid topics are insufficent, add a new topic to the `lintcommit.js` script.',
+        'ci: configure CI/CD': undefined,
+        'config: update configuration files': undefined,
+        'docs: update documentation': undefined,
+        'feat(foo): add new feature': undefined,
+        'feat(foo):': 'empty subject',
+        'feat foo):': 'topic contains whitespace: "feat foo)"',
+        'feat(foo)): sujet': 'invalid topic "feat(foo))"',
+        'feat(foo: sujet': 'invalid topic "feat(foo"',
+        'feat(q foo bar): bar':
+            'do not use "chore" as a topic. If the existing valid topics are insufficent, add a new topic to the `lintcommit.js` script.',
+        'feat(Q Foo Bar): bar': 'invalid scope (must be lowercase, ascii only): "Q Foo Bar"',
+        'feat(scope):': 'empty subject',
+        'feat(q foo bar): bar': undefined,
+        'feat(foo): x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x ':
+            'invalid subject (must be <=100 chars)',
+        'fix(a-b-c): resolve issue': undefined,
+        'foo (scope): bar': 'topic contains whitespace: "foo "',
+        'invalid title': 'missing colon (:) char',
+        'perf: optimize performance': undefined,
+        'refactor: improve code structure': undefined,
+        'revert: feat: add new feature': undefined,
+        'style: format code': undefined,
+        'test: add new tests': undefined,
+        'types: add type definitions': undefined,
+    }
+
+    let passed = 0
+    let failed = 0
+
+    for (const [title, expected] of Object.entries(tests)) {
+        const result = validateTitle(title)
+        if (result === expected) {
+            console.log(`✅ Test passed for "${title}"`)
+            passed++
+        } else {
+            console.log(`❌ Test failed for "${title}" (expected "${expected}", got "${result}")`)
+            failed++
+        }
+    }
+
+    console.log(`\n${passed} tests passed, ${failed} tests failed`)
+}
+
+function main() {
+    const mode = process.argv[2]
+
+    if (mode === 'test') {
+        _test()
+    } else {
+        run()
+    }
+}
+
+main()

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,40 @@ on:
         branches: [master, feature/*, mynah-dev]
 
 jobs:
+    lint-commits:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 20
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+            - name: Check PR title and commit message
+              run: |
+                  node "$GITHUB_WORKSPACE/.github/workflows/lintcommit.js"
+
+    lint:
+        needs: lint-commits
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [16.x]
+                vscode-version: [stable]
+        env:
+            NODE_OPTIONS: '--max-old-space-size=8192'
+        steps:
+            - uses: actions/checkout@v4
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - run: npm ci
+            - run: npm run testCompile
+            - run: npm run lint
+
     macos:
+        needs: lint-commits
         name: test macOS
         runs-on: macos-latest
         strategy:
@@ -80,6 +113,7 @@ jobs:
                   token: ${{ secrets.CODECOV_TOKEN }}
 
     web:
+        needs: lint-commits
         name: test Web
         runs-on: ubuntu-latest
         strategy:
@@ -105,6 +139,7 @@ jobs:
                   run: npm run testWeb
 
     windows:
+        needs: lint-commits
         name: test Windows
         runs-on: windows-2019
         strategy:
@@ -135,22 +170,3 @@ jobs:
                   verbose: true
                   file: ./coverage/lcov.info
                   token: ${{ secrets.CODECOV_TOKEN }}
-
-    lint:
-        name: Lint
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                node-version: [16.x]
-                vscode-version: [stable]
-        env:
-            NODE_OPTIONS: '--max-old-space-size=8192'
-        steps:
-            - uses: actions/checkout@v4
-            - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ matrix.node-version }}
-            - run: npm ci
-            - run: npm run testCompile
-            - run: npm run lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,34 +279,50 @@ user's point of view.
 > -   If there are multiple unrelated changes, run `npm run newChange` for each change.
 > -   Include the feature that the change affects, Q, CodeWhisperer, etc.
 
-### Commit messages
+### Pull request title
 
-Generally your PR description should be a copy-paste of your commit message(s).
-If your PR description provides insight and context, that also should exist in
-the commit message. Source control (Git) is our source-of-truth, not GitHub.
+The title of your pull request must follow this format (checked by [lintcommit.js](.github/workflows/lintcommit.js)):
 
-Follow these [commit message guidelines](https://cbea.ms/git-commit/):
+-   format: `topic(scope): subject...`
+-   topic: must be a valid topic (`build`, `ci`, `config`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `telemetry`, `test`, `types`)
+    -   see [lintcommit.js](.github/workflows/lintcommit.js))
+    -   "chore" is intentionally rejected because it tends to be over-used.
+    -   user-facing changes should always choose "feat" or "fix", and include a [changelog](#changelog) item.
+-   scope: lowercase, <30 chars
+-   subject: must be <100 chars
 
--   Subject: single line up to 50-72 characters
-    -   Imperative voice ("Fix bug", not "Fixed"/"Fixes"/"Fixing").
--   Body: for non-trivial or uncommon changes, explain your motivation for the
-    change and contrast your implementation with previous behavior.
-    -   Often you can save a _lot_ of words by using this simple template:
-        ```
-        Problem: …
-        Solution: …
-        ```
+### Pull request description
 
-A [good commit message](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project)
-has a short subject line and unlimited detail in the body.
+Your PR description should provide a brief "Problem" and "Solution" pair. This
+structure often gives much more clarity, more concisely, than a typical
+paragraph of explanation.
+
+    Problem:
+    Foo does nothing when user clicks it.
+
+    Solution:
+    - Listen to the click event.
+    - Emit telemetry on success/failure.
+
 [Good explanations](https://nav.al/explanations) are acts of creativity. The
 "tiny subject line" constraint reminds you to clarify the essence of the
 commit, and makes the log easy for humans to scan. The commit log is an
 artifact that will outlive most code.
 
-Prefix the subject with `type(topic):` ([conventional
-commits](https://www.conventionalcommits.org/) format): this again helps humans
-(and scripts) scan and omit ranges of the history at a glance.
+### Commit messages
+
+Source control (Git) is our source-of-truth, not GitHub. However since most PRs
+are squash-merged, it's most important that your [pull request description](#pull-request-description)
+is well-formed so that the merged commit has the relevant info.
+
+If you expect your commits to be preserved ("regular merge"), then follow [these
+guidelines](https://cbea.ms/git-commit/):
+
+-   Subject: single line up to 50-72 characters
+    -   Imperative voice ("Fix bug", not "Fixed"/"Fixes"/"Fixing").
+    -   [Formatted as `topic(scope): subject...`](#pull-request-title).
+        -   Helps humans _and_ scripts scan and omit ranges of the history at a glance.
+-   Body: describe the change as a [Problem/Solution pair](#pull-request-description).
 
 ## Tooling
 


### PR DESCRIPTION
# Problem

Pull requests and commits often lack a clear, concise explanation or even just a useful, clear, concise title. 

This increases the cost of reviewing the PRs. And results in low-quality commit log, which adds friction to understanding why a change was made (and reduces learning/communication for observers).

# Solution

- add a CI check (github action) which enforces a custom flavor of https://www.conventionalcommits.org/ for *PR titles*.
    - currently doesn't check commit messages because those are usually squash-merged.
- update docs.

<img width="832" alt="image" src="https://github.com/user-attachments/assets/fab6e275-4c97-4c6f-b02a-cd743e68578e">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
