### PR TITLE
telemetry: add function stack to auth connection change

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
@@ -290,7 +290,7 @@ describe('AuthUtil', async function () {
         )
         await authUtil.secondaryAuth.useNewConnection(conn3)
 
-        await authUtil.clearExtraConnections('test') // method under test
+        await authUtil.clearExtraConnections() // method under test
 
         // Only the conn that AuthUtil is using is remaining
         assert.deepStrictEqual(

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -62,6 +62,8 @@ import {
 import { isSageMaker, isCloud9, isAmazonQ } from '../shared/extensionUtilities'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { randomUUID } from '../shared/crypto'
+import { asStringifiedStack } from '../shared/telemetry/spans'
+import { withTelemetryContext } from '../shared/telemetry/util'
 
 interface AuthService {
     /**
@@ -124,6 +126,9 @@ export type AuthType = Auth
 export type DeletedConnection = { connId: Connection['id']; storedProfile?: StoredProfile }
 type DeclaredConnection = Pick<SsoProfile, 'ssoRegion' | 'startUrl'> & { source: string }
 
+// Must be declared outside of class for use by decorator
+const authClassName = 'Auth'
+
 export class Auth implements AuthService, ConnectionManager {
     readonly #ssoCache = getCache()
     readonly #validationErrors = new Map<Connection['id'], Error>()
@@ -162,6 +167,7 @@ export class Auth implements AuthService, ConnectionManager {
         return Object.values(this._declaredConnections)
     }
 
+    @withTelemetryContext({ name: 'restorePreviousSession', class: authClassName })
     public async restorePreviousSession(): Promise<Connection | undefined> {
         const id = this.store.getCurrentProfileId()
         if (id === undefined) {
@@ -177,6 +183,7 @@ export class Auth implements AuthService, ConnectionManager {
 
     public async reauthenticate({ id }: Pick<SsoConnection, 'id'>, invalidate?: boolean): Promise<SsoConnection>
     public async reauthenticate({ id }: Pick<IamConnection, 'id'>, invalidate?: boolean): Promise<IamConnection>
+    @withTelemetryContext({ name: 'reauthenticate', class: authClassName })
     public async reauthenticate({ id }: Pick<Connection, 'id'>, invalidate?: boolean): Promise<Connection> {
         const shouldInvalidate = invalidate ?? true
         const profile = this.store.getProfileOrThrow(id)
@@ -195,6 +202,7 @@ export class Auth implements AuthService, ConnectionManager {
 
     public async useConnection({ id }: Pick<SsoConnection, 'id'>): Promise<SsoConnection>
     public async useConnection({ id }: Pick<IamConnection, 'id'>): Promise<IamConnection>
+    @withTelemetryContext({ name: 'useConnection', class: authClassName })
     public async useConnection({ id }: Pick<Connection, 'id'>): Promise<Connection> {
         await this.refreshConnectionState({ id })
 
@@ -211,6 +219,7 @@ export class Auth implements AuthService, ConnectionManager {
         return conn
     }
 
+    @withTelemetryContext({ name: 'logout', class: authClassName })
     public async logout(): Promise<void> {
         if (this.activeConnection === undefined) {
             return
@@ -222,6 +231,7 @@ export class Auth implements AuthService, ConnectionManager {
         this.#onDidChangeActiveConnection.fire(undefined)
     }
 
+    @withTelemetryContext({ name: 'listConnections', class: authClassName })
     public async listConnections(): Promise<Connection[]> {
         await loadIamProfilesIntoStore(this.store, this.iamProfileProvider)
 
@@ -281,6 +291,7 @@ export class Auth implements AuthService, ConnectionManager {
     }
 
     public async createConnection(profile: SsoProfile): Promise<SsoConnection>
+    @withTelemetryContext({ name: 'createConnection', class: authClassName })
     public async createConnection(profile: Profile): Promise<Connection> {
         if (profile.type === 'iam') {
             throw new Error('Creating IAM connections is not supported')
@@ -311,6 +322,7 @@ export class Auth implements AuthService, ConnectionManager {
         }
     }
 
+    @withTelemetryContext({ name: 'deleteConnection', class: authClassName })
     public async deleteConnection(connection: Pick<Connection, 'id'>): Promise<void> {
         const connId = connection.id
         const profile = this.store.getProfile(connId)
@@ -343,6 +355,7 @@ export class Auth implements AuthService, ConnectionManager {
      *
      * Forget about a connection without logging out, invalidating it, or deleting it from disk.
      */
+    @withTelemetryContext({ name: 'forgetConnection', class: authClassName })
     public async forgetConnection(connection: Pick<Connection, 'id'>): Promise<void> {
         const connId = connection.id
         const profile = this.store.getProfile(connId)
@@ -355,6 +368,7 @@ export class Auth implements AuthService, ConnectionManager {
         this.#onDidDeleteConnection.fire({ connId, storedProfile: profile })
     }
 
+    @withTelemetryContext({ name: 'clearStaleLinkedIamConnections', class: authClassName })
     private async clearStaleLinkedIamConnections() {
         // Updates our store, evicting stale IAM credential profiles if the
         // SSO they are linked to was removed.
@@ -373,6 +387,7 @@ export class Auth implements AuthService, ConnectionManager {
      *
      * Put the SSO connection in to an expired state
      */
+    @withTelemetryContext({ name: 'expireConnection', class: authClassName })
     public async expireConnection(conn: Pick<SsoConnection, 'id'>): Promise<void> {
         getLogger().info(`auth: Expiring connection ${conn.id}`)
         const profile = this.store.getProfileOrThrow(conn.id)
@@ -398,6 +413,7 @@ export class Auth implements AuthService, ConnectionManager {
      * Alternatively you can use the `getToken()` call on an SSO connection to do the same thing,
      * but it will additionally prompt for reauthentication if the connection is invalid.
      */
+    @withTelemetryContext({ name: 'refreshConnectionState', class: authClassName })
     public async refreshConnectionState(connection?: Pick<Connection, 'id'>): Promise<undefined> {
         if (connection === undefined) {
             return
@@ -416,6 +432,7 @@ export class Auth implements AuthService, ConnectionManager {
         profile: SsoProfile,
         invalidate?: boolean
     ): Promise<SsoConnection>
+    @withTelemetryContext({ name: 'updateConnection', class: authClassName })
     public async updateConnection(
         connection: Pick<Connection, 'id'>,
         profile: Profile,
@@ -458,6 +475,7 @@ export class Auth implements AuthService, ConnectionManager {
      *
      * @returns undefined if authentication succeeds, otherwise object with error info
      */
+    @withTelemetryContext({ name: 'authenticateData', class: authClassName })
     public async authenticateData(data: StaticProfile): Promise<StaticProfileKeyErrorMessage | undefined> {
         const tempId = await this.addTempCredential(data)
         const tempIdString = asString(tempId)
@@ -507,6 +525,7 @@ export class Auth implements AuthService, ConnectionManager {
      * For SSO, this involves an API call to clear server-side state. The call happens
      * before the local token(s) are cleared as they are needed in the request.
      */
+    @withTelemetryContext({ name: 'invalidateConnection', class: authClassName })
     private async invalidateConnection(id: Connection['id'], opt?: { skipGlobalLogout?: boolean }) {
         getLogger().info(`auth: Invalidating connection: ${id}`)
         const profile = this.store.getProfileOrThrow(id)
@@ -534,6 +553,7 @@ export class Auth implements AuthService, ConnectionManager {
         await this.updateConnectionState(id, 'invalid')
     }
 
+    @withTelemetryContext({ name: 'updateConnectionState', class: authClassName })
     private async updateConnectionState(id: Connection['id'], connectionState: ProfileMetadata['connectionState']) {
         getLogger().info(`auth: Updating connection state of ${id} to ${connectionState}`)
 
@@ -544,24 +564,38 @@ export class Auth implements AuthService, ConnectionManager {
 
         const oldProfile = this.store.getProfileOrThrow(id)
         if (oldProfile.metadata.connectionState === connectionState) {
+            // new state is same as old state, no need to do anything
             return oldProfile
         }
 
-        const profile = await this.store.updateMetadata(id, { connectionState })
-        if (connectionState !== 'invalid') {
-            this.#validationErrors.delete(id)
-            this.#invalidCredentialsTimeouts.get(id)?.dispose()
-        }
+        // Emit an event for when the connection changes state. This the the root of the
+        // state change. We rely on functions higher in the stack to have added their contexts
+        // so this event has useful information in the `source` field.
+        return telemetry.auth_modifyConnection.run(async (span) => {
+            span.record({
+                action: 'updateConnectionState',
+                connectionState,
+                source: asStringifiedStack(telemetry.getFunctionStack()),
+                credentialStartUrl: oldProfile.type === 'sso' ? oldProfile.startUrl : undefined,
+            })
 
-        if (this.#activeConnection?.id === id) {
-            this.#activeConnection.state = connectionState
-            this.#onDidChangeActiveConnection.fire(this.#activeConnection)
-        }
-        this.#onDidChangeConnectionState.fire({ id, state: connectionState })
+            const profile = await this.store.updateMetadata(id, { connectionState })
+            if (connectionState !== 'invalid') {
+                this.#validationErrors.delete(id)
+                this.#invalidCredentialsTimeouts.get(id)?.dispose()
+            }
 
-        return profile
+            if (this.#activeConnection?.id === id) {
+                this.#activeConnection.state = connectionState
+                this.#onDidChangeActiveConnection.fire(this.#activeConnection)
+            }
+            this.#onDidChangeConnectionState.fire({ id, state: connectionState })
+
+            return profile
+        })
     }
 
+    @withTelemetryContext({ name: 'validateConnection', class: authClassName })
     private async validateConnection<T extends Profile>(id: Connection['id'], profile: StoredProfile<T>) {
         const runCheck = async () => {
             if (profile.type === 'sso') {
@@ -747,6 +781,7 @@ export class Auth implements AuthService, ConnectionManager {
     }
 
     private readonly authenticate = keyedDebounce(this._authenticate.bind(this))
+    @withTelemetryContext({ name: 'authenticate', class: authClassName })
     private async _authenticate<T>(id: Connection['id'], callback: () => Promise<T>, invalidate?: boolean): Promise<T> {
         const originalState = this.getConnectionState({ id }) ?? 'unauthenticated'
         await this.updateConnectionState(id, 'authenticating')
@@ -780,6 +815,7 @@ export class Auth implements AuthService, ConnectionManager {
     }
 
     private readonly getToken = keyedDebounce(this._getToken.bind(this))
+    @withTelemetryContext({ name: '_getToken', class: authClassName })
     private async _getToken(id: Connection['id'], provider: SsoAccessTokenProvider): Promise<SsoToken> {
         const token = await provider.getToken().catch((err) => {
             this.throwOnNetworkError(err)
@@ -817,6 +853,7 @@ export class Auth implements AuthService, ConnectionManager {
         }
     }
 
+    @withTelemetryContext({ name: 'handleInvalidCredentials', class: authClassName })
     private async handleInvalidCredentials<T>(id: Connection['id'], refresh: () => Promise<T>): Promise<T> {
         getLogger().info(`auth: Handling invalid credentials of connection: ${id}`)
         const profile = this.store.getProfile(id)
@@ -861,7 +898,9 @@ export class Auth implements AuthService, ConnectionManager {
         return this.authenticate(id, refresh)
     }
 
-    public readonly tryAutoConnect = once(async () => {
+    public readonly tryAutoConnect = once(async () => this._tryAutoConnect())
+    @withTelemetryContext({ name: 'tryAutoConnect', class: authClassName })
+    private async _tryAutoConnect() {
         if (this.activeConnection !== undefined) {
             return
         }
@@ -940,7 +979,7 @@ export class Auth implements AuthService, ConnectionManager {
                 }
             }
         }
-    })
+    }
 
     static #instance: Auth | undefined
     public static get instance() {

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -86,7 +86,7 @@ export abstract class SsoAccessTokenProvider {
                     source: asStringifiedStack(telemetry.getFunctionStack()),
                     action: 'deleteSsoCache',
                     credentialStartUrl: this.profile.startUrl,
-                    sessionDuration: getSessionDuration(this.tokenCacheKey),
+                    sessionDuration: this.getSessionDuration(),
                 })
 
                 // Use allSettled() instead of all() to ensure all clear() calls are resolved.
@@ -212,6 +212,10 @@ export abstract class SsoAccessTokenProvider {
 
             throw err
         }
+    }
+
+    getSessionDuration() {
+        return getSessionDuration(this.tokenCacheKey)
     }
 
     protected formatToken(token: SsoToken, registration: ClientRegistration) {

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -70,6 +70,7 @@ import { securityScanLanguageContext } from './util/securityScanLanguageContext'
 import { registerWebviewErrorHandler } from '../webviews/server'
 import { logAndShowError, logAndShowWebviewError } from '../shared/utilities/logAndShowUtils'
 import { openSettings } from '../shared/settings'
+import { telemetry } from '../shared/telemetry'
 
 let localize: nls.LocalizeFunc
 
@@ -294,18 +295,25 @@ export async function activate(context: ExtContext): Promise<void> {
         vscode.commands.registerCommand('aws.amazonq.openEditorAtRange', openEditorAtRange)
     )
 
-    await auth.restore('startup')
-    await auth.clearExtraConnections('startup')
+    // run the auth startup code with context for telemetry
+    await telemetry.function_call.run(
+        async () => {
+            await auth.restore()
+            await auth.clearExtraConnections()
 
-    if (auth.isConnectionExpired()) {
-        auth.showReauthenticatePrompt().catch((e) => {
-            const defaulMsg = localize('AWS.generic.message.error', 'Failed to reauth:')
-            void logAndShowError(localize, e, 'showReauthenticatePrompt', defaulMsg)
-        })
-        if (auth.isEnterpriseSsoInUse()) {
-            await auth.notifySessionConfiguration()
-        }
-    }
+            if (auth.isConnectionExpired()) {
+                auth.showReauthenticatePrompt().catch((e) => {
+                    const defaulMsg = localize('AWS.generic.message.error', 'Failed to reauth:')
+                    void logAndShowError(localize, e, 'showReauthenticatePrompt', defaulMsg)
+                })
+                if (auth.isEnterpriseSsoInUse()) {
+                    await auth.notifySessionConfiguration()
+                }
+            }
+        },
+        { emit: false, functionId: { name: 'activateCwCore' } }
+    )
+
     if (auth.isValidEnterpriseSsoInUse()) {
         await notifyNewCustomizations()
     }

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -40,6 +40,8 @@ import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 import { telemetry } from '../../shared/telemetry/telemetry'
+import { asStringifiedStack } from '../../shared/telemetry/spans'
+import { withTelemetryContext } from '../../shared/telemetry/util'
 
 /** Backwards compatibility for connections w pre-chat scopes */
 export const codeWhispererCoreScopes = [...scopesCodeWhispererCore]
@@ -73,6 +75,8 @@ export const isValidAmazonQConnection = (conn?: Connection): conn is Connection 
     )
 }
 
+const authClassName = 'AuthQ'
+
 export class AuthUtil {
     static #instance: AuthUtil
     protected static readonly logIfChanged = onceChanged((s: string) => getLogger().info(s))
@@ -104,7 +108,7 @@ export class AuthUtil {
         'Amazon Q',
         isValidCodeWhispererCoreConnection
     )
-    public readonly restore = (source?: string) => this.secondaryAuth.restoreConnection(source)
+    public readonly restore = () => this.secondaryAuth.restoreConnection()
 
     public constructor(public readonly auth = Auth.instance) {}
 
@@ -193,6 +197,7 @@ export class AuthUtil {
         return this.conn !== undefined && isBuilderIdConnection(this.conn)
     }
 
+    @withTelemetryContext({ name: 'connectToAwsBuilderId', class: authClassName })
     public async connectToAwsBuilderId(): Promise<SsoConnection> {
         let conn = (await this.auth.listConnections()).find(isBuilderIdConnection)
 
@@ -209,6 +214,7 @@ export class AuthUtil {
         return (await this.secondaryAuth.useNewConnection(conn)) as SsoConnection
     }
 
+    @withTelemetryContext({ name: 'connectToEnterpriseSso', class: authClassName })
     public async connectToEnterpriseSso(startUrl: string, region: string): Promise<SsoConnection> {
         let conn = (await this.auth.listConnections()).find(
             (conn): conn is SsoConnection =>
@@ -237,6 +243,7 @@ export class AuthUtil {
         return self
     }
 
+    @withTelemetryContext({ name: 'getBearerToken', class: authClassName })
     public async getBearerToken(): Promise<string> {
         await this.restore()
 
@@ -252,6 +259,7 @@ export class AuthUtil {
         return bearerToken.accessToken
     }
 
+    @withTelemetryContext({ name: 'getCredentials', class: authClassName })
     public async getCredentials() {
         await this.restore()
 
@@ -304,6 +312,7 @@ export class AuthUtil {
         AuthUtil.logIfChanged(logStr)
     }
 
+    @withTelemetryContext({ name: 'reauthenticate', class: authClassName })
     public async reauthenticate() {
         try {
             if (this.conn?.type !== 'sso') {
@@ -328,6 +337,7 @@ export class AuthUtil {
         await Commands.tryExecute('aws.amazonq.refreshStatusBar')
     }
 
+    @withTelemetryContext({ name: 'showReauthenticatePrompt', class: authClassName })
     public async showReauthenticatePrompt(isAutoTrigger?: boolean) {
         if (isAutoTrigger && this.reauthenticatePromptShown) {
             return
@@ -380,6 +390,7 @@ export class AuthUtil {
         })
     }
 
+    @withTelemetryContext({ name: 'notifyReauthenticate', class: authClassName })
     public async notifyReauthenticate(isAutoTrigger?: boolean) {
         void this.showReauthenticatePrompt(isAutoTrigger)
         await this.setVscodeContextProps()
@@ -394,6 +405,7 @@ export class AuthUtil {
      * It guarantees the latest state is correct at the risk of modifying connection state.
      * If this guarantee is not required, use sync method getChatAuthStateSync()
      */
+    @withTelemetryContext({ name: 'getChatAuthState', class: authClassName })
     public async getChatAuthState(): Promise<FeatureAuthState> {
         // The state of the connection may not have been properly validated
         // and the current state we see may be stale, so refresh for latest state.
@@ -439,29 +451,32 @@ export class AuthUtil {
      * auth connections that the Amazon Q extension has cached. We need to remove these
      * as they are irrelevant to the Q extension and can cause issues.
      */
-    public async clearExtraConnections(source: string): Promise<void> {
+    public async clearExtraConnections(): Promise<void> {
         const currentQConn = this.conn
         // Q currently only maintains 1 connection at a time, so we assume everything else is extra.
         // IMPORTANT: In the case Q starts to manage multiple connections, this implementation will need to be updated.
         const allOtherConnections = (await this.auth.listConnections()).filter((c) => c.id !== currentQConn?.id)
         for (const conn of allOtherConnections) {
             getLogger().warn(`forgetting extra amazon q connection: %O`, conn)
-            await telemetry.auth_modifyConnection.run(async () => {
-                telemetry.record({
-                    connectionState: Auth.instance.getConnectionState(conn) ?? 'undefined',
-                    source,
-                    ...(await getTelemetryMetadataForConn(conn)),
-                })
+            await telemetry.auth_modifyConnection.run(
+                async () => {
+                    telemetry.record({
+                        connectionState: Auth.instance.getConnectionState(conn) ?? 'undefined',
+                        source: asStringifiedStack(telemetry.getFunctionStack()),
+                        ...(await getTelemetryMetadataForConn(conn)),
+                    })
 
-                if (isInDevEnv()) {
-                    telemetry.record({ action: 'forget' })
-                    // in a Dev Env the connection may be used by code catalyst, so we forget instead of fully deleting
-                    await this.auth.forgetConnection(conn)
-                } else {
-                    telemetry.record({ action: 'delete' })
-                    await this.auth.deleteConnection(conn)
-                }
-            })
+                    if (isInDevEnv()) {
+                        telemetry.record({ action: 'forget' })
+                        // in a Dev Env the connection may be used by code catalyst, so we forget instead of fully deleting
+                        await this.auth.forgetConnection(conn)
+                    } else {
+                        telemetry.record({ action: 'delete' })
+                        await this.auth.deleteConnection(conn)
+                    }
+                },
+                { functionId: { name: 'clearExtraConnections', class: authClassName } }
+            )
         }
     }
 }

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -15,7 +15,9 @@ import { debounce } from 'lodash'
 import { AuthError, AuthFlowState, userCancelled } from '../types'
 import { builderIdStartUrl } from '../../../../auth/sso/model'
 import { ToolkitError } from '../../../../shared/errors'
+import { withTelemetryContext } from '../../../../shared/telemetry/util'
 
+const className = 'AmazonQLoginWebview'
 export class AmazonQLoginWebview extends CommonAuthWebview {
     public override id: string = 'aws.amazonq.AmazonCommonAuth'
     public static sourcePath: string = 'vue/src/login/webview/vue/amazonq/index.js'
@@ -102,7 +104,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
              * IMPORTANT: During this process {@link this.onActiveConnectionModified} is triggered. This
              * causes the reauth page to refresh before the user is actually done the whole reauth flow.
              */
-            this.reauthError = await this.ssoSetup('reauthenticate', async () => {
+            this.reauthError = await this.ssoSetup('reauthenticateAmazonQ', async () => {
                 this.storeMetricMetadata({
                     authEnabledFeatures: this.getAuthEnabledFeatures(conn),
                     isReAuth: true,
@@ -156,6 +158,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
         return this.authState
     }
 
+    @withTelemetryContext({ name: 'signout', class: className })
     override async signout(): Promise<void> {
         const conn = AuthUtil.instance.secondaryAuth.activeConnection
         if (!isSsoConnection(conn)) {

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -34,6 +34,7 @@ import { AuthSSOServer } from '../../../auth/sso/server'
 import { getLogger } from '../../../shared/logger/logger'
 
 export abstract class CommonAuthWebview extends VueWebview {
+    private readonly className = 'CommonAuthWebview'
     private metricMetadata: TelemetryMetadata = {}
 
     // authSource should be set by whatever triggers the auth page flow.
@@ -126,7 +127,13 @@ export abstract class CommonAuthWebview extends VueWebview {
             }
         }
 
-        const result = await runSetup()
+        // Add context to our telemetry by adding the methodName argument to the function stack
+        const result = await telemetry.function_call.run(
+            async () => {
+                return runSetup()
+            },
+            { emit: false, functionId: { name: methodName, class: this.className } }
+        )
 
         if (postMetrics) {
             this.storeMetricMetadata(this.getResultForMetrics(result))

--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -361,9 +361,8 @@ export class TelemetryTracer extends TelemetryBase {
      * index being the top level call, and the last index being the final
      * nested call.
      *
-     * Ensure that {@link TelemetryTracer.runWithCallEntry()} and/or {@link TelemetrySpan.recordCallEntry()}
-     * have been used before this method is called, otherwise it will return
-     * no useful information.
+     * Ensure that there are uses of {@link TelemetryTracer.run()} with {@link SpanOptions.functionId}
+     * before this method is called, otherwise it will return no useful information.
      *
      * Use {@link asStringifiedStack} to create a stringified version of this stack.
      */

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1066,6 +1066,10 @@
                     "required": false
                 },
                 {
+                    "type": "sessionDuration",
+                    "required": false
+                },
+                {
                     "type": "source",
                     "required": true
                 },
@@ -1082,8 +1086,9 @@
         },
         {
             "name": "function_call",
-            "description": "Represents a function call",
-            "metadata": []
+            "description": "Represents a function call. In most cases this should wrap code with a run(), then you can add context.",
+            "metadata": [],
+            "passive": true
         }
     ]
 }

--- a/packages/core/src/shared/vscode/commands2.ts
+++ b/packages/core/src/shared/vscode/commands2.ts
@@ -496,15 +496,20 @@ function getInstrumenter(
     const fields = findFieldsToAddToMetric(id.args, id.compositeKey)
 
     return <T extends Callback>(fn: T, ...args: Parameters<T>) =>
-        span.run((span) => {
-            ;(span as Metric<VscodeExecuteCommand>).record({
-                command: id.id,
-                debounceCount,
-                ...fields,
-            })
+        span.run(
+            (span) => {
+                ;(span as Metric<VscodeExecuteCommand>).record({
+                    command: id.id,
+                    debounceCount,
+                    ...fields,
+                })
 
-            return fn(...args)
-        })
+                return fn(...args)
+            },
+            // wrap all command executions with their ID as context for telemetry.
+            // this will give us a better idea on the entrypoints of executions
+            { functionId: { name: id.id, class: 'Commands' } }
+        )
 }
 
 export const unsetSource = 'sourceImproperlySet'

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -59,11 +59,13 @@ describe('Auth', function () {
                 action: 'updateConnectionState',
                 connectionState: 'valid',
                 source: 'Auth#createConnection,updateConnectionState',
+                sessionDuration: undefined,
             },
             {
                 action: 'updateConnectionState',
                 connectionState: 'invalid',
                 source: 'Auth#deleteConnection,invalidateConnection,updateConnectionState',
+                sessionDuration: 11223355,
             },
         ])
     })
@@ -80,11 +82,13 @@ describe('Auth', function () {
                 action: 'updateConnectionState',
                 connectionState: 'valid',
                 source: 'Auth#createConnection,updateConnectionState',
+                sessionDuration: undefined,
             },
             {
                 action: 'updateConnectionState',
                 connectionState: 'invalid',
                 source: 'Auth#deleteConnection,logout,invalidateConnection,updateConnectionState',
+                sessionDuration: 11223355,
             },
         ])
     })
@@ -113,11 +117,13 @@ describe('Auth', function () {
                 action: 'updateConnectionState',
                 connectionState: 'valid',
                 source: 'Auth#createConnection,updateConnectionState',
+                sessionDuration: undefined,
             },
             {
                 action: 'updateConnectionState',
                 connectionState: 'invalid',
                 source: 'Auth#logout,invalidateConnection,updateConnectionState',
+                sessionDuration: 11223355,
             },
         ])
     })

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -9,7 +9,7 @@ import fs from '../../shared/fs/fs'
 import { ToolkitError, isUserCancelledError } from '../../shared/errors'
 import { assertTreeItem } from '../shared/treeview/testUtil'
 import { getTestWindow } from '../shared/vscode/window'
-import { captureEventOnce } from '../testUtil'
+import { assertTelemetry, captureEventOnce } from '../testUtil'
 import { createBuilderIdProfile, createSsoProfile, createTestAuth } from './testUtil'
 import { toCollection } from '../../shared/utilities/asyncCollection'
 import globals from '../../shared/extensionGlobals'
@@ -54,6 +54,18 @@ describe('Auth', function () {
         const conn = await auth.createConnection(ssoProfile)
         await auth.deleteConnection({ id: conn.id })
         assert.strictEqual((await auth.listConnections()).length, 0)
+        assertTelemetry('auth_modifyConnection', [
+            {
+                action: 'updateConnectionState',
+                connectionState: 'valid',
+                source: 'Auth#createConnection,updateConnectionState',
+            },
+            {
+                action: 'updateConnectionState',
+                connectionState: 'invalid',
+                source: 'Auth#deleteConnection,invalidateConnection,updateConnectionState',
+            },
+        ])
     })
 
     it('can delete an active connection', async function () {
@@ -63,6 +75,18 @@ describe('Auth', function () {
         await auth.deleteConnection(auth.activeConnection)
         assert.strictEqual((await auth.listConnections()).length, 0)
         assert.strictEqual(auth.activeConnection, undefined)
+        assertTelemetry('auth_modifyConnection', [
+            {
+                action: 'updateConnectionState',
+                connectionState: 'valid',
+                source: 'Auth#createConnection,updateConnectionState',
+            },
+            {
+                action: 'updateConnectionState',
+                connectionState: 'invalid',
+                source: 'Auth#deleteConnection,logout,invalidateConnection,updateConnectionState',
+            },
+        ])
     })
 
     it('does not throw when creating a duplicate connection', async function () {
@@ -84,6 +108,18 @@ describe('Auth', function () {
         await auth.logout()
         assert.strictEqual(auth.activeConnection, undefined)
         assert.strictEqual(auth.activeConnectionEvents.last, undefined)
+        assertTelemetry('auth_modifyConnection', [
+            {
+                action: 'updateConnectionState',
+                connectionState: 'valid',
+                source: 'Auth#createConnection,updateConnectionState',
+            },
+            {
+                action: 'updateConnectionState',
+                connectionState: 'invalid',
+                source: 'Auth#logout,invalidateConnection,updateConnectionState',
+            },
+        ])
     })
 
     describe('useConnection', function () {

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -108,6 +108,9 @@ describe('SsoAccessTokenProvider', function () {
 
             assert.strictEqual(await cache.token.load(startUrl), undefined)
             assert.strictEqual(await cache.registration.load({ startUrl, region }), undefined)
+            assertTelemetry(`auth_modifyConnection`, [
+                { action: 'deleteSsoCache', source: 'SsoAccessTokenProvider#invalidate' },
+            ])
         })
     })
 

--- a/packages/core/src/test/credentials/testUtil.ts
+++ b/packages/core/src/test/credentials/testUtil.ts
@@ -81,6 +81,7 @@ function createTestTokenProvider() {
         async () => (token = { accessToken: String(++counter), expiresAt: new Date(Date.now() + 1000000) })
     )
     provider.invalidate.callsFake(async () => (token = undefined))
+    provider.getSessionDuration.callsFake(() => 11223355)
 
     return provider
 }

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -248,9 +248,13 @@ export function assertTelemetry<K extends MetricName>(
     const query = { metricName: name }
     const metadata = globals.telemetry.logger.query(query)
 
-    // succeeds if no results found, but none were expected
-    if (Array.isArray(expected) && expected.length === 0 && metadata.length === 0) {
-        return
+    // When an empty expected array was given
+    if (Array.isArray(expected) && expected.length === 0) {
+        if (metadata.length === 0) {
+            // succeeds if no results found, but none were expected
+            return
+        }
+        assert.fail(`Expected no metrics for "${name}", but some exist`)
     }
 
     assert.ok(metadata.length > 0, `telemetry metric not found: "${name}"`)


### PR DESCRIPTION
## Problem:

When an auth connection changes, eg goes from valid to invalid, there were cases for some users where it happened unexpectedly. It was difficult to answer why the users connection became invalid

## Solution:

Wrap many auth related functions with their "function entry" context. This will then allow the final telemetry event in `Auth.updateConnectionState()` to report the entire call stack in its `source` field for the metric `auth_modifyConnection`. What this results in is a string like: `AmazonQ#signoutButton:AuthUtil#signout:Auth#signout,deleteConnection,updateConnectionState` which tells us the path taken to get to updating the connection state.

Example metric when I click signout in the Amazon Q quick pick:

```
[debug] telemetry: auth_modifyConnection {
  Metadata: {
    action: 'updateConnectionState',
    connectionState: 'invalid',
    source: 'Commands#aws.amazonq.signout:SecondaryAuth#deleteConnection:Auth#deleteConnection,logout,invalidateConnection,updateConnectionState',
    credentialStartUrl: 'https://view.awsapps.com/start',
    ...
  },
  ...
}
```

In telemetry we can then follow the change in a users connection state and hopefully determine why they may have expired prematurely since the functions which can expire a connection will now emit telemetry.

There is additionally a metric emitted when the users `~/.aws/sso/cache` file is deleted:
```
auth_modifyConnection: {
  action: 'deleteSsoCache',
  source: '',
  sessionDuration: ''
}
```

## Implementation Details:

- A decorator, `withTelemetryContext` was created to wrap a Class Method with its context for telemetry
  - Every method that uses it adds their function name and class as context
  - Under the hood it wraps the Class Method in a `telemetry.function_call.run()` with some predefined values
  - It does not emit a telemetry event by default, as we only need it to contribute to the function stack
  - This decorator significantly reduces the diff compared to using the explicit `run()` since all method code would need to be explicitly wrapped in it.
  - **Note that decorators only work with class methods**
- For non class methods we just use `telemetry.function_call.run()`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
