### PR TITLE
fix: isSyntaxError() function

### DIFF
--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -788,7 +788,7 @@ export function isNetworkError(err?: unknown): err is Error & { code: string } {
     if (
         isVSCodeProxyError(err) ||
         isSocketTimeoutError(err) ||
-        isNonJsonHttpResponse(err) ||
+        isHttpSyntaxError(err) ||
         isEnoentError(err) ||
         isEaccesError(err) ||
         isEbadfError(err) ||
@@ -849,11 +849,13 @@ function isSocketTimeoutError(err: Error): boolean {
 /**
  * Expected JSON response from HTTP request, but got an error HTML error page instead.
  *
- * Example error message:
- * "Unexpected token '<', "<html><bod"... is not valid JSON Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object."
+ * IMPORTANT:
+ *
+ * This function is influenced by {@link getReasonFromSyntaxError()} since it modifies the error
+ * message with the real underlying reason, instead of the default "Unexpected token" message.
  */
-function isNonJsonHttpResponse(err: Error): boolean {
-    return isError(err, 'SyntaxError', 'Unexpected token')
+function isHttpSyntaxError(err: Error): boolean {
+    return isError(err, 'SyntaxError', 'SDK Client unexpected error response')
 }
 
 /**
@@ -889,6 +891,9 @@ function isError(err: Error, id: string, messageIncludes: string = '') {
  * of attempt to deserialize the non-JSON data.
  * While the contents of the response may contain sensitive information, there may be a reason
  * for failure embedded. This function attempts to extract that reason.
+ *
+ * Example error message before extracting:
+ * "Unexpected token '<', "<html><bod"... is not valid JSON Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object."
  *
  * If the reason cannot be found or the error is not a SyntaxError, return undefined.
  */

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -492,7 +492,7 @@ describe('util', function () {
             false,
             'Incorrectly indicated as network error'
         )
-        let err = new Error("Unexpected token '<'")
+        let err = new Error('SDK Client unexpected error response: Blah Blah Blah')
         err.name = 'SyntaxError'
         assert.deepStrictEqual(isNetworkError(err), true, 'Did not indicate SyntaxError as network error')
 


### PR DESCRIPTION
## Problem:

Due to a recent change the isSyntaxError() function was not returning when expected. We were still seeing it appear in `auth_refreshCredentials` even though it should have been filtered out.

## Solution:

Fix the function so it reports correctly identifies syntax error when it happens.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
