### PR TITLE
tests: check "keepAlive" techdebt

### DIFF
--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -28,6 +28,12 @@ describe('tech debt', function () {
             semver.lt(minVscode, '1.75.0'),
             'remove AsyncLocalStorage polyfill used in `spans.ts` if Cloud9 is on node 14+'
         )
+
+        // see https://github.com/microsoft/vscode/issues/173861
+        assert.ok(
+            semver.lt(minVscode, '1.93.0'),
+            'keepAlive works properly in vscode 1.93+. Remove src/codewhisperer/client/agent.ts and other code related to https://github.com/aws/aws-toolkit-vscode-staging/pull/1214'
+        )
     })
 
     it('nodejs minimum version', async function () {


### PR DESCRIPTION
## Problem

we have a keepAlive workaround that is fixed in vscode 1.93 https://github.com/microsoft/vscode/issues/173861

## Solution

add a techdebt reminder.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
