### PR TITLE
tests: fix telemetry span test timeout

### DIFF
--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -96,18 +96,17 @@ describe('TelemetrySpan', function () {
 
 describe('TelemetryTracer', function () {
     let tracer: TelemetryTracer
-    let clock: ReturnType<typeof installFakeClock>
+    let clock: ReturnType<typeof installFakeClock> | undefined
     let sandbox: SinonSandbox
     const metricName = 'test_metric' as MetricName
 
     beforeEach(function () {
         tracer = new TelemetryTracer()
-        clock = installFakeClock()
         sandbox = sinon.createSandbox()
     })
 
     afterEach(function () {
-        clock.uninstall()
+        clock?.uninstall()
         sandbox.restore()
     })
 
@@ -269,11 +268,12 @@ describe('TelemetryTracer', function () {
         })
 
         it('records performance', function () {
+            clock = installFakeClock()
             const { expectedCpuUsage, expectedHeapTotal } = stubPerformance(sandbox)
             tracer.run(
                 'function_call',
                 () => {
-                    clock.tick(90)
+                    clock?.tick(90)
                 },
                 {
                     trackPerformance: true,


### PR DESCRIPTION
## Problem
- "returns the correct call stack when the context switches" uses sleep under the hood which requires manual ticks when fake clocks are installed. When we added the fake clock it caused this test to fail

## Solution
- only install the fake clock for "records performance"

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
