### PR TITLE
fix(amazonq): fix when reject command is not found after ctrl + z

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -106,10 +106,6 @@
                         "amazonQWelcomePage": {
                             "type": "boolean",
                             "default": false
-                        },
-                        "amazonQSessionConfigurationMessage": {
-                            "type": "boolean",
-                            "default": false
                         }
                     },
                     "additionalProperties": false
@@ -605,7 +601,7 @@
                 "command": "aws.amazonq.rejectCodeSuggestion",
                 "key": "escape",
                 "mac": "escape",
-                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected"
+                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected && aws.codewhisperer.inlineCompletionActive"
             },
             {
                 "command": "aws.amazonq.dismissTutorial",
@@ -616,12 +612,12 @@
             {
                 "key": "right",
                 "command": "editor.action.inlineSuggest.showNext",
-                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected"
+                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected && aws.codewhisperer.inlineCompletionActive"
             },
             {
                 "key": "left",
                 "command": "editor.action.inlineSuggest.showPrevious",
-                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected"
+                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected && aws.codewhisperer.inlineCompletionActive"
             }
         ],
         "icons": {

--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -454,6 +454,7 @@ export class RecommendationHandler {
             this.cancelPaginatedRequest()
             this.clearRecommendations()
             this.disposeInlineCompletion()
+            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.inlineCompletionActive', false)
             await vscode.commands.executeCommand('aws.amazonq.refreshStatusBar')
             this.disposeCommandOverrides()
             // fix a regression that requires user to hit Esc twice to clear inline ghost text
@@ -621,6 +622,7 @@ export class RecommendationHandler {
                 await vscode.commands.executeCommand(`editor.action.inlineSuggest.trigger`)
                 this.sendPerceivedLatencyTelemetry()
             }
+            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.inlineCompletionActive', true)
         })
     }
 


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/issues/5390

## Solution

Make sure our command is only active when our suggestion is active using when clause context. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
