### PR TITLE
fix(auth): handle network errors during restore/getChatAuthState

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-910f825b-6832-42ac-80b4-ffcac58d15c5.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-910f825b-6832-42ac-80b4-ffcac58d15c5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth: Users may be silently logged out due to network issues when starting the extension."
+}

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -263,7 +263,7 @@ export class SecondaryAuth<T extends Connection = Connection> {
                     connectionState: 'undefined',
                 })
                 await this.auth.tryAutoConnect()
-                this.#savedConnection = await this.loadSavedConnection()
+                this.#savedConnection = await this._loadSavedConnection()
                 this.#onDidChangeActiveConnection.fire(this.activeConnection)
 
                 telemetry.record(await getTelemetryMetadataForConn(this.#savedConnection))
@@ -274,7 +274,10 @@ export class SecondaryAuth<T extends Connection = Connection> {
         }
     }
 
-    private async loadSavedConnection() {
+    /**
+     * Provides telemetry if called by restoreConnection() (or another auth_modifyConnection context)
+     */
+    private async _loadSavedConnection() {
         // TODO: fix this
         // eslint-disable-next-line aws-toolkits/no-banned-usages
         const globalState = globals.context.globalState
@@ -296,6 +299,8 @@ export class SecondaryAuth<T extends Connection = Connection> {
             }
 
             let connectionState = this.auth.getConnectionState(conn)
+
+            // This function is expected to be called in the contest of restoreConnection()
             telemetry.auth_modifyConnection.record({
                 connectionState,
                 authStatus: getAuthStatus(connectionState),

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -300,7 +300,7 @@ export class SecondaryAuth<T extends Connection = Connection> {
 
             let connectionState = this.auth.getConnectionState(conn)
 
-            // This function is expected to be called in the contest of restoreConnection()
+            // This function is expected to be called in the context of restoreConnection()
             telemetry.auth_modifyConnection.record({
                 connectionState,
                 authStatus: getAuthStatus(connectionState),

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -17,6 +17,7 @@ import { indent } from '../shared/utilities/textUtilities'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { asStringifiedStack } from '../shared/telemetry/spans'
 import { withTelemetryContext } from '../shared/telemetry/util'
+import { runIgnoreNetError } from '../shared/errors'
 
 export type ToolId = 'codecatalyst' | 'codewhisperer' | 'testId'
 
@@ -297,7 +298,10 @@ export class SecondaryAuth<T extends Connection = Connection> {
             getLogger().warn(`auth (${this.toolId}): saved connection "${this.key}" is not valid`)
             await globalState.update(this.key, undefined)
         } else {
-            await this.auth.refreshConnectionState(conn)
+            await runIgnoreNetError(
+                () => this.auth.refreshConnectionState(conn),
+                'loadSavedConnection: Cannot refresh connection state due to network error: %s'
+            )
             return conn
         }
     }

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -403,6 +403,9 @@ export class AuthUtil {
      * Asynchronously returns a snapshot of the overall auth state of CodeWhisperer + Chat features.
      * It guarantees the latest state is correct at the risk of modifying connection state.
      * If this guarantee is not required, use sync method getChatAuthStateSync()
+     *
+     * By default, network errors are ignored when determining auth state since they may be silently
+     * recoverable later.
      */
     @withTelemetryContext({ name: 'getChatAuthState', class: authClassName })
     public async getChatAuthState(ignoreNetErr: boolean = true): Promise<FeatureAuthState> {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -414,7 +414,7 @@ export class AuthUtil {
         if (ignoreNetErr) {
             await tryRun(
                 () => this.auth.refreshConnectionState(this.conn),
-                (err: Error) => isNetworkError(err),
+                isNetworkError,
                 'getChatAuthState: Cannot refresh connection state due to network error: %s'
             )
         } else {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -414,7 +414,7 @@ export class AuthUtil {
         if (ignoreNetErr) {
             await tryRun(
                 () => this.auth.refreshConnectionState(this.conn),
-                isNetworkError,
+                (err) => !isNetworkError(err),
                 'getChatAuthState: Cannot refresh connection state due to network error: %s'
             )
         } else {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import * as localizedText from '../../shared/localizedText'
 import { Auth } from '../../auth/auth'
-import { ToolkitError, runIgnoreNetError } from '../../shared/errors'
+import { ToolkitError, isNetworkError, tryRun } from '../../shared/errors'
 import { getSecondaryAuth, setScopes } from '../../auth/secondaryAuth'
 import { isCloud9, isSageMaker } from '../../shared/extensionUtilities'
 import { AmazonQPromptSettings } from '../../shared/settings'
@@ -412,8 +412,9 @@ export class AuthUtil {
         // The state of the connection may not have been properly validated
         // and the current state we see may be stale, so refresh for latest state.
         if (ignoreNetErr) {
-            await runIgnoreNetError(
+            await tryRun(
                 () => this.auth.refreshConnectionState(this.conn),
+                (err: Error) => isNetworkError(err),
                 'getChatAuthState: Cannot refresh connection state due to network error: %s'
             )
         } else {

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -930,12 +930,11 @@ export function tryRun<T>(
     // The function signature pattern will accept both async and non-async types.
 
     const catchErr = (err: Error) => {
-        if (!shouldThrow(err)) {
-            getLogger().error(logMsg ?? 'unknown caller: Error ignored: %s', err)
-            return
+        if (shouldThrow(err)) {
+            throw err
         }
 
-        throw err
+        getLogger().error(logMsg ?? 'unknown caller: Error ignored: %s', err)
     }
 
     try {

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -927,8 +927,10 @@ export function tryRun<T>(
     shouldThrow: (err: Error) => boolean,
     logMsg?: string
 ): T | Promise<T | void> | undefined {
+    // The function signature pattern will accept both async and non-async types.
+
     const catchErr = (err: Error) => {
-        if (shouldThrow(err)) {
+        if (!shouldThrow(err)) {
             getLogger().error(logMsg ?? 'unknown caller: Error ignored: %s', err)
             return
         }

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -913,6 +913,10 @@ export function getReasonFromSyntaxError(err: Error): string | undefined {
     return undefined
 }
 
+/**
+ * Run a function and swallow any network errors that are thrown inside.
+ * Other types of errors are still thrown.
+ */
 export function runIgnoreNetError<T>(fn: () => T, logMsg?: string): T | undefined
 export function runIgnoreNetError<T>(fn: () => Promise<T>, logMsg?: string): Promise<T> | undefined
 export function runIgnoreNetError<T>(fn: () => T | Promise<T>, logMsg?: string): T | Promise<T | void> | undefined {

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1069,6 +1069,10 @@
                     "required": false
                 },
                 {
+                    "type": "authStatus",
+                    "required": false
+                },
+                {
                     "type": "connectionState",
                     "required": true
                 },

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -248,7 +248,7 @@
         {
             "name": "authStatus",
             "type": "string",
-            "allowedValues": ["connected", "notConnected", "expired"],
+            "allowedValues": ["connected", "notConnected", "expired", "connectedWithNetworkError"],
             "description": "Status of the an auth connection."
         },
         {

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -289,6 +289,7 @@ describe('Auth', function () {
             const networkError = new ToolkitError('test', { code: 'ETIMEDOUT' })
             const expectedError = new ToolkitError('Failed to update connection due to networking issues', {
                 cause: networkError,
+                code: 'ETIMEDOUT',
             })
             const conn = await auth.createConnection(ssoProfile)
             auth.getTestTokenProvider(conn)?.getToken.rejects(networkError)

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -16,6 +16,7 @@ import {
     resolveErrorMessageToDisplay,
     scrubNames,
     ToolkitError,
+    tryRun,
     UnknownError,
 } from '../../shared/errors'
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
@@ -556,5 +557,51 @@ describe('util', function () {
         assert.deepStrictEqual(scrubNames('unix ~jdoe123/.aws/config failed', fakeUser), 'unix ~x/.aws/config failed')
         assert.deepStrictEqual(scrubNames('unix ../../.aws/config failed', fakeUser), 'unix ../../.aws/config failed')
         assert.deepStrictEqual(scrubNames('unix ~/.aws/config failed', fakeUser), 'unix ~/.aws/config failed')
+    })
+})
+
+describe('errors.tryRun()', function () {
+    it('swallows error from sync fn', function () {
+        const err = new Error('err')
+        tryRun(
+            () => {
+                throw err
+            },
+            () => false
+        )
+    })
+
+    it('swallows error from async fn', async function () {
+        const err = new Error('err')
+        await tryRun(
+            async () => {
+                throw err
+            },
+            () => false
+        )
+    })
+
+    it('throws error from sync fn', function () {
+        const err = new Error('err')
+        assert.throws(() => {
+            tryRun(
+                () => {
+                    throw err
+                },
+                () => true
+            )
+        }, err)
+    })
+
+    it('throws error from async fn', async function () {
+        const err = new Error('err')
+        await assert.rejects(async () => {
+            await tryRun(
+                async () => {
+                    throw err
+                },
+                () => true
+            )
+        }, err)
     })
 })

--- a/packages/toolkit/.changes/next-release/Bug Fix-a9d6d04d-f861-49ce-8d08-ff50b3e0bb2b.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-a9d6d04d-f861-49ce-8d08-ff50b3e0bb2b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth: Users may be silently logged out due to network issues when starting the extension."
+}


### PR DESCRIPTION
## Problem

During extension startup, the auth system tries to restore the connection. This may result in a `refreshToken` call. If a network error happens during this, the connection restore fails and no connection is set to active. Then, Amazon Q will clean up any "leftover" connections, including this one, and the user will be completely logged out. The connection is technically valid despite having an expired token, and another call may clear up the network error and allow us to get better token.

## Solution
The auth system will restore this connection even if it runs into a network error. Then, Amazon Q will display as if its logged in normally. If the network error was one-off, then there is no indication that there was an issue to the user. If there are still network issues, using chat or inline-suggestions will make an error display until `refreshToken` is successful (or the registration expires).

Also, some telemetry updates were included to help make this visible.

Side effects:
- On session startup (with network error):
  - No notification for new CW customizations
  - "featureConfig" AKA A/B testing? will not initialize.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
