### PR TITLE
telemetry: add env type `cloudDesktop-amzn` & `ec2-amzn`

### DIFF
--- a/packages/core/src/shared/telemetry/telemetryClient.ts
+++ b/packages/core/src/shared/telemetry/telemetryClient.ts
@@ -108,7 +108,7 @@ export class DefaultTelemetryClient implements TelemetryClient {
                         ClientID: this.clientId,
                         OS: os.platform(),
                         OSVersion: os.release(),
-                        ComputeEnv: getComputeEnvType(),
+                        ComputeEnv: await getComputeEnvType(),
                         ParentProduct: vscode.env.appName,
                         ParentProductVersion: vscode.version,
                         MetricData: batch,
@@ -135,14 +135,14 @@ export class DefaultTelemetryClient implements TelemetryClient {
                     AWSProductVersion: extensionVersion,
                     OS: os.platform(),
                     OSVersion: os.release(),
-                    ComputeEnv: getComputeEnvType(),
+                    ComputeEnv: await getComputeEnvType(),
                     ParentProduct: vscode.env.appName,
                     ParentProductVersion: vscode.version,
                     Comment: feedback.comment,
                     Sentiment: feedback.sentiment,
                 })
                 .promise()
-            this.logger.debug(`ComputeEnv detected for telemetry: ${getComputeEnvType()}`)
+            this.logger.debug(`ComputeEnv detected for telemetry: ${await getComputeEnvType()}`)
             this.logger.info('Successfully posted feedback')
         } catch (err) {
             this.logger.error(`Failed to post feedback: ${err}`)

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -19,7 +19,7 @@ import { isValidationExemptMetric } from './exemptMetrics'
 import { isAmazonQ, isCloud9, isSageMaker } from '../../shared/extensionUtilities'
 import { randomUUID } from '../crypto'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
-import { FunctionEntry } from './spans'
+import { FunctionEntry, type TelemetryTracer } from './spans'
 import { telemetry } from './telemetry'
 
 const legacySettingsTelemetryValueDisable = 'Disable'

--- a/packages/core/src/shared/vscode/env.ts
+++ b/packages/core/src/shared/vscode/env.ts
@@ -6,6 +6,7 @@
 import * as semver from 'semver'
 import * as vscode from 'vscode'
 import * as packageJson from '../../../package.json'
+import * as os from 'os'
 import { getLogger } from '../logger'
 import { onceChanged } from '../utilities/functionUtils'
 import { ChildProcess } from '../utilities/childProcess'
@@ -92,6 +93,31 @@ export function isInDevEnv(): boolean {
 
 export function isRemoteWorkspace(): boolean {
     return vscode.env.remoteName === 'ssh-remote'
+}
+
+/**
+ * There is Amazon Linux 2, but additionally an Amazon Linux 2 Internal.
+ * The internal version is for Amazon employees only. And this version can
+ * be used by either EC2 OR CloudDesktop. It is not exclusive to either.
+ *
+ * Use {@link isCloudDesktop()} to know if we are specifically using it.
+ *
+ * Example: `5.10.220-188.869.amzn2int.x86_64`
+ */
+export function isAmazonInternalOs() {
+    return os.release().includes('amzn2int')
+}
+
+/**
+ * Returns true if we are in an internal Amazon Cloud Desktop
+ */
+export async function isCloudDesktop() {
+    if (!isAmazonInternalOs()) {
+        return false
+    }
+
+    // This heuristic is explained in IDE-14524
+    return (await new ChildProcess('/apollo/bin/getmyfabric').run().then((r) => r.exitCode)) === 0
 }
 
 /** Returns true if OS is Windows. */

--- a/packages/core/src/test/shared/vscode/env.test.ts
+++ b/packages/core/src/test/shared/vscode/env.test.ts
@@ -4,9 +4,30 @@
  */
 
 import assert from 'assert'
-import { getEnvVars, getServiceEnvVarConfig } from '../../../shared/vscode/env'
+import {
+    isCloudDesktop,
+    getEnvVars,
+    getServiceEnvVarConfig,
+    isAmazonInternalOs as isAmazonInternalOS,
+} from '../../../shared/vscode/env'
+import { ChildProcess } from '../../../shared/utilities/childProcess'
+import * as sinon from 'sinon'
+import os from 'os'
+import vscode from 'vscode'
+import { getComputeEnvType } from '../../../shared/telemetry/util'
 
 describe('env', function () {
+    // create a sinon sandbox instance and instantiate in a beforeEach
+    let sandbox: sinon.SinonSandbox
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+    })
+
     describe('getServiceEnvVarConfig', function () {
         const envVars: string[] = []
 
@@ -54,6 +75,53 @@ describe('env', function () {
             }
             const envVar = getEnvVars('codewhisperer', Object.keys(expectedEnvVars))
             assert.deepStrictEqual(envVar, expectedEnvVars)
+        })
+    })
+
+    function stubOsVersion(verson: string) {
+        return sandbox.stub(os, 'release').returns(verson)
+    }
+
+    it('isAmazonInternalOS', function () {
+        const versionStub = stubOsVersion('5.10.220-188.869.amzn2int.x86_64')
+        assert.strictEqual(isAmazonInternalOS(), true)
+
+        versionStub.returns('5.10.220-188.869.NOT_INTERNAL.x86_64')
+        assert.strictEqual(isAmazonInternalOS(), false)
+    })
+
+    it('isCloudDesktop', async function () {
+        stubOsVersion('5.10.220-188.869.amzn2int.x86_64')
+
+        const runStub = sandbox.stub(ChildProcess.prototype, 'run').resolves({ exitCode: 0 } as any)
+        assert.strictEqual(await isCloudDesktop(), true)
+
+        runStub.resolves({ exitCode: 1 } as any)
+        assert.strictEqual(await isCloudDesktop(), false)
+    })
+
+    describe('getComputeEnvType', async function () {
+        it('cloudDesktop', async function () {
+            sandbox.stub(vscode.env, 'remoteName').value('ssh-remote')
+            stubOsVersion('5.10.220-188.869.amzn2int.x86_64')
+            sandbox.stub(ChildProcess.prototype, 'run').resolves({ exitCode: 0 } as any)
+
+            assert.deepStrictEqual(await getComputeEnvType(), 'cloudDesktop-amzn')
+        })
+
+        it('ec2-internal', async function () {
+            sandbox.stub(vscode.env, 'remoteName').value('ssh-remote')
+            stubOsVersion('5.10.220-188.869.amzn2int.x86_64')
+            sandbox.stub(ChildProcess.prototype, 'run').resolves({ exitCode: 1 } as any)
+
+            assert.deepStrictEqual(await getComputeEnvType(), 'ec2-amzn')
+        })
+
+        it('ec2', async function () {
+            sandbox.stub(vscode.env, 'remoteName').value('ssh-remote')
+            stubOsVersion('5.10.220-188.869.NOT_INTERNAL.x86_64')
+
+            assert.deepStrictEqual(await getComputeEnvType(), 'ec2')
         })
     })
 })


### PR DESCRIPTION
## Problem:

Anything that was a ssh-remote environment was labeled as `ec2` in our
telemetry. But there are more nuanced cases for Amazon internal ssh connections.

## Solution:

Add more specific checks for a Cloud Desktop and an internal ec2
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
