### PR TITLE
fix(amazonq): "rejectCodeSuggestion not found" after ctrl-z

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-43d1cc50-8f12-4467-9331-f9b1fe89381d.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-43d1cc50-8f12-4467-9331-f9b1fe89381d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix bug when undo inline suggestion causes command not found"
+}

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -454,6 +454,7 @@ export async function activate(context: ExtContext): Promise<void> {
     }
 
     async function setSubscriptionsforInlineCompletion() {
+        RecommendationHandler.instance.subscribeSuggestionCommands()
         /**
          * Automated trigger
          */

--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -455,7 +455,6 @@ export class RecommendationHandler {
             this.clearRecommendations()
             this.disposeInlineCompletion()
             await vscode.commands.executeCommand('aws.amazonq.refreshStatusBar')
-            this.disposeCommandOverrides()
             // fix a regression that requires user to hit Esc twice to clear inline ghost text
             // because disposing a provider does not clear the UX
             if (isVscHavingRegressionInlineCompletionApi()) {
@@ -668,8 +667,6 @@ export class RecommendationHandler {
             })
             this.reportUserDecisions(-1)
         } else if (session.recommendations.length > 0) {
-            this.subscribeSuggestionCommands()
-            // await this.startRejectionTimer(editor)
             await this.showRecommendation(0, true)
         }
     }

--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -59,8 +59,10 @@ const nextCommand = Commands.declare('editor.action.inlineSuggest.showNext', () 
 })
 
 const rejectCommand = Commands.declare('aws.amazonq.rejectCodeSuggestion', () => async () => {
+    if (!isCloud9('any')) {
+        await vscode.commands.executeCommand('editor.action.inlineSuggest.hide')
+    }
     RecommendationHandler.instance.reportUserDecisions(-1)
-
     await Commands.tryExecute('aws.amazonq.refreshAnnotation')
 })
 


### PR DESCRIPTION
## Problem

This is an alternative to the fix in https://github.com/aws/aws-toolkit-vscode/pull/5474/files.


## Solution

Test case 1: Trigger suggestion, accept it, ctrl +z, saw same suggestion, press Esc, suggestion disappears. The error  command not found is not thrown. In this case, user can also reject it by keep typing to ignore it. 

Test case 2: Install Vim. Trigger suggestion, accept it, ctrl +z, saw same suggestion, press Esc,  suggestion disappears.  The error  command not found is not thrown. In this case, user can also reject it by keep typing to ignore it. .

Test case 3: Install Vim. Trigger suggestion, press left or right, the navigation is still not working(because Vim overrides the left right keys with highest priority), however, there is no crash anymore and user can still accept or reject the inline suggestion.

Test case 4: Install Q and other code suggestion extensions, with this change, the key bindings are always under our extension, so when their suggestion shows, it triggers our command which breaks their experience. 


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
