### PR TITLE
docs: minimize PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,13 @@
-## Problem
+Problem
+-------
 
-## Solution
 
-<!---
-    REMINDER:
-    - Read CONTRIBUTING.md first.
-    - Add test coverage for your changes.
-    - Update the changelog using `npm run newChange`.
-    - Link to related issues/commits.
-    - Testing: how did you test your changes?
-    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
--->
+Solution
+--------
 
-## License
 
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+---
+
+<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->
+
+License: I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 out
 CHANGELOG.md
+.github/PULL_REQUEST_TEMPLATE.md
 .changes
 *.d.ts
 *.gen.ts


### PR DESCRIPTION
## Problem:
For better or worse, PRs tend to be squash-merged, so devs tend to neglect commit messages, and the PR description (as opposed to commit messages) contains the relevant info.

Therefore to encourage a useful git commit history, we have configured the github repo to use the PR description as the "Default commit message".

But the `PULL_REQUEST_TEMPLATE.md` contains a lot of boilerplate that would then get pasted into the merged commit message unless the merging party takes time to delete it.

## Solution:
Minimize `PULL_REQUEST_TEMPLATE.md` boilerplate to avoid lots of noise in the git commit messages.



---

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
