### PR TITLE
ci: conventional commits

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,4 @@
-# github actions: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# github actions: https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-nodejs
 # setup-node: https://github.com/actions/setup-node
 
 name: CI
@@ -8,6 +8,19 @@ on:
         branches: [master]
     pull_request:
         branches: [master, feature/*, mynah-dev]
+        # Default = opened + synchronize + reopened.
+        # We also want "edited" so that lint-commits runs when PR title is updated.
+        # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
+        types:
+            - edited
+            - opened
+            - reopened
+            - synchronize
+
+# Cancel old jobs when a pull request is updated.
+concurrency:
+    group: ${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
 
 jobs:
     lint-commits:


### PR DESCRIPTION
Problem:
`lint-commits` job does not trigger if contributor updates the PR title.

Solution:
- Specify `on.pull_request.types` to include `edited` event.
- Skip `edited` event for all jobs except `lint-commits`.

Reference:
- https://github.com/orgs/community/discussions/48695
- https://github.com/orgs/community/discussions/101695
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#pull_request


License: By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
