### PR TITLE
fix(amazonq): Release mynah-ui v 4.15.7 with a bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3324,10 +3324,11 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.15.6",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.6.tgz",
-            "integrity": "sha512-YzM1l48yYhj1OZvz9yY+CDIT0K5dIcLMf7hubbVjJqHvRyKyNsCotTDF7ZJIq+IWG17mGUlo8X/s2oAhcYvMNg==",
+            "version": "4.15.7",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.7.tgz",
+            "integrity": "sha512-3LzkHz1VIqvTfThckFygQPeVfQdf/zY/j+fRpxcubiavqAywNgJqR7EWka7e5yKBHHM1aLi3elC5iucUJNs8tg==",
             "hasInstallScript": true,
+            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
@@ -18871,7 +18872,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.15.6",
+                "@aws/mynah-ui": "^4.15.7",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-738aa5e7-6e07-4b9e-8c03-2ca25d60f7db.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-738aa5e7-6e07-4b9e-8c03-2ca25d60f7db.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix bug with code indentation and nested list formatting in chat response prompt"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4111,7 +4111,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.15.6",
+        "@aws/mynah-ui": "^4.15.7",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem

New version of MynahUI requires release in vscode.

## Solution

Release new version of MynahUI with the following bug fix: [Nested list parsing doesn't work in Mynah UI](https://github.com/aws/mynah-ui/issues/97).
MynahUI v4.15.7 release notes: https://github.com/aws/mynah-ui/releases/tag/v4.15.7
The release fixes:
- markdown formatting in nested lists in response prompt
- code indentation in response prompt

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
