### PR TITLE
feat(dev): include in progress state agent details in code generation

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-0da66e82-7f81-46c7-be39-5634cf0a64f3.json
+++ b/packages/amazonq/.changes/next-release/Feature-0da66e82-7f81-46c7-be39-5634cf0a64f3.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q /dev: include in progress state agent in code generation"
+}

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -294,7 +294,7 @@
     "AWS.amazonq.featureDev.pillText.newTask": "Work on new task",
     "AWS.amazonq.featureDev.pillText.generateCode": "Generate code",
     "AWS.amazonq.featureDev.pillText.generatingCode": "Generating code ...",
-    "AWS.amazonq.featureDev.pillText.generatedCode": "Here's your code. You can choose a file to see a diff with the changes I'm proposing.",
+
     "AWS.amazonq.featureDev.pillText.generatingPlan": "Generating plan ...",
     "AWS.amazonq.featureDev.pillText.requestingChanges": "Requesting changes ...",
     "AWS.amazonq.featureDev.pillText.insertCode": "Insert code",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -294,7 +294,7 @@
     "AWS.amazonq.featureDev.pillText.newTask": "Work on new task",
     "AWS.amazonq.featureDev.pillText.generateCode": "Generate code",
     "AWS.amazonq.featureDev.pillText.generatingCode": "Generating code ...",
-    "AWS.amazonq.featureDev.pillText.generatedCode": "Code generation done. You can find it below:",
+    "AWS.amazonq.featureDev.pillText.generatedCode": "Here's your code. You can choose a file to see a diff with the changes I'm proposing.",
     "AWS.amazonq.featureDev.pillText.generatingPlan": "Generating plan ...",
     "AWS.amazonq.featureDev.pillText.requestingChanges": "Requesting changes ...",
     "AWS.amazonq.featureDev.pillText.insertCode": "Insert code",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -294,6 +294,7 @@
     "AWS.amazonq.featureDev.pillText.newTask": "Work on new task",
     "AWS.amazonq.featureDev.pillText.generateCode": "Generate code",
     "AWS.amazonq.featureDev.pillText.generatingCode": "Generating code ...",
+    "AWS.amazonq.featureDev.pillText.generatedCode": "Code generation done. You can find it below:",
     "AWS.amazonq.featureDev.pillText.generatingPlan": "Generating plan ...",
     "AWS.amazonq.featureDev.pillText.requestingChanges": "Requesting changes ...",
     "AWS.amazonq.featureDev.pillText.insertCode": "Insert code",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -294,7 +294,6 @@
     "AWS.amazonq.featureDev.pillText.newTask": "Work on new task",
     "AWS.amazonq.featureDev.pillText.generateCode": "Generate code",
     "AWS.amazonq.featureDev.pillText.generatingCode": "Generating code ...",
-
     "AWS.amazonq.featureDev.pillText.generatingPlan": "Generating plan ...",
     "AWS.amazonq.featureDev.pillText.requestingChanges": "Requesting changes ...",
     "AWS.amazonq.featureDev.pillText.insertCode": "Insert code",

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -43,6 +43,7 @@ import { AuthUtil } from '../../codewhisperer/util/authUtil'
 import { randomUUID } from '../../shared/crypto'
 import { collectFiles, getWorkspaceFoldersByPrefixes } from '../../shared/utilities/workspaceUtils'
 import { i18n } from '../../shared/i18n-helper'
+import { Messenger } from '../controllers/chat/messenger/messenger'
 
 export class ConversationNotStartedState implements Omit<SessionState, 'uploadId'> {
     public tokenSource: vscode.CancellationTokenSource
@@ -245,11 +246,13 @@ abstract class CodeGenBase {
     }
 
     async generateCode({
+        messenger,
         fs,
         codeGenerationId,
         telemetry: telemetry,
         workspaceFolders,
     }: {
+        messenger: Messenger
         fs: VirtualFileSystem
         codeGenerationId: string
         telemetry: TelemetryHelper
@@ -288,6 +291,15 @@ abstract class CodeGenBase {
                 }
                 case CodeGenerationStatus.PREDICT_READY:
                 case CodeGenerationStatus.IN_PROGRESS: {
+                    if (codegenResult.codeGenerationStatusDetail) {
+                        messenger.sendAnswer({
+                            message:
+                                i18n('AWS.amazonq.featureDev.pillText.generatingCode') +
+                                `\n\n${codegenResult.codeGenerationStatusDetail}`,
+                            type: 'answer-part',
+                            tabID: this.tabID,
+                        })
+                    }
                     await new Promise((f) => globals.clock.setTimeout(f, this.requestDelay))
                     break
                 }
@@ -381,6 +393,7 @@ export class CodeGenState extends CodeGenBase implements SessionState {
                 })
 
                 const codeGeneration = await this.generateCode({
+                    messenger: action.messenger,
                     fs: action.fs,
                     codeGenerationId,
                     telemetry: action.telemetry,

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -282,14 +282,6 @@ abstract class CodeGenBase {
                     const newFileInfo = registerNewFiles(fs, newFileContents, this.uploadId, workspaceFolders)
                     telemetry.setNumberOfFilesGenerated(newFileInfo.length)
 
-                    if (newFileContents.length !== 0 || deletedFiles.length !== 0) {
-                        messenger.sendAnswer({
-                            message: i18n('AWS.amazonq.featureDev.pillText.generatedCode'),
-                            type: 'answer-part',
-                            tabID: this.tabID,
-                        })
-                    }
-
                     return {
                         newFiles: newFileInfo,
                         deletedFiles: getDeletedFileInfos(deletedFiles, workspaceFolders),

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -281,6 +281,15 @@ abstract class CodeGenBase {
                         await this.config.proxyClient.exportResultArchive(this.conversationId)
                     const newFileInfo = registerNewFiles(fs, newFileContents, this.uploadId, workspaceFolders)
                     telemetry.setNumberOfFilesGenerated(newFileInfo.length)
+
+                    if (newFileContents.length !== 0 || deletedFiles.length !== 0) {
+                        messenger.sendAnswer({
+                            message: i18n('AWS.amazonq.featureDev.pillText.generatedCode'),
+                            type: 'answer-part',
+                            tabID: this.tabID,
+                        })
+                    }
+
                     return {
                         newFiles: newFileInfo,
                         deletedFiles: getDeletedFileInfos(deletedFiles, workspaceFolders),
@@ -399,6 +408,7 @@ export class CodeGenState extends CodeGenBase implements SessionState {
                     telemetry: action.telemetry,
                     workspaceFolders: this.config.workspaceFolders,
                 })
+
                 this.filePaths = codeGeneration.newFiles
                 this.deletedFiles = codeGeneration.deletedFiles
                 this.references = codeGeneration.references


### PR DESCRIPTION
## Problem

Currently we display a long-running message "Generating code ... " while in code generation still IN_PROGRESS state. There is an often customer feedback based on this experience that its "stuck" or not "progressing".

Although the RTS and LLM are processing the request, user expects some feedback on whats is doing or if its actually stuck processing.

## Solution

This PR provides exposure for the codeGenerationStatusDetail which will be leveraged to return the strings in the following format:

![Screenshot 2024-08-28 at 10 49 02 AM](https://github.com/user-attachments/assets/94618e5e-37ca-4c1f-a12b-6712a9a33472)
![Screenshot 2024-08-28 at 10 47 54 AM](https://github.com/user-attachments/assets/dcf9e4f6-5e72-4200-bc18-8ca461317ec0)

LLM actions example returned:

"I have reviewed 7 files and applied changes to 3 files in total so far.

Most recently, I reviewed 2 files and applied changes to 1 file. "

Error scenario while IN_PROGRESS:

"The previous attempt failed. I am retrying now. For reference, the previous 
attempt took approximately 1 minute and involved 3 files."

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
