### PR TITLE
telemetry: ide_editCodeFile is noisy

### DIFF
--- a/packages/core/src/shared/fs/watchedFiles.ts
+++ b/packages/core/src/shared/fs/watchedFiles.ts
@@ -9,7 +9,6 @@ import * as pathutils from '../utilities/pathUtils'
 import * as path from 'path'
 import { globDirPatterns, isUntitledScheme, normalizeVSCodeUri } from '../utilities/vsCodeUtils'
 import { Settings } from '../settings'
-import { once } from '../utilities/functionUtils'
 import { Timeout } from '../utilities/timeoutUtils'
 
 /**
@@ -60,7 +59,6 @@ export function getExcludePattern() {
     const excludePattern = `**/{${excludePatternsStr}}/`
     return excludePattern
 }
-const getExcludePatternOnce = once(getExcludePattern)
 
 /**
  * WatchedFiles lets us watch files on the filesystem. It is used
@@ -180,6 +178,9 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
 
     /**
      * Adds a regex pattern to ignore paths containing the pattern
+     *
+     * TODO: this does NOT prevent addWatchPatterns() from creating a massive, expensive, recursive
+     * filewatcher for these patterns 🤦, it merely skips processing at event-time.
      */
     public addExcludedPattern(pattern: RegExp) {
         if (this._isDisposed) {
@@ -309,7 +310,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
         let skips = 0
         const found: vscode.Uri[] = []
 
-        const exclude = getExcludePatternOnce()
+        const exclude = getExcludePattern()
         getLogger().info(`${this.name}: building with: ${this.outputPatterns()}`)
 
         for (let i = 0; i < this.globs.length && !cancel?.completed; i++) {

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -20,16 +20,16 @@ import { DeclaredCommand } from '../shared/vscode/commands2'
 const testTempDirs: string[] = []
 
 /**
- * Writes the string form of `o` to `filePathParts` as UTF-8 text.
+ * Writes the string form of `o` to `filepath` as UTF-8 text.
  *
- * Creates parent directories in `filePathParts`, if necessary.
+ * Creates parent directories in `filepath`, if necessary.
  */
-export async function toFile(o: any, ...filePathParts: string[]) {
-    const text = o ? o.toString() : ''
-    const filePath = path.join(...filePathParts)
-    const dir = path.dirname(filePath)
+export async function toFile(o: any, filepath: string | vscode.Uri) {
+    const file = typeof filepath === 'string' ? filepath : filepath.fsPath
+    const text = o === undefined ? '' : o.toString()
+    const dir = path.dirname(file)
     await fs2.mkdir(dir)
-    await fs2.writeFile(filePath, text)
+    await fs2.writeFile(file, text)
 }
 
 /**

--- a/packages/core/src/testFixtures/workspaceFolder/test.ssm.json
+++ b/packages/core/src/testFixtures/workspaceFolder/test.ssm.json
@@ -1,0 +1,28 @@
+{
+    "description": "Attach IAM Policy to Instance",
+    "assumeRole": "{{ AutomationAssumeRole }}",
+    "schemaVersion": "0.3",
+    "parameters": {
+        "AutomationAssumeRole": {
+            "description": "ARN role",
+            "type": "String"
+        },
+        "InstanceId": {
+            "description": "Instance ID",
+            "type": "String"
+        }
+    },
+    "mainSteps": [
+        {
+            "inputs": {
+                "FunctionName": "SSMOnboardingLambda",
+                "InputPayload": {
+                    "instance_id": "{{ InstanceId }}"
+                }
+            },
+            "name": "AttachPoliciesToInstance",
+            "action": "aws:invokeLambdaFunction",
+            "onFailure": "Abort"
+        }
+    ]
+}

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -211,7 +211,7 @@ describe('collectFiles', function () {
         const workspaceFolder = await createTestWorkspace(fileAmount, { fileNamePrefix, fileContent })
 
         const writeFile = (pathParts: string[], fileContent: string) => {
-            return toFile(fileContent, workspaceFolder.uri.fsPath, ...pathParts)
+            return toFile(fileContent, path.join(workspaceFolder.uri.fsPath, ...pathParts))
         }
 
         sinon.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder])
@@ -307,18 +307,18 @@ describe('collectFiles', function () {
         const fileContent = ''
         for (const fmt of ['txt', 'md']) {
             // root license files
-            await toFile(fileContent, workspace.uri.fsPath, `license.${fmt}`)
-            await toFile(fileContent, workspace.uri.fsPath, `License.${fmt}`)
-            await toFile(fileContent, workspace.uri.fsPath, `LICENSE.${fmt}`)
+            await toFile(fileContent, path.join(workspace.uri.fsPath, `license.${fmt}`))
+            await toFile(fileContent, path.join(workspace.uri.fsPath, `License.${fmt}`))
+            await toFile(fileContent, path.join(workspace.uri.fsPath, `LICENSE.${fmt}`))
 
             // nested license files
-            await toFile(fileContent, workspace.uri.fsPath, 'src', `license.${fmt}`)
-            await toFile(fileContent, workspace.uri.fsPath, 'src', `License.${fmt}`)
-            await toFile(fileContent, workspace.uri.fsPath, 'src', `LICENSE.${fmt}`)
+            await toFile(fileContent, path.join(workspace.uri.fsPath, `src/license.${fmt}`))
+            await toFile(fileContent, path.join(workspace.uri.fsPath, `src/License.${fmt}`))
+            await toFile(fileContent, path.join(workspace.uri.fsPath, `src/LICENSE.${fmt}`))
         }
 
         // add a non license file too, to make sure it is returned
-        await toFile(fileContent, workspace.uri.fsPath, 'non-license.md')
+        await toFile(fileContent, path.join(workspace.uri.fsPath, 'non-license.md'))
 
         const result = await collectFiles([workspace.uri.fsPath], [workspace], true)
 
@@ -438,7 +438,7 @@ describe('collectFilesForIndex', function () {
         const workspaceFolder = await createTestWorkspace(fileAmount, { fileNamePrefix, fileContent })
 
         const writeFile = (pathParts: string[], fileContent: string) => {
-            return toFile(fileContent, workspaceFolder.uri.fsPath, ...pathParts)
+            return toFile(fileContent, path.join(workspaceFolder.uri.fsPath, ...pathParts))
         }
 
         sinon.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder])


### PR DESCRIPTION
## Problem:
- Pseudo-documents like `foo.git`, `output://…`, and `~/.vscode/argv.json` are included in `ide_editCodeFile` metrics even though they were not actually opened by the user.
- `onDidOpenTextDocument` doesn't correctly represent user activity: it fires for *all* documents opened with `onDidOpenTextDocument()`, which includes all documents/buffers opened for programmatic purposes by application or library code.

## Solution:
- Listen to `onDidChangeActiveTextEditor` instead of `onDidOpenTextDocument`. This represents when a user actually opens a file in the IDE.
- Ignore various "noise" documents.

---

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
