### PR TITLE
fix(tests): improve reliability of performance tests

### DIFF
--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -222,7 +222,8 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
             const performanceMetrics = this.#performance?.stop()
             if (performanceMetrics) {
                 this.record({
-                    cpuUsage: performanceMetrics.cpuUsage,
+                    userCpuUsage: performanceMetrics.userCpuUsage,
+                    systemCpuUsage: performanceMetrics.systemCpuUsage,
                     heapTotal: performanceMetrics.heapTotal,
                     functionName: this.#options.functionId?.name ?? this.name,
                 } as any)

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -8,18 +8,13 @@
         {
             "name": "documentFormat",
             "type": "string",
-            "allowedValues": [
-                "JSON, YAML"
-            ],
+            "allowedValues": ["JSON, YAML"],
             "description": "SSM Create document format selection"
         },
         {
             "name": "ssmOperation",
             "type": "string",
-            "allowedValues": [
-                "Create",
-                "Update"
-            ],
+            "allowedValues": ["Create", "Update"],
             "description": "SSM Publish Document operation type"
         },
         {
@@ -45,11 +40,7 @@
         {
             "name": "cwsprChatTriggerInteraction",
             "type": "string",
-            "allowedValues": [
-                "hotkeys",
-                "click",
-                "contextMenu"
-            ],
+            "allowedValues": ["hotkeys", "click", "contextMenu"],
             "description": "Identifies the specific interaction that opens the chat panel"
         },
         {
@@ -114,11 +105,7 @@
         {
             "name": "cwsprChatConversationType",
             "type": "string",
-            "allowedValues": [
-                "Chat",
-                "Assign",
-                "Transform"
-            ],
+            "allowedValues": ["Chat", "Assign", "Transform"],
             "description": "Identifies the type of conversation"
         },
         {
@@ -245,12 +232,7 @@
         {
             "name": "cwsprChatCommandType",
             "type": "string",
-            "allowedValues": [
-                "clear",
-                "help",
-                "transform",
-                "auth"
-            ],
+            "allowedValues": ["clear", "help", "transform", "auth"],
             "description": "Type of chat command (/command) executed"
         },
         {
@@ -266,11 +248,7 @@
         {
             "name": "authStatus",
             "type": "string",
-            "allowedValues": [
-                "connected",
-                "notConnected",
-                "expired"
-            ],
+            "allowedValues": ["connected", "notConnected", "expired"],
             "description": "Status of the an auth connection."
         },
         {
@@ -299,9 +277,14 @@
             "description": "A detailed state of a specific auth connection. Use `authStatus` for a higher level view of an extension's general connection."
         },
         {
-            "name": "cpuUsage",
+            "name": "userCpuUsage",
             "type": "int",
-            "description": "Percentage of cpu usage"
+            "description": "Percentage of user cpu usage (user space)"
+        },
+        {
+            "name": "systemCpuUsage",
+            "type": "int",
+            "description": "Percentage of system cpu usage (kernal space)"
         },
         {
             "name": "heapTotal",
@@ -1117,7 +1100,11 @@
             "description": "Represents a function call. In most cases this should wrap code with a run(), then you can add context.",
             "metadata": [
                 {
-                    "type": "cpuUsage",
+                    "type": "userCpuUsage",
+                    "required": true
+                },
+                {
+                    "type": "systemCpuUsage",
                     "required": true
                 },
                 {

--- a/packages/core/src/test/shared/performance/performance.test.ts
+++ b/packages/core/src/test/shared/performance/performance.test.ts
@@ -21,12 +21,14 @@ describe('performance tooling', () => {
 
     describe('PerformanceTracker', () => {
         it('gets performance metrics', () => {
-            const { expectedCpuUsage, expectedHeapTotal, expectedTotalSeconds } = stubPerformance(sandbox)
+            const { expectedUserCpuUsage, expectedSystemCpuUsage, expectedHeapTotal, expectedTotalSeconds } =
+                stubPerformance(sandbox)
             const perf = new PerformanceTracker('foo')
             perf.start()
             const metrics = perf.stop()
 
-            assert.deepStrictEqual(metrics?.cpuUsage, expectedCpuUsage)
+            assert.deepStrictEqual(metrics?.userCpuUsage, expectedUserCpuUsage)
+            assert.deepStrictEqual(metrics?.systemCpuUsage, expectedSystemCpuUsage)
             assert.deepStrictEqual(metrics?.heapTotal, expectedHeapTotal)
             assert.deepStrictEqual(metrics?.duration, expectedTotalSeconds)
         })

--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -78,7 +78,7 @@ describe('TelemetrySpan', function () {
     })
 
     it('records performance', function () {
-        const { expectedCpuUsage, expectedHeapTotal } = stubPerformance(sandbox)
+        const { expectedUserCpuUsage, expectedSystemCpuUsage, expectedHeapTotal } = stubPerformance(sandbox)
         const span = new TelemetrySpan('function_call', {
             trackPerformance: true,
         })
@@ -86,7 +86,8 @@ describe('TelemetrySpan', function () {
         clock.tick(90)
         span.stop()
         assertTelemetry('function_call', {
-            cpuUsage: expectedCpuUsage,
+            userCpuUsage: expectedUserCpuUsage,
+            systemCpuUsage: expectedSystemCpuUsage,
             heapTotal: expectedHeapTotal,
             duration: 90,
             result: 'Succeeded',
@@ -269,7 +270,7 @@ describe('TelemetryTracer', function () {
 
         it('records performance', function () {
             clock = installFakeClock()
-            const { expectedCpuUsage, expectedHeapTotal } = stubPerformance(sandbox)
+            const { expectedUserCpuUsage, expectedSystemCpuUsage, expectedHeapTotal } = stubPerformance(sandbox)
             tracer.run(
                 'function_call',
                 () => {
@@ -281,7 +282,8 @@ describe('TelemetryTracer', function () {
             )
 
             assertTelemetry('function_call', {
-                cpuUsage: expectedCpuUsage,
+                userCpuUsage: expectedUserCpuUsage,
+                systemCpuUsage: expectedSystemCpuUsage,
                 heapTotal: expectedHeapTotal,
                 duration: 90,
                 result: 'Succeeded',

--- a/packages/core/src/test/utilities/performance.ts
+++ b/packages/core/src/test/utilities/performance.ts
@@ -6,11 +6,11 @@
 import Sinon from 'sinon'
 
 export function stubPerformance(sandbox: Sinon.SinonSandbox) {
-    const expectedCpuUsage = { user: 10000, system: 2000 }
+    const cpuUsage = { user: 10000, system: 2000 }
     const initialHeapTotal = 1
     const totalNanoseconds = 30000000 // 0.03 seconds
 
-    sandbox.stub(process, 'cpuUsage').returns(expectedCpuUsage)
+    sandbox.stub(process, 'cpuUsage').returns(cpuUsage)
 
     const memoryUsageStub = sandbox.stub(process, 'memoryUsage')
     memoryUsageStub
@@ -21,7 +21,8 @@ export function stubPerformance(sandbox: Sinon.SinonSandbox) {
     sandbox.stub(process, 'hrtime').onCall(0).returns([0, 0]).onCall(1).returns([0, totalNanoseconds])
 
     return {
-        expectedCpuUsage: 40,
+        expectedUserCpuUsage: 33.333333333333336,
+        expectedSystemCpuUsage: 6.666666666666667,
         expectedHeapTotal: 10,
         expectedTotalSeconds: totalNanoseconds / 1e9,
     }


### PR DESCRIPTION
## Problem
- We currently do a one-shot performance test measurement, which can be be impacted by the underlying cpu

## Solution
- Run 5 performance tests by default, this should give us a more accurate reading

### Performance of the last 10 test runs on my computer:
```
{userCpuUsage: 27.763992642839753, systemCpuUsage: 5.8700764000563925, duration: 0.0488549862, heapTotal: 0.15}
{userCpuUsage: 32.432557472712574, systemCpuUsage: 7.287778251185924, duration: 0.0350972354, heapTotal: 0.15}
{userCpuUsage: 36.17269595509756, systemCpuUsage: 8.190125881726889, duration: 0.0313357906, heapTotal: 0.15}
{userCpuUsage: 23.575720185158513, systemCpuUsage: 5.680905138190308, duration: 0.0468292694, heapTotal: 0.05}
{userCpuUsage: 29.722270663855547, systemCpuUsage: 6.725376761131834, duration: 0.044072017399999996, heapTotal: 0.05}
{userCpuUsage: 30.981420694546227, systemCpuUsage: 6.724871937232588, duration: 0.0404778744, heapTotal: 0.05}
{userCpuUsage: 29.15659118178076, systemCpuUsage: 6.544881314879868, duration: 0.0438601896, heapTotal: 0.15}
{userCpuUsage: 29.66190894781342, systemCpuUsage: 6.556456308274413, duration: 0.042828962400000004, heapTotal: 0.1}
{userCpuUsage: 32.209253755861006, systemCpuUsage: 7.245284221753529, duration: 0.036528329, heapTotal: 0.1}
{userCpuUsage: 30.4379237001285, systemCpuUsage: 6.790691656039722, duration: 0.0378142194, heapTotal: 0.1}
{userCpuUsage: 28.075430930361144, systemCpuUsage: 6.952612678963097, duration: 0.042763791, heapTotal: 0.1}
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
