### PR TITLE
fix(amazonq): Release mynah-ui v 4.15.8 with bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3324,11 +3324,10 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.15.7",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.7.tgz",
-            "integrity": "sha512-3LzkHz1VIqvTfThckFygQPeVfQdf/zY/j+fRpxcubiavqAywNgJqR7EWka7e5yKBHHM1aLi3elC5iucUJNs8tg==",
+            "version": "4.15.8",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.8.tgz",
+            "integrity": "sha512-A0qkACykrhx3Tr0qi15HpY2dCSwVYVZTecp2nXny5uwjh3StYo88daUqUG+4mX2LGL49jIr3X5IUgWYb9/vatg==",
             "hasInstallScript": true,
-            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
@@ -18872,7 +18871,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.15.7",
+                "@aws/mynah-ui": "^4.15.8",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-7386c56a-07b9-4c6e-98f2-4321ec9cea28.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-7386c56a-07b9-4c6e-98f2-4321ec9cea28.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix bug when pasting text from Mynah card with inline code causes new line breaks to form around the inline code text"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-7386c56a-07b9-4c6e-98f2-4321ec9cea28.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-7386c56a-07b9-4c6e-98f2-4321ec9cea28.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix bug when pasting text from Mynah card with inline code causes new line breaks to form around the inline code text"
+	"description": "Fix bug where text with inline code copied from Amazon Q Chat had new line breaks around the inline code text"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-7ab2c6fa-1678-4834-8edd-80eb2c12953e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-7ab2c6fa-1678-4834-8edd-80eb2c12953e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix bug when disabled commands does not get filtered in quick actions"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4111,7 +4111,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.15.7",
+        "@aws/mynah-ui": "^4.15.8",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
New version of MynahUI requires release in vscode.

## Solution
Release new version of MynahUI with the following bug fixes:
- Fix copy pasting inline code texts https://github.com/aws/mynah-ui/issues/98
- Fix disabled commands not filtered in quick actions

MynahUI v4.15.8 release notes: https://github.com/aws/mynah-ui/releases/tag/v4.15.8

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
