### PR TITLE
ci: run github CI in private repo

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
     push:
-        branches: [master]
+        branches: [master, staging]
     pull_request:
-        branches: [master, feature/*, mynah-dev]
+        branches: [master, feature/*, staging]
         # Default = opened + synchronize + reopened.
         # We also want "edited" so that lint-commits runs when PR title is updated.
         # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request


### PR DESCRIPTION
## Problem

github CI is not triggered on PRs in the private "staging" repo.

## Solution

update workflow trigger.

example: https://github.com/aws/aws-toolkit-vscode-staging/pull/1678


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
