### PR TITLE
fix(amazonq): allow symlinks for JDK path

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-59842853-a46a-4ffd-b866-e62bec96ad45.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-59842853-a46a-4ffd-b866-e62bec96ad45.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Code Transformation: allow symlinks for JDK path"
+}

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -506,5 +506,5 @@ export class GumbyController {
  */
 function extractPath(text: string): string | undefined {
     const resolvedPath = path.resolve(text.trim())
-    return nodefs.existsSync(resolvedPath) && nodefs.lstatSync(resolvedPath).isDirectory() ? resolvedPath : undefined
+    return nodefs.existsSync(resolvedPath) ? resolvedPath : undefined
 }


### PR DESCRIPTION
## Problem

Some users provide a symlink when QCT prompts them for a JDK path, and this previously was not being accepted.


## Solution

Remove part of a conditional check (`isDirectory`, since that is always false for symlinks). This allows users to use symlinks, which will work fine during the local build. Even if someone provides a path that is *not* a directory now, the local build will fail and build error logs will open up for them to debug, as usual.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
