### PR TITLE
ci(toolkit): Only run issue notification on pull requests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,6 +38,7 @@ jobs:
                   script: |
                       const notify = require('.github/workflows/notify.js')
                       await notify({github, context})
+              if: github.event_name == 'pull_request'
             - name: Check PR title
               run: |
                   node "$GITHUB_WORKSPACE/.github/workflows/lintcommit.js"


### PR DESCRIPTION
## Problem
The notification step of lint-commits fials on master since a pull request is not defined

## Solution
If the linting isn't in a PR then don't run the notification step

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
