### PR TITLE
test(toolkit): Stub all instances of process.hrtime in records perfomance test

### DIFF
--- a/packages/core/src/test/utilities/performance.ts
+++ b/packages/core/src/test/utilities/performance.ts
@@ -18,7 +18,7 @@ export function stubPerformance(sandbox: Sinon.SinonSandbox) {
         .returns({ heapTotal: initialHeapTotal, arrayBuffers: 0, external: 0, rss: 0, heapUsed: 0 })
     memoryUsageStub.onCall(1).returns({ heapTotal: 10485761, arrayBuffers: 0, external: 0, rss: 0, heapUsed: 0 })
 
-    sandbox.stub(process, 'hrtime').onCall(0).returns([0, 0]).onCall(1).returns([0, totalNanoseconds])
+    sandbox.stub(process, 'hrtime').returns([0, totalNanoseconds])
 
     return {
         expectedUserCpuUsage: 33.333333333333336,


### PR DESCRIPTION
## Problem
We're seeing some flakiness with the `TelemetrySpan records performance` test. I _think_ it could be related to the fact we [stub certain calls on process.hrtime](https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/test/utilities/performance.ts#L21) instead of stubbing all instances. This can potentially cause [nodeClock](https://github.com/aws/aws-sdk-js/blob/master/lib/realclock/nodeClock.js#L4) to use or not use stubbed values depending on when things are executed.

Previously we would see a failure this:
```
TypeError: Cannot read properties of undefined (reading '0')
    at Object.now (/codebuild/output/src575830969/src/github.com/aws/aws-toolkit-vscode/node_modules/aws-sdk/lib/realclock/nodeClock.js:5:18)
```

## Solution
Stub all instances of process.hrtime during that test

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
