### PR TITLE
telemetry: Add `sessionId` to metrics

### DIFF
--- a/packages/core/src/shared/crypto.ts
+++ b/packages/core/src/shared/crypto.ts
@@ -39,6 +39,6 @@ export function randomUUID(): `${string}-${string}-${string}-${string}-${string}
  */
 export function isUuid(uuid: string): boolean {
     // NOTE: This pattern must match, or at least be a subset of the "Session ID" pattern in `telemetry/service-2.json`
-    const uuidv4Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-    return uuidv4Pattern.test(uuid)
+    const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    return uuidPattern.test(uuid)
 }

--- a/packages/core/src/shared/crypto.ts
+++ b/packages/core/src/shared/crypto.ts
@@ -30,3 +30,15 @@ export function randomUUID(): `${string}-${string}-${string}-${string}-${string}
 
     return require('crypto').randomUUID()
 }
+
+/**
+ * Returns true if the given string is a UUID
+ *
+ * NOTE: There are different UUID versions, this function does not discriminate between them.
+ * See: https://stackoverflow.com/questions/7905929/how-to-test-valid-uuid-guid
+ */
+export function isUUID(uuid: string): boolean {
+    // pattern match the uuid to a uuid string
+    const uuidv4Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    return uuidv4Pattern.test(uuid)
+}

--- a/packages/core/src/shared/crypto.ts
+++ b/packages/core/src/shared/crypto.ts
@@ -37,8 +37,8 @@ export function randomUUID(): `${string}-${string}-${string}-${string}-${string}
  * NOTE: There are different UUID versions, this function does not discriminate between them.
  * See: https://stackoverflow.com/questions/7905929/how-to-test-valid-uuid-guid
  */
-export function isUUID(uuid: string): boolean {
-    // pattern match the uuid to a uuid string
+export function isUuid(uuid: string): boolean {
+    // NOTE: This pattern must match, or at least be a subset of the "Session ID" pattern in `telemetry/service-2.json`
     const uuidv4Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
     return uuidv4Pattern.test(uuid)
 }

--- a/packages/core/src/shared/telemetry/activation.ts
+++ b/packages/core/src/shared/telemetry/activation.ts
@@ -14,7 +14,7 @@ import { DefaultTelemetryService } from './telemetryService'
 import { getLogger } from '../logger'
 import { getComputeRegion, isAmazonQ, isCloud9, productName } from '../extensionUtilities'
 import { openSettingsId, Settings } from '../settings'
-import { TelemetryConfig } from './util'
+import { getSessionId, TelemetryConfig } from './util'
 import { isAutomation, isReleaseVersion } from '../vscode/env'
 import { AWSProduct } from './clienttelemetry'
 import { DefaultTelemetryClient } from './telemetryClient'
@@ -76,6 +76,12 @@ export async function activate(
         }
 
         await globals.telemetry.start()
+
+        if (globals.telemetry.telemetryEnabled) {
+            // Only log the IDs if telemetry is enabled, so that users who have it disabled do not think we are sending events.
+            getLogger().info(`Telemetry Client ID: ${globals.telemetry.clientId}`)
+            getLogger().info(`Telemetry Session ID: ${getSessionId()}`)
+        }
     } catch (e) {
         // Only throw in a production build because:
         //   1. Telemetry must never prevent normal Toolkit operation.

--- a/packages/core/src/shared/telemetry/service-2.json
+++ b/packages/core/src/shared/telemetry/service-2.json
@@ -58,6 +58,10 @@
       "type":"string",
       "pattern":"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
     },
+    "SessionID":{
+      "type":"string",
+      "pattern":"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+    },
     "Command":{
       "type":"string",
       "max":2000
@@ -207,6 +211,7 @@
         "AWSProduct":{"shape":"AWSProduct"},
         "AWSProductVersion":{"shape":"AWSProductVersion"},
         "ClientID":{"shape":"ClientID"},
+        "SessionID":{"shape":"SessionID"},
         "OS":{"shape":"Value"},
         "OSVersion":{"shape":"Value"},
         "ComputeEnv": {"shape":"ComputeEnv"},

--- a/packages/core/src/shared/telemetry/telemetryClient.ts
+++ b/packages/core/src/shared/telemetry/telemetryClient.ts
@@ -17,7 +17,7 @@ import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 import globals from '../extensionGlobals'
 import { DevSettings } from '../settings'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
-import { getComputeEnvType } from './util'
+import { getComputeEnvType, getSessionId } from './util'
 
 export const accountMetadataKey = 'awsAccount'
 export const regionKey = 'awsRegion'
@@ -106,6 +106,7 @@ export class DefaultTelemetryClient implements TelemetryClient {
                         AWSProduct: DefaultTelemetryClient.productName,
                         AWSProductVersion: extensionVersion,
                         ClientID: this.clientId,
+                        SessionID: getSessionId(),
                         OS: os.platform(),
                         OSVersion: os.release(),
                         ComputeEnv: await getComputeEnvType(),

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -105,7 +105,9 @@ export function convertLegacy(value: unknown): boolean {
  * - The session ID must be different from all other IDs on the machine
  * - A session ID exists until the application instance is terminated.
  *   It should never be used again after termination.
- * - All extensions on the same application instance should return the same session ID.
+ * - All extensions on the same application instance MUST return the same session ID.
+ *   - This will allow us to know which of our extensions (eg Q vs Toolkit) are in the
+ *     same VS Code window.
  *
  * `vscode.env.sessionId` behaves as described aboved, EXCEPT its
  * value looks close to a UUID by does not exactly match it (has additional characters).
@@ -115,9 +117,11 @@ export function convertLegacy(value: unknown): boolean {
  */
 export const getSessionId = once(() => uuidV5(vscode.env.sessionId, sessionIdNonce))
 /**
- * This is a nonce that is used in creating a v5 UUID for Session ID.
+ * This is an arbitrary nonce that is used in creating a v5 UUID for Session ID. We only
+ * have this since the spec requires it.
  * - This should ONLY be used by {@link getSessionId}.
- * - This should NEVER change
+ * - This value MUST NOT change during runtime, otherwise {@link getSessionId} will lose its
+ *   idempotency. But, if there was a reason to change the value in a PR, it would not be an issue.
  * - This is exported only for testing.
  */
 export const sessionIdNonce = '44cfdb20-b30b-4585-a66c-9f48f24f99b5' as const

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -8,7 +8,7 @@ import { env, version } from 'vscode'
 import * as os from 'os'
 import { getLogger } from '../logger'
 import { fromExtensionManifest, migrateSetting, Settings } from '../settings'
-import { memoize } from '../utilities/functionUtils'
+import { memoize, once } from '../utilities/functionUtils'
 import {
     isInDevEnv,
     extensionVersion,
@@ -28,6 +28,7 @@ import { randomUUID } from '../crypto'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 import { FunctionEntry, type TelemetryTracer } from './spans'
 import { telemetry } from './telemetry'
+import { v5 as uuidV5 } from 'uuid'
 
 const legacySettingsTelemetryValueDisable = 'Disable'
 const legacySettingsTelemetryValueEnable = 'Enable'
@@ -89,6 +90,37 @@ export function convertLegacy(value: unknown): boolean {
         throw new TypeError(`Unknown telemetry setting: ${value}`)
     }
 }
+
+/**
+ * Returns an identifier that uniquely identifies a single application
+ * instance/window of a specific IDE. I.e if I have multiple VS Code
+ * windows open each one will have a unique session ID. This session ID
+ * can be used in conjunction with the client ID to differntiate between
+ * different VS Code windows on a users machine.
+ *
+ * ### Rules:
+ *
+ * - On startup of a new application instance, a new session ID must be created.
+ *   - This identifier must be a `UUID`, it is enforced by the telemetry service.
+ * - The session ID must be different from all other IDs on the machine
+ * - A session ID exists until the application instance is terminated.
+ *   It should never be used again after termination.
+ * - All extensions on the same application instance should return the same session ID.
+ *
+ * `vscode.env.sessionId` behaves as described aboved, EXCEPT its
+ * value looks close to a UUID by does not exactly match it (has additional characters).
+ * As a result we process it through uuidV5 which creates a proper UUID from it.
+ * uuidV5 is idempotent, so as long as `vscode.env.sessionId` returns the same value,
+ * we will get the same UUID.
+ */
+export const getSessionId = once(() => uuidV5(vscode.env.sessionId, sessionIdNonce))
+/**
+ * This is a nonce that is used in creating a v5 UUID for Session ID.
+ * - This should ONLY be used by {@link getSessionId}.
+ * - This should NEVER change
+ * - This is exported only for testing.
+ */
+export const sessionIdNonce = '44cfdb20-b30b-4585-a66c-9f48f24f99b5' as const
 
 /**
  * Calculates the clientId for the current profile. This calculation is performed once

--- a/packages/core/src/test/shared/crypto.test.ts
+++ b/packages/core/src/test/shared/crypto.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { randomUUID } from '../../shared/crypto'
+import { isUUID, randomUUID } from '../../shared/crypto'
 
 describe('crypto', function () {
     describe('randomUUID()', function () {
@@ -24,5 +24,23 @@ describe('crypto', function () {
         it('test pattern fails on non-uuid', function () {
             assert(uuidPattern.test('not-a-uuid') === false)
         })
+    })
+
+    describe('isUUID()', function () {
+        assert.equal(isUUID(''), false)
+        assert.equal(isUUID('not-a-uuid'), false)
+        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971'), false)
+        assert.equal(isUUID('47fe01cf_f37a_4e7c-b971-@10fe5897763'), false)
+        // The '9' in '9e7c' must actually be between 1-5 based on the UUID spec: https://stackoverflow.com/a/38191104
+        assert.equal(isUUID('47fe01cf-f37a-9e7c-b971-d10fe5897763'), false)
+        assert.equal(isUUID(' 47fe01cf-f37a-4e7c-b971-d10fe5897763'), false) // leading whitespace
+        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971-d10fe5897763 '), false) // trailing whitespace
+        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971-d10fe5897763z'), false) // one extra character
+        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971-d10fe5897763 blah'), false) // trailing word
+
+        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971-d10fe5897763'), true)
+        // The telemetry services indicates that per postel's law, uppercase is valid to pass in
+        // as they will lowerCase when necessary.
+        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971-d10fe5897763'.toUpperCase()), true)
     })
 })

--- a/packages/core/src/test/shared/crypto.test.ts
+++ b/packages/core/src/test/shared/crypto.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { isUUID, randomUUID } from '../../shared/crypto'
+import { isUuid, randomUUID } from '../../shared/crypto'
 
 describe('crypto', function () {
     describe('randomUUID()', function () {
@@ -26,21 +26,21 @@ describe('crypto', function () {
         })
     })
 
-    describe('isUUID()', function () {
-        assert.equal(isUUID(''), false)
-        assert.equal(isUUID('not-a-uuid'), false)
-        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971'), false)
-        assert.equal(isUUID('47fe01cf_f37a_4e7c-b971-@10fe5897763'), false)
+    describe('isUuid()', function () {
+        assert.equal(isUuid(''), false)
+        assert.equal(isUuid('not-a-uuid'), false)
+        assert.equal(isUuid('47fe01cf-f37a-4e7c-b971'), false)
+        assert.equal(isUuid('47fe01cf_f37a_4e7c-b971-@10fe5897763'), false)
         // The '9' in '9e7c' must actually be between 1-5 based on the UUID spec: https://stackoverflow.com/a/38191104
-        assert.equal(isUUID('47fe01cf-f37a-9e7c-b971-d10fe5897763'), false)
-        assert.equal(isUUID(' 47fe01cf-f37a-4e7c-b971-d10fe5897763'), false) // leading whitespace
-        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971-d10fe5897763 '), false) // trailing whitespace
-        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971-d10fe5897763z'), false) // one extra character
-        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971-d10fe5897763 blah'), false) // trailing word
+        assert.equal(isUuid('47fe01cf-f37a-9e7c-b971-d10fe5897763'), false)
+        assert.equal(isUuid(' 47fe01cf-f37a-4e7c-b971-d10fe5897763'), false) // leading whitespace
+        assert.equal(isUuid('47fe01cf-f37a-4e7c-b971-d10fe5897763 '), false) // trailing whitespace
+        assert.equal(isUuid('47fe01cf-f37a-4e7c-b971-d10fe5897763z'), false) // one extra character
+        assert.equal(isUuid('47fe01cf-f37a-4e7c-b971-d10fe5897763 blah'), false) // trailing word
 
-        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971-d10fe5897763'), true)
+        assert.equal(isUuid('47fe01cf-f37a-4e7c-b971-d10fe5897763'), true)
         // The telemetry services indicates that per postel's law, uppercase is valid to pass in
         // as they will lowerCase when necessary.
-        assert.equal(isUUID('47fe01cf-f37a-4e7c-b971-d10fe5897763'.toUpperCase()), true)
+        assert.equal(isUuid('47fe01cf-f37a-4e7c-b971-d10fe5897763'.toUpperCase()), true)
     })
 })

--- a/packages/core/src/test/shared/telemetry/util.test.ts
+++ b/packages/core/src/test/shared/telemetry/util.test.ts
@@ -9,8 +9,10 @@ import { Settings } from '../../../shared/settings'
 import {
     convertLegacy,
     getClientId,
+    getSessionId,
     getUserAgent,
     platformPair,
+    sessionIdNonce,
     telemetryClientIdEnvKey,
     TelemetryConfig,
 } from '../../../shared/telemetry/util'
@@ -18,6 +20,7 @@ import { extensionVersion } from '../../../shared/vscode/env'
 import { FakeMemento } from '../../fakeExtensionContext'
 import { GlobalState } from '../../../shared/globalState'
 import { randomUUID } from 'crypto'
+import { isUUID } from '../../../shared/crypto'
 
 describe('TelemetryConfig', function () {
     const settingKey = 'aws.telemetry'
@@ -104,6 +107,19 @@ describe('TelemetryConfig', function () {
                 assert.deepStrictEqual(tryConvert(), scenario.expectedSanitizedValue)
             })
         })
+    })
+})
+
+describe('getSessionId', function () {
+    it('returns a random UUIDv4', function () {
+        const result = getSessionId()
+
+        assert.deepStrictEqual(isUUID(result), true)
+        assert.deepStrictEqual(getSessionId(), result, 'Subsequent call did not return the same UUID')
+    })
+
+    it('nonce is the same as always', function () {
+        assert.deepStrictEqual(sessionIdNonce, '44cfdb20-b30b-4585-a66c-9f48f24f99b5')
     })
 })
 

--- a/packages/core/src/test/shared/telemetry/util.test.ts
+++ b/packages/core/src/test/shared/telemetry/util.test.ts
@@ -20,7 +20,7 @@ import { extensionVersion } from '../../../shared/vscode/env'
 import { FakeMemento } from '../../fakeExtensionContext'
 import { GlobalState } from '../../../shared/globalState'
 import { randomUUID } from 'crypto'
-import { isUUID } from '../../../shared/crypto'
+import { isUuid } from '../../../shared/crypto'
 
 describe('TelemetryConfig', function () {
     const settingKey = 'aws.telemetry'
@@ -111,10 +111,10 @@ describe('TelemetryConfig', function () {
 })
 
 describe('getSessionId', function () {
-    it('returns a random UUIDv4', function () {
+    it('returns a stable UUID', function () {
         const result = getSessionId()
 
-        assert.deepStrictEqual(isUUID(result), true)
+        assert.deepStrictEqual(isUuid(result), true)
         assert.deepStrictEqual(getSessionId(), result, 'Subsequent call did not return the same UUID')
     })
 


### PR DESCRIPTION
### Do not merge until service changes are live

## Problem:

I have filtered all the metrics in Kibana by `clientId: "XXXXXX"`, but if they had multiple IDE windows opened at the same time sending metrics I cannot know which window they are coming from since they share the same clientID.

## Solution:

This adds a new field to the telemetry service  called `sessionId` which uniquely identifies a part of the UI in an IDE window. It is adjacent to `clientId`.

Now in my metrics I will be able to differentiate metrics by their sessionID since they both share the same clientId by design.

## Implementation Details:

Changes in the Telemetry service need to be merged before this change can since they update the endpoint to accept this new field.

The updates of this commit only mirror the upstream, so this process is manual.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
