### PR TITLE
fix(auth): SyntaxError not being considered Network Error

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-54ae3b04-fe8b-40e8-866a-7f9f73f3c7cb.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-54ae3b04-fe8b-40e8-866a-7f9f73f3c7cb.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth: `SyntaxError` causing unexpected SSO logout"
+}

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -299,7 +299,7 @@ export class ChatController {
             errorMessage = e.toUpperCase()
         } else if (e instanceof SyntaxError) {
             // Workaround to handle case when LB returns web-page with error and our client doesn't return proper exception
-            errorMessage = AwsClientResponseError.getReasonFromSyntaxError(e) ?? defaultMessage
+            errorMessage = AwsClientResponseError.tryExtractReasonFromSyntaxError(e) ?? defaultMessage
         } else if (e instanceof CodeWhispererStreamingServiceException) {
             errorMessage = e.message
             requestID = e.$metadata.requestId

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -48,7 +48,7 @@ import { LspController } from '../../../amazonq/lsp/lspController'
 import { CodeWhispererSettings } from '../../../codewhisperer/util/codewhispererSettings'
 import { getSelectedCustomization } from '../../../codewhisperer/util/customizationUtil'
 import { FeatureConfigProvider } from '../../../shared/featureConfig'
-import { getHttpStatusCode, getReasonFromSyntaxError } from '../../../shared/errors'
+import { getHttpStatusCode, AwsClientResponseError } from '../../../shared/errors'
 
 export interface ChatControllerMessagePublishers {
     readonly processPromptChatMessage: MessagePublisher<PromptMessage>
@@ -299,7 +299,7 @@ export class ChatController {
             errorMessage = e.toUpperCase()
         } else if (e instanceof SyntaxError) {
             // Workaround to handle case when LB returns web-page with error and our client doesn't return proper exception
-            errorMessage = getReasonFromSyntaxError(e) ?? defaultMessage
+            errorMessage = AwsClientResponseError.getReasonFromSyntaxError(e) ?? defaultMessage
         } else if (e instanceof CodeWhispererStreamingServiceException) {
             errorMessage = e.message
             requestID = e.$metadata.requestId

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -888,24 +888,22 @@ function isError(err: Error, id: string, messageIncludes: string = '') {
  * Once we extract the real error message from the hidden field `$response.reason` we get messages similar to:
  *  - "SDK Client unexpected error response: data response code: 403, data reason: Forbidden | Unexpected ..."
  */
-export class AwsClientResponseError extends ToolkitError {
-    public static readonly code: string = 'AwsClientResponseError'
-
-    /** Use {@link instanceIf} to create instance. */
+export class AwsClientResponseError extends Error {
+    /** Use {@link isError} to create instance. */
     protected constructor(err: unknown) {
         const underlyingErrorMsg = AwsClientResponseError.tryExtractReasonFromSyntaxError(err)
 
         /**
-         * This condition should never be hit since {@link AwsClientResponseError.instanceIf}
+         * This condition should never be hit since {@link AwsClientResponseError.isError}
          * is the only way to create an instance of this class, due to the constructor not being public.
          *
-         * The following only exists to make the types checker happy.
+         * The following only exists to make the type checker happy.
          */
         if (!(underlyingErrorMsg && err instanceof Error)) {
             throw Error(`Cannot create AwsClientResponseError from ${JSON.stringify(err)}}`)
         }
 
-        super(underlyingErrorMsg, { code: AwsClientResponseError.code, cause: err })
+        super(underlyingErrorMsg)
     }
 
     /**
@@ -922,7 +920,7 @@ export class AwsClientResponseError extends ToolkitError {
     }
 
     /**
-     * Returns the true underlying error message from a SyntaxError, if possible.
+     * Returns the true underlying error message from a `SyntaxError`, if possible.
      * Otherwise returning undefined.
      */
     static tryExtractReasonFromSyntaxError(err: unknown): string | undefined {

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -895,7 +895,13 @@ export class AwsClientResponseError extends ToolkitError {
     protected constructor(err: unknown) {
         const underlyingErrorMsg = AwsClientResponseError.tryExtractReasonFromSyntaxError(err)
 
-        if (!(underlyingErrorMsg && err instanceof SyntaxError)) {
+        /**
+         * This condition should never be hit since {@link AwsClientResponseError.instanceIf}
+         * is the only way to create an instance of this class, due to the constructor not being public.
+         *
+         * The following only exists to make the types checker happy.
+         */
+        if (!(underlyingErrorMsg && err instanceof Error)) {
             throw Error(`Cannot create AwsClientResponseError from ${JSON.stringify(err)}}`)
         }
 

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -885,16 +885,16 @@ function isError(err: Error, id: string, messageIncludes: string = '') {
  *
  * Example SyntaxError message before extracting the underlying issue:
  *  - "Unexpected token '<', "<html><bod"... is not valid JSON Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object."
- * Once we extract the real error message from the hidden field `$response.reason` we get messages similar to:
+ * Once we extract the real error message from the hidden field, `$response.reason`, we get messages similar to:
  *  - "SDK Client unexpected error response: data response code: 403, data reason: Forbidden | Unexpected ..."
  */
 export class AwsClientResponseError extends Error {
-    /** Use {@link isError} to create instance. */
+    /** Use {@link instanceIf} to create instance. */
     protected constructor(err: unknown) {
         const underlyingErrorMsg = AwsClientResponseError.tryExtractReasonFromSyntaxError(err)
 
         /**
-         * This condition should never be hit since {@link AwsClientResponseError.isError}
+         * This condition should never be hit since {@link AwsClientResponseError.instanceIf}
          * is the only way to create an instance of this class, due to the constructor not being public.
          *
          * The following only exists to make the type checker happy.

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -789,11 +789,11 @@ export function isNetworkError(err?: unknown): err is Error & { code: string } {
     if (
         isVSCodeProxyError(err) ||
         isSocketTimeoutError(err) ||
-        isHttpSyntaxError(err) ||
         isEnoentError(err) ||
         isEaccesError(err) ||
         isEbadfError(err) ||
-        isEconnRefusedError(err)
+        isEconnRefusedError(err) ||
+        err instanceof AwsClientResponseError
     ) {
         return true
     }
@@ -848,18 +848,6 @@ function isSocketTimeoutError(err: Error): boolean {
 }
 
 /**
- * Expected JSON response from HTTP request, but got an error HTML error page instead.
- *
- * IMPORTANT:
- *
- * This function is influenced by {@link getReasonFromSyntaxError()} since it modifies the error
- * message with the real underlying reason, instead of the default "Unexpected token" message.
- */
-function isHttpSyntaxError(err: Error): boolean {
-    return isError(err, 'SyntaxError', 'SDK Client unexpected error response')
-}
-
-/**
  * We were seeing errors of ENOENT for the oidc FQDN (eg: oidc.us-east-1.amazonaws.com) during the SSO flow.
  * Our assumption is that this is an intermittent error.
  */
@@ -887,30 +875,62 @@ function isError(err: Error, id: string, messageIncludes: string = '') {
 }
 
 /**
- * AWS SDK clients may rarely make requests that results in something other than JSON data
- * being returned (e.g html). This will cause the client to throw a SyntaxError as a result
+ * AWS SDK clients make requests with the expected result to be JSON data.
+ * But in some cases the request may fail and result in an error HTML page being returned instead
+ * of the JSON. This will cause the client to throw a `SyntaxError` as a result
  * of attempt to deserialize the non-JSON data.
- * While the contents of the response may contain sensitive information, there may be a reason
- * for failure embedded. This function attempts to extract that reason.
  *
- * Example error message before extracting:
+ * But within the `SyntaxError` instance is the real reason for the failure.
+ * This class attempts to extract the underlying issue from the SyntaxError.
+ *
+ * Example SyntaxError message before extracting the underlying issue:
  * "Unexpected token '<', "<html><bod"... is not valid JSON Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object."
- *
- * If the reason cannot be found or the error is not a SyntaxError, return undefined.
  */
-export function getReasonFromSyntaxError(err: Error): string | undefined {
-    if (!(err instanceof SyntaxError)) {
+export class AwsClientResponseError extends ToolkitError {
+    public static readonly code: string = 'AwsClientResponseError'
+
+    /** Use {@link instanceIf} to create instance. */
+    protected constructor(err: unknown) {
+        const underlyingErrorMsg = AwsClientResponseError.getReasonFromSyntaxError(err)
+
+        if (!(underlyingErrorMsg && err instanceof SyntaxError)) {
+            throw Error(`Cannot create AwsClientResponseError from ${JSON.stringify(err)}}`)
+        }
+
+        super(underlyingErrorMsg, { code: AwsClientResponseError.code, cause: err })
+    }
+
+    /**
+     * Resolves an instance of {@link AwsClientResponseError} if the given error matches certain criteria.
+     * Otherwise the original error is returned.
+     */
+    static instanceIf<T>(err: T): AwsClientResponseError | T {
+        if (AwsClientResponseError.getReasonFromSyntaxError(err)) {
+            getLogger().debug(`Creating AwsClientResponseError from SyntaxError: %O`, err)
+            return new AwsClientResponseError(err)
+        }
+        return err
+    }
+
+    /**
+     * Returns the true underlying error message from a SyntaxError, if possible.
+     * Otherwise returning undefined.
+     */
+    static getReasonFromSyntaxError(err: unknown): string | undefined {
+        if (!(err instanceof SyntaxError)) {
+            return undefined
+        }
+
+        // See the class docstring to explain how we know the existence of the following keys
+        if (hasKey(err, '$response')) {
+            const response = err['$response']
+            if (response && hasKey(response, 'reason')) {
+                return response['reason'] as string
+            }
+        }
+
         return undefined
     }
-
-    if (hasKey(err, '$response')) {
-        const response = err['$response']
-        if (response && hasKey(response, 'reason')) {
-            return response['reason'] as string
-        }
-    }
-
-    return undefined
 }
 
 /**

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -525,9 +525,7 @@ describe('util', function () {
         assert(!(responseError instanceof SyntaxError))
         assert(responseError instanceof Error)
         assert(responseError instanceof AwsClientResponseError)
-        assert(responseError.code === AwsClientResponseError.code)
         assert(responseError.message === 'SDK Client unexpected error response: data response code: 500')
-        assert.deepStrictEqual(responseError.cause, syntaxError)
     })
 
     it('scrubNames()', async function () {

--- a/packages/toolkit/.changes/next-release/Bug Fix-48f605af-ae0d-477f-b1bb-1691b64ad96c.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-48f605af-ae0d-477f-b1bb-1691b64ad96c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth: `SyntaxError` causing unexpected SSO logout"
+}


### PR DESCRIPTION
## Problem:

There were some previous changes that caused the existing implementation of a `SyntaxError` to not be considered a Network Error. And during token refresh we were seeing SyntaxErrors still appearing

## Solution:

Create a single class which wraps a `SyntaxError`, called `AwsClientResponseError`. Under the hood of a SyntaxError is the real error that originates from a failed AWS SDK Client response, this is how we determine if it should be an `AwsClientResponseError`. This new class can only be created if given the correct SyntaxError instance to `AwsClientResponseError.instanceIf()`.

Then we can simply check if an error matches by using `instanceif AwsClientResponseError`

Any existing code that was related to this scenario has all been centralized in to the AwsClientResponseError class.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
