### PR TITLE
ci: lintcommit.js regressions

### DIFF
--- a/.github/workflows/lintcommit.js
+++ b/.github/workflows/lintcommit.js
@@ -11,7 +11,6 @@
 //
 
 const fs = require('fs')
-const { parsePRTitle } = require('./utils')
 // This script intentionally avoids github APIs so that:
 //   1. it is locally-debuggable
 //   2. the CI job is fast ("npm install" is slow)
@@ -69,7 +68,20 @@ void scopes
  * Returns undefined if `title` is valid, else an error message.
  */
 function validateTitle(title) {
-    const { type, scope, subject } = parsePRTitle(title)
+    const parts = title.split(':')
+    const subject = parts.slice(1).join(':').trim()
+
+    if (title.startsWith('Merge')) {
+        return undefined
+    }
+
+    if (parts.length < 2) {
+        return 'missing colon (:) char'
+    }
+
+    const typeScope = parts[0]
+
+    const [type, scope] = typeScope.split(/\(([^)]+)\)$/)
 
     if (/\s+/.test(type)) {
         return `type contains whitespace: "${type}"`

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -4,6 +4,7 @@
 name: Notifications
 
 on:
+    # `pull_request_target` (as opposed to `pull_request`) gives permissions to comment on PRs.
     pull_request_target:
         branches: [master, feature/*, staging]
         # Default = opened + synchronize + reopened.

--- a/.github/workflows/notify.js
+++ b/.github/workflows/notify.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const { parsePRTitle, hasPath, dedupComment } = require('./utils')
+const { hasPath, dedupComment } = require('./utils')
 
 const testFilesMessage =
     'This pull request modifies files in src/ but no tests were added/updated. Confirm whether tests should be added or ensure the PR description explains why tests are not required.'
@@ -59,8 +59,7 @@ module.exports = async ({ github, context }) => {
  */
 function requiresChangelogMessage(filenames, title) {
     try {
-        const { type } = parsePRTitle(title)
-        return !hasPath(filenames, '.changes') && (type === 'fix' || type === 'feat')
+        return !hasPath(filenames, '.changes') && (title.startsWith('fix') || title.startsWith('feat'))
     } catch (e) {
         console.log(e)
         return undefined

--- a/.github/workflows/utils.js
+++ b/.github/workflows/utils.js
@@ -3,28 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-function parsePRTitle(title) {
-    const parts = title.split(':')
-    const subject = parts.slice(1).join(':').trim()
-
-    if (title.startsWith('Merge')) {
-        return undefined
-    }
-
-    if (parts.length < 2) {
-        return 'missing colon (:) char'
-    }
-
-    const typeScope = parts[0]
-
-    const [type, scope] = typeScope.split(/\(([^)]+)\)$/)
-    return {
-        type,
-        scope,
-        subject,
-    }
-}
-
 /**
  * Create a comment on a PR if one does not already exist
  */
@@ -49,7 +27,6 @@ function hasPath(filenames, path) {
 }
 
 module.exports = {
-    parsePRTitle,
     dedupComment,
     hasPath,
 }


### PR DESCRIPTION
Problem:
Since 8e34c5e650f3, `node lintcommit.js test` fails various tests and CI fails for those cases too:

    /home/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/.github/workflows/lintcommit.js:80
        } else if (!scope && typeScope.includes('(')) {

Solution:
Revert the changes from 8e34c5e650f3. It's good to avoid code duplication, but in this case `parsePRTitle()` is not the right abstraction:
- it doesn't signal failures in a way that is handled by callers
- its return type is awkward (`undefined | string | object`)
- notify.js doesn't actually need `parsePRTitle`, it only needs to check `startsWith()`.

