### PR TITLE
telemetry(auth): snooze techdebt and add telemetry for evaluation

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -579,6 +579,7 @@ export class Auth implements AuthService, ConnectionManager {
                     : undefined
             span.record({
                 action: 'updateConnectionState',
+                id,
                 connectionState,
                 source: asStringifiedStack(telemetry.getFunctionStack()),
                 credentialStartUrl: oldProfile.type === 'sso' ? oldProfile.startUrl : undefined,

--- a/packages/core/src/auth/connection.ts
+++ b/packages/core/src/auth/connection.ts
@@ -282,15 +282,15 @@ export class ProfileStore {
     public async addProfile(id: string, profile: IamProfile): Promise<StoredProfile<IamProfile>>
     @withTelemetryContext({ name: 'addProfile', class: profileStoreClassName })
     public async addProfile(id: string, profile: Profile): Promise<StoredProfile> {
-        return telemetry.auth_modifyConnection.run(async () => {
-            telemetry.record({
+        return telemetry.auth_modifyConnection.run(async (span) => {
+            span.record({
                 action: 'addProfile',
                 id,
                 source: asStringifiedStack(telemetry.getFunctionStack()),
             })
 
             const newProfile = this.initMetadata(profile)
-            telemetry.record(getTelemetryForProfile(newProfile))
+            span.record(getTelemetryForProfile(newProfile))
 
             return await this.putProfile(id, newProfile)
         })
@@ -298,8 +298,8 @@ export class ProfileStore {
 
     @withTelemetryContext({ name: 'updateProfile', class: profileStoreClassName })
     public async updateProfile(id: string, profile: Profile): Promise<StoredProfile> {
-        return telemetry.auth_modifyConnection.run(async () => {
-            telemetry.record({
+        return telemetry.auth_modifyConnection.run(async (span) => {
+            span.record({
                 action: 'updateProfile',
                 id,
                 source: asStringifiedStack(telemetry.getFunctionStack()),
@@ -311,7 +311,7 @@ export class ProfileStore {
             }
 
             const newProfile = await this.putProfile(id, { ...oldProfile, ...profile })
-            telemetry.record(getTelemetryForProfile(newProfile))
+            span.record(getTelemetryForProfile(newProfile))
             return newProfile
         })
     }
@@ -324,15 +324,15 @@ export class ProfileStore {
 
     @withTelemetryContext({ name: 'deleteProfile', class: profileStoreClassName })
     public async deleteProfile(id: string): Promise<void> {
-        return telemetry.auth_modifyConnection.run(async () => {
-            telemetry.record({
+        return telemetry.auth_modifyConnection.run(async (span) => {
+            span.record({
                 action: 'deleteProfile',
                 id,
                 source: asStringifiedStack(telemetry.getFunctionStack()),
             })
 
             const data = this.getData()
-            telemetry.record(getTelemetryForProfile(data[id]))
+            span.record(getTelemetryForProfile(data[id]))
             delete (data as Mutable<typeof data>)[id]
 
             await this.updateData(data)

--- a/packages/core/src/auth/connection.ts
+++ b/packages/core/src/auth/connection.ts
@@ -489,11 +489,13 @@ export interface AwsConnection {
 }
 
 type Writeable<T> = { -readonly [U in keyof T]: T[U] }
-export type TelemetryMetadata = Partial<Writeable<AuthAddConnection | AwsLoginWithBrowser>>
+export type TelemetryMetadata = Partial<Writeable<AuthAddConnection & AwsLoginWithBrowser & AuthModifyConnection>>
 
 export async function getTelemetryMetadataForConn(conn?: Connection): Promise<TelemetryMetadata> {
     if (conn === undefined) {
-        return {}
+        return {
+            id: 'undefined',
+        }
     }
 
     if (isSsoConnection(conn)) {

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -270,7 +270,6 @@ export class SecondaryAuth<T extends Connection = Connection> {
                 const conn = this.#savedConnection
                 if (conn) {
                     telemetry.record({
-                        id: conn.id,
                         connectionState: this.auth.getConnectionState(conn),
                         ...(await getTelemetryMetadataForConn(conn)),
                     })

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -256,8 +256,8 @@ export class SecondaryAuth<T extends Connection = Connection> {
     @withTelemetryContext({ name: 'restoreConnection', class: secondaryAuthClassName })
     private async _restoreConnection(): Promise<T | undefined> {
         try {
-            return await telemetry.auth_modifyConnection.run(async () => {
-                telemetry.record({
+            return await telemetry.auth_modifyConnection.run(async (span) => {
+                span.record({
                     source: asStringifiedStack(telemetry.getFunctionStack()),
                     action: 'restore',
                     id: 'undefined',
@@ -269,7 +269,7 @@ export class SecondaryAuth<T extends Connection = Connection> {
 
                 const conn = this.#savedConnection
                 if (conn) {
-                    telemetry.record({
+                    span.record({
                         connectionState: this.auth.getConnectionState(conn),
                         ...(await getTelemetryMetadataForConn(conn)),
                     })

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -260,13 +260,22 @@ export class SecondaryAuth<T extends Connection = Connection> {
                 telemetry.record({
                     source: asStringifiedStack(telemetry.getFunctionStack()),
                     action: 'restore',
+                    id: 'undefined',
                     connectionState: 'undefined',
                 })
                 await this.auth.tryAutoConnect()
                 this.#savedConnection = await this._loadSavedConnection()
                 this.#onDidChangeActiveConnection.fire(this.activeConnection)
 
-                telemetry.record(await getTelemetryMetadataForConn(this.#savedConnection))
+                const conn = this.#savedConnection
+                if (conn) {
+                    telemetry.record({
+                        id: conn.id,
+                        connectionState: this.auth.getConnectionState(conn),
+                        ...(await getTelemetryMetadataForConn(conn)),
+                    })
+                }
+
                 return this.#savedConnection
             })
         } catch (err) {

--- a/packages/core/src/codecatalyst/activation.ts
+++ b/packages/core/src/codecatalyst/activation.ts
@@ -58,10 +58,9 @@ export async function activate(ctx: ExtContext): Promise<void> {
                     const conn = authProvider.activeConnection
                     telemetry.record({
                         action: 'forget',
-                        id: conn?.id ?? 'undefined',
                         source: asStringifiedStack(telemetry.getFunctionStack()),
                         connectionState: conn ? authProvider.auth.getConnectionState(conn) : undefined,
-                        ...getTelemetryMetadataForConn(conn),
+                        ...(await getTelemetryMetadataForConn(conn)),
                     })
 
                     await authProvider.secondaryAuth.forgetConnection()

--- a/packages/core/src/codecatalyst/activation.ts
+++ b/packages/core/src/codecatalyst/activation.ts
@@ -25,8 +25,10 @@ import { getLogger } from '../shared/logger/logger'
 import { DevEnvActivityStarter } from './devEnv'
 import { learnMoreCommand, onboardCommand, reauth } from './explorer'
 import { isInDevEnv } from '../shared/vscode/env'
-import { hasScopes, scopesCodeWhispererCore } from '../auth/connection'
+import { hasScopes, scopesCodeWhispererCore, getTelemetryMetadataForConn } from '../auth/connection'
 import { SessionSeparationPrompt } from '../auth/auth'
+import { telemetry } from '../shared/telemetry/telemetry'
+import { asStringifiedStack } from '../shared/telemetry/spans'
 
 const localize = nls.loadMessageBundle()
 
@@ -50,8 +52,24 @@ export async function activate(ctx: ExtContext): Promise<void> {
     // Note: credentials on disk in the dev env cannot have Q scopes, so it will never be forgotten.
     // TODO: Remove after some time?
     if (authProvider.isConnected() && hasScopes(authProvider.activeConnection!, scopesCodeWhispererCore)) {
-        await authProvider.secondaryAuth.forgetConnection()
-        await SessionSeparationPrompt.instance.showForCommand('aws.codecatalyst.manageConnections')
+        await telemetry.function_call.run(
+            async () => {
+                await telemetry.auth_modifyConnection.run(async () => {
+                    const conn = authProvider.activeConnection
+                    telemetry.record({
+                        action: 'forget',
+                        id: conn?.id ?? 'undefined',
+                        source: asStringifiedStack(telemetry.getFunctionStack()),
+                        connectionState: conn ? authProvider.auth.getConnectionState(conn) : undefined,
+                        ...getTelemetryMetadataForConn(conn),
+                    })
+
+                    await authProvider.secondaryAuth.forgetConnection()
+                    await SessionSeparationPrompt.instance.showForCommand('aws.codecatalyst.manageConnections')
+                })
+            },
+            { emit: false, functionId: { name: 'activate', class: 'CodeCatalyst' } }
+        )
     }
 
     ctx.extensionContext.subscriptions.push(

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -472,6 +472,7 @@ export class AuthUtil {
             await telemetry.auth_modifyConnection.run(
                 async () => {
                     telemetry.record({
+                        id: conn.id,
                         connectionState: Auth.instance.getConnectionState(conn) ?? 'undefined',
                         source: asStringifiedStack(telemetry.getFunctionStack()),
                         ...(await getTelemetryMetadataForConn(conn)),

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -472,7 +472,6 @@ export class AuthUtil {
             await telemetry.auth_modifyConnection.run(
                 async () => {
                     telemetry.record({
-                        id: conn.id,
                         connectionState: Auth.instance.getConnectionState(conn) ?? 'undefined',
                         source: asStringifiedStack(telemetry.getFunctionStack()),
                         ...(await getTelemetryMetadataForConn(conn)),

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1074,7 +1074,7 @@
                 },
                 {
                     "type": "connectionState",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "credentialStartUrl",
@@ -1094,6 +1094,10 @@
                 },
                 {
                     "type": "ssoRegistrationExpiresAt",
+                    "required": false
+                },
+                {
+                    "type": "id",
                     "required": false
                 }
             ],

--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -56,10 +56,25 @@ describe('Auth', function () {
         assert.strictEqual((await auth.listConnections()).length, 0)
         assertTelemetry('auth_modifyConnection', [
             {
+                action: 'addProfile',
+                connectionState: 'unauthenticated',
+                source: 'Auth#createConnection:ProfileStore#addProfile',
+            },
+            {
+                action: 'getProfile',
+                connectionState: 'unauthenticated',
+                source: 'Auth#createConnection,updateConnectionState:ProfileStore#getProfileOrThrow',
+            },
+            {
                 action: 'updateConnectionState',
                 connectionState: 'valid',
                 source: 'Auth#createConnection,updateConnectionState',
                 sessionDuration: undefined,
+            },
+            {
+                action: 'getProfile',
+                connectionState: 'valid',
+                source: 'Auth#deleteConnection,invalidateConnection:ProfileStore#getProfileOrThrow',
             },
             {
                 action: 'updateConnectionState',
@@ -79,10 +94,25 @@ describe('Auth', function () {
         assert.strictEqual(auth.activeConnection, undefined)
         assertTelemetry('auth_modifyConnection', [
             {
+                action: 'addProfile',
+                connectionState: 'unauthenticated',
+                source: 'Auth#createConnection:ProfileStore#addProfile',
+            },
+            {
+                action: 'getProfile',
+                connectionState: 'unauthenticated',
+                source: 'Auth#createConnection,updateConnectionState:ProfileStore#getProfileOrThrow',
+            },
+            {
                 action: 'updateConnectionState',
                 connectionState: 'valid',
                 source: 'Auth#createConnection,updateConnectionState',
                 sessionDuration: undefined,
+            },
+            {
+                action: 'getProfile',
+                connectionState: 'valid',
+                source: 'Auth#useConnection,refreshConnectionState,validateConnection,updateConnectionState:ProfileStore#getProfileOrThrow',
             },
             {
                 action: 'updateConnectionState',
@@ -114,10 +144,25 @@ describe('Auth', function () {
         assert.strictEqual(auth.activeConnectionEvents.last, undefined)
         assertTelemetry('auth_modifyConnection', [
             {
+                action: 'addProfile',
+                connectionState: 'unauthenticated',
+                source: 'Auth#createConnection:ProfileStore#addProfile',
+            },
+            {
+                action: 'getProfile',
+                connectionState: 'unauthenticated',
+                source: 'Auth#createConnection,updateConnectionState:ProfileStore#getProfileOrThrow',
+            },
+            {
                 action: 'updateConnectionState',
                 connectionState: 'valid',
                 source: 'Auth#createConnection,updateConnectionState',
                 sessionDuration: undefined,
+            },
+            {
+                action: 'getProfile',
+                connectionState: 'valid',
+                source: 'Auth#useConnection,refreshConnectionState,validateConnection,updateConnectionState:ProfileStore#getProfileOrThrow',
             },
             {
                 action: 'updateConnectionState',

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -49,7 +49,11 @@ describe('tech debt', function () {
     it('remove separate sessions login edge cases', async function () {
         // src/auth/auth.ts:SessionSeparationPrompt
         // forgetConnection() function and calls
-        fixByDate('2024-08-30', 'Remove the edge case code from the commit that this test is a part of.')
+
+        // Monitor telemtry to determine removal or snooze
+        // toolkit_showNotification.id = sessionSeparation
+        // auth_modifyConnection.action = deleteProfile OR auth_modifyConnection.source contains CodeCatalyst
+        fixByDate('2024-9-30', 'Remove the edge case code from the commit that this test is a part of.')
     })
 
     it('remove deprecated code transform metrics', async function () {


### PR DESCRIPTION
We are still getting hits in telemetry for users seeing the split session notification. Adding more fine-grained telemetry to determined if this users are still migrating. This telemetry will also help us track other auth issues.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
