### PR TITLE
perf(toolkit): add additional metrics for measuring performance

### DIFF
--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -228,6 +228,7 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
                     systemCpuUsage: performanceMetrics.systemCpuUsage,
                     heapTotal: performanceMetrics.heapTotal,
                     functionName: this.#options.functionId?.name ?? this.name,
+                    architecture: process.arch,
                 } as any)
             }
         }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -300,6 +300,21 @@
             "name": "webviewName",
             "type": "string",
             "description": "The name of the webview"
+        },
+        {
+            "name": "architecture",
+            "type": "string",
+            "description": "The CPU architecture"
+        },
+        {
+            "name": "totalFileSizeInMB",
+            "type": "int",
+            "description": "The total size of all files being sent to Amazon Q"
+        },
+        {
+            "name": "totalFiles",
+            "type": "int",
+            "description": "The total number of files being sent to Amazon Q"
         }
     ],
     "metrics": [
@@ -1110,15 +1125,27 @@
             "metadata": [
                 {
                     "type": "userCpuUsage",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "systemCpuUsage",
-                    "required": true
+                    "required": false
+                },
+                {
+                    "type": "totalFiles",
+                    "required": false
+                },
+                {
+                    "type": "totalFileSizeInMB",
+                    "required": false
+                },
+                {
+                    "type": "architecture",
+                    "required": false
                 },
                 {
                     "type": "heapTotal",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "functionName",

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -350,8 +350,9 @@ export async function collectFiles(
                     new vscode.RelativePattern(rootPath, '**'),
                     getExcludePattern()
                 )
-                totalFiles += allFiles.length
+
                 const files = respectGitIgnore ? await filterOutGitignoredFiles(rootPath, allFiles) : allFiles
+                totalFiles += files.length
 
                 for (const file of files) {
                     const relativePath = getWorkspaceRelativePath(file.fsPath, { workspaceFolders })

--- a/packages/core/src/testInteg/globalSetup.test.ts
+++ b/packages/core/src/testInteg/globalSetup.test.ts
@@ -15,6 +15,7 @@ import * as sinon from 'sinon'
 import * as tokenProvider from '../auth/sso/ssoAccessTokenProvider'
 import * as testUtil from '../test/testUtil'
 import { DeviceFlowAuthorization } from '../auth/sso/ssoAccessTokenProvider'
+import { globals } from '../shared'
 
 // ASSUMPTION: Tests are not run concurrently
 
@@ -57,6 +58,10 @@ export async function mochaGlobalTeardown(this: Mocha.Context) {
 }
 
 export const mochaHooks = {
+    beforeEach(this: Mocha.Context) {
+        globals.telemetry.clearRecords()
+        globals.telemetry.logger.clear()
+    },
     afterEach(this: Mocha.Context) {
         patchWindow()
     },

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -18,7 +18,7 @@ import {
 import { getTestWorkspaceFolder } from '../../integrationTestsUtilities'
 import globals from '../../../shared/extensionGlobals'
 import { CodelensRootRegistry } from '../../../shared/fs/codelensRootRegistry'
-import { createTestWorkspace, createTestWorkspaceFolder, toFile } from '../../../test/testUtil'
+import { assertTelemetry, createTestWorkspace, createTestWorkspaceFolder, toFile } from '../../../test/testUtil'
 import sinon from 'sinon'
 
 describe('findParentProjectFile', async function () {
@@ -297,6 +297,12 @@ describe('collectFiles', function () {
             ] satisfies typeof result,
             result
         )
+
+        assertTelemetry('function_call', {
+            totalFiles: 13,
+            totalFileSizeInMB: 0.0002593994140625,
+            functionName: 'collectFiles',
+        })
     })
 
     it('does not return license files', async function () {

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -299,7 +299,7 @@ describe('collectFiles', function () {
         )
 
         assertTelemetry('function_call', {
-            totalFiles: 13,
+            totalFiles: 8,
             totalFileSizeInMB: 0.0002593994140625,
             functionName: 'collectFiles',
         })


### PR DESCRIPTION
## Problem
- Right now we can't really corelate cpuusage to anything because we don't know how big users projects are (file size or total files)

## Solution
- Add additional metrics for file size and total file count


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
