### PR TITLE
telemetry(amazonq): Add webview load metric for amazonq

### DIFF
--- a/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
+++ b/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
@@ -36,7 +36,7 @@ export function dispatchWebViewMessagesToApps(
         if (msg.type === 'error') {
             const event = msg.event === 'webview_load' ? telemetry.webview_load : telemetry.webview_error
             event.emit({
-                webviewName: 'amazonq',
+                webviewName: 'amazonqChat',
                 result: 'Failed',
                 reasonDesc: msg.errorMessage,
             })

--- a/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
+++ b/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
@@ -33,6 +33,16 @@ export function dispatchWebViewMessagesToApps(
             return
         }
 
+        if (msg.type === 'error') {
+            const event = msg.event === 'webview_load' ? telemetry.webview_load : telemetry.webview_error
+            event.emit({
+                webviewName: 'amazonq',
+                result: 'Failed',
+                reasonDesc: msg.errorMessage,
+            })
+            return
+        }
+
         const appMessagePublisher = webViewToAppsMessagePublishers.get(msg.tabType)
         if (appMessagePublisher === undefined) {
             return

--- a/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
+++ b/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
@@ -8,12 +8,31 @@ import { MessagePublisher } from '../../messages/messagePublisher'
 import { MessageListener } from '../../messages/messageListener'
 import { TabType } from '../ui/storages/tabsStorage'
 import { getLogger } from '../../../shared/logger'
+import { amazonqMark } from '../../../shared/performance/marks'
+import { telemetry } from '../../../shared/telemetry'
 
 export function dispatchWebViewMessagesToApps(
     webview: Webview,
     webViewToAppsMessagePublishers: Map<TabType, MessagePublisher<any>>
 ) {
     webview.onDidReceiveMessage((msg) => {
+        if (msg.command === 'ui-is-ready') {
+            /**
+             * ui-is-ready isn't associated to any tab so just record the telemetry event and continue.
+             * This would be equivalent of the duration between "user clicked open q" and "ui has become available"
+             * NOTE: Amazon Q UI is only loaded ONCE. The state is saved between each hide/show of the webview.
+             */
+
+            telemetry.webview_load.emit({
+                webviewName: 'amazonq',
+                duration: performance.measure(amazonqMark.uiReady, amazonqMark.open).duration,
+                result: 'Succeeded',
+            })
+            performance.clearMarks(amazonqMark.uiReady)
+            performance.clearMarks(amazonqMark.open)
+            return
+        }
+
         const appMessagePublisher = webViewToAppsMessagePublishers.get(msg.tabType)
         if (appMessagePublisher === undefined) {
             return

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -64,7 +64,7 @@ export class Connector {
     private readonly tabsStorage
     private readonly amazonqCommonsConnector: AmazonQCommonsConnector
 
-    private isUIReady = false
+    isUIReady = false
 
     constructor(props: ConnectorProps) {
         this.sendMessageToExtension = props.sendMessageToExtension

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -22,6 +22,16 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
     let mynahUI: MynahUI
     // eslint-disable-next-line prefer-const
     let connector: Connector
+
+    window.addEventListener('error', (e) => {
+        const { error, message } = e
+        ideApi.postMessage({
+            type: 'error',
+            event: connector.isUIReady ? 'webview_error' : 'webview_load',
+            errorMessage: error ? error.toString() : message,
+        })
+    })
+
     const tabsStorage = new TabsStorage({
         onTabTimeout: (tabID) => {
             mynahUI.addChatItem(tabID, {

--- a/packages/core/src/amazonq/webview/webView.ts
+++ b/packages/core/src/amazonq/webview/webView.ts
@@ -21,6 +21,7 @@ import { MessagePublisher } from '../messages/messagePublisher'
 import { TabType } from './ui/storages/tabsStorage'
 import { deactivateInitialViewBadge, shouldShowBadge } from '../util/viewBadgeHandler'
 import { telemetry } from '../../shared/telemetry/telemetry'
+import { amazonqMark } from '../../shared/performance/marks'
 
 export class AmazonQChatViewProvider implements WebviewViewProvider {
     public static readonly viewType = 'aws.AmazonQChatView'
@@ -63,6 +64,8 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
             this.extensionContext.extensionUri,
             webviewView.webview
         )
+
+        performance.mark(amazonqMark.open)
 
         // badge is shown, emit telemetry for first time an existing, unscoped user tries Q
         // note: this will fire on any not-properly-scoped Q entry.

--- a/packages/core/src/shared/performance/marks.ts
+++ b/packages/core/src/shared/performance/marks.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const amazonqMark = {
+    open: 'amazonq/webview/open',
+    uiReady: 'amazonq/webview/uiReady',
+}

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1133,6 +1133,16 @@
                     "required": true
                 }
             ]
+        },
+        {
+            "name": "webview_error",
+            "description": "Represents an error that occurs in a webview",
+            "metadata": [
+                {
+                    "type": "webviewName",
+                    "required": true
+                }
+            ]
         }
     ]
 }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -295,6 +295,11 @@
             "name": "functionName",
             "type": "string",
             "description": "The name of the function"
+        },
+        {
+            "name": "webviewName",
+            "type": "string",
+            "description": "The name of the webview"
         }
     ],
     "metrics": [
@@ -1118,6 +1123,16 @@
             ],
             "passive": true,
             "trackPerformance": true
+        },
+        {
+            "name": "webview_load",
+            "description": "Represents a webview load event",
+            "metadata": [
+                {
+                    "type": "webviewName",
+                    "required": true
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Problem
- We have no detailed information on how long the amazonq webview took for first meaningful paint
- We have no way to keep track whether or not webviews fail to load or any error events are that emitted


## Solution
- The onready event gets fired when "UI is initialized and rendered". See https://github.com/aws/mynah-ui/blob/main/docs/PROPERTIES.md#onready
- Listen to error events on the window and forward them to the vscode side

## I'm trying to answer the following questions with these metrics :
- How long are webviews taking to load?
- How long until they're interactive?
- What errors are occurring in the webview?

TODO:
- tests (if I even can?)
- move webview events to commons repo

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
