### PR TITLE
feat(amazonq): Reduce @workspace indexing time by 50% 

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-d4728cdd-22be-4255-b5e9-4d897a646782.json
+++ b/packages/amazonq/.changes/next-release/Feature-d4728cdd-22be-4255-b5e9-4d897a646782.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Reduce workspace CPU indexing time by 50%"
+}

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -67,7 +67,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.4']
+const supportedLspServerVersions = ['0.1.5']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 /*


### PR DESCRIPTION
## Problem

The indexing of @workspace feature is slow.

## Solution

By upgrading ONNX version from 1.18 to 1.19 in the 0.1.5 LSP, we observed reduction in indexing time by about 50% when using CPU for index. There is no improvement when using GPU or AMD CPU on Windows. There is no customer facing change or customer experience change. 



---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
