### PR TITLE
fix(amazonq): telemetry updates

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,18 +24,18 @@
         "onFileSystem:s3",
         "onFileSystem:s3-readonly"
     ],
-    "main": "./dist/src/extension.js",
+    "main": "./dist/src/extensionNode.js",
     "browser": "./dist/src/extensionWebCore.js",
     "exports": {
         ".": "./dist/src/extension.js",
+        "./node": "./dist/src/extensionNode.js",
         "./web": "./dist/src/extensionWeb.js",
         "./webShared": "./dist/src/extensionWebShared.js",
-        "./extensionCommon": "./dist/src/extensionCommon.js",
-        "./common": "./dist/src/common/index.js",
         "./amazonq": "./dist/src/amazonq/index.js",
         "./codewhisperer": "./dist/src/codewhisperer/index.js",
-        "./codewhispererCommon": "./dist/src/codewhisperer/indexCommon.js",
+        "./codewhisperer/node": "./dist/src/codewhisperer/indexNode.js",
         "./shared": "./dist/src/shared/index.js",
+        "./sharedNode": "./dist/src/shared/indexNode.js",
         "./auth": "./dist/src/auth/index.js",
         "./amazonqGumby": "./dist/src/amazonqGumby/index.js",
         "./amazonqFeatureDev": "./dist/src/amazonqFeatureDev/index.js",
@@ -4015,11 +4015,10 @@
         }
     },
     "scripts": {
-        "postinstall": "npm run generateTelemetry && npm run generateConfigurationAttributes && npm run compile",
-        "generateConfigurationAttributes": "ts-node ./scripts/build/generateConfigurationAttributes.ts",
+        "postinstall": "npm run generateTelemetry && npm run compile",
         "clean": "ts-node ../../scripts/clean.ts dist/",
         "copyFiles": "ts-node ./scripts/build/copyFiles.ts",
-        "buildScripts": "npm run generateClients && npm run generatePackage && npm run copyFiles",
+        "buildScripts": "npm run generateClients && npm run generateIcons && npm run copyFiles",
         "compile": "npm run testCompile && webpack",
         "compileOnly": "tsc -p ./",
         "compileDev": "npm run compile -- --mode development",
@@ -4033,7 +4032,7 @@
         "testInteg": "npm run testCompile && c8 ts-node ./scripts/test/testInteg.ts",
         "lint": "ts-node ./scripts/lint/testLint.ts",
         "generateClients": "ts-node ./scripts/build/generateServiceClient.ts ",
-        "generatePackage": "ts-node ./scripts/build/generateIcons.ts",
+        "generateIcons": "ts-node ../../scripts/generateIcons.ts",
         "generateTelemetry": "node ../../node_modules/@aws-toolkits/telemetry/lib/generateTelemetry.js --extraInput=src/shared/telemetry/vscodeTelemetry.json --output=src/shared/telemetry/telemetry.gen.ts"
     },
     "scriptsComments": {
@@ -4045,7 +4044,6 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws-toolkits/telemetry": "^1.0.216",
         "@aws/fully-qualified-names": "^2.1.4",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
@@ -4113,7 +4111,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.15.2",
+        "@aws/mynah-ui": "^4.15.8",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -119,7 +119,7 @@ async function validateJavaHome(): Promise<boolean> {
     if (javaVersionUsedByMaven !== transformByQState.getSourceJDKVersion()) {
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-            codeTransformPreValidationError: 'ProjectJDKDiffersFromMavenJDK',
+            codeTransformPreValidationError: 'ProjectJDKDiffersFromBuildSystemJDK',
             result: MetadataResult.Fail,
             reason: `${transformByQState.getSourceJDKVersion()} (project) - ${javaVersionUsedByMaven} (maven)`,
         })

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -118,19 +118,10 @@ export async function uploadArtifactToS3(
             Math.round(uploadFileByteSize / 1000)
         )
 
-        const apiStartTime = Date.now()
         const response = await request.fetch('PUT', resp.uploadUrl, {
             body: buffer,
             headers: getHeadersObj(sha256, resp.kmsKeyArn),
         }).response
-        telemetry.codeTransform_logApiLatency.emit({
-            codeTransformApiNames: 'UploadZip',
-            codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-            codeTransformUploadId: resp.uploadId,
-            codeTransformRunTimeLatency: calculateTotalLatency(apiStartTime),
-            codeTransformTotalByteSize: uploadFileByteSize,
-            result: MetadataResult.Pass,
-        })
         getLogger().info(`CodeTransformation: Status from S3 Upload = ${response.status}`)
     } catch (e: any) {
         let errorMessage = `The upload failed due to: ${
@@ -152,20 +143,11 @@ export async function uploadArtifactToS3(
 
 export async function resumeTransformationJob(jobId: string, userActionStatus: TransformationUserActionStatus) {
     try {
-        const apiStartTime = Date.now()
         const response = await codeWhisperer.codeWhispererClient.codeModernizerResumeTransformation({
             transformationJobId: jobId,
             userActionStatus, // can be "COMPLETED" or "REJECTED"
         })
         if (response) {
-            telemetry.codeTransform_logApiLatency.emit({
-                codeTransformApiNames: 'ResumeTransformation',
-                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                codeTransformJobId: jobId,
-                codeTransformRunTimeLatency: calculateTotalLatency(apiStartTime),
-                codeTransformRequestId: response.$response.requestId,
-                result: MetadataResult.Pass,
-            })
             // always store request ID, but it will only show up in a notification if an error occurs
             return response.transformationStatus
         }
@@ -205,7 +187,6 @@ export async function uploadPayload(payloadFileName: string, uploadContext?: Upl
     throwIfCancelled()
     let response = undefined
     try {
-        const apiStartTime = Date.now()
         response = await codeWhisperer.codeWhispererClient.createUploadUrl({
             contentChecksum: sha256,
             contentChecksumType: CodeWhispererConstants.contentChecksumType,
@@ -215,14 +196,6 @@ export async function uploadPayload(payloadFileName: string, uploadContext?: Upl
         if (response.$response.requestId) {
             transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
         }
-        telemetry.codeTransform_logApiLatency.emit({
-            codeTransformApiNames: 'CreateUploadUrl',
-            codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-            codeTransformRunTimeLatency: calculateTotalLatency(apiStartTime),
-            codeTransformUploadId: response.uploadId,
-            codeTransformRequestId: response.$response.requestId,
-            result: MetadataResult.Pass,
-        })
     } catch (e: any) {
         const errorMessage = `The upload failed due to: ${(e as Error).message}`
         getLogger().error(`CodeTransformation: CreateUploadUrl error: = ${e}`)
@@ -421,7 +394,6 @@ export async function startJob(uploadId: string) {
     const sourceLanguageVersion = `JAVA_${transformByQState.getSourceJDKVersion()}`
     const targetLanguageVersion = `JAVA_${transformByQState.getTargetJDKVersion()}`
     try {
-        const apiStartTime = Date.now()
         const response = await codeWhisperer.codeWhispererClient.codeModernizerStartCodeTransformation({
             workspaceState: {
                 uploadId: uploadId,
@@ -436,14 +408,6 @@ export async function startJob(uploadId: string) {
         if (response.$response.requestId) {
             transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
         }
-        telemetry.codeTransform_logApiLatency.emit({
-            codeTransformApiNames: 'StartTransformation',
-            codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-            codeTransformRunTimeLatency: calculateTotalLatency(apiStartTime),
-            codeTransformJobId: response.transformationJobId,
-            codeTransformRequestId: response.$response.requestId,
-            result: MetadataResult.Pass,
-        })
         return response.transformationJobId
     } catch (e: any) {
         const errorMessage = `Starting the job failed due to: ${(e as Error).message}`
@@ -560,18 +524,9 @@ export async function getTransformationPlan(jobId: string) {
         response = await codeWhisperer.codeWhispererClient.codeModernizerGetCodeTransformationPlan({
             transformationJobId: jobId,
         })
-        const apiStartTime = Date.now()
         if (response.$response.requestId) {
             transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
         }
-        telemetry.codeTransform_logApiLatency.emit({
-            codeTransformApiNames: 'GetTransformationPlan',
-            codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-            codeTransformJobId: jobId,
-            codeTransformRunTimeLatency: calculateTotalLatency(apiStartTime),
-            codeTransformRequestId: response.$response.requestId,
-            result: MetadataResult.Pass,
-        })
 
         const stepZeroProgressUpdates = response.transformationPlan.transformationSteps[0].progressUpdates
 
@@ -623,21 +578,12 @@ export async function getTransformationSteps(jobId: string, handleThrottleFlag: 
         if (handleThrottleFlag) {
             await sleep(2000)
         }
-        const apiStartTime = Date.now()
         const response = await codeWhisperer.codeWhispererClient.codeModernizerGetCodeTransformationPlan({
             transformationJobId: jobId,
         })
         if (response.$response.requestId) {
             transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
         }
-        telemetry.codeTransform_logApiLatency.emit({
-            codeTransformApiNames: 'GetTransformationPlan',
-            codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-            codeTransformJobId: jobId,
-            codeTransformRunTimeLatency: calculateTotalLatency(apiStartTime),
-            codeTransformRequestId: response.$response.requestId,
-            result: MetadataResult.Pass,
-        })
         return response.transformationPlan.transformationSteps.slice(1) // skip step 0 (contains supplemental info)
     } catch (e: any) {
         const errorMessage = (e as Error).message
@@ -652,17 +598,8 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
     while (true) {
         throwIfCancelled()
         try {
-            const apiStartTime = Date.now()
             const response = await codeWhisperer.codeWhispererClient.codeModernizerGetCodeTransformation({
                 transformationJobId: jobId,
-            })
-            telemetry.codeTransform_logApiLatency.emit({
-                codeTransformApiNames: 'GetTransformation',
-                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                codeTransformJobId: jobId,
-                codeTransformRunTimeLatency: calculateTotalLatency(apiStartTime),
-                codeTransformRequestId: response.$response.requestId,
-                result: MetadataResult.Pass,
             })
             status = response.transformationJob.status!
             if (CodeWhispererConstants.validStatesForBuildSucceeded.includes(status)) {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformProjectValidationHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformProjectValidationHandler.ts
@@ -166,7 +166,7 @@ export async function validateOpenProjects(
             void vscode.window.showErrorMessage(CodeWhispererConstants.noPomXmlFoundNotification)
             telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
                 codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                codeTransformPreValidationError: 'NonMavenProject',
+                codeTransformPreValidationError: 'UnsupportedBuildSystem',
                 result: MetadataResult.Fail,
                 reason: 'NoPomFileFound',
             })

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -348,15 +348,6 @@ export class ProposedTransformationExplorer {
                 })
                 await setContext('gumby.reviewState', TransformByQReviewStatus.NotStarted)
                 getLogger().error(`CodeTransformation: ExportResultArchive error = ${downloadErrorMessage}`)
-                telemetry.codeTransform_logApiError.emit({
-                    codeTransformApiNames: 'ExportResultArchive',
-                    codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                    codeTransformJobId: transformByQState.getJobId(),
-                    codeTransformApiErrorMessage: downloadErrorMessage,
-                    codeTransformRequestId: e.requestId ?? '',
-                    result: MetadataResult.Fail,
-                    reason: 'ExportResultArchiveFailed',
-                })
                 throw new Error('Error downloading diff')
             } finally {
                 // This metric is emitted when user clicks Download Proposed Changes button

--- a/packages/core/src/shared/utilities/download.ts
+++ b/packages/core/src/shared/utilities/download.ts
@@ -6,10 +6,6 @@
 import path from 'path'
 import { CodeWhispererStreaming, ExportResultArchiveCommandInput } from '@amzn/codewhisperer-streaming'
 import { ToolkitError } from '../errors'
-import { CodeTransformTelemetryState } from '../../amazonqGumby/telemetry/codeTransformTelemetryState'
-import { transformByQState } from '../../codewhisperer/models/model'
-import { calculateTotalLatency } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
-import { telemetry } from '../telemetry/telemetry'
 import fs from '../fs/fs'
 
 /**
@@ -26,7 +22,6 @@ export async function downloadExportResultArchive(
     exportResultArchiveArgs: ExportResultArchiveCommandInput,
     toPath: string
 ) {
-    const apiStartTime = Date.now()
     let totalDownloadBytes = 0
     const result = await cwStreamingClient.exportResultArchive(exportResultArchiveArgs)
 
@@ -47,12 +42,4 @@ export async function downloadExportResultArchive(
     }
 
     await fs.writeFile(toPath, Buffer.concat(buffer))
-    telemetry.codeTransform_logApiLatency.emit({
-        codeTransformApiNames: 'ExportResultArchive',
-        codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-        codeTransformJobId: transformByQState.getJobId(),
-        codeTransformRunTimeLatency: calculateTotalLatency(apiStartTime),
-        codeTransformTotalByteSize: totalDownloadBytes,
-        codeTransformRequestId: result.$metadata.requestId,
-    })
 }

--- a/packages/core/src/shared/utilities/download.ts
+++ b/packages/core/src/shared/utilities/download.ts
@@ -6,7 +6,12 @@
 import path from 'path'
 import { CodeWhispererStreaming, ExportResultArchiveCommandInput } from '@amzn/codewhisperer-streaming'
 import { ToolkitError } from '../errors'
+import { CodeTransformTelemetryState } from '../../amazonqGumby/telemetry/codeTransformTelemetryState'
+import { transformByQState } from '../../codewhisperer/models/model'
+import { calculateTotalLatency } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
+import { telemetry } from '../telemetry/telemetry'
 import fs from '../fs/fs'
+import globals from '../../shared/extensionGlobals'
 
 /**
  * This class represents the structure of the archive returned by the ExportResultArchive endpoint
@@ -22,6 +27,7 @@ export async function downloadExportResultArchive(
     exportResultArchiveArgs: ExportResultArchiveCommandInput,
     toPath: string
 ) {
+    const apiStartTime = globals.clock.Date.now()
     let totalDownloadBytes = 0
     const result = await cwStreamingClient.exportResultArchive(exportResultArchiveArgs)
 
@@ -42,4 +48,12 @@ export async function downloadExportResultArchive(
     }
 
     await fs.writeFile(toPath, Buffer.concat(buffer))
+    telemetry.codeTransform_logApiLatency.emit({
+        codeTransformApiNames: 'ExportResultArchive',
+        codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+        codeTransformJobId: transformByQState.getJobId(),
+        codeTransformRunTimeLatency: calculateTotalLatency(apiStartTime),
+        codeTransformTotalByteSize: totalDownloadBytes,
+        codeTransformRequestId: result.$metadata.requestId,
+    })
 }


### PR DESCRIPTION
## Problem

Update: getting confused about a couple of things so I'm going to move this to another PR once I understand what exactly needs to happen.

1) We decided to no longer emit frontend telemetry for API errors and latency and 2) I made some minor updates to the common telemetry package and so need to use those updated fields.


## Solution

Remove unneeded emit calls and use updated fields.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
