### PR TITLE
fix(amazonq): update security scan languages

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/securityScanLanguageContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/securityScanLanguageContext.test.ts
@@ -39,6 +39,12 @@ describe('securityScanLanguageContext', function () {
             ['html', false],
             ['r', false],
             ['vb', false],
+            ['xml', false],
+            ['toml', false],
+            ['pip-requirements', false],
+            ['java-properties', false],
+            ['go.mod', false],
+            ['go.sum', false],
         ]
 
         beforeEach(async function () {
@@ -100,6 +106,12 @@ describe('securityScanLanguageContext', function () {
             ['packer', 'tf'],
             ['plaintext', 'plaintext'],
             ['jsonc', 'json'],
+            ['xml', 'plaintext'],
+            ['toml', 'plaintext'],
+            ['pip-requirements', 'plaintext'],
+            ['java-properties', 'plaintext'],
+            ['go.mod', 'plaintext'],
+            ['go.sum', 'plaintext'],
         ]
 
         for (const [securityScanLanguageId, expectedCwsprLanguageId] of securityScanLanguageIds) {

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -283,11 +283,11 @@ export async function activate(context: ExtContext): Promise<void> {
             ImportAdderProvider.instance
         ),
         vscode.languages.registerHoverProvider(
-            [...CodeWhispererConstants.platformLanguageIds],
+            [...CodeWhispererConstants.securityScanLanguageIds],
             SecurityIssueHoverProvider.instance
         ),
         vscode.languages.registerCodeActionsProvider(
-            [...CodeWhispererConstants.platformLanguageIds],
+            [...CodeWhispererConstants.securityScanLanguageIds],
             SecurityIssueCodeActionProvider.instance
         ),
         vscode.commands.registerCommand('aws.amazonq.openEditorAtRange', openEditorAtRange)

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -258,6 +258,12 @@ export const securityScanLanguageIds = [
     'c',
     'cpp',
     'php',
+    'xml',
+    'toml',
+    'pip-requirements',
+    'java-properties',
+    'go.mod',
+    'go.sum',
 ] as const
 
 export type SecurityScanLanguageId = (typeof securityScanLanguageIds)[number]

--- a/packages/core/src/codewhisperer/util/securityScanLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/securityScanLanguageContext.ts
@@ -34,6 +34,12 @@ export class SecurityScanLanguageContext {
             c: 'c',
             cpp: 'cpp',
             php: 'php',
+            xml: 'plaintext', // xml does not exist in CodewhispererLanguage
+            toml: 'plaintext',
+            'pip-requirements': 'plaintext',
+            'java-properties': 'plaintext',
+            'go.mod': 'plaintext',
+            'go.sum': 'plaintext',
         })
     }
 


### PR DESCRIPTION
## Problem

Sometimes security issues have a Diagnostic but not SecurityIssueHover issue. This happens when the document's languageId is not enabled when registering the hover/code actions provider.


## Solution

Update the enabled languageIds for security scans feature.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
