### PR TITLE
test(core): Remove cpu usage/heap total performance measuring

### DIFF
--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -8,18 +8,6 @@ import { getLogger } from '../logger'
 import { isWeb } from '../extensionGlobals'
 
 interface PerformanceMetrics {
-    /**
-     * The percentange of CPU time spent executing the user-space portions
-     * of the application, (javascript and user-space libraries/dependencies)
-     */
-    userCpuUsage: number
-
-    /**
-     * The percentage CPU time spent executing system-level operations
-     * related to the application, (file I/O, network, ipc, other kernel-space tasks)
-     */
-    systemCpuUsage: number
-    heapTotal: number
     duration: number
 }
 
@@ -38,8 +26,6 @@ export interface PerformanceSpan<T> {
 export class PerformanceTracker {
     #startPerformance:
         | {
-              cpuUsage: NodeJS.CpuUsage
-              memory: number
               duration: [number, number]
           }
         | undefined
@@ -52,31 +38,16 @@ export class PerformanceTracker {
 
     start() {
         this.#startPerformance = {
-            cpuUsage: process.cpuUsage(),
-            memory: process.memoryUsage().heapTotal,
             duration: process.hrtime(),
         }
     }
 
     stop(): PerformanceMetrics | undefined {
         if (this.#startPerformance) {
-            const endCpuUsage = process.cpuUsage(this.#startPerformance?.cpuUsage)
-            const userCpuUsage = endCpuUsage.user / 1000000
-            const systemCpuUsage = endCpuUsage.system / 1000000
-
             const elapsedTime = process.hrtime(this.#startPerformance.duration)
             const duration = elapsedTime[0] + elapsedTime[1] / 1e9 // convert microseconds to seconds
 
-            const totalUserUsage = (userCpuUsage / duration) * 100
-            const totalSystemUsage = (systemCpuUsage / duration) * 100
-
-            const endMemoryUsage = process.memoryUsage().heapTotal - this.#startPerformance?.memory
-            const endMemoryUsageInMB = endMemoryUsage / (1024 * 1024) // converting bytes to MB
-
             return {
-                userCpuUsage: totalUserUsage,
-                systemCpuUsage: totalSystemUsage,
-                heapTotal: endMemoryUsageInMB,
                 duration,
             }
         } else {
@@ -119,21 +90,12 @@ export function performanceTest(options: TestOptions, name: string, fn: () => vo
         }
 
         after(async () => {
-            const totalUserCPUUsage =
-                testRunMetrics.reduce((acc, metric) => acc + metric.userCpuUsage, 0) / testRunMetrics.length
-            const totalSystemCPUUsage =
-                testRunMetrics.reduce((acc, metric) => acc + metric.systemCpuUsage, 0) / testRunMetrics.length
-            const totalMemoryUsage =
-                testRunMetrics.reduce((acc, metric) => acc + metric.heapTotal, 0) / testRunMetrics.length
             const totalDuration =
                 testRunMetrics.reduce((acc, metric) => acc + metric.duration, 0) / testRunMetrics.length
 
             assertPerformanceMetrics(
                 {
-                    userCpuUsage: totalUserCPUUsage,
-                    systemCpuUsage: totalSystemCPUUsage,
                     duration: totalDuration,
-                    heapTotal: totalMemoryUsage,
                 },
                 name,
                 testOption
@@ -147,29 +109,6 @@ function assertPerformanceMetrics(
     name: string,
     testOption?: Partial<PerformanceMetrics>
 ) {
-    const expectedUserCPUUsage = testOption?.userCpuUsage ?? 50
-    const foundUserCPUUsage = performanceMetrics.userCpuUsage
-
-    assert(
-        foundUserCPUUsage < expectedUserCPUUsage,
-        `Expected total user CPU usage for ${name} to be less than ${expectedUserCPUUsage}. Actual user CPU usage was ${foundUserCPUUsage}`
-    )
-
-    const expectedSystemCPUUsage = testOption?.systemCpuUsage ?? 20
-    const foundSystemCPUUsage = performanceMetrics.systemCpuUsage
-
-    assert(
-        foundSystemCPUUsage < expectedUserCPUUsage,
-        `Expected total system CPU usage for ${name} to be less than ${expectedSystemCPUUsage}. Actual system CPU usage was ${foundSystemCPUUsage}`
-    )
-
-    const expectedMemoryUsage = testOption?.heapTotal ?? 400
-    const foundMemoryUsage = performanceMetrics.heapTotal
-    assert(
-        foundMemoryUsage < expectedMemoryUsage,
-        `Expected total memory usage for ${name} to be less than ${expectedMemoryUsage}. Actual memory usage was ${foundMemoryUsage}`
-    )
-
     const expectedDuration = testOption?.duration ?? 5
     const foundDuration = performanceMetrics.duration
     assert(

--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -224,9 +224,6 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
             const performanceMetrics = this.#performance?.stop()
             if (performanceMetrics) {
                 this.record({
-                    userCpuUsage: performanceMetrics.userCpuUsage,
-                    systemCpuUsage: performanceMetrics.systemCpuUsage,
-                    heapTotal: performanceMetrics.heapTotal,
                     functionName: this.#options.functionId?.name ?? this.name,
                     architecture: process.arch,
                 } as any)

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -277,21 +277,6 @@
             "description": "A detailed state of a specific auth connection. Use `authStatus` for a higher level view of an extension's general connection."
         },
         {
-            "name": "userCpuUsage",
-            "type": "int",
-            "description": "Percentage of user cpu usage (user space)"
-        },
-        {
-            "name": "systemCpuUsage",
-            "type": "int",
-            "description": "Percentage of system cpu usage (kernal space)"
-        },
-        {
-            "name": "heapTotal",
-            "type": "int",
-            "description": "Memory heap usage in MB"
-        },
-        {
             "name": "functionName",
             "type": "string",
             "description": "The name of the function"
@@ -300,21 +285,6 @@
             "name": "webviewName",
             "type": "string",
             "description": "The name of the webview"
-        },
-        {
-            "name": "architecture",
-            "type": "string",
-            "description": "The CPU architecture"
-        },
-        {
-            "name": "totalFileSizeInMB",
-            "type": "int",
-            "description": "The total size of all files being sent to Amazon Q"
-        },
-        {
-            "name": "totalFiles",
-            "type": "int",
-            "description": "The total number of files being sent to Amazon Q"
         }
     ],
     "metrics": [
@@ -1127,30 +1097,6 @@
             "name": "function_call",
             "description": "Represents a function call. In most cases this should wrap code with a run(), then you can add context.",
             "metadata": [
-                {
-                    "type": "userCpuUsage",
-                    "required": false
-                },
-                {
-                    "type": "systemCpuUsage",
-                    "required": false
-                },
-                {
-                    "type": "totalFiles",
-                    "required": false
-                },
-                {
-                    "type": "totalFileSizeInMB",
-                    "required": false
-                },
-                {
-                    "type": "architecture",
-                    "required": false
-                },
-                {
-                    "type": "heapTotal",
-                    "required": false
-                },
                 {
                     "type": "functionName",
                     "required": true

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -344,7 +344,6 @@ export async function collectFiles(
             }
 
             let totalSizeBytes = 0
-            let totalFiles = 0
             for (const rootPath of sourcePaths) {
                 const allFiles = await vscode.workspace.findFiles(
                     new vscode.RelativePattern(rootPath, '**'),
@@ -352,7 +351,6 @@ export async function collectFiles(
                 )
 
                 const files = respectGitIgnore ? await filterOutGitignoredFiles(rootPath, allFiles) : allFiles
-                totalFiles += files.length
 
                 for (const file of files) {
                     const relativePath = getWorkspaceRelativePath(file.fsPath, { workspaceFolders })

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -385,7 +385,6 @@ export async function collectFiles(
                     })
                 }
             }
-            span.record({ totalFiles, totalFileSizeInMB: totalSizeBytes / (1024 * 1024) })
             return storage
         },
         {

--- a/packages/core/src/test/shared/performance/performance.test.ts
+++ b/packages/core/src/test/shared/performance/performance.test.ts
@@ -21,15 +21,11 @@ describe('performance tooling', () => {
 
     describe('PerformanceTracker', () => {
         it('gets performance metrics', () => {
-            const { expectedUserCpuUsage, expectedSystemCpuUsage, expectedHeapTotal, expectedTotalSeconds } =
-                stubPerformance(sandbox)
+            const { expectedTotalSeconds } = stubPerformance(sandbox)
             const perf = new PerformanceTracker('foo')
             perf.start()
             const metrics = perf.stop()
 
-            assert.deepStrictEqual(metrics?.userCpuUsage, expectedUserCpuUsage)
-            assert.deepStrictEqual(metrics?.systemCpuUsage, expectedSystemCpuUsage)
-            assert.deepStrictEqual(metrics?.heapTotal, expectedHeapTotal)
             assert.deepStrictEqual(metrics?.duration, expectedTotalSeconds)
         })
     })

--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -14,7 +14,6 @@ import { sleep } from '../../../shared'
 import { withTelemetryContext } from '../../../shared/telemetry/util'
 import { SinonSandbox } from 'sinon'
 import sinon from 'sinon'
-import { stubPerformance } from '../../utilities/performance'
 
 describe('TelemetrySpan', function () {
     let clock: ReturnType<typeof installFakeClock>
@@ -78,7 +77,6 @@ describe('TelemetrySpan', function () {
     })
 
     it('records performance', function () {
-        const { expectedUserCpuUsage, expectedSystemCpuUsage, expectedHeapTotal } = stubPerformance(sandbox)
         const span = new TelemetrySpan('function_call', {
             emit: true,
         })
@@ -86,9 +84,6 @@ describe('TelemetrySpan', function () {
         clock.tick(90)
         span.stop()
         assertTelemetry('function_call', {
-            userCpuUsage: expectedUserCpuUsage,
-            systemCpuUsage: expectedSystemCpuUsage,
-            heapTotal: expectedHeapTotal,
             duration: 90,
             result: 'Succeeded',
         })
@@ -270,7 +265,6 @@ describe('TelemetryTracer', function () {
 
         it('records performance', function () {
             clock = installFakeClock()
-            const { expectedUserCpuUsage, expectedSystemCpuUsage, expectedHeapTotal } = stubPerformance(sandbox)
             tracer.run(
                 'function_call',
                 () => {
@@ -282,9 +276,6 @@ describe('TelemetryTracer', function () {
             )
 
             assertTelemetry('function_call', {
-                userCpuUsage: expectedUserCpuUsage,
-                systemCpuUsage: expectedSystemCpuUsage,
-                heapTotal: expectedHeapTotal,
                 duration: 90,
                 result: 'Succeeded',
             })

--- a/packages/core/src/test/utilities/performance.ts
+++ b/packages/core/src/test/utilities/performance.ts
@@ -6,24 +6,11 @@
 import Sinon from 'sinon'
 
 export function stubPerformance(sandbox: Sinon.SinonSandbox) {
-    const cpuUsage = { user: 10000, system: 2000 }
-    const initialHeapTotal = 1
     const totalNanoseconds = 30000000 // 0.03 seconds
-
-    sandbox.stub(process, 'cpuUsage').returns(cpuUsage)
-
-    const memoryUsageStub = sandbox.stub(process, 'memoryUsage')
-    memoryUsageStub
-        .onCall(0)
-        .returns({ heapTotal: initialHeapTotal, arrayBuffers: 0, external: 0, rss: 0, heapUsed: 0 })
-    memoryUsageStub.onCall(1).returns({ heapTotal: 10485761, arrayBuffers: 0, external: 0, rss: 0, heapUsed: 0 })
 
     sandbox.stub(process, 'hrtime').returns([0, totalNanoseconds])
 
     return {
-        expectedUserCpuUsage: 33.333333333333336,
-        expectedSystemCpuUsage: 6.666666666666667,
-        expectedHeapTotal: 10,
         expectedTotalSeconds: totalNanoseconds / 1e9,
     }
 }

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -299,8 +299,6 @@ describe('collectFiles', function () {
         )
 
         assertTelemetry('function_call', {
-            totalFiles: 8,
-            totalFileSizeInMB: 0.0002593994140625,
             functionName: 'collectFiles',
         })
     })


### PR DESCRIPTION
## Problem
- We're getting a signal that cpu usage/heap total can't be used to performance measure vscode extensions. This is because all vscode extensions run in a single process, causing other extensions to interfere with our monitoring.


## Solution
- Remove cpu usage/memory performance measuring
- Keep duration measuring for now to see if this can be useful for regression testing (at least its better than nothing?)


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
