### PR TITLE
ci(toolkit): Disable notifications on non public vscode toolkit repos

### DIFF
--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -6,7 +6,7 @@ name: Notifications
 on:
     # `pull_request_target` (as opposed to `pull_request`) gives permissions to comment on PRs.
     pull_request_target:
-        branches: [master, feature/*, staging]
+        branches: [master, feature/*, staging, jpinkney-aws/disable-private-notifications]
         # Default = opened + synchronize + reopened.
         # We also want "edited" so that changelog notifications runs when PR title is updated.
         # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
@@ -34,10 +34,10 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: '20'
-            - name: Check for tests
+            - name: Notify
               uses: actions/github-script@v7
               with:
                   script: |
                       const notify = require('.github/workflows/notify.js')
                       await notify({github, context})
-              if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' && github.event.repository.name == 'aws-toolkit-vscode'


### PR DESCRIPTION
## Problem
- The notifications workflow can't run on private forks against private repos without someone providing their PAT. If we provide a PAT it leaves the comment of the username of whoever provided the PAT

## Solution
- Only enable notifications if the repository is aws-toolkit-vscode

## Alternative:
- If we had a bot PAT we could set that instead and it wouldn't matter

github workflows 🙃 
---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
