### PR TITLE
fix(auth): handle SyntaxError edge case in refresh credentials

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b8b46fa8-b467-4b35-9741-ce6962c8f674.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b8b46fa8-b467-4b35-9741-ce6962c8f674.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix SyntaxError causing premature expiration (edge case)"
+}

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -484,7 +484,10 @@ describe('util', function () {
     })
 
     function makeSyntaxErrorWithSdkClientError() {
-        const syntaxError: Error = new SyntaxError('The SyntaxError message')
+        // The following error messages are not arbitrary, changing them can break functionality
+        const syntaxError: Error = new SyntaxError(
+            'Unexpected token \'<\', "<html><bod"... is not valid JSON Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.'
+        )
         // Under the hood of a SyntaxError may be a hidden field with the real reason for the failure
         ;(syntaxError as any)['$response'] = { reason: 'SDK Client unexpected error response: data response code: 500' }
         return syntaxError
@@ -538,7 +541,7 @@ describe('util', function () {
     })
 
     it('AwsClientResponseError', function () {
-        const syntaxError = makeSyntaxErrorWithSdkClientError()
+        let syntaxError = makeSyntaxErrorWithSdkClientError()
 
         assert.deepStrictEqual(
             AwsClientResponseError.tryExtractReasonFromSyntaxError(syntaxError),
@@ -549,6 +552,41 @@ describe('util', function () {
         assert(responseError instanceof Error)
         assert(responseError instanceof AwsClientResponseError)
         assert(responseError.message === 'SDK Client unexpected error response: data response code: 500')
+
+        // The SyntaxError message does not mention it has an underlying error
+        syntaxError = makeSyntaxErrorWithSdkClientError()
+        syntaxError.message = 'This does not mention a "$response" field existing'
+        assert(!(AwsClientResponseError.instanceIf(syntaxError) instanceof AwsClientResponseError))
+        assert.equal(syntaxError, AwsClientResponseError.instanceIf(syntaxError))
+
+        // No '$response' field in SyntaxError
+        syntaxError = makeSyntaxErrorWithSdkClientError()
+        delete (syntaxError as any)['$response']
+        assertIsAwsClientResponseError(syntaxError, `No '$response' field in SyntaxError | ${syntaxError.message}`)
+        syntaxError = makeSyntaxErrorWithSdkClientError()
+        ;(syntaxError as any)['$response'] = undefined
+        assertIsAwsClientResponseError(syntaxError, `No '$response' field in SyntaxError | ${syntaxError.message}`)
+
+        // No 'reason' in '$response'
+        syntaxError = makeSyntaxErrorWithSdkClientError()
+        let response = (syntaxError as any)['$response']
+        delete response['reason']
+        assertIsAwsClientResponseError(
+            syntaxError,
+            `No 'reason' field in '$response' | ${JSON.stringify(response)} | ${syntaxError.message}`
+        )
+        syntaxError = makeSyntaxErrorWithSdkClientError()
+        response = (syntaxError as any)['$response']
+        response['reason'] = undefined
+        assertIsAwsClientResponseError(
+            syntaxError,
+            `No 'reason' field in '$response' | ${JSON.stringify(response)} | ${syntaxError.message}`
+        )
+
+        function assertIsAwsClientResponseError(e: Error, expectedMessage: string) {
+            assert.deepStrictEqual(AwsClientResponseError.tryExtractReasonFromSyntaxError(e), expectedMessage)
+            assert(AwsClientResponseError.instanceIf(e) instanceof AwsClientResponseError)
+        }
     })
 
     it('scrubNames()', async function () {

--- a/packages/toolkit/.changes/next-release/Bug Fix-9ae19be3-32f5-475c-8206-cb82f4ffe30e.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-9ae19be3-32f5-475c-8206-cb82f4ffe30e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix SyntaxError causing premature expiration (edge case)"
+}


### PR DESCRIPTION
## Problem:

There is a small edge case where there are SOMETIMES missing fields in a SyntaxError, in this case the $response or its reason field do not exist. Due to this those cases are causing a connection to become invalid when refresh credentials fails.

## Solution:

Handle the case where those fields are missing and gracefully handle them by still marking it as an AwsClientResponseError. Since we cannot extract the underlying error message, we set a custom errors message for those cases.

Now this will not cause a failed refresh credential to invalidate.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
