### PR TITLE
fix: Patch ux for sso start url login field

### DIFF
--- a/packages/core/src/auth/sso/constants.ts
+++ b/packages/core/src/auth/sso/constants.ts
@@ -9,7 +9,7 @@
  */
 
 export const ssoUrlFormatRegex =
-    /^(https?:\/\/(.+)\.awsapps\.com\/start|https?:\/\/identitycenter\.amazonaws\.com\/ssoins-[\da-zA-Z]{16})\/?$/
+    /^(https?:\/\/(.+)\.awsapps\.com\/start|https?:\/\/identitycenter\.amazonaws\.com\/ssoins-[\da-zA-Z]{16})\/?#?$/
 
 export const ssoUrlFormatMessage =
     'URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start'

--- a/packages/core/src/auth/sso/constants.ts
+++ b/packages/core/src/auth/sso/constants.ts
@@ -18,3 +18,6 @@ export const ssoUrlProtocolMessage =
 
 export const ssoUrlFormatMessage =
     'URLs must be in the following format. Example: https://d-xxxxxxxxxx.awsapps.com/start (trailing `/` or `/#` allowed)'
+
+export const ssoUrlExistsMessage =
+    'A connection for this start URL already exists. Sign out before creating a new one.'

--- a/packages/core/src/auth/sso/constants.ts
+++ b/packages/core/src/auth/sso/constants.ts
@@ -8,8 +8,13 @@
  * web, node, or vue.
  */
 
+export const ssoUrlProtocolRegex = /^(https?:\/\/)/;
+
 export const ssoUrlFormatRegex =
     /^(https?:\/\/(.+)\.awsapps\.com\/start|https?:\/\/identitycenter\.amazonaws\.com\/ssoins-[\da-zA-Z]{16})\/?#?$/
 
-export const ssoUrlFormatMessage =
+export const ssoUrlProtocolMessage =
     'URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start'
+
+export const ssoUrlFormatMessage =
+    'URLs must be in the following format. Example: https://d-xxxxxxxxxx.awsapps.com/start (trailing `/` or `/#` allowed)'

--- a/packages/core/src/auth/sso/constants.ts
+++ b/packages/core/src/auth/sso/constants.ts
@@ -13,11 +13,8 @@ export const ssoUrlProtocolRegex = /^(https?:\/\/)/;
 export const ssoUrlFormatRegex =
     /^(https?:\/\/(.+)\.awsapps\.com\/start|https?:\/\/identitycenter\.amazonaws\.com\/ssoins-[\da-zA-Z]{16})\/?#?$/
 
-export const ssoUrlProtocolMessage =
-    'URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start'
-
-export const ssoUrlFormatMessage =
-    'URLs must be in the following format. Example: https://d-xxxxxxxxxx.awsapps.com/start (trailing `/` or `/#` allowed)'
-
-export const ssoUrlExistsMessage =
-    'A connection for this start URL already exists. Sign out before creating a new one.'
+export enum SsoStartUrlErrorMsg {
+    ALREADY_EXISTS = 'A connection for this start URL already exists. Sign out before creating a new one.',
+    FORMAT = 'URLs must be in the following format. Example: https://d-xxxxxxxxxx.awsapps.com/start (trailing `/` or `/#` allowed)',
+    PROTOCOL = 'URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start',
+}

--- a/packages/core/src/auth/sso/validation.ts
+++ b/packages/core/src/auth/sso/validation.ts
@@ -6,16 +6,16 @@ import * as vscode from 'vscode'
 import { UnknownError } from '../../shared/errors'
 import { AuthType } from '../auth'
 import { SsoConnection, hasScopes, isAnySsoConnection } from '../connection'
-import { ssoUrlFormatMessage, ssoUrlFormatRegex } from './constants'
+import { ssoUrlFormatMessage, ssoUrlFormatRegex, ssoUrlProtocolMessage, ssoUrlProtocolRegex } from './constants'
 
 /**
  * Returns an error message if the url is not properly formatted.
  * Otherwise, returns undefined.
  */
 export function validateSsoUrlFormat(url: string) {
-    if (!ssoUrlFormatRegex.test(url)) {
-        return ssoUrlFormatMessage
-    }
+    return !ssoUrlProtocolRegex.test(url) ? ssoUrlProtocolMessage
+        : !ssoUrlFormatRegex.test(url) ? ssoUrlFormatMessage
+        : undefined;
 }
 
 export async function validateIsNewSsoUrlAsync(

--- a/packages/core/src/auth/sso/validation.ts
+++ b/packages/core/src/auth/sso/validation.ts
@@ -6,15 +6,15 @@ import * as vscode from 'vscode'
 import { UnknownError } from '../../shared/errors'
 import { AuthType } from '../auth'
 import { SsoConnection, hasScopes, isAnySsoConnection } from '../connection'
-import { ssoUrlFormatMessage, ssoUrlFormatRegex, ssoUrlProtocolMessage, ssoUrlProtocolRegex, ssoUrlExistsMessage } from './constants'
+import { ssoUrlFormatRegex, ssoUrlProtocolRegex, SsoStartUrlErrorMsg } from './constants'
 
 /**
  * Returns an error message if the url is not properly formatted.
  * Otherwise, returns undefined.
  */
 export function validateSsoUrlFormat(url: string) {
-    return !ssoUrlProtocolRegex.test(url) ? ssoUrlProtocolMessage
-        : !ssoUrlFormatRegex.test(url) ? ssoUrlFormatMessage
+    return !ssoUrlProtocolRegex.test(url) ? SsoStartUrlErrorMsg.PROTOCOL
+        : !ssoUrlFormatRegex.test(url) ? SsoStartUrlErrorMsg.FORMAT
         : undefined;
 }
 
@@ -40,7 +40,7 @@ export function validateIsNewSsoUrl(
         const oldConn = existingSsoConns.find((conn) => isSameAuthority(vscode.Uri.parse(conn.startUrl), uri))
 
         if (oldConn && (!requiredScopes || hasScopes(oldConn, requiredScopes))) {
-            return ssoUrlExistsMessage
+            return SsoStartUrlErrorMsg.ALREADY_EXISTS
         }
     } catch (err) {
         return `URL is malformed: ${UnknownError.cast(err).message}`

--- a/packages/core/src/auth/sso/validation.ts
+++ b/packages/core/src/auth/sso/validation.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode'
 import { UnknownError } from '../../shared/errors'
 import { AuthType } from '../auth'
 import { SsoConnection, hasScopes, isAnySsoConnection } from '../connection'
-import { ssoUrlFormatMessage, ssoUrlFormatRegex, ssoUrlProtocolMessage, ssoUrlProtocolRegex } from './constants'
+import { ssoUrlFormatMessage, ssoUrlFormatRegex, ssoUrlProtocolMessage, ssoUrlProtocolRegex, ssoUrlExistsMessage } from './constants'
 
 /**
  * Returns an error message if the url is not properly formatted.
@@ -40,7 +40,7 @@ export function validateIsNewSsoUrl(
         const oldConn = existingSsoConns.find((conn) => isSameAuthority(vscode.Uri.parse(conn.startUrl), uri))
 
         if (oldConn && (!requiredScopes || hasScopes(oldConn, requiredScopes))) {
-            return 'A connection for this start URL already exists. Sign out before creating a new one.'
+            return ssoUrlExistsMessage
         }
     } catch (err) {
         return `URL is malformed: ${UnknownError.cast(err).message}`

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -278,7 +278,7 @@ import { LoginOption } from './types'
 import { CommonAuthWebview } from './backend'
 import { WebviewClientFactory } from '../../../webviews/client'
 import { Region } from '../../../shared/regions/endpoints'
-import { ssoUrlFormatRegex, ssoUrlFormatMessage, ssoUrlProtocolRegex, ssoUrlProtocolMessage, ssoUrlExistsMessage } from '../../../auth/sso/constants'
+import { ssoUrlFormatRegex, ssoUrlProtocolRegex, SsoStartUrlErrorMsg } from '../../../auth/sso/constants'
 
 const client = WebviewClientFactory.create<CommonAuthWebview>()
 
@@ -477,11 +477,11 @@ export default defineComponent({
         },
         handleUrlInput() {
             if (this.startUrl && !ssoUrlProtocolRegex.test(this.startUrl)) {
-                this.startUrlError = ssoUrlProtocolMessage
+                this.startUrlError = SsoStartUrlErrorMsg.PROTOCOL
             } else if (this.startUrl && !ssoUrlFormatRegex.test(this.startUrl)) {
-                this.startUrlError = ssoUrlFormatMessage
+                this.startUrlError = SsoStartUrlErrorMsg.FORMAT
             } else if (this.startUrl && this.existingStartUrls.some((url) => url === this.startUrl)) {
-                this.startUrlError = ssoUrlExistsMessage
+                this.startUrlError = SsoStartUrlErrorMsg.ALREADY_EXISTS
             } else {
                 this.startUrlError = ''
                 void client.storeMetricMetadata({

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -278,7 +278,7 @@ import { LoginOption } from './types'
 import { CommonAuthWebview } from './backend'
 import { WebviewClientFactory } from '../../../webviews/client'
 import { Region } from '../../../shared/regions/endpoints'
-import { ssoUrlFormatRegex, ssoUrlFormatMessage } from '../../../auth/sso/constants'
+import { ssoUrlFormatRegex, ssoUrlFormatMessage, ssoUrlProtocolRegex, ssoUrlProtocolMessage } from '../../../auth/sso/constants'
 
 const client = WebviewClientFactory.create<CommonAuthWebview>()
 
@@ -476,7 +476,9 @@ export default defineComponent({
             }
         },
         handleUrlInput() {
-            if (this.startUrl && !ssoUrlFormatRegex.test(this.startUrl)) {
+            if (this.startUrl && !ssoUrlProtocolRegex.test(this.startUrl)) {
+                this.startUrlError = ssoUrlProtocolMessage
+            } else if (this.startUrl && !ssoUrlFormatRegex.test(this.startUrl)) {
                 this.startUrlError = ssoUrlFormatMessage
             } else if (this.startUrl && this.existingStartUrls.some((url) => url === this.startUrl)) {
                 this.startUrlError =

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -278,7 +278,7 @@ import { LoginOption } from './types'
 import { CommonAuthWebview } from './backend'
 import { WebviewClientFactory } from '../../../webviews/client'
 import { Region } from '../../../shared/regions/endpoints'
-import { ssoUrlFormatRegex, ssoUrlFormatMessage, ssoUrlProtocolRegex, ssoUrlProtocolMessage } from '../../../auth/sso/constants'
+import { ssoUrlFormatRegex, ssoUrlFormatMessage, ssoUrlProtocolRegex, ssoUrlProtocolMessage, ssoUrlExistsMessage } from '../../../auth/sso/constants'
 
 const client = WebviewClientFactory.create<CommonAuthWebview>()
 
@@ -481,8 +481,7 @@ export default defineComponent({
             } else if (this.startUrl && !ssoUrlFormatRegex.test(this.startUrl)) {
                 this.startUrlError = ssoUrlFormatMessage
             } else if (this.startUrl && this.existingStartUrls.some((url) => url === this.startUrl)) {
-                this.startUrlError =
-                    'A connection for this start URL already exists. Sign out before creating a new one.'
+                this.startUrlError = ssoUrlExistsMessage
             } else {
                 this.startUrlError = ''
                 void client.storeMetricMetadata({


### PR DESCRIPTION
## Problem
The Start URL field in the Workforce (SSO) sign-in page provides a single error message when the user's input fails validation. Error message: `URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start`. In some cases, this error message can be misleading or a false positive where the user's input contains a valid protocol or scheme yet fails some other form of validation required for the Start URL field. 

### Use case
Users who copy or retrieve their start URL from the **Get credentials for [SampleRole]**  in the AWS Access portal for a given IAM Identity Center user will notice their start URL, for example, `https://d-xxxxxxxxxx.awsapps.com/start/#`, fail validation and get the following error message displayed: `URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start`. By default, the start URL from the **Get credentials for [SampleRole]** window includes a trailing forward slash and hashtag, (`/#`).

> ℹ This differs from the start URL copied from the IAM Identity Center user Console which does _not_ end with a trailing forward slash `/` or hashtag `#`

### Example 
![aws-sso-error](https://github.com/user-attachments/assets/a17e98ac-9e7b-4c7e-a389-01842d2ff164)


## Solution
> This PR closes the following corresponding issue. 

Resolves: #5462

This PR introduces patches to enhance the UX for the Start URL login field:
- Permit trailing hashtag to ensure a start URL copied by a user from the **Get credentials for [SampleRole]** window will not display an error message.
- Add a new error message and update validation logic to ensure input URLs with the correct protocol/scheme provide a new semantic error instead of the default.

### Decisions
> This section outlines notable considerations for developers/maintainers.

- [refactor] Encapsulate all error messages related to the **Start URL** in an `enum` type.

---

## License
License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
