### PR TITLE
ci(core): Seperate setup, execution, and verification of performance tests

### DIFF
--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -104,7 +104,7 @@ export function performanceTest(options: TestOptions, name: string, fn: () => vo
             this.timeout(60000)
 
             // Wait until the user/system cpu usage stabilizes on a lower amount
-            await waitUntil(
+            const opt = await waitUntil(
                 async () => {
                     const endCpuUsage = process.cpuUsage()
                     const userCpuUsage = endCpuUsage.user / 1000000
@@ -118,6 +118,9 @@ export function performanceTest(options: TestOptions, name: string, fn: () => vo
                     timeout: 60000,
                 }
             )
+            if (!opt) {
+                assert.fail('CPU Usage failed to drop below 15/5')
+            }
 
             performanceTracker = new PerformanceTracker(name)
             performanceTracker.start()

--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -109,6 +109,8 @@ export function performanceTest(options: TestOptions, name: string, fn: () => vo
                     const endCpuUsage = process.cpuUsage()
                     const userCpuUsage = endCpuUsage.user / 1000000
                     const systemCpuUsage = endCpuUsage.system / 1000000
+                    // eslint-disable-next-line aws-toolkits/no-console-log
+                    console.log(`userCpuUsage: ${userCpuUsage}, systemCpuUsage: ${systemCpuUsage}`)
                     return userCpuUsage < 15 && systemCpuUsage < 5
                 },
                 {
@@ -126,6 +128,8 @@ export function performanceTest(options: TestOptions, name: string, fn: () => vo
             if (!metrics) {
                 assert.fail('Performance metrics not found')
             }
+            // eslint-disable-next-line aws-toolkits/no-console-log
+            console.log(`performanceMetrics: %O`, metrics)
             testRunMetrics.push(metrics)
         })
 

--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -122,7 +122,7 @@ export function performanceTest(
                     const systemCpuUsage = endCpuUsage.system / 1000000
                     // eslint-disable-next-line aws-toolkits/no-console-log
                     console.log(`userCpuUsage: ${userCpuUsage}, systemCpuUsage: ${systemCpuUsage}`)
-                    return userCpuUsage < 15 && systemCpuUsage < 5
+                    return userCpuUsage < 20 && systemCpuUsage < 8
                 },
                 {
                     interval: 5000,
@@ -147,10 +147,10 @@ export function performanceTest(
                 if (!metrics) {
                     assert.fail('Performance metrics not found')
                 }
-                await args.assertTests(setup)
                 // eslint-disable-next-line aws-toolkits/no-console-log
                 console.log(`performanceMetrics: %O`, metrics)
                 testRunMetrics.push(metrics)
+                await args.assertTests(setup)
             })
         }
 

--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -104,6 +104,20 @@ export function performanceTest(
     fn: () => PerformanceTest | Promise<PerformanceTest>
 ) {
     const testOption = options[process.platform as 'linux' | 'darwin' | 'win32']
+    const internalOptions = {
+        darwin: {
+            userCpuUsage: 20,
+            systemCpuUsage: 8,
+        },
+        linux: {
+            userCpuUsage: 20,
+            systemCpuUsage: 8,
+        },
+        win32: {
+            userCpuUsage: 28, // this ci seems to have notably higher default cpu usage
+            systemCpuUsage: 8,
+        },
+    }[process.platform as 'linux' | 'darwin' | 'win32']
 
     const totalTestRuns = options.testRuns ?? 10
 
@@ -122,7 +136,9 @@ export function performanceTest(
                     const systemCpuUsage = endCpuUsage.system / 1000000
                     // eslint-disable-next-line aws-toolkits/no-console-log
                     console.log(`userCpuUsage: ${userCpuUsage}, systemCpuUsage: ${systemCpuUsage}`)
-                    return userCpuUsage < 20 && systemCpuUsage < 8
+                    return (
+                        userCpuUsage < internalOptions.userCpuUsage && systemCpuUsage < internalOptions.systemCpuUsage
+                    )
                 },
                 {
                     interval: 5000,

--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -3,11 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as os from 'os'
 import assert from 'assert'
 import { getLogger } from '../logger'
 import { isWeb } from '../extensionGlobals'
-// import { waitUntil } from '../utilities/timeoutUtils'
 
 interface PerformanceMetrics {
     /**
@@ -98,21 +96,6 @@ interface PerformanceTestFunction<TSetup, TExecute> {
     verify: (setup: TSetup, execute: TExecute) => Promise<void> | void
 }
 
-// const defaultPollingUsage = {
-//     darwin: {
-//         userCpuUsage: 20,
-//         systemCpuUsage: 8,
-//     },
-//     linux: {
-//         userCpuUsage: 35, // codebuild has a higher default user cpu usage
-//         systemCpuUsage: 8,
-//     },
-//     win32: {
-//         userCpuUsage: 28, // this ci seems to have notably higher default cpu usage
-//         systemCpuUsage: 8,
-//     },
-// }[process.platform as 'linux' | 'darwin' | 'win32']
-
 /**
  * Generate a test suite that runs fn options.testRuns times and gets the average performance metrics of all the test runs
  */
@@ -125,41 +108,15 @@ export function performanceTest<TSetup, TExecute>(
 
     const totalTestRuns = options.testRuns ?? 10
 
-    return describe(`${name} performance tests`, function () {
+    return describe(`${name} performance tests`, () => {
         let performanceTracker: PerformanceTracker | undefined
         const testRunMetrics: PerformanceMetrics[] = []
 
         beforeEach(async () => {
-            this.timeout(60000)
-
-            // Wait until the user/system cpu usage stabilizes on a lower amount
-            // const opt = await waitUntil(
-            //     async () => {
-            //         const endCpuUsage = process.cpuUsage()
-            //         const userCpuUsage = endCpuUsage.user / 1000000
-            //         const systemCpuUsage = endCpuUsage.system / 1000000
-
-            //         // log these messages for now so we can better understand flakiness
-            //         // eslint-disable-next-line aws-toolkits/no-console-log
-            //         console.log(
-            //             `Waiting until cpu usage stablizies: userCpuUsage: ${userCpuUsage}, systemCpuUsage: ${systemCpuUsage}`
-            //         )
-
-            //         return (
-            //             userCpuUsage < defaultPollingUsage.userCpuUsage &&
-            //             systemCpuUsage < defaultPollingUsage.systemCpuUsage
-            //         )
-            //     },
-            //     {
-            //         interval: 5000,
-            //         timeout: 60000,
-            //     }
-            // )
-            // if (!opt) {
-            //     assert.fail(
-            //         `CPU Usage failed to drop below user cpu usage: ${defaultPollingUsage.userCpuUsage} and system cpu usage: ${defaultPollingUsage.systemCpuUsage}`
-            //     )
-            // }
+            const startCpuUsage = process.cpuUsage()
+            const userCpuUsage = startCpuUsage.user / 1000000
+            const systemCpuUsage = startCpuUsage.system / 1000000
+            getLogger().info(`Starting CPU usage for "${name}" - User: ${userCpuUsage}%, System: ${systemCpuUsage}%`)
 
             performanceTracker = new PerformanceTracker(name)
         })
@@ -196,19 +153,13 @@ export function performanceTest<TSetup, TExecute>(
             const totalDuration =
                 testRunMetrics.reduce((acc, metric) => acc + metric.duration, 0) / testRunMetrics.length
 
+            // log these messages for now so we can better understand flakiness
             // eslint-disable-next-line aws-toolkits/no-console-log
             console.log('Average performance metrics: %O', {
                 userCpuUsage: totalUserCPUUsage,
                 systemCpuUsage: totalSystemCPUUsage,
                 heapTotal: totalMemoryUsage,
                 duration: totalDuration,
-            })
-
-            // eslint-disable-next-line aws-toolkits/no-console-log
-            console.log('OS Specific Metrics: %O', {
-                loadavg: os.loadavg(),
-                cpus: os.cpus(),
-                priority: os.getPriority(),
             })
 
             assertPerformanceMetrics(

--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -7,7 +7,7 @@ import * as os from 'os'
 import assert from 'assert'
 import { getLogger } from '../logger'
 import { isWeb } from '../extensionGlobals'
-import { waitUntil } from '../utilities/timeoutUtils'
+// import { waitUntil } from '../utilities/timeoutUtils'
 
 interface PerformanceMetrics {
     /**
@@ -98,20 +98,20 @@ interface PerformanceTestFunction<TSetup, TExecute> {
     verify: (setup: TSetup, execute: TExecute) => Promise<void> | void
 }
 
-const defaultPollingUsage = {
-    darwin: {
-        userCpuUsage: 20,
-        systemCpuUsage: 8,
-    },
-    linux: {
-        userCpuUsage: 35, // codebuild has a higher default user cpu usage
-        systemCpuUsage: 8,
-    },
-    win32: {
-        userCpuUsage: 28, // this ci seems to have notably higher default cpu usage
-        systemCpuUsage: 8,
-    },
-}[process.platform as 'linux' | 'darwin' | 'win32']
+// const defaultPollingUsage = {
+//     darwin: {
+//         userCpuUsage: 20,
+//         systemCpuUsage: 8,
+//     },
+//     linux: {
+//         userCpuUsage: 35, // codebuild has a higher default user cpu usage
+//         systemCpuUsage: 8,
+//     },
+//     win32: {
+//         userCpuUsage: 28, // this ci seems to have notably higher default cpu usage
+//         systemCpuUsage: 8,
+//     },
+// }[process.platform as 'linux' | 'darwin' | 'win32']
 
 /**
  * Generate a test suite that runs fn options.testRuns times and gets the average performance metrics of all the test runs
@@ -133,33 +133,33 @@ export function performanceTest<TSetup, TExecute>(
             this.timeout(60000)
 
             // Wait until the user/system cpu usage stabilizes on a lower amount
-            const opt = await waitUntil(
-                async () => {
-                    const endCpuUsage = process.cpuUsage()
-                    const userCpuUsage = endCpuUsage.user / 1000000
-                    const systemCpuUsage = endCpuUsage.system / 1000000
+            // const opt = await waitUntil(
+            //     async () => {
+            //         const endCpuUsage = process.cpuUsage()
+            //         const userCpuUsage = endCpuUsage.user / 1000000
+            //         const systemCpuUsage = endCpuUsage.system / 1000000
 
-                    // log these messages for now so we can better understand flakiness
-                    // eslint-disable-next-line aws-toolkits/no-console-log
-                    console.log(
-                        `Waiting until cpu usage stablizies: userCpuUsage: ${userCpuUsage}, systemCpuUsage: ${systemCpuUsage}`
-                    )
+            //         // log these messages for now so we can better understand flakiness
+            //         // eslint-disable-next-line aws-toolkits/no-console-log
+            //         console.log(
+            //             `Waiting until cpu usage stablizies: userCpuUsage: ${userCpuUsage}, systemCpuUsage: ${systemCpuUsage}`
+            //         )
 
-                    return (
-                        userCpuUsage < defaultPollingUsage.userCpuUsage &&
-                        systemCpuUsage < defaultPollingUsage.systemCpuUsage
-                    )
-                },
-                {
-                    interval: 5000,
-                    timeout: 60000,
-                }
-            )
-            if (!opt) {
-                assert.fail(
-                    `CPU Usage failed to drop below user cpu usage: ${defaultPollingUsage.userCpuUsage} and system cpu usage: ${defaultPollingUsage.systemCpuUsage}`
-                )
-            }
+            //         return (
+            //             userCpuUsage < defaultPollingUsage.userCpuUsage &&
+            //             systemCpuUsage < defaultPollingUsage.systemCpuUsage
+            //         )
+            //     },
+            //     {
+            //         interval: 5000,
+            //         timeout: 60000,
+            //     }
+            // )
+            // if (!opt) {
+            //     assert.fail(
+            //         `CPU Usage failed to drop below user cpu usage: ${defaultPollingUsage.userCpuUsage} and system cpu usage: ${defaultPollingUsage.systemCpuUsage}`
+            //     )
+            // }
 
             performanceTracker = new PerformanceTracker(name)
         })

--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as os from 'os'
 import assert from 'assert'
 import { getLogger } from '../logger'
 import { isWeb } from '../extensionGlobals'
@@ -211,6 +212,13 @@ export function performanceTest<T>(
                 systemCpuUsage: totalSystemCPUUsage,
                 heapTotal: totalMemoryUsage,
                 duration: totalDuration,
+            })
+
+            // eslint-disable-next-line aws-toolkits/no-console-log
+            console.log('OS Specific Metrics: %O', {
+                loadavg: os.loadavg(),
+                cpus: os.cpus(),
+                priority: os.getPriority(),
             })
 
             assertPerformanceMetrics(

--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -104,7 +104,7 @@ const defaultPollingUsage = {
         systemCpuUsage: 8,
     },
     linux: {
-        userCpuUsage: 20,
+        userCpuUsage: 35, // codebuild has a higher default user cpu usage
         systemCpuUsage: 8,
     },
     win32: {

--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -205,6 +205,14 @@ export function performanceTest<T>(
             const totalDuration =
                 testRunMetrics.reduce((acc, metric) => acc + metric.duration, 0) / testRunMetrics.length
 
+            // eslint-disable-next-line aws-toolkits/no-console-log
+            console.log('Average performance metrics: %O', {
+                userCpuUsage: totalUserCPUUsage,
+                systemCpuUsage: totalSystemCPUUsage,
+                heapTotal: totalMemoryUsage,
+                duration: totalDuration,
+            })
+
             assertPerformanceMetrics(
                 {
                     userCpuUsage: totalUserCPUUsage,

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -496,6 +496,7 @@ describe('startSecurityScanPerformanceTest', function () {
             return { commandSpy, securityScanRenderSpy }
         }
 
+        // function under performance test
         async function runTests() {
             await startSecurityScan.startSecurityScan(
                 mockSecurityPanelViewProvider,

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -506,7 +506,13 @@ describe('startSecurityScanPerformanceTest', function () {
             )
         }
 
-        function assertTests({ commandSpy, securityScanRenderSpy }: { commandSpy: any; securityScanRenderSpy: any }) {
+        function assertTests({
+            commandSpy,
+            securityScanRenderSpy,
+        }: {
+            commandSpy: sinon.SinonSpy
+            securityScanRenderSpy: sinon.SinonSpy
+        }) {
             assert.ok(commandSpy.neverCalledWith('workbench.action.problems.focus'))
             assert.ok(securityScanRenderSpy.calledOnce)
             const warnings = getTestWindow().shownMessages.filter((m) => m.severity === SeverityLevel.Warning)

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -488,46 +488,39 @@ describe('startSecurityScanPerformanceTest', function () {
     }
 
     performanceTest({}, 'Should calculate cpu and memory usage for file scans', function () {
-        async function setup() {
-            getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
-            const commandSpy = sinon.spy(vscode.commands, 'executeCommand')
-            const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
-            await model.CodeScansState.instance.setScansEnabled(true)
-            return { commandSpy, securityScanRenderSpy }
-        }
-
-        // function under performance test
-        async function runTests() {
-            await startSecurityScan.startSecurityScan(
-                mockSecurityPanelViewProvider,
-                editor,
-                createClient(),
-                extensionContext,
-                CodeAnalysisScope.FILE
-            )
-        }
-
-        function assertTests({
-            commandSpy,
-            securityScanRenderSpy,
-        }: {
-            commandSpy: sinon.SinonSpy
-            securityScanRenderSpy: sinon.SinonSpy
-        }) {
-            assert.ok(commandSpy.neverCalledWith('workbench.action.problems.focus'))
-            assert.ok(securityScanRenderSpy.calledOnce)
-            const warnings = getTestWindow().shownMessages.filter((m) => m.severity === SeverityLevel.Warning)
-            assert.strictEqual(warnings.length, 0)
-            assertTelemetry('codewhisperer_securityScan', {
-                codewhispererCodeScanScope: 'FILE',
-                passive: true,
-            })
-        }
-
         return {
-            setup,
-            runTests,
-            assertTests,
+            setup: async () => {
+                getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
+                const commandSpy = sinon.spy(vscode.commands, 'executeCommand')
+                const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
+                await model.CodeScansState.instance.setScansEnabled(true)
+                return { commandSpy, securityScanRenderSpy }
+            },
+            execute: async () => {
+                await startSecurityScan.startSecurityScan(
+                    mockSecurityPanelViewProvider,
+                    editor,
+                    createClient(),
+                    extensionContext,
+                    CodeAnalysisScope.FILE
+                )
+            },
+            verify: ({
+                commandSpy,
+                securityScanRenderSpy,
+            }: {
+                commandSpy: sinon.SinonSpy
+                securityScanRenderSpy: sinon.SinonSpy
+            }) => {
+                assert.ok(commandSpy.neverCalledWith('workbench.action.problems.focus'))
+                assert.ok(securityScanRenderSpy.calledOnce)
+                const warnings = getTestWindow().shownMessages.filter((m) => m.severity === SeverityLevel.Warning)
+                assert.strictEqual(warnings.length, 0)
+                assertTelemetry('codewhisperer_securityScan', {
+                    codewhispererCodeScanScope: 'FILE',
+                    passive: true,
+                })
+            },
         }
     })
 })

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -337,18 +337,8 @@ describe('collectFiles', function () {
     performanceTest(
         // collecting all files in the workspace and zipping them is pretty resource intensive
         {
-            darwin: {
-                userCpuUsage: 85,
-                heapTotal: 2,
-                duration: 0.8,
-            },
             linux: {
                 userCpuUsage: 85,
-                heapTotal: 2,
-                duration: 0.8,
-            },
-            win32: {
-                userCpuUsage: 100,
                 heapTotal: 2,
                 duration: 0.8,
             },

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -20,6 +20,8 @@ import globals from '../../../shared/extensionGlobals'
 import { CodelensRootRegistry } from '../../../shared/fs/codelensRootRegistry'
 import { assertTelemetry, createTestWorkspace, createTestWorkspaceFolder, toFile } from '../../../test/testUtil'
 import sinon from 'sinon'
+import { performanceTest } from '../../../shared/performance/performance'
+import { randomUUID } from '../../../shared/crypto'
 
 describe('findParentProjectFile', async function () {
     const workspaceDir = getTestWorkspaceFolder()
@@ -331,6 +333,66 @@ describe('collectFiles', function () {
         assert.deepStrictEqual(1, result.length)
         assert.deepStrictEqual('non-license.md', result[0].relativeFilePath)
     })
+
+    performanceTest(
+        // collecting all files in the workspace and zipping them is pretty resource intensive
+        {
+            darwin: {
+                userCpuUsage: 85,
+                heapTotal: 2,
+                duration: 0.8,
+            },
+            linux: {
+                userCpuUsage: 85,
+                heapTotal: 2,
+                duration: 0.8,
+            },
+            win32: {
+                userCpuUsage: 100,
+                heapTotal: 2,
+                duration: 0.8,
+            },
+        },
+        'calculate cpu and memory usage',
+        function () {
+            const totalFiles = 100
+            return {
+                setup: async () => {
+                    const workspace = await createTestWorkspaceFolder()
+
+                    sinon.stub(vscode.workspace, 'workspaceFolders').value([workspace])
+
+                    const fileContent = randomUUID()
+                    for (let x = 0; x < totalFiles; x++) {
+                        await toFile(fileContent, path.join(workspace.uri.fsPath, `file.${x}`))
+                    }
+
+                    return {
+                        workspace,
+                    }
+                },
+                execute: async ({ workspace }: { workspace: vscode.WorkspaceFolder }) => {
+                    return {
+                        result: await collectFiles([workspace.uri.fsPath], [workspace], true),
+                    }
+                },
+                verify: (
+                    _: { workspace: vscode.WorkspaceFolder },
+                    { result }: { result: Awaited<ReturnType<typeof collectFiles>> }
+                ) => {
+                    assert.deepStrictEqual(result.length, totalFiles)
+                    const sortedFiles = [...result].sort((a, b) => {
+                        const numA = parseInt(a.relativeFilePath.split('.')[1])
+                        const numB = parseInt(b.relativeFilePath.split('.')[1])
+                        return numA - numB
+                    })
+                    for (let x = 0; x < totalFiles; x++) {
+                        assert.deepStrictEqual(sortedFiles[x].relativeFilePath, `file.${x}`)
+                    }
+                },
+            }
+        }
+    )
 })
 
 describe('getWorkspaceFoldersByPrefixes', function () {


### PR DESCRIPTION
## Problem
We are currently running performance tests without waiting for the cpu to recover. This could be part of the reason why our tests could be flaky.

These were suggestions made by George on Friday

## Solution
Wait until the the cpu usage is at a reasonable (determined using previous test runs) starting cpu usage before continuing on with the tests


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
