### PR TITLE
feat(amazonq): switch to relative path for inline Completion API field

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -2,11 +2,15 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import assert from 'assert'
 import * as codewhispererClient from 'aws-core-vscode/codewhisperer'
 import * as EditorContext from 'aws-core-vscode/codewhisperer'
-import { createMockTextEditor, createMockClientRequest, resetCodeWhispererGlobalVariables } from 'aws-core-vscode/test'
+import {
+    createMockTextEditor,
+    createMockClientRequest,
+    resetCodeWhispererGlobalVariables,
+    openATextEditorWithText,
+} from 'aws-core-vscode/test'
 import { globals } from 'aws-core-vscode/shared'
 import { GenerateCompletionsRequest } from 'aws-core-vscode/codewhisperer'
 
@@ -74,7 +78,7 @@ describe('editorContext', function () {
         })
     })
 
-    describe('getfileNameForRequest', function () {
+    describe('getFileRelativePath', function () {
         it('Should return a new filename with correct extension given a .ipynb file', function () {
             const languageToExtension = new Map<string, string>([
                 ['python', 'py'],
@@ -86,10 +90,17 @@ describe('editorContext', function () {
 
             languageToExtension.forEach((extension, language) => {
                 const editor = createMockTextEditor('', 'test.ipynb', language, 1, 17)
-                const actual = EditorContext.getFileNameForRequest(editor)
+                const actual = EditorContext.getFileRelativePath(editor)
                 const expected = 'test.' + extension
                 assert.strictEqual(actual, expected)
             })
+        })
+
+        it('Should return relative path', async function () {
+            const editor = await openATextEditorWithText('tttt', 'test.py', 'a/b/c')
+            const actual = EditorContext.getFileRelativePath(editor)
+            const expected = 'a/b/c/test.py'
+            assert.strictEqual(actual, expected)
         })
     })
 

--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -2,7 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import * as path from 'path'
 import assert from 'assert'
 import * as codewhispererClient from 'aws-core-vscode/codewhisperer'
 import * as EditorContext from 'aws-core-vscode/codewhisperer'
@@ -11,12 +10,15 @@ import {
     createMockClientRequest,
     resetCodeWhispererGlobalVariables,
     openATextEditorWithText,
+    createTestWorkspaceFolder,
+    closeAllEditors,
 } from 'aws-core-vscode/test'
 import { globals } from 'aws-core-vscode/shared'
 import { GenerateCompletionsRequest } from 'aws-core-vscode/codewhisperer'
 
 describe('editorContext', function () {
     let telemetryEnabledDefault: boolean
+    let tempFolder: string
 
     beforeEach(async function () {
         await resetCodeWhispererGlobalVariables()
@@ -71,7 +73,7 @@ describe('editorContext', function () {
             assert.strictEqual(actual, expected)
         })
 
-        it('Should return expected filename for a long filename', function () {
+        it('Should return expected filename for a long filename', async function () {
             const editor = createMockTextEditor('', 'a'.repeat(1500), 'python', 1, 17)
             const actual = EditorContext.getFileName(editor)
             const expected = 'a'.repeat(1024)
@@ -80,6 +82,10 @@ describe('editorContext', function () {
     })
 
     describe('getFileRelativePath', function () {
+        this.beforeEach(async function () {
+            tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
+        })
+
         it('Should return a new filename with correct extension given a .ipynb file', function () {
             const languageToExtension = new Map<string, string>([
                 ['python', 'py'],
@@ -98,10 +104,14 @@ describe('editorContext', function () {
         })
 
         it('Should return relative path', async function () {
-            const editor = await openATextEditorWithText('tttt', 'test.py', 'a')
+            const editor = await openATextEditorWithText('tttt', 'test.py', tempFolder)
             const actual = EditorContext.getFileRelativePath(editor)
-            const expected = path.join('a', 'test.py')
+            const expected = 'test.py'
             assert.strictEqual(actual, expected)
+        })
+
+        afterEach(async function () {
+            await closeAllEditors()
         })
     })
 

--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as path from 'path'
 import assert from 'assert'
 import * as codewhispererClient from 'aws-core-vscode/codewhisperer'
 import * as EditorContext from 'aws-core-vscode/codewhisperer'
@@ -97,9 +98,9 @@ describe('editorContext', function () {
         })
 
         it('Should return relative path', async function () {
-            const editor = await openATextEditorWithText('tttt', 'test.py', 'a/b/c')
+            const editor = await openATextEditorWithText('tttt', 'test.py', 'a')
             const actual = EditorContext.getFileRelativePath(editor)
-            const expected = 'a/b/c/test.py'
+            const expected = path.join('a', 'test.py')
             assert.strictEqual(actual, expected)
         })
     })

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -38,33 +38,16 @@ export function extractContextForCodeWhisperer(editor: vscode.TextEditor): codew
             document.positionAt(offset + CodeWhispererConstants.charactersLimit)
         )
     )
-    if (checkLeftContextKeywordsForJsonAndYaml(caretLeftFileContext, editor.document.languageId)) {
-        return {
-            filename: getFileNameForRequest(editor),
-            programmingLanguage: {
-                languageName: 'plaintext',
-            },
-            leftFileContent: caretLeftFileContext,
-            rightFileContent: caretRightFileContext,
-        } as codewhispererClient.FileContext
-    }
-
-    if (checkLeftContextKeywordsForJsonAndYaml(caretLeftFileContext, editor.document.languageId)) {
-        return {
-            filename: getFileNameForRequest(editor),
-            programmingLanguage: {
-                languageName: 'plaintext',
-            },
-            leftFileContent: caretLeftFileContext,
-            rightFileContent: caretRightFileContext,
-        } as codewhispererClient.FileContext
+    let languageName = 'plaintext'
+    if (!checkLeftContextKeywordsForJsonAndYaml(caretLeftFileContext, editor.document.languageId)) {
+        languageName =
+            runtimeLanguageContext.normalizeLanguage(editor.document.languageId) ?? editor.document.languageId
     }
 
     return {
-        filename: getFileNameForRequest(editor),
+        filename: getFileRelativePath(editor),
         programmingLanguage: {
-            languageName:
-                runtimeLanguageContext.normalizeLanguage(editor.document.languageId) ?? editor.document.languageId,
+            languageName: languageName,
         },
         leftFileContent: caretLeftFileContext,
         rightFileContent: caretRightFileContext,
@@ -76,19 +59,27 @@ export function getFileName(editor: vscode.TextEditor): string {
     return fileName.substring(0, CodeWhispererConstants.filenameCharsLimit)
 }
 
-export function getFileNameForRequest(editor: vscode.TextEditor): string {
+export function getFileRelativePath(editor: vscode.TextEditor): string {
     const fileName = path.basename(editor.document.fileName)
-
+    let relativePath = ''
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(editor.document.uri)
+    if (!workspaceFolder) {
+        relativePath = fileName
+    } else {
+        const workspacePath = workspaceFolder.uri.fsPath
+        const filePath = editor.document.uri.fsPath
+        relativePath = path.relative(workspacePath, filePath)
+    }
     // For notebook files, we want to use the programming language for each cell for the code suggestions, so change
     // the filename sent in the request to reflect that language
-    if (fileName.endsWith('.ipynb')) {
+    if (relativePath.endsWith('.ipynb')) {
         const fileExtension = runtimeLanguageContext.getLanguageExtensionForNotebook(editor.document.languageId)
         if (fileExtension !== undefined) {
-            const filenameWithNewExtension = fileName.substring(0, fileName.length - 5) + fileExtension
+            const filenameWithNewExtension = relativePath.substring(0, relativePath.length - 5) + fileExtension
             return filenameWithNewExtension.substring(0, CodeWhispererConstants.filenameCharsLimit)
         }
     }
-    return fileName.substring(0, CodeWhispererConstants.filenameCharsLimit)
+    return relativePath.substring(0, CodeWhispererConstants.filenameCharsLimit)
 }
 
 export async function buildListRecommendationRequest(

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -43,7 +43,6 @@ export function extractContextForCodeWhisperer(editor: vscode.TextEditor): codew
         languageName =
             runtimeLanguageContext.normalizeLanguage(editor.document.languageId) ?? editor.document.languageId
     }
-
     return {
         filename: getFileRelativePath(editor),
         programmingLanguage: {
@@ -68,7 +67,7 @@ export function getFileRelativePath(editor: vscode.TextEditor): string {
     } else {
         const workspacePath = workspaceFolder.uri.fsPath
         const filePath = editor.document.uri.fsPath
-        relativePath = path.relative(workspacePath, filePath)
+        relativePath = path.join(path.basename(workspacePath), path.relative(workspacePath, filePath))
     }
     // For notebook files, we want to use the programming language for each cell for the code suggestions, so change
     // the filename sent in the request to reflect that language

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -67,7 +67,7 @@ export function getFileRelativePath(editor: vscode.TextEditor): string {
     } else {
         const workspacePath = workspaceFolder.uri.fsPath
         const filePath = editor.document.uri.fsPath
-        relativePath = path.join(path.basename(workspacePath), path.relative(workspacePath, filePath))
+        relativePath = path.relative(workspacePath, filePath)
     }
     // For notebook files, we want to use the programming language for each cell for the code suggestions, so change
     // the filename sent in the request to reflect that language


### PR DESCRIPTION
## Problem
Inline completion quality can be improved by passing the relative path instead of file name. 

## Solution
In the inline API request payload, we send relative path instead of file name.

No user facing change log item is added. The service controls what is sent for generation, this change will not have immediate customer impact.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
