### PR TITLE
fix(amazonq): sign-in notification displaying if user is signed in

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-cf81a6d7-2bc9-4888-9142-ce036245dd0e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-cf81a6d7-2bc9-4888-9142-ce036245dd0e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "UI: 'Start using Amazon Q' may display even if the user is signed in."
+}

--- a/packages/amazonq/src/app/chat/activation.ts
+++ b/packages/amazonq/src/app/chat/activation.ts
@@ -5,9 +5,8 @@
 
 import * as vscode from 'vscode'
 import { ExtensionContext, window } from 'vscode'
-import { Auth } from 'aws-core-vscode/auth'
 import { telemetry } from 'aws-core-vscode/telemetry'
-import { CodeWhispererSettings } from 'aws-core-vscode/codewhisperer'
+import { AuthUtil, CodeWhispererSettings } from 'aws-core-vscode/codewhisperer'
 import { Commands, placeholder, funcUtil } from 'aws-core-vscode/shared'
 import * as amazonq from 'aws-core-vscode/amazonq'
 
@@ -81,7 +80,7 @@ async function setupAuthNotification() {
 
     async function tryShowNotification() {
         // Do not show the notification if the IDE starts and user is already authenticated.
-        if (Auth.instance.activeConnection) {
+        if (AuthUtil.instance.isConnected()) {
             notificationDisplayed = true
         }
 


### PR DESCRIPTION
Problem: `Start using Amazon Q` can display if there is some error restoring the connection object in the main Auth class. May be a network error or some other error. This is fine because Q uses secondary auth, so it only needs to be restored in that class. However, the notification logic access is in the Auth class which may not be restored.

Solution: Use AuthUtil to check if there is a connection instead of Auth.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
