### PR TITLE
fix(amazonq): Inline code blocks are not aligned with text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5829,10 +5829,11 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.15.8",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.8.tgz",
-            "integrity": "sha512-A0qkACykrhx3Tr0qi15HpY2dCSwVYVZTecp2nXny5uwjh3StYo88daUqUG+4mX2LGL49jIr3X5IUgWYb9/vatg==",
+            "version": "4.15.9",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.9.tgz",
+            "integrity": "sha512-iiXEoQ30hugmk+28NVYUwuOwYVJM+zvHQT+rqs+f54mhGkjPIUpQc58L/w7ChCggUY3kXQEp/4lCQsocuSWJkw==",
             "hasInstallScript": true,
+            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
@@ -21899,7 +21900,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.15.8",
+                "@aws/mynah-ui": "^4.15.9",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-cedd6c55-8a91-432e-87a0-1832248b9e7e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-cedd6c55-8a91-432e-87a0-1832248b9e7e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Fixed inline code blocks are not vertically aligned with texts"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4111,7 +4111,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.15.8",
+        "@aws/mynah-ui": "^4.15.9",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
In the latest VSCode IDE, Amazon Q Chat inline code block items are not aligned with the texts.

## Solution
Implemented a solution through a [mynah-ui update](https://github.com/aws/mynah-ui/releases/tag/v4.15.9) which specifically adjusts the inline code block items to align in the middle.

### Before
<img width="449" alt="image" src="https://github.com/user-attachments/assets/ffad805c-c380-4c27-b430-02bf583cad98">

### After
<img width="469" alt="Screenshot 2024-09-04 at 11 45 00" src="https://github.com/user-attachments/assets/db2f90e4-a578-4a26-bd89-dbfb9678dbc5">

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
