### PR TITLE
fix(auth): File System error during SSO token refresh expires session

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -110,6 +110,10 @@
                         "amazonQSessionConfigurationMessage": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "ssoCacheError": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -192,6 +192,10 @@
                         "codeCatalystConnectionExpired": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "ssoCacheError": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -20,7 +20,9 @@ import { hasProps, hasStringProps, RequiredProps, selectFrom } from '../../share
 import { OidcClient } from './clients'
 import { loadOr } from '../../shared/utilities/cacheUtils'
 import {
+    DiskCacheError,
     ToolkitError,
+    getErrorMsg,
     getRequestId,
     getTelemetryReason,
     getTelemetryReasonDesc,
@@ -33,16 +35,18 @@ import { AwsLoginWithBrowser, AwsRefreshCredentials, telemetry } from '../../sha
 import { indent, toBase64URL } from '../../shared/utilities/textUtilities'
 import { AuthSSOServer } from './server'
 import { CancellationError, sleep } from '../../shared/utilities/timeoutUtils'
-import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
+import { getIdeProperties, isAmazonQ, isCloud9 } from '../../shared/extensionUtilities'
 import { randomBytes, createHash } from 'crypto'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { randomUUID } from '../../shared/crypto'
 import { isRemoteWorkspace, isWebWorkspace } from '../../shared/vscode/env'
 import { showInputBox } from '../../shared/ui/inputPrompter'
-import { DevSettings } from '../../shared/settings'
+import { AmazonQPromptSettings, DevSettings, PromptSettings, ToolkitPromptSettings } from '../../shared/settings'
 import { onceChanged } from '../../shared/utilities/functionUtils'
 import { NestedMap } from '../../shared/utilities/map'
 import { asStringifiedStack } from '../../shared/telemetry/spans'
+import { showViewLogsMessage } from '../../shared/utilities/messages'
+import _ from 'lodash'
 
 export const authenticationPath = 'sso/authenticated'
 
@@ -188,6 +192,25 @@ export abstract class SsoAccessTokenProvider {
 
             return refreshed
         } catch (err) {
+            const possibleCacheError = DiskCacheError.instanceIf(err)
+            if (possibleCacheError instanceof DiskCacheError) {
+                /**
+                 * Background:
+                 * - During token refresh when saving to our filesystem/cache there are sometimes file system
+                 *   related errors.
+                 * - When these errors ocurr it will cause the token refresh process to fail, and the users SSO
+                 *   connection to become invalid.
+                 * - Because these filesystem errors do not indicate the SSO session is actually stale,
+                 *   we want to catch these filesystem errors and not invalidate the users SSO connection since a
+                 *   subsequent attempt to refresh may succeed.
+                 * - To give the user a chance to resolve their filesystem related issue, we want to point them
+                 *   to the logs where the error was logged. Hopefully they can use this information to fix the issue,
+                 *   or at least hint for them to provide the logs in a bug report.
+                 */
+                void DiskCacheErrorMessage.instance.showMessageThrottled(possibleCacheError)
+                throw possibleCacheError
+            }
+
             if (!isNetworkError(err)) {
                 const reason = getTelemetryReason(err)
                 telemetry.aws_refreshCredentials.emit({
@@ -760,4 +783,54 @@ type ReAuthStateKey = Pick<SsoProfile, 'identifier' | 'startUrl'>
 type ReAuthStateValue = {
     // the latest reason for why the connection was moved in to a "needs reauth" state
     reAuthReason?: string
+}
+
+/**
+ * Singleton class that manages showing the user a message during
+ * failures that ocurr during SSO disk cache operations.
+ *
+ * Background:
+ * - We need this {@link DiskCacheErrorMessage} specifically as a singleton since we want to ensure
+ *   that only 1 instance of this message appears at a time. There are cases where it shows multiple messages
+ *   if not used as a singleton.
+ */
+class DiskCacheErrorMessage {
+    static #instance: DiskCacheErrorMessage
+    static get instance() {
+        return (this.#instance ??= new DiskCacheErrorMessage())
+    }
+
+    /**
+     * Show a `"don't show again"`-able message which tells the user about a file system related error
+     * with the sso cache.
+     */
+    public showMessageThrottled(error: Error) {
+        return this._showMessageThrottled(error)
+    }
+    private _showMessageThrottled = _.throttle(async (error: Error) => this._showMessage(error), 60_000, {
+        leading: true,
+    })
+    private async _showMessage(error: Error) {
+        const dontShow = 'Never warn again'
+
+        const promptSettings: PromptSettings = isAmazonQ()
+            ? AmazonQPromptSettings.instance
+            : ToolkitPromptSettings.instance
+
+        // We know 'ssoCacheError' is in all extension prompt settings
+        if (await promptSettings.isPromptEnabled('ssoCacheError')) {
+            const result = await showMessage()
+            if (result === dontShow) {
+                await promptSettings.disablePrompt('ssoCacheError')
+            }
+        }
+
+        function showMessage() {
+            return showViewLogsMessage(
+                `File system related error during SSO cache operation:\n"${getErrorMsg(error, true)}"`,
+                'error',
+                [dontShow]
+            )
+        }
+    }
 }

--- a/packages/core/src/shared/settings-amazonq.gen.ts
+++ b/packages/core/src/shared/settings-amazonq.gen.ts
@@ -16,7 +16,8 @@ export const amazonqSettings = {
         "codeWhispererNewWelcomeMessage": {},
         "codeWhispererConnectionExpired": {},
         "amazonQWelcomePage": {},
-        "amazonQSessionConfigurationMessage": {}
+        "amazonQSessionConfigurationMessage": {},
+        "ssoCacheError": {}
     },
     "amazonQ.showInlineCodeSuggestionsWithCodeReferences": {},
     "amazonQ.importRecommendationForInlineCodeSuggestions": {},

--- a/packages/core/src/shared/settings-toolkit.gen.ts
+++ b/packages/core/src/shared/settings-toolkit.gen.ts
@@ -36,7 +36,8 @@ export const toolkitSettings = {
         "createCredentialsProfile": {},
         "samcliConfirmDevStack": {},
         "remoteConnected": {},
-        "codeCatalystConnectionExpired": {}
+        "codeCatalystConnectionExpired": {},
+        "ssoCacheError": {}
     },
     "aws.experiments": {
         "jsonResourceModification": {}

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -620,10 +620,13 @@ export function fromExtensionManifest<T extends TypeDescriptor & Partial<Section
  */
 export const toolkitPrompts = settingsProps['aws.suppressPrompts']
 type toolkitPromptName = keyof typeof toolkitPrompts
-export class ToolkitPromptSettings extends Settings.define(
-    'aws.suppressPrompts',
-    toRecord(keys(toolkitPrompts), () => Boolean)
-) {
+export class ToolkitPromptSettings
+    extends Settings.define(
+        'aws.suppressPrompts',
+        toRecord(keys(toolkitPrompts), () => Boolean)
+    )
+    implements PromptSettings
+{
     public async isPromptEnabled(promptName: toolkitPromptName): Promise<boolean> {
         try {
             return !this._getOrThrow(promptName, false)
@@ -650,10 +653,13 @@ export class ToolkitPromptSettings extends Settings.define(
 
 export const amazonQPrompts = settingsProps['amazonQ.suppressPrompts']
 type amazonQPromptName = keyof typeof amazonQPrompts
-export class AmazonQPromptSettings extends Settings.define(
-    'amazonQ.suppressPrompts',
-    toRecord(keys(amazonQPrompts), () => Boolean)
-) {
+export class AmazonQPromptSettings
+    extends Settings.define(
+        'amazonQ.suppressPrompts',
+        toRecord(keys(amazonQPrompts), () => Boolean)
+    )
+    implements PromptSettings
+{
     public async isPromptEnabled(promptName: amazonQPromptName): Promise<boolean> {
         try {
             return !this._getOrThrow(promptName, false)
@@ -676,6 +682,18 @@ export class AmazonQPromptSettings extends Settings.define(
     public static get instance() {
         return (this.#instance ??= new this())
     }
+}
+
+/**
+ * Use cautiously as this is misleading. Ideally we create a type
+ * which is the intersection of the types (only the values that occur
+ * in each are selected), but idk how to do that.
+ */
+type AllPromptNames = amazonQPromptName | toolkitPromptName
+
+export interface PromptSettings {
+    isPromptEnabled(promptName: AllPromptNames): Promise<boolean>
+    disablePrompt(promptName: AllPromptNames): Promise<void>
 }
 
 const experiments = settingsProps['aws.experiments']

--- a/packages/core/src/shared/utilities/cacheUtils.ts
+++ b/packages/core/src/shared/utilities/cacheUtils.ts
@@ -19,14 +19,14 @@ import type { MapSync } from './map'
  *
  * Look to use {@link MapSync} instead if you need atomicity.
  */
-export interface KeyedCache<T, K = string> {
+export interface KeyedCache<V, K = string> {
     /**
      * Attempts to read data stored at {@link key}.
      *
      * @param key Target key to read from.
-     * @returns `T` on success, `undefined` if {@link key} doesn't exist.
+     * @returns `V` on success, `undefined` if {@link key} doesn't exist.
      */
-    load(key: K): Promise<T | undefined>
+    load(key: K): Promise<V | undefined>
 
     /**
      * Writes {@link data} to {@link key}.
@@ -34,7 +34,7 @@ export interface KeyedCache<T, K = string> {
      * @param key Target key to write to.
      * @param data Data to write.
      */
-    save(key: K, data: T): Promise<void>
+    save(key: K, data: V): Promise<void>
 
     /**
      * Deletes data stored at {@link key}, if any.
@@ -50,7 +50,7 @@ export interface KeyedCache<T, K = string> {
  *
  * If the item does not exist, {@link fn} is executed. The result is saved using {@link key}.
  */
-export async function loadOr<T, K>(cache: KeyedCache<T, K>, key: K, fn: () => Promise<T>): Promise<T> {
+export async function loadOr<V, K>(cache: KeyedCache<V, K>, key: K, fn: () => Promise<V>): Promise<V> {
     const data = await cache.load(key)
 
     if (data === undefined) {
@@ -69,16 +69,20 @@ export async function loadOr<T, K>(cache: KeyedCache<T, K>, key: K, fn: () => Pr
  * Transform functions are not invoked if the specified key does not exist in the cache.
  *
  * @param cache Target cache. The original is _not_ affected.
- * @param get Function applied to all **read** operations from the cache.
- * @param set Function applied to all **write** operations from the cache.
+ * @param loadTransform Function applied to all **read** operations from the cache.
+ * @param saveTransform Function applied to all **write** operations from the cache.
  */
-export function mapCache<T, U, K>(cache: KeyedCache<T, K>, get: (data: T) => U, set: (data: U) => T): KeyedCache<U, K> {
-    const getIf = (data?: T) => (data !== undefined ? get(data) : undefined)
+export function mapCache<V, Vt, K>(
+    cache: KeyedCache<V, K>,
+    loadTransform: (data: V) => Vt,
+    saveTransform: (data: Vt) => V
+): KeyedCache<Vt, K> {
+    const getIf = (data?: V) => (data !== undefined ? loadTransform(data) : undefined)
 
     return {
         clear: (key, reason) => cache.clear(key, reason),
         load: (key) => cache.load(key).then(getIf),
-        save: (key, data) => cache.save(key, set(data)),
+        save: (key, data) => cache.save(key, saveTransform(data)),
     }
 }
 
@@ -92,10 +96,10 @@ export function mapCache<T, U, K>(cache: KeyedCache<T, K>, get: (data: T) => U, 
  * @param mapKey Function that should describe how a key `K` is mapped to the file system.
  * @param logger Optional logger callback. Omitting this parameter disables logging.
  */
-export function createDiskCache<T, K>(
+export function createDiskCache<V, K>(
     mapKey: (key: K) => string,
     logger?: (message: string) => void
-): KeyedCache<T, K> {
+): KeyedCache<V, K> {
     function log(msg: string, key: K): void {
         if (logger) {
             const keyMessage = typeof key === 'object' ? JSON.stringify(key) : key

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -218,6 +218,10 @@
                         "codeCatalystConnectionExpired": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "ssoCacheError": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
## Problem:

When we get SSO cache errors, such as a failed write, we do not want to
invalidate the connection. Instead we want to gracefully handle this similar
to network errors, since the connection can still be recovered on a subsequent
token refresh.

A place that this happens is during SSO token refresh. Where if there is a filesystem
error when writing the new token to disk, the connection will become invalid.

## Solution:

Catch sso cache errors and wrap them in a high level `DiskCacheError` so
that we can easily determine an sso cache error during token refresh. Then we can
know not to invalidate the connection when there is a cache error since `isRecoverableError()` will
catch the error.

Additionally a message is shown to the user explaining how the sso token refresh failed and guides
them to the logs in hopes that they can fix it themselves, or at least give it to us when the report the error.

Signed-off-by: Nikolas Komonen <nkomonen@amazon.com>

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
