### PR TITLE
test: fix unrecognized method

### DIFF
--- a/packages/core/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
+++ b/packages/core/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
@@ -215,7 +215,7 @@ describe('StepFunctions VisualizeStateMachine', async function () {
         }
 
         assert.ok(postMessage.calledOnce)
-        assert.deepEqual(postMessage.firstCall.args, [message])
+        assert.deepStrictEqual(postMessage.firstCall.args, [message])
     })
 
     it('Test AslVisualisation sendUpdateMessage posts a correct update message for invalid YAML files', async function () {
@@ -238,7 +238,7 @@ describe('StepFunctions VisualizeStateMachine', async function () {
         }
 
         assert.ok(postMessage.calledOnce)
-        assert.deepEqual(postMessage.firstCall.args, [message])
+        assert.deepStrictEqual(postMessage.firstCall.args, [message])
     })
 
     it('Test AslVisualisation sendUpdateMessage posts a correct update message for ASL files', async function () {
@@ -261,7 +261,7 @@ describe('StepFunctions VisualizeStateMachine', async function () {
         }
 
         assert.ok(postMessage.calledOnce)
-        assert.deepEqual(postMessage.firstCall.args, [message])
+        assert.deepStrictEqual(postMessage.firstCall.args, [message])
     })
 })
 


### PR DESCRIPTION
For some reason I started getting errors saying that `deepEqual` does not exist. This fixes that




---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
