### PR TITLE
refactor(telemetry): prepend the error code/name to the `reasonDesc` field

### DIFF
--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -827,7 +827,7 @@ class DiskCacheErrorMessage {
 
         function showMessage() {
             return showViewLogsMessage(
-                `File system related error during SSO cache operation:\n"${getErrorMsg(error, true)}"`,
+                `File system related error during SSO cache operation:\n"${getErrorMsg(error, { withCause: true, withId: true })}"`,
                 'error',
                 [dontShow]
             )

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -827,7 +827,7 @@ class DiskCacheErrorMessage {
 
         function showMessage() {
             return showViewLogsMessage(
-                `File system related error during SSO cache operation:\n"${getErrorMsg(error, { withCause: true, withId: true })}"`,
+                `File system related error during SSO cache operation:\n"${getErrorMsg(error, true)}"`,
                 'error',
                 [dontShow]
             )

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -434,8 +434,8 @@ export function getTelemetryReasonDesc(err: unknown | undefined): string | undef
     const m = typeof err === 'string' ? err : getErrorMsg(err as Error, { withCause: true, withId: true }) ?? ''
     const msg = scrubNames(m, _username)
 
-    // Truncate to 200 chars.
-    return msg && msg.length > 0 ? msg.substring(0, 200) : undefined
+    // Truncate message as these strings can be very long.
+    return msg && msg.length > 0 ? msg.substring(0, 350) : undefined
 }
 
 export function getTelemetryReason(error: unknown | undefined): string | undefined {

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -385,7 +385,7 @@ describe('startSecurityScan', function () {
             codewhispererCodeScanScope: 'PROJECT',
             result: 'Failed',
             reason: 'CodeScanJobFailedError',
-            reasonDesc: 'Security scan failed.',
+            reasonDesc: 'CodeScanJobFailedError: Security scan failed.',
             passive: false,
         } as unknown as CodewhispererSecurityScan)
     })
@@ -413,7 +413,7 @@ describe('startSecurityScan', function () {
             codewhispererCodeScanScope: 'PROJECT',
             result: 'Failed',
             reason: 'ThrottlingException',
-            reasonDesc: 'Maximum project scan count reached for this month.',
+            reasonDesc: 'ThrottlingException: Maximum project scan count reached for this month.',
             passive: false,
         } as unknown as CodewhispererSecurityScan)
     })
@@ -444,7 +444,7 @@ describe('startSecurityScan', function () {
             codewhispererCodeScanScope: 'FILE',
             result: 'Failed',
             reason: 'ThrottlingException',
-            reasonDesc: 'Maximum auto-scans count reached for this month.',
+            reasonDesc: 'ThrottlingException: Maximum auto-scans count reached for this month.',
             passive: true,
         } as unknown as CodewhispererSecurityScan)
     })

--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -258,7 +258,7 @@ describe('TelemetryTracer', function () {
             assertTelemetry('aws_loginWithBrowser', {
                 result: 'Failed',
                 reason: 'InvalidRequestException',
-                reasonDesc: 'Invalid client ID provided',
+                reasonDesc: 'InvalidRequestException: Invalid client ID provided',
                 httpStatusCode: '400',
             })
             const metric = getMetrics('aws_loginWithBrowser')[0]


### PR DESCRIPTION
## Problem:

In telemetry we sometimes add the error message to the `reasonDesc` field.
Additionally when using `getTelemetryReasonDesc()` it will recurse through the causal
chain of the error and return a value composed of all the error messages.

Eg: `Reason A | Reason B | Reason C`

The issue is that the nested errors may have useful context (in addition to the message) in their
id (code or name). And currently this is lost.

## Solution:

Prepend the code/name to the error messages when using `getTelemetryReasonDesc()`

Eg: `CodeA: Reason A | CodeB: Reason B | NameC: Reason C`

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
