### PR TITLE
refactor(auth): redo `DiskCacheError` with proper context

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -13,7 +13,7 @@ import * as localizedText from '../shared/localizedText'
 import { Credentials } from '@aws-sdk/types'
 import { SsoAccessTokenProvider } from './sso/ssoAccessTokenProvider'
 import { Timeout } from '../shared/utilities/timeoutUtils'
-import { DiskCacheError, errorCode, isAwsError, isNetworkError, ToolkitError, UnknownError } from '../shared/errors'
+import { errorCode, isAwsError, isNetworkError, ToolkitError, UnknownError } from '../shared/errors'
 import { getCache } from './sso/cache'
 import { isNonNullable, Mutable } from '../shared/utilities/tsUtils'
 import { builderIdStartUrl, SsoToken, truncateStartUrl } from './sso/model'
@@ -64,6 +64,7 @@ import { telemetry } from '../shared/telemetry/telemetry'
 import { randomUUID } from '../shared/crypto'
 import { asStringifiedStack } from '../shared/telemetry/spans'
 import { withTelemetryContext } from '../shared/telemetry/util'
+import { DiskCacheError } from '../shared/utilities/cacheUtils'
 
 interface AuthService {
     /**
@@ -854,11 +855,10 @@ export class Auth implements AuthService, ConnectionManager {
             })
         }
 
-        const possibleCacheError = DiskCacheError.instanceIf(e)
-        if (possibleCacheError instanceof DiskCacheError) {
+        if (e instanceof DiskCacheError) {
             throw new ToolkitError('Failed to update connection due to file system operation failures', {
-                cause: possibleCacheError,
-                code: possibleCacheError.code,
+                cause: e,
+                code: e.code,
             })
         }
     }

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -1004,65 +1004,6 @@ export class AwsClientResponseError extends Error {
 }
 
 /**
- * Represents a generalized error that happened during a disk cache operation.
- *
- * For example, when SSO refreshes a token a disk cache error can occur when it
- * attempts to read/write the disk cache. These errors can be recoverable and do not
- * imply that the SSO session is stale. So by wrapping those errors in an instance of
- * this class it will help to distinguish them.
- */
-export class DiskCacheError extends Error {
-    #code: string | undefined
-
-    /** Use {@link DiskCacheError.instanceIf()} to create an instance */
-    protected constructor(message: string, options?: { code?: string }) {
-        super(message)
-        this.#code = options?.code
-    }
-
-    /**
-     * We are seeing these errors in telemetry, but they have no error message attached.
-     * The best we can do is assume these are filesystem errors in the context that we see them.
-     */
-    private static fileSystemErrorsWithoutMessage = ['EACCES', 'EBADF']
-
-    /**
-     * Return an instance of {@link DiskCacheError} that consists of the properties from the
-     * given error IF certain conditions are met. Otherwise, the original error is returned.
-     *
-     * - Also returns the original error if it is already a {@link DiskCacheError}.
-     */
-    public static instanceIf<T>(err: T): DiskCacheError | T {
-        if (!(err instanceof Error) || err instanceof DiskCacheError) {
-            return err
-        }
-
-        const errorId = (err as any).code ?? err.name
-
-        if (DiskCacheError.fileSystemErrorsWithoutMessage.includes(errorId)) {
-            // The error message will probably be blank
-            const message = err.message ? err.message : 'No msg'
-            return new DiskCacheError(message, { code: errorId })
-        }
-
-        // These are errors we were seeing in telemetry
-        if (
-            isError(err, 'ENOSPC', 'no space left on device') ||
-            isError(err, 'EPERM', 'operation not permitted') ||
-            isError(err, 'EBUSY', 'resource busy or locked')
-        ) {
-            return new DiskCacheError(err.message, { code: errorId })
-        }
-
-        return err // the error does no meet the conditions to be a DiskCacheError
-    }
-
-    public get code() {
-        return this.#code
-    }
-}
-
-/**
  * Run a function and swallow any errors that are not specified by `shouldThrow`
  */
 export function tryRun<T>(fn: () => T, shouldThrow: (err: Error) => boolean, logMsg?: string): T | undefined

--- a/packages/core/src/shared/utilities/cacheUtils.ts
+++ b/packages/core/src/shared/utilities/cacheUtils.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { dirname } from 'path'
-import { ToolkitError, isFileNotFoundError } from '../errors'
+import { ErrorInformation, ToolkitError, isFileNotFoundError } from '../errors'
 import fs from '../../shared/fs/fs'
 import { isWeb } from '../extensionGlobals'
 import type { MapSync } from './map'
@@ -121,10 +121,7 @@ export function createDiskCache<V, K>(
                     return
                 }
                 log(`read failed ${error}`, key)
-                throw ToolkitError.chain(error, `Failed to read from "${target}"`, {
-                    code: 'FSReadFailed',
-                    details: { key },
-                })
+                throw createDiskCacheError(error, 'LOAD', target, key)
             }
         },
         save: async (key, data) => {
@@ -142,10 +139,7 @@ export function createDiskCache<V, K>(
                     await fs.writeFile(target, JSON.stringify(data), { mode: 0o600, atomic: true })
                 }
             } catch (error) {
-                throw ToolkitError.chain(error, `Failed to save "${target}"`, {
-                    code: 'FSWriteFailed',
-                    details: { key },
-                })
+                throw createDiskCacheError(error, 'SAVE', target, key)
             }
 
             log('saved', key)
@@ -160,14 +154,33 @@ export function createDiskCache<V, K>(
                     return log('file not found', key)
                 }
 
-                throw ToolkitError.chain(error, `Failed to delete "${target}"`, {
-                    code: 'FSDeleteFailed',
-                    details: { key },
-                })
+                throw createDiskCacheError(error, 'CLEAR', target, key)
             }
 
             log(`deleted (reason: ${reason})`, key)
         },
+    }
+
+    /** Helper to make a disk cache error */
+    function createDiskCacheError(error: unknown, operation: 'LOAD' | 'SAVE' | 'CLEAR', target: string, key: K) {
+        return DiskCacheError.chain(error, `${operation} failed for '${target}'`, {
+            details: { key },
+        })
+    }
+}
+
+/**
+ * Represents a generalized error that happened during a disk cache operation.
+ *
+ * For example, when SSO refreshes a token a disk cache error can occur when it
+ * attempts to read/write the disk cache. These errors can be recoverable and do not
+ * imply that the SSO session is stale. So by creating a context specific instance it
+ * will help to distinguish them when we need to decide if the SSO session is actually
+ * stale.
+ */
+export class DiskCacheError extends ToolkitError.named('DiskCacheError') {
+    public constructor(message: string, info?: Omit<ErrorInformation, 'code'>) {
+        super(message, { ...info, code: 'DiskCacheError' })
     }
 }
 


### PR DESCRIPTION
## Problem:

The original implementation of DiskCacheError can be simplified and still achieve it's original purpose.

## Solution:

During token refresh we eventually write to the disk cache. Sometimes this process fails due to filesystem errors.

We dont need to care about the actual file system error, but only that the error came during a DiskCache operation (i.e when it attempts to save the token to disk)

So instead, at the root of where the disk cache errors ocurr, we will wrap caught errors in a DiskCacheError.
This adds context to the error and allows anything upstream to specifically check for that context, instead of needing to parse the error to see if it was filesystem related.

Additionally not all file system errors were guaranteed to come from the disk cache, so this change allows us to target the right errors.

Signed-off-by: Nikolas Komonen <nkomonen@amazon.com>

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
