### PR TITLE
feat(amazonq): workspace indexing only applies to new files that are changed

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-8fc46bec-9ca5-4544-85dc-a71e0dee1b82.json
+++ b/packages/amazonq/.changes/next-release/Feature-8fc46bec-9ca5-4544-85dc-a71e0dee1b82.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Improve workspace indexing by only index files that are changed since last indexing"
+}

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -173,7 +173,7 @@ export async function activate(extensionContext: ExtensionContext) {
             handledSchemaProtocols: ['file', 'untitled'], // language server only loads file-URI. Fetching schemas with other protocols ('http'...) are made on the client.
             provideFormatter: false, // tell the server to not provide formatting capability and ignore the `aws.stepfunctions.asl.format.enable` setting.
             // this is used by LSP to determine index cache path, move to this folder so that when extension updates index is not deleted.
-            extensionPath: path.join(fs.getUserHomeDir(), '.aws', 'amazonq', 'cache', 'VSCode'),
+            extensionPath: path.join(fs.getUserHomeDir(), '.aws', 'amazonq', 'cache'),
         },
     }
 

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -20,7 +20,7 @@ import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } f
 import { GetUsageRequestType, IndexRequestType, QueryRequestType, UpdateIndexRequestType, Usage } from './types'
 import { Writable } from 'stream'
 import { CodeWhispererSettings } from '../../codewhisperer/util/codewhispererSettings'
-import { getLogger } from '../../shared'
+import { fs, getLogger } from '../../shared'
 
 const localize = nls.loadMessageBundle()
 
@@ -172,7 +172,8 @@ export async function activate(extensionContext: ExtensionContext) {
         initializationOptions: {
             handledSchemaProtocols: ['file', 'untitled'], // language server only loads file-URI. Fetching schemas with other protocols ('http'...) are made on the client.
             provideFormatter: false, // tell the server to not provide formatting capability and ignore the `aws.stepfunctions.asl.format.enable` setting.
-            extensionPath: extensionContext.extensionPath,
+            // this is used by LSP to determine cache path
+            extensionPath: path.join(fs.getUserHomeDir(), '.aws', 'amazonq', 'cache', 'VSCode'),
         },
     }
 

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -172,7 +172,7 @@ export async function activate(extensionContext: ExtensionContext) {
         initializationOptions: {
             handledSchemaProtocols: ['file', 'untitled'], // language server only loads file-URI. Fetching schemas with other protocols ('http'...) are made on the client.
             provideFormatter: false, // tell the server to not provide formatting capability and ignore the `aws.stepfunctions.asl.format.enable` setting.
-            // this is used by LSP to determine cache path
+            // this is used by LSP to determine index cache path, move to this folder so that when extension updates index is not deleted.
             extensionPath: path.join(fs.getUserHomeDir(), '.aws', 'amazonq', 'cache', 'VSCode'),
         },
     }

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -67,7 +67,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.5']
+const supportedLspServerVersions = ['0.1.6']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 /*


### PR DESCRIPTION
## Problem

In current build, when workspace index expires, the IDE rebuild index for all files, which is slow. 

## Solution

Whenever the current index is out of date, the IDE rebuild index for only the files that are changed since last index. 

Meanwhile, this change will also make the index refresh mush faster. New index will be created and refreshed if the existing index is more than 12 hours old.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
