### PR TITLE
fix(auth): add more errors to `isNetworkError()`

### DIFF
--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -829,6 +829,7 @@ export function isNetworkError(err?: unknown): err is Error & { code: string } {
         'EAI_FAIL',
         '502', // This may be irrelevant as isBadResponseCode() may be all we need
         'InternalServerException',
+        'ERR_SSL_WRONG_VERSION_NUMBER',
     ].includes(err.code)
 }
 
@@ -890,7 +891,7 @@ export function isError(err: Error, id: string, messageIncludes: string = '') {
  * These are the errors explicitly seen in telemetry. We can instead do any non-200 response code
  * later, but this will give us better visibility in to the actual error codes we are currently getting.
  */
-const errorResponseCodes = [302, 403, 502]
+const errorResponseCodes = [302, 403, 404, 502, 503]
 
 /**
  * Returns true if the given error is a bad response code

--- a/packages/core/src/test/shared/errors.test.ts
+++ b/packages/core/src/test/shared/errors.test.ts
@@ -526,13 +526,6 @@ describe('util', function () {
         reponseCodeErr.name = '502'
         assert.deepStrictEqual(isNetworkError(reponseCodeErr), true, 'Did not indicate 502 error as network error')
         reponseCodeErr = new Error()
-        reponseCodeErr.name = '503'
-        assert.deepStrictEqual(
-            isNetworkError(reponseCodeErr),
-            false,
-            'Incorrectly indicated 503 error as network error'
-        )
-        reponseCodeErr = new Error()
         reponseCodeErr.name = '200'
         assert.deepStrictEqual(
             isNetworkError(reponseCodeErr),


### PR DESCRIPTION
These showed up in telemetry during `aws_refreshCredentials`

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
