### PR TITLE
refactor(logging): removed types input in getLogger()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ You can also use these NPM tasks (see `npm run` for the full list):
     1. Declare a global unhandledRejection handler.
         ```ts
         process.on('unhandledRejection', (e) => {
-            getLogger('channel').error(
+            getLogger().error(
                 localize(
                     'AWS.channel.aws.toolkit.activation.error',
                     'Error Activating {0} Toolkit: {1}',

--- a/packages/core/src/extensionNode.ts
+++ b/packages/core/src/extensionNode.ts
@@ -237,7 +237,7 @@ export async function activate(context: vscode.ExtensionContext) {
         if (stacktrace !== undefined && stacktrace.length > 40) {
             stacktrace.length = 40
         }
-        getLogger('channel').error(
+        getLogger().error(
             localize(
                 'AWS.channel.aws.toolkit.activation.error',
                 'Error Activating {0} Toolkit: {1} \n{2}',

--- a/packages/core/src/lambda/commands/createNewSamApp.ts
+++ b/packages/core/src/lambda/commands/createNewSamApp.ts
@@ -100,7 +100,7 @@ export async function resumeCreateNewSamApp(
         reason = 'error'
 
         globals.outputChannel.show(true)
-        getLogger('channel').error(
+        getLogger().error(
             localize('AWS.samcli.initWizard.resume.error', 'Error resuming SAM Application creation. {0}', checklogs())
         )
 
@@ -235,7 +235,7 @@ export async function createNewSamApplication(
                 destinationDirectory: vscode.Uri.file(destinationDirectory),
             }
             schemaCodeDownloader = createSchemaCodeDownloaderObject(client!, globals.outputChannel)
-            getLogger('channel').info(
+            getLogger().info(
                 localize(
                     'AWS.message.info.schemas.downloadCodeBindings.start',
                     'Downloading code for schema {0}...',
@@ -333,7 +333,7 @@ export async function createNewSamApplication(
         reason = getTelemetryReason(err)
 
         globals.outputChannel.show(true)
-        getLogger('channel').error(
+        getLogger().error(
             localize('AWS.samcli.initWizard.general.error', 'Error creating new SAM Application. {0}', checklogs())
         )
 

--- a/packages/core/src/lambda/commands/deploySamApplication.ts
+++ b/packages/core/src/lambda/commands/deploySamApplication.ts
@@ -158,7 +158,7 @@ async function buildOperation(params: {
     invoker: SamCliProcessInvoker
 }): Promise<boolean> {
     try {
-        getLogger('channel').info(localize('AWS.samcli.deploy.workflow.init', 'Building SAM Application...'))
+        getLogger().info(localize('AWS.samcli.deploy.workflow.init', 'Building SAM Application...'))
 
         const buildDestination = getBuildRootFolder(params.deployParameters.deployRootFolder)
 
@@ -173,7 +173,7 @@ async function buildOperation(params: {
 
         return true
     } catch (err) {
-        getLogger('channel').warn(
+        getLogger().warn(
             localize(
                 'AWS.samcli.build.failedBuild',
                 '"sam build" failed: {0}',
@@ -200,7 +200,7 @@ async function packageOperation(
         )
     }
 
-    getLogger('channel').info(
+    getLogger().info(
         localize(
             'AWS.samcli.deploy.workflow.packaging',
             'Packaging SAM Application to S3 Bucket: {0}',
@@ -232,7 +232,7 @@ async function deployOperation(params: {
     invoker: SamCliProcessInvoker
 }): Promise<void> {
     try {
-        getLogger('channel').info(
+        getLogger().info(
             localize(
                 'AWS.samcli.deploy.workflow.stackName.initiated',
                 'Deploying SAM Application to CloudFormation Stack: {0}',
@@ -273,13 +273,13 @@ async function deploy(params: {
     window: WindowFunctions
 }): Promise<void> {
     globals.outputChannel.show(true)
-    getLogger('channel').info(localize('AWS.samcli.deploy.workflow.start', 'Starting SAM Application deployment...'))
+    getLogger().info(localize('AWS.samcli.deploy.workflow.start', 'Starting SAM Application deployment...'))
 
     const buildSuccessful = await buildOperation(params)
     await packageOperation(params, buildSuccessful)
     await deployOperation(params)
 
-    getLogger('channel').info(
+    getLogger().info(
         localize(
             'AWS.samcli.deploy.workflow.success',
             'Deployed SAM Application to CloudFormation Stack: {0}',
@@ -311,10 +311,10 @@ function enhanceAwsCloudFormationInstructions(
 }
 
 function outputDeployError(error: Error) {
-    getLogger('channel').error(error)
+    getLogger().error(error)
 
     globals.outputChannel.show(true)
-    getLogger('channel').error('AWS.samcli.deploy.general.error', 'Error deploying a SAM Application. {0}', checklogs())
+    getLogger().error('AWS.samcli.deploy.general.error', 'Error deploying a SAM Application. {0}', checklogs())
 }
 
 function getDefaultWindowFunctions(): WindowFunctions {

--- a/packages/core/src/lambda/local/debugConfiguration.ts
+++ b/packages/core/src/lambda/local/debugConfiguration.ts
@@ -256,7 +256,7 @@ export function getArchitecture(
         const isArch = isArchitecture(arch)
 
         if (!isArch) {
-            getLogger('channel').warn('SAM Invoke: Invalid architecture. Defaulting to x86_64.')
+            getLogger().warn('SAM Invoke: Invalid architecture. Defaulting to x86_64.')
             void vscode.window.showWarningMessage(
                 localize(
                     'AWS.output.sam.invalidArchitecture',

--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -71,27 +71,21 @@ export async function activate(
  * @param opts.logLevel Log messages at or above this level
  * @param opts.logPaths Array of paths to output log entries to
  * @param opts.outputChannels Array of output channels to log entries to
- * @param opts.useDebugConsole If true, outputs log entries to `vscode.debug.activeDebugConsole`
  * @param opts.useConsoleLog If true, outputs log entries to the nodejs or browser devtools console.
  */
 export function makeLogger(opts: {
     logLevel: LogLevel
     logPaths?: vscode.Uri[]
     outputChannels?: vscode.OutputChannel[]
-    useDebugConsole?: boolean
     useConsoleLog?: boolean
 }): Logger {
     const logger = new WinstonToolkitLogger(opts.logLevel)
     // debug console can show ANSI colors, output channels can not
-    const stripAnsi = opts.useDebugConsole ?? false
     for (const logPath of opts.logPaths ?? []) {
         logger.logToFile(logPath)
     }
     for (const outputChannel of opts.outputChannels ?? []) {
-        logger.logToOutputChannel(outputChannel, stripAnsi)
-    }
-    if (opts.useDebugConsole) {
-        logger.logToDebugConsole()
+        logger.logToOutputChannel(outputChannel)
     }
     if (opts.useConsoleLog) {
         logger.logToConsole()

--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -46,16 +46,6 @@ export async function activate(
 
     setLogger(mainLogger)
 
-    // Logs to "AWS Toolkit" output channel.
-    setLogger(
-        makeLogger({
-            logLevel: chanLogLevel,
-            logPaths: logUri ? [logUri] : undefined,
-            outputChannels: [outputChannel, logChannel],
-        }),
-        'channel'
-    )
-
     // Logs to vscode Debug Console.
     setLogger(
         makeLogger({

--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -51,7 +51,7 @@ export async function activate(
         makeLogger({
             logLevel: chanLogLevel,
             outputChannels: [outputChannel, logChannel],
-            useDebugConsole: true,
+            useConsoleLog: true,
         }),
         'debugConsole'
     )

--- a/packages/core/src/shared/logger/index.ts
+++ b/packages/core/src/shared/logger/index.ts
@@ -12,4 +12,5 @@ export type Loggable = Error | string
 export type Logger = logger.Logger
 export type LogLevel = logger.LogLevel
 export const getLogger = logger.getLogger
+export const getDebugConsoleLogger = logger.getDebugConsoleLogger
 export const getNullLogger = logger.getNullLogger

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -84,18 +84,19 @@ export function compareLogLevel(l1: LogLevel, l2: LogLevel): number {
 
 /**
  * Gets the logger if it has been initialized
- * @param type Gets the logger type:
- * * `'main'` or `undefined`: Main logger; default impl: logs to log file and log output channel
- * * `'channel'`: Channel Logger; default impl: logs to the `main` channels and the `AWS Toolkit` output channel
- * * `'debug'`: Debug Console Logger; default impl: logs to the `channel` channels and the currently-active VS Code Debug Console pane.
+ * the logger is of `'main'` or `undefined`: Main logger; default impl: logs to log file and log output channel
  */
-export function getLogger(type?: keyof typeof toolkitLoggers): Logger {
-    const logger = toolkitLoggers[type ?? 'main']
+export function getLogger(): Logger {
+    const logger = toolkitLoggers['main']
     if (!logger) {
         return new ConsoleLogger()
     }
 
     return logger
+}
+
+export function getDebugConsoleLogger(): Logger {
+    return toolkitLoggers['debugConsole'] ?? new ConsoleLogger()
 }
 
 export class NullLogger implements Logger {
@@ -187,7 +188,7 @@ export class ConsoleLogger implements Logger {
     public enableDebugConsole(): void {}
 }
 
-export function getNullLogger(type?: 'channel' | 'debugConsole' | 'main'): Logger {
+export function getNullLogger(type?: 'debugConsole' | 'main'): Logger {
     return new NullLogger()
 }
 /**
@@ -195,6 +196,6 @@ export function getNullLogger(type?: 'channel' | 'debugConsole' | 'main'): Logge
  * The Extension is expected to call this only once per log type.
  * Tests should call this to set up a logger prior to executing code that accesses a logger.
  */
-export function setLogger(logger: Logger | undefined, type?: 'channel' | 'debugConsole' | 'main') {
+export function setLogger(logger: Logger | undefined, type?: 'debugConsole' | 'main') {
     toolkitLoggers[type ?? 'main'] = logger
 }

--- a/packages/core/src/shared/logger/winstonToolkitLogger.ts
+++ b/packages/core/src/shared/logger/winstonToolkitLogger.ts
@@ -44,7 +44,7 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
     }
 
     public enableDebugConsole(): void {
-        this.logToDebugConsole()
+        this.logToConsole()
     }
 
     public setLogLevel(logLevel: LogLevel) {
@@ -74,7 +74,7 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
         this.logger.add(fileTransport)
     }
 
-    public logToOutputChannel(outputChannel: vscode.OutputChannel, stripAnsi: boolean): void {
+    public logToOutputChannel(outputChannel: vscode.OutputChannel, stripAnsi: boolean = false): void {
         const outputChannelTransport: winston.transport = new OutputChannelTransport({
             outputChannel,
             stripAnsi,
@@ -82,16 +82,6 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
         const channelUri: vscode.Uri = vscode.Uri.parse(`channel://${outputChannel.name}`)
         outputChannelTransport.on('logged', (obj: any) => this.parseLogObject(channelUri, obj))
         this.logger.add(outputChannelTransport)
-    }
-
-    public logToDebugConsole(): void {
-        const debugConsoleTransport = new OutputChannelTransport({
-            name: 'DebugConsole',
-            outputChannel: vscode.debug.activeDebugConsole,
-        })
-        const debugConsoleUri: vscode.Uri = vscode.Uri.parse('console://debug')
-        debugConsoleTransport.on('logged', (obj: any) => this.parseLogObject(debugConsoleUri, obj))
-        this.logger.add(debugConsoleTransport)
     }
 
     public logToConsole(): void {

--- a/packages/core/src/shared/sam/cli/samCliInvoker.ts
+++ b/packages/core/src/shared/sam/cli/samCliInvoker.ts
@@ -52,7 +52,7 @@ export class DefaultSamCliProcessInvoker implements SamCliProcessInvoker {
             spawnOptions: await addTelemetryEnvVar(options?.spawnOptions),
         })
 
-        getLogger('channel').info(localize('AWS.running.command', 'Command: {0}', `${this.childProcess}`))
+        getLogger().info(localize('AWS.running.command', 'Command: {0}', `${this.childProcess}`))
         log.verbose(`running: ${this.childProcess}`)
         return await this.childProcess.run({
             onStdout: (text, context) => {

--- a/packages/core/src/shared/sam/cli/samCliInvoker.ts
+++ b/packages/core/src/shared/sam/cli/samCliInvoker.ts
@@ -36,6 +36,7 @@ export class DefaultSamCliProcessInvoker implements SamCliProcessInvoker {
         const invokeOptions = makeRequiredSamCliProcessInvokeOptions(options)
         const logging = options?.logging !== false
         const getLogger = logging ? logger.getLogger : logger.getNullLogger
+        const getDebugConsoleLogger = logging ? logger.getDebugConsoleLogger : logger.getNullLogger
         const log = getLogger()
 
         const sam = await this.context.getOrDetectSamCli()
@@ -55,12 +56,12 @@ export class DefaultSamCliProcessInvoker implements SamCliProcessInvoker {
         log.verbose(`running: ${this.childProcess}`)
         return await this.childProcess.run({
             onStdout: (text, context) => {
-                getLogger('debugConsole').info(text)
+                getDebugConsoleLogger().info(text)
                 log.verbose(`stdout: ${text}`)
                 options?.onStdout?.(text, context)
             },
             onStderr: (text, context) => {
-                getLogger('debugConsole').info(text)
+                getDebugConsoleLogger().info(text)
                 log.verbose(`stderr: ${text}`)
                 options?.onStderr?.(text, context)
             },

--- a/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -7,7 +7,7 @@ import * as proc from 'child_process'
 import { pushIf } from '../../utilities/collectionUtils'
 import * as nls from 'vscode-nls'
 import { fileExists } from '../../filesystemUtilities'
-import { getLogger, Logger } from '../../logger'
+import { getLogger, getDebugConsoleLogger, Logger } from '../../logger'
 import { ChildProcess } from '../../utilities/childProcess'
 import { Timeout } from '../../utilities/timeoutUtils'
 import { removeAnsi } from '../../utilities/textUtilities'
@@ -74,13 +74,13 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                     rejectOnError: true,
                     timeout: params.timeout,
                     onStdout: (text: string): void => {
-                        getLogger('debugConsole').info(text, { raw: true })
+                        getDebugConsoleLogger().info(text, { raw: true })
                         // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                         params.timeout?.refresh()
                         this.logger.verbose('SAM: pid %d: stdout: %s', childProcess.pid(), removeAnsi(text))
                     },
                     onStderr: (text: string): void => {
-                        getLogger('debugConsole').info(text, { raw: true })
+                        getDebugConsoleLogger().info(text, { raw: true })
                         // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                         params.timeout?.refresh()
                         this.logger.verbose('SAM: pid %d: stderr: %s', childProcess.pid(), removeAnsi(text))

--- a/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -62,7 +62,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
         const childProcess = new ChildProcess(params.command, params.args, {
             spawnOptions: await addTelemetryEnvVar(options),
         })
-        getLogger('channel').info('AWS.running.command', 'Command: {0}', `${childProcess}`)
+        getLogger().info('AWS.running.command', 'Command: {0}', `${childProcess}`)
         // "sam local invoke", "sam local start-api", etc.
         const samCommandName = `sam ${params.args[0]} ${params.args[1]}`
 
@@ -97,7 +97,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                     },
                 })
                 .catch((error) => {
-                    getLogger('channel').error(
+                    getLogger().error(
                         localize('AWS.samcli.error', 'Error running command "{0}": {1}', samCommandName, error.message)
                     )
                     reject(error)

--- a/packages/core/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/packages/core/src/shared/sam/debugger/csharpSamDebug.ts
@@ -112,7 +112,7 @@ async function _installDebugger({ debuggerPath }: InstallDebuggerArgs): Promise<
     await ensureDir(debuggerPath)
 
     try {
-        getLogger('channel').info(
+        getLogger().info(
             localize(
                 'AWS.samcli.local.invoke.debugger.install',
                 'Installing .NET Core Debugger to {0}...',
@@ -173,7 +173,7 @@ async function _installDebugger({ debuggerPath }: InstallDebuggerArgs): Promise<
             throw new Error(`command failed (exit code: ${install.exitCode}): ${installCommand}`)
         }
     } catch (err) {
-        getLogger('channel').info(
+        getLogger().info(
             localize(
                 'AWS.samcli.local.invoke.debugger.install.failed',
                 'Error installing .NET Core Debugger: {0}',

--- a/packages/core/src/shared/sam/debugger/goSamDebug.ts
+++ b/packages/core/src/shared/sam/debugger/goSamDebug.ts
@@ -192,7 +192,7 @@ async function makeInstallScript(debuggerPath: string, isWindows: boolean): Prom
         let repoPath: string = path.join(goPath, 'src', delveRepo)
 
         if (!getDelveVersion(repoPath, true)) {
-            getLogger('channel').info(
+            getLogger().info(
                 localize(
                     'AWS.sam.debugger.godelve.download',
                     'The Delve repo was not found in your GOPATH. Downloading in a temporary directory...'
@@ -249,15 +249,15 @@ async function installDebugger(debuggerPath: string): Promise<boolean> {
 
         const childProcess = new ChildProcess(installScript.path, [], { spawnOptions: installScript.options })
         const install = await childProcess.run({
-            onStdout: (text: string) => getLogger('channel').info(`[Delve install script] -> ${text}`),
-            onStderr: (text: string) => getLogger('channel').error(`[Delve install script] -> ${text}`),
+            onStdout: (text: string) => getLogger().info(`[Delve install script] -> ${text}`),
+            onStderr: (text: string) => getLogger().error(`[Delve install script] -> ${text}`),
         })
 
         const code = install.exitCode
         if (!fs.existsSync(path.join(debuggerPath, 'dlv'))) {
             throw new Error(`Install script did not generate the Delve binary: exit code ${code}`)
         } else if (code) {
-            getLogger('channel').warn(`Install script did not sucessfully run, using old Delve binary...`)
+            getLogger().warn(`Install script did not sucessfully run, using old Delve binary...`)
         } else {
             getLogger().info(`Installed Delve debugger in ${debuggerPath}`)
         }

--- a/packages/core/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/packages/core/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -161,10 +161,10 @@ async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
 
         try {
             const tsConfig = JSON.parse(readFileSync(tsConfigPath).toString())
-            getLogger('channel').info(`Using base TypeScript config: ${tsConfigPath}`)
+            getLogger().info(`Using base TypeScript config: ${tsConfigPath}`)
             return tsConfig
         } catch (err) {
-            getLogger('channel').error(`Unable to use TypeScript base: ${tsConfigPath}`)
+            getLogger().error(`Unable to use TypeScript base: ${tsConfigPath}`)
         }
 
         return undefined
@@ -176,7 +176,7 @@ async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
         loadBaseConfig(tsConfigPath) ?? loadBaseConfig(path.join(config.codeRoot, tsConfigInitialBaseFile)) ?? {}
 
     if (tsConfig.compilerOptions === undefined) {
-        getLogger('channel').info('Creating TypeScript config')
+        getLogger().info('Creating TypeScript config')
         tsConfig.compilerOptions = {
             target: 'es6',
             module: 'commonjs',
@@ -207,7 +207,7 @@ async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
     // resolve ts lambda handler to point into build directory relative to codeRoot
     const tsLambdaHandler = path.relative(config.codeRoot, path.join(tsBuildDir, config.invokeTarget.lambdaHandler))
     config.invokeTarget.lambdaHandler = pathutil.normalizeSeparator(tsLambdaHandler)
-    getLogger('channel').info(`Resolved compiled lambda handler to ${tsLambdaHandler}`)
+    getLogger().info(`Resolved compiled lambda handler to ${tsLambdaHandler}`)
 
     const tsc = await findTypescriptCompiler()
     if (!tsc) {
@@ -215,10 +215,10 @@ async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
     }
 
     try {
-        getLogger('channel').info(`Compiling TypeScript app with: "${tsc}"`)
+        getLogger().info(`Compiling TypeScript app with: "${tsc}"`)
         await new ChildProcess(tsc, ['--project', tsConfigPath]).run()
     } catch (error) {
-        getLogger('channel').error(`TypeScript compile error: ${error}`)
+        getLogger().error(`TypeScript compile error: ${error}`)
         throw Error('Failed to compile TypeScript app')
     }
 }

--- a/packages/core/src/shared/sam/localLambdaRunner.ts
+++ b/packages/core/src/shared/sam/localLambdaRunner.ts
@@ -125,7 +125,7 @@ async function buildLambdaHandler(
 ): Promise<string> {
     const processInvoker = new DefaultSamCliProcessInvoker(settings)
 
-    getLogger('channel').info(localize('AWS.output.building.sam.application', 'Building SAM application...'))
+    getLogger().info(localize('AWS.output.building.sam.application', 'Building SAM application...'))
     const samBuildOutputFolder = path.join(config.baseBuildDir!, 'output')
 
     const samCliArgs: SamCliBuildInvocationArguments = {
@@ -167,7 +167,7 @@ async function buildLambdaHandler(
             throw ToolkitError.chain(err, msg, { code: 'BuildFailure' })
         }
     }
-    getLogger('channel').info(localize('AWS.output.building.sam.application.complete', 'Build complete.'))
+    getLogger().info(localize('AWS.output.building.sam.application.complete', 'Build complete.'))
 
     return path.join(samBuildOutputFolder, 'template.yaml')
 }
@@ -178,7 +178,7 @@ async function invokeLambdaHandler(
     config: SamLaunchRequestArgs,
     settings: SamCliSettings
 ): Promise<ChildProcess> {
-    getLogger('channel').info(localize('AWS.output.starting.sam.app.locally', 'Starting SAM application locally'))
+    getLogger().info(localize('AWS.output.starting.sam.app.locally', 'Starting SAM application locally'))
     getLogger().debug(`localLambdaRunner.invokeLambdaFunction: ${config.name}`)
 
     const debugPort = !config.noDebug ? config.debugPort?.toString() : undefined
@@ -283,11 +283,9 @@ export async function runLambdaFunction(
         const msg =
             (config.invokeTarget.target === 'api' ? `API "${config.api?.path}", ` : '') +
             `Lambda "${config.handlerName}"`
-        getLogger('channel').info(localize('AWS.output.sam.local.startDebug', 'Preparing to debug locally: {0}', msg))
+        getLogger().info(localize('AWS.output.sam.local.startDebug', 'Preparing to debug locally: {0}', msg))
     } else {
-        getLogger('channel').info(
-            localize('AWS.output.sam.local.startRun', 'Preparing to run locally: {0}', config.handlerName)
-        )
+        getLogger().info(localize('AWS.output.sam.local.startRun', 'Preparing to run locally: {0}', config.handlerName))
     }
 
     const envVars = {
@@ -336,9 +334,7 @@ export async function runLambdaFunction(
 
     async function attach() {
         if (config.onWillAttachDebugger) {
-            getLogger('channel').info(
-                localize('AWS.output.sam.local.waiting', 'Waiting for SAM application to start...')
-            )
+            getLogger().info(localize('AWS.output.sam.local.waiting', 'Waiting for SAM application to start...'))
             await config.onWillAttachDebugger(config.debugPort!, timer)
         }
         // HACK: remove non-serializable properties before attaching.
@@ -423,7 +419,7 @@ async function requestLocalApi(
         // TODO: api?.stageVariables,
     }
 
-    getLogger('channel').info(localize('AWS.sam.localApi.request', 'Sending request to local API: {0}', uri))
+    getLogger().info(localize('AWS.sam.localApi.request', 'Sending request to local API: {0}', uri))
 
     await got(uri, reqOpts).catch((err: RequestError) => {
         if (err.code === 'ETIMEDOUT') {
@@ -468,7 +464,7 @@ export async function attachDebugger({
         )}`
     )
 
-    getLogger('channel').info(localize('AWS.output.sam.local.attaching', 'Attaching debugger to SAM application...'))
+    getLogger().info(localize('AWS.output.sam.local.attaching', 'Attaching debugger to SAM application...'))
 
     // The Python extension will silently fail, so it's ok for us to automatically retry
     // Users still will not be able to stop debugging without clicking stop a bunch, but
@@ -495,7 +491,7 @@ export async function attachDebugger({
         }
     }
 
-    getLogger('channel').info(localize('AWS.output.sam.local.attach.success', 'Debugger attached'))
+    getLogger().info(localize('AWS.output.sam.local.attach.success', 'Debugger attached'))
     getLogger().verbose(
         `SAM: debug session: "${vscode.debug.activeDebugSession?.name}" / ${vscode.debug.activeDebugSession?.id}`
     )
@@ -516,13 +512,11 @@ export async function waitForPort(port: number, timeout: Timeout, isDebugPort: b
     } catch (err) {
         getLogger().warn(`Timeout after ${time} ms: port was not used: ${port}`)
         if (isDebugPort) {
-            getLogger('channel').warn(
+            getLogger().warn(
                 localize('AWS.samcli.local.invoke.portUnavailable', 'Failed to use debugger port: {0}', port.toString())
             )
         } else {
-            getLogger('channel').warn(
-                localize('AWS.apig.portUnavailable', 'Failed to use API port: {0}', port.toString())
-            )
+            getLogger().warn(localize('AWS.apig.portUnavailable', 'Failed to use API port: {0}', port.toString()))
         }
     }
 }

--- a/packages/core/src/shared/utilities/cliUtils.ts
+++ b/packages/core/src/shared/utilities/cliUtils.ts
@@ -258,7 +258,7 @@ async function installSsmCli(
     const finalPath = path.join(getToolkitLocalCliPath(), getOsCommand(awsClis['session-manager-plugin']))
     const TimedProcess = ChildProcess.extend({ timeout, rejectOnError: true, rejectOnErrorCode: true })
 
-    getLogger('channel').info(`Installing SSM CLI from ${ssmInstaller} to ${outDir}...`)
+    getLogger().info(`Installing SSM CLI from ${ssmInstaller} to ${outDir}...`)
     progress.report({ message: msgInstallingLocal })
 
     return handleError(install())
@@ -340,7 +340,7 @@ export async function getOrInstallCli(cli: AwsClis, confirm: boolean): Promise<s
 //     const awsInstaller = await downloadCliSource(AWS_CLIS.aws, tempDir)
 //     fs.chmodSync(awsInstaller, 0o700)
 
-//     getLogger('channel').info(`Installing AWS CLI from ${awsInstaller} to ${getToolkitCliDir()}...`)
+//     getLogger().info(`Installing AWS CLI from ${awsInstaller} to ${getToolkitCliDir()}...`)
 //     progress.report({ message: msgInstallingLocal })
 //     switch (process.platform) {
 //         case 'win32': {

--- a/packages/core/src/test/globalSetup.test.ts
+++ b/packages/core/src/test/globalSetup.test.ts
@@ -138,7 +138,6 @@ function setupTestLogger(): TestLogger {
     // That way, we don't have to worry about which channel is being logged to for inspection.
     const logger = new TestLogger()
     setLogger(logger, 'main')
-    setLogger(logger, 'channel')
     setLogger(logger, 'debugConsole')
 
     return logger
@@ -148,7 +147,6 @@ function teardownTestLogger(testName: string) {
     writeLogsToFile(testName)
 
     setLogger(undefined, 'main')
-    setLogger(undefined, 'channel')
     setLogger(undefined, 'debugConsole')
 }
 


### PR DESCRIPTION
## Problem
Currently we use `getLogger()` for all log messages.

`getLogger()` takes a type input, indicating one of three logger types: 'channel', 'debugConsole', and 'main'.

- The `channel` type is out dated and no longer carries meaning. Might even confuse other developers if they come across this.
- The `debugConsole` type logging calls are only used in SamCLI, we shouldn’t complicate a very popular interface with something so specific and rarely used. 
- It's discovered in implementation that the current `debugConsole` is not printing to IDE's debug console, this is fixed in one of the commits. 


This change is also a pre-rec of the following project:
https://quip-amazon.com/B4hTAcZSsGXF/VSC-Better-Logging-With-Headers

## Solution
1. The `channel` type should be removed, converting existing calls into `main` type.
2. Move the `debugConsole` type logger out of the `getLogger`, into a separate function `debugConsoleLogger()' only for the rare calls in SamCLI.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
