### PR TITLE
fix(amazonq): fix chat project context telemetry discrepancy

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -332,7 +332,9 @@ export class CWCTelemetryHelper {
 
     public recordAddMessage(triggerPayload: TriggerPayload, message: PromptAnswer) {
         const triggerEvent = this.triggerEventsStorage.getLastTriggerEventByTabID(message.tabID)
-
+        const hasProjectLevelContext = triggerPayload.relevantTextDocuments
+            ? triggerPayload.relevantTextDocuments.length > 0 && triggerPayload.useRelevantDocuments === true
+            : false
         const event: AmazonqAddMessage = {
             result: 'Succeeded',
             cwsprChatConversationId: this.getConversationId(message.tabID) ?? '',
@@ -356,15 +358,14 @@ export class CWCTelemetryHelper {
             cwsprChatConversationType: 'Chat',
             credentialStartUrl: AuthUtil.instance.startUrl,
             codewhispererCustomizationArn: triggerPayload.customization.arn,
-            cwsprChatHasProjectContext: triggerPayload.relevantTextDocuments
-                ? triggerPayload.relevantTextDocuments.length > 0 && triggerPayload.useRelevantDocuments === true
-                : false,
+            cwsprChatHasProjectContext: hasProjectLevelContext,
         }
 
         telemetry.amazonq_addMessage.emit(event)
         const language = this.isProgrammingLanguageSupported(triggerPayload.fileLanguage)
             ? { languageName: triggerPayload.fileLanguage as string }
             : undefined
+
         codeWhispererClient
             .sendTelemetryEvent({
                 telemetryEvent: {
@@ -381,9 +382,7 @@ export class CWCTelemetryHelper {
                         requestLength: event.cwsprChatRequestLength,
                         responseLength: event.cwsprChatResponseLength,
                         numberOfCodeBlocks: event.cwsprChatResponseCodeSnippetCount,
-                        hasProjectLevelContext: triggerPayload.relevantTextDocuments
-                            ? triggerPayload.relevantTextDocuments.length > 0
-                            : false,
+                        hasProjectLevelContext: hasProjectLevelContext,
                         customizationArn: undefinedIfEmpty(getSelectedCustomization().arn),
                     },
                 },

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -332,9 +332,7 @@ export class CWCTelemetryHelper {
 
     public recordAddMessage(triggerPayload: TriggerPayload, message: PromptAnswer) {
         const triggerEvent = this.triggerEventsStorage.getLastTriggerEventByTabID(message.tabID)
-        const hasProjectLevelContext = triggerPayload.relevantTextDocuments
-            ? triggerPayload.relevantTextDocuments.length > 0 && triggerPayload.useRelevantDocuments === true
-            : false
+        const hasProjectLevelContext = triggerPayload.relevantTextDocuments &&            triggerPayload.relevantTextDocuments.length > 0 && triggerPayload.useRelevantDocuments === true            
         const event: AmazonqAddMessage = {
             result: 'Succeeded',
             cwsprChatConversationId: this.getConversationId(message.tabID) ?? '',

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -332,7 +332,10 @@ export class CWCTelemetryHelper {
 
     public recordAddMessage(triggerPayload: TriggerPayload, message: PromptAnswer) {
         const triggerEvent = this.triggerEventsStorage.getLastTriggerEventByTabID(message.tabID)
-        const hasProjectLevelContext = triggerPayload.relevantTextDocuments &&            triggerPayload.relevantTextDocuments.length > 0 && triggerPayload.useRelevantDocuments === true            
+        const hasProjectLevelContext =
+            triggerPayload.relevantTextDocuments &&
+            triggerPayload.relevantTextDocuments.length > 0 &&
+            triggerPayload.useRelevantDocuments === true
         const event: AmazonqAddMessage = {
             result: 'Succeeded',
             cwsprChatConversationId: this.getConversationId(message.tabID) ?? '',


### PR DESCRIPTION
## Problem
There is a discrepancy between STE telemetry and toolkit telemetry in terms of field `cwsprChatHasProjectContext` in 
`AmazonqAddMessage`.

## Solution

Use same boolean field for `cwsprChatHasProjectContext`

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
