### PR TITLE
telemetry(amazonq): measure e2e latency for amazon q requests

### DIFF
--- a/packages/core/src/amazonq/messages/chatMessageDuration.ts
+++ b/packages/core/src/amazonq/messages/chatMessageDuration.ts
@@ -11,7 +11,7 @@ export class AmazonQChatMessageDuration {
     /**
      * Record the initial requests in the chat message flow
      */
-    static startListening(msg: { traceId: string; startTime: number; trigger?: string }) {
+    static startChatMessageTelemetry(msg: { traceId: string; startTime: number; trigger?: string }) {
         const { traceId, startTime, trigger } = msg
 
         uiEventRecorder.set(traceId, {
@@ -34,7 +34,7 @@ export class AmazonQChatMessageDuration {
     /**
      * Stop listening to all incoming events and emit what we've found
      */
-    static stopListening(msg: { traceId: string }) {
+    static stopChatMessageTelemetry(msg: { traceId: string }) {
         const { traceId } = msg
 
         // We can't figure out what trace this event was associated with

--- a/packages/core/src/amazonq/messages/chatMessageDuration.ts
+++ b/packages/core/src/amazonq/messages/chatMessageDuration.ts
@@ -1,0 +1,93 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globals } from '../../shared'
+import { telemetry } from '../../shared/telemetry'
+import { Event, uiEventRecorder } from '../util/eventRecorder'
+
+export class AmazonQChatMessageDuration {
+    /**
+     * Record the initial requests in the chat message flow
+     */
+    static startListening(msg: { traceId: string; startTime: number; trigger?: string }) {
+        const { traceId, startTime, trigger } = msg
+
+        uiEventRecorder.set(traceId, {
+            events: {
+                chatMessageSent: startTime,
+            },
+        })
+        uiEventRecorder.set(traceId, {
+            events: {
+                editorReceivedMessage: globals.clock.Date.now(),
+            },
+        })
+        if (trigger) {
+            uiEventRecorder.set(traceId, {
+                trigger,
+            })
+        }
+    }
+
+    /**
+     * Stop listening to all incoming events and emit what we've found
+     */
+    static stopListening(msg: { traceId: string }) {
+        const { traceId } = msg
+
+        // We can't figure out what trace this event was associated with
+        if (!traceId) {
+            return
+        }
+
+        uiEventRecorder.set(traceId, {
+            events: {
+                messageDisplayed: globals.clock.Date.now(),
+            },
+        })
+
+        const metrics = uiEventRecorder.get(traceId)
+
+        // get events sorted by the time they were created
+        const events = Object.entries(metrics.events)
+            .map((x) => ({
+                event: x[0],
+                duration: x[1],
+            }))
+            .sort((a, b) => {
+                return a.duration - b.duration
+            })
+
+        const chatMessageSentTime = events[events.length - 1].duration
+        // Get the total duration by subtracting when the message was displayed and when the chat message was first sent
+        const totalDuration = events[events.length - 1].duration - events[0].duration
+
+        /**
+         * Find the time it took to get between two metric events
+         */
+        const timings = new Map<Event, number>()
+        for (let i = 1; i < events.length; i++) {
+            const currentEvent = events[i]
+            const previousEvent = events[i - 1]
+
+            const timeDifference = currentEvent.duration - previousEvent.duration
+
+            timings.set(currentEvent.event as Event, timeDifference)
+        }
+
+        telemetry.amazonq_chatRoundTrip.emit({
+            amazonqChatMessageSentTime: chatMessageSentTime,
+            amazonqEditorReceivedMessageMs: timings.get('editorReceivedMessage') ?? -1,
+            amazonqFeatureReceivedMessageMs: timings.get('featureReceivedMessage') ?? -1,
+            amazonqMessageDisplayedMs: timings.get('messageDisplayed') ?? -1,
+            source: metrics.trigger,
+            duration: totalDuration,
+            result: 'Succeeded',
+            traceId,
+        })
+
+        uiEventRecorder.delete(traceId)
+    }
+}

--- a/packages/core/src/amazonq/util/eventRecorder.ts
+++ b/packages/core/src/amazonq/util/eventRecorder.ts
@@ -13,6 +13,15 @@ export type Event =
 
 /**
  * For a given traceID, map an event to a time
+ *
+ * This is used to correlated disjoint events that are happening in different
+ * parts of Q Chat.
+ *
+ * It allows us to tracks time intervals between key events:
+ *  - when VSCode received the message
+ *  - when the feature starts processing the message
+ *  - final message rendering
+ * and emit those as a final result, rather than having to emit each event individually
  */
 export const uiEventRecorder = new RecordMap<{
     trigger: string

--- a/packages/core/src/amazonq/util/eventRecorder.ts
+++ b/packages/core/src/amazonq/util/eventRecorder.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { RecordMap } from '../../shared/utilities/map'
+
+export type Event =
+    | 'chatMessageSent' // initial on chat prompt event in the ui
+    | 'editorReceivedMessage' // message gets from the chat prompt to VSCode
+    | 'featureReceivedMessage' // message gets redirected from VSCode -> Partner team features implementation
+    | 'messageDisplayed' // message gets received in the UI
+
+/**
+ * For a given traceID, map an event to a time
+ */
+export const uiEventRecorder = new RecordMap<{
+    trigger: string
+    events: Partial<Record<Event, number>>
+}>()

--- a/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
+++ b/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
@@ -10,6 +10,7 @@ import { TabType } from '../ui/storages/tabsStorage'
 import { getLogger } from '../../../shared/logger'
 import { amazonqMark } from '../../../shared/performance/marks'
 import { telemetry } from '../../../shared/telemetry'
+import { AmazonQChatMessageDuration } from '../../messages/chatMessageDuration'
 
 export function dispatchWebViewMessagesToApps(
     webview: Webview,
@@ -30,6 +31,14 @@ export function dispatchWebViewMessagesToApps(
             })
             performance.clearMarks(amazonqMark.uiReady)
             performance.clearMarks(amazonqMark.open)
+            return
+        }
+
+        if (msg.type === 'startListening') {
+            AmazonQChatMessageDuration.startListening(msg)
+            return
+        } else if (msg.type === 'stopListening') {
+            AmazonQChatMessageDuration.stopListening(msg)
             return
         }
 

--- a/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
+++ b/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
@@ -34,11 +34,11 @@ export function dispatchWebViewMessagesToApps(
             return
         }
 
-        if (msg.type === 'startListening') {
-            AmazonQChatMessageDuration.startListening(msg)
+        if (msg.type === 'startChatMessageTelemetry') {
+            AmazonQChatMessageDuration.startChatMessageTelemetry(msg)
             return
-        } else if (msg.type === 'stopListening') {
-            AmazonQChatMessageDuration.stopListening(msg)
+        } else if (msg.type === 'stopChatMessageTelemetry') {
+            AmazonQChatMessageDuration.stopChatMessageTelemetry(msg)
             return
         }
 

--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -8,9 +8,11 @@ import { ExtensionMessage } from '../commands'
 import { CodeReference } from './amazonqCommonsConnector'
 import { TabOpenType, TabsStorage } from '../storages/tabsStorage'
 import { FollowUpGenerator } from '../followUps/generator'
+import { TracedChatItem } from '../connector'
 
 interface ChatPayload {
     chatMessage: string
+    traceId?: string
     chatCommand?: string
 }
 
@@ -188,6 +190,7 @@ export class Connector {
                 command: 'chat-prompt',
                 chatMessage: payload.chatMessage,
                 chatCommand: payload.chatCommand,
+                traceId: payload.traceId,
                 tabType: 'cwc',
             })
         })
@@ -258,13 +261,14 @@ export class Connector {
                       }
                     : undefined
 
-            const answer: ChatItem = {
+            const answer: TracedChatItem = {
                 type: messageData.messageType,
                 messageId: messageData.messageID ?? messageData.triggerID,
                 body: messageData.message,
                 followUp: followUps,
                 canBeVoted: true,
                 codeReference: messageData.codeReference,
+                traceId: messageData.traceId,
             }
 
             // If it is not there we will not set it
@@ -291,7 +295,7 @@ export class Connector {
             return
         }
         if (messageData.messageType === ChatItemType.ANSWER) {
-            const answer: ChatItem = {
+            const answer: TracedChatItem = {
                 type: messageData.messageType,
                 body: undefined,
                 relatedContent: undefined,
@@ -304,6 +308,7 @@ export class Connector {
                               options: messageData.followUps,
                           }
                         : undefined,
+                traceId: messageData.traceId,
             }
             this.onChatAnswerReceived(messageData.tabID, answer)
 

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -26,18 +26,23 @@ export interface CodeReference {
 
 export interface ChatPayload {
     chatMessage: string
+    traceId?: string // TODO: instrumented for cwc, not for gumby/featuredev. Remove the ? once we support all features
     chatCommand?: string
+}
+
+export interface TracedChatItem extends ChatItem {
+    traceId?: string
 }
 
 export interface ConnectorProps {
     sendMessageToExtension: (message: ExtensionMessage) => void
     onMessageReceived?: (tabID: string, messageData: any, needToShowAPIDocsTab: boolean) => void
     onChatAnswerUpdated?: (tabID: string, message: ChatItem) => void
-    onChatAnswerReceived?: (tabID: string, message: ChatItem) => void
+    onChatAnswerReceived?: (tabID: string, message: TracedChatItem) => void
     onWelcomeFollowUpClicked: (tabID: string, welcomeFollowUpType: WelcomeFollowupType) => void
     onAsyncEventProgress: (tabID: string, inProgress: boolean, message: string | undefined) => void
     onQuickHandlerCommand: (tabID: string, command?: string, eventId?: string) => void
-    onCWCContextCommandMessage: (message: ChatItem, command?: string) => string | undefined
+    onCWCContextCommandMessage: (message: TracedChatItem, command?: string) => string | undefined
     onOpenSettingsMessage: (tabID: string) => void
     onError: (tabID: string, message: string, title: string) => void
     onWarning: (tabID: string, message: string, title: string) => void

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -236,8 +236,13 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
                 tabsStorage.updateTabStatus(tabID, 'free')
 
                 if (item.traceId) {
+                    /**
+                     * We've received an answer for a traceId and this message has
+                     * completed its round trip. Send that information back to
+                     * VSCode so we can emit a round trip event
+                     **/
                     ideApi.postMessage({
-                        type: 'stopListening',
+                        type: 'stopChatMessageTelemetry',
                         tabID,
                         traceId: item.traceId,
                         tabType: tabsStorage.getTab(tabID)?.type,
@@ -394,9 +399,12 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
                 return
             }
 
-            // When a user presses "enter"
+            /**
+             * When a user presses "enter" send an event that indicates
+             * we should start tracking the round trip time for this message
+             **/
             ideApi.postMessage({
-                type: 'startListening',
+                type: 'startChatMessageTelemetry',
                 trigger: 'onChatPrompt',
                 tabID,
                 traceId: eventId,

--- a/packages/core/src/amazonq/webview/ui/messages/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/messages/handler.ts
@@ -24,7 +24,7 @@ export class TextMessageHandler {
         this.tabsStorage = props.tabsStorage
     }
 
-    public handle(chatPrompt: ChatPrompt, tabID: string) {
+    public handle(chatPrompt: ChatPrompt, tabID: string, eventID: string) {
         this.tabsStorage.updateTabTypeFromUnknown(tabID, 'cwc')
         this.tabsStorage.resetTabTimer(tabID)
         this.connector.onUpdateTabType(tabID)
@@ -44,6 +44,7 @@ export class TextMessageHandler {
             .requestGenerativeAIAnswer(tabID, {
                 chatMessage: chatPrompt.prompt ?? '',
                 chatCommand: chatPrompt.command,
+                traceId: eventID,
             })
             .then(() => {})
     }

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -49,6 +49,9 @@ import { CodeWhispererSettings } from '../../../codewhisperer/util/codewhisperer
 import { getSelectedCustomization } from '../../../codewhisperer/util/customizationUtil'
 import { FeatureConfigProvider } from '../../../shared/featureConfig'
 import { getHttpStatusCode, AwsClientResponseError } from '../../../shared/errors'
+import { uiEventRecorder } from '../../../amazonq/util/eventRecorder'
+import { globals } from '../../../shared'
+import { telemetry } from '../../../shared/telemetry'
 
 export interface ChatControllerMessagePublishers {
     readonly processPromptChatMessage: MessagePublisher<PromptMessage>
@@ -122,7 +125,16 @@ export class ChatController {
         })
 
         this.chatControllerMessageListeners.processPromptChatMessage.onMessage((data) => {
-            return this.processPromptChatMessage(data)
+            if (data.traceId) {
+                uiEventRecorder.set(data.traceId, {
+                    events: {
+                        featureReceivedMessage: globals.clock.Date.now(),
+                    },
+                })
+            }
+            return telemetry.withTraceId(() => {
+                return this.processPromptChatMessage(data)
+            }, data.traceId ?? randomUUID())
         })
 
         this.chatControllerMessageListeners.processTabCreatedMessage.onMessage((data) => {
@@ -485,6 +497,7 @@ export class ChatController {
                         codeQuery: context?.focusAreaContext?.names,
                         userIntent: this.userIntentRecognizer.getFromPromptChatMessage(message),
                         customization: getSelectedCustomization(),
+                        traceId: message.traceId,
                     },
                     triggerID
                 )

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -132,6 +132,11 @@ export class ChatController {
                     },
                 })
             }
+            /**
+             * traceId is only instrumented for chat-prompt but not for things
+             * like follow-up-was-clicked. In those cases we fallback to a different
+             * uuid
+             **/
             return telemetry.withTraceId(() => {
                 return this.processPromptChatMessage(data)
             }, data.traceId ?? randomUUID())

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -293,6 +293,7 @@ export class Messenger {
                             relatedSuggestions: undefined,
                             triggerID,
                             messageID,
+                            traceId: triggerPayload.traceId,
                         },
                         tabID
                     )

--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -70,6 +70,7 @@ export type ChatPromptCommandType =
 export interface PromptMessage {
     message: string | undefined
     messageId: string
+    traceId?: string
     command: ChatPromptCommandType | undefined
     userIntent: UserIntent | undefined
     tabID: string
@@ -143,6 +144,7 @@ export interface TriggerPayload {
     readonly customization: Customization
     relevantTextDocuments?: RelevantTextDocument[]
     useRelevantDocuments?: boolean
+    traceId?: string
 }
 
 export interface InsertedCode {

--- a/packages/core/src/codewhispererChat/view/connector/connector.ts
+++ b/packages/core/src/codewhispererChat/view/connector/connector.ts
@@ -141,6 +141,7 @@ export interface ChatMessageProps {
     readonly codeReference?: CodeReference[]
     readonly triggerID: string
     readonly messageID: string
+    readonly traceId?: string
 }
 
 export class ChatMessage extends UiMessage {
@@ -153,6 +154,7 @@ export class ChatMessage extends UiMessage {
     readonly followUpsHeader: string | undefined
     readonly triggerID: string
     readonly messageID: string | undefined
+    readonly traceId?: string
     override type = 'chatMessage'
 
     constructor(props: ChatMessageProps, tabID: string) {
@@ -165,6 +167,7 @@ export class ChatMessage extends UiMessage {
         this.codeReference = props.codeReference
         this.triggerID = props.triggerID
         this.messageID = props.messageID
+        this.traceId = props.traceId
     }
 }
 

--- a/packages/core/src/codewhispererChat/view/messages/messageListener.ts
+++ b/packages/core/src/codewhispererChat/view/messages/messageListener.ts
@@ -202,6 +202,7 @@ export class UIMessageListener {
             tabID: msg.tabID,
             messageId: msg.messageId,
             userIntent: msg.userIntent !== '' ? msg.userIntent : undefined,
+            traceId: msg.traceId,
         })
     }
 

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1221,7 +1221,7 @@
         },
         {
             "name": "amazonq_chatRoundTrip",
-            "description": "Captures the time it takes for different events between when a user presses enter and receives the message back",
+            "description": "Measures sequential response times in Q chat, from user input to message display. Tracks time intervals between key events: editor receiving the message, feature processing, and final message rendering",
             "passive": true,
             "metadata": [
                 {

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -320,6 +320,26 @@
             "name": "traceId",
             "type": "string",
             "description": "The unique identifier of a trace"
+        },
+        {
+            "name": "amazonqChatMessageSentTime",
+            "type": "int",
+            "description": "Time when a user initial pressed enter in the chat"
+        },
+        {
+            "name": "amazonqEditorReceivedMessageMs",
+            "type": "int",
+            "description": "Duration between user pressing enter and the editor receiving the message in ms"
+        },
+        {
+            "name": "amazonqFeatureReceivedMessageMs",
+            "type": "int",
+            "description": "Duration between the editor receiving the message and the partner teams code receiving it in ms"
+        },
+        {
+            "name": "amazonqMessageDisplayedMs",
+            "type": "int",
+            "description": "Duration between the partner teams code receiving the message and when the message was finally displayed in ms"
         }
     ],
     "metrics": [
@@ -1196,6 +1216,29 @@
                 {
                     "type": "name",
                     "required": true
+                }
+            ]
+        },
+        {
+            "name": "amazonq_chatRoundTrip",
+            "description": "Captures the time it takes for different events between when a user presses enter and receives the message back",
+            "passive": true,
+            "metadata": [
+                {
+                    "type": "amazonqChatMessageSentTime"
+                },
+                {
+                    "type": "amazonqEditorReceivedMessageMs"
+                },
+                {
+                    "type": "amazonqFeatureReceivedMessageMs"
+                },
+                {
+                    "type": "amazonqMessageDisplayedMs"
+                },
+                {
+                    "type": "source",
+                    "required": false
                 }
             ]
         }

--- a/packages/core/src/shared/utilities/map.ts
+++ b/packages/core/src/shared/utilities/map.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import _ from 'lodash'
 import { getLogger } from '../logger'
 import type { KeyedCache } from './cacheUtils'
 
@@ -35,12 +36,15 @@ export abstract class NestedMap<Key, Value = { [key: string]: any }> implements 
 
     set(key: Key, data: Partial<Value>): void {
         const currentData = this.get(key)
-        this.data[this.hash(key)] = { ...currentData, ...data }
+        // deep merge the objects
+        this.data[this.hash(key)] = _.merge(currentData, data)
     }
 
-    delete(key: Key, reason: string): void {
+    delete(key: Key, reason?: string): void {
         delete this.data[this.hash(key)]
-        getLogger().debug(`${this.name}: cleared cache, key: ${JSON.stringify(key)}, reason: ${reason}`)
+        if (reason) {
+            getLogger().debug(`${this.name}: cleared cache, key: ${JSON.stringify(key)}, reason: ${reason}`)
+        }
     }
 
     /**
@@ -58,6 +62,24 @@ export abstract class NestedMap<Key, Value = { [key: string]: any }> implements 
      * The default value returned from {@link get}() when {@link has}() is false
      */
     protected abstract get default(): Value
+}
+
+/**
+ * An implementation of NestedMap specifically used for mapping strings to objects.
+ * It's basically a map, except you can partially add values
+ */
+export class RecordMap<Value = { [key: string]: any }> extends NestedMap<string, Value> {
+    protected override hash(key: string): string {
+        return key
+    }
+
+    protected override get name(): string {
+        return 'RecordMap'
+    }
+
+    protected override get default(): Value {
+        return {} as Value
+    }
 }
 
 /**


### PR DESCRIPTION
## Problem:
- We can't measure e2e how long a chat request takes

## Solution:
- Plumb the trace id through to the webview -> vscode -> webview. This allows us to know exactly what is happening to a message and how long everything took to get there
- chat e2e latency can be linked with the other telemetry events via the traceId


<details closed>
<summary>Previous PR description</summary>

## Problem
This is just a draft of what we could potentially do to measure e2e latency in amazon q chat message requests. Feel free to leave comments on the PR

### Main code level problems:
- It's hard to connect a tab id to a conversation id. Tab ID's exist pretty much to send/receive messages but they don't really live along side conversation id's. Conversation id's are exclusively related to the session. The only place they meetup is in their chat session storages
- Do we want to track individual events like webviewToDispatcher as metrics?
    - Though there wouldn't really be a way to "listen" on these events except for if we manually allow-listed metrics since theres no reason to attach a tabID to that metric
- How do we listen to events emitted from telemetry so that we can find them later?
    - One solution is proposed in this PR where we listen to events being emitted and then check if we want to track them
- Could we connect these with a parent/child mechanism like we want to introduce eventually?
    - We kind of do this because the "listener" event is the parent and the things it finds are the children. The problem is we can really have only one "listener" for these Q events, since we don't know what tabs are related to what conversation ID's until much later (after the first request). This is why we build up the map of conversation metrics and tab metrics and join them together before we emit

## Solution


This PR does a couple things:
- Moves up the chat session storage for codewhisperer chat. This allows us to eventually connect conversation ids to tabs
- Introduces a chat storage facades that allows us to call getConversationId on any tab type. This is only implemented for cwc right now
- Introduces a listener pattern that allows telemetry events to "listen" to metrics that are being emitted
- emits a sample events that can you can trace from "pressing enter" to "receives message in ui"

### Sample event when sending a request in amazon q chat:
```
2024-09-11 10:11:05.712 [debug] telemetry: chat_roundTrip {
  Metadata: {
    duration: '14585',
    name: 'onChatPrompt',
    child_metrics: 'initialRequestTime,webviewToDispatcher,dispatcherToFeature,amazonq_enterFocusConversation,amazonq_startConversation,amazonq_addMessage,finalRequestTime',
    child_metric_durations: '{"webviewToDispatcher":1,"dispatcherToFeature":3,"amazonq_enterFocusConversation":1542,"amazonq_startConversation":2,"amazonq_addMessage":13003,"finalRequestTime":34}',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}
```

### You can also get events from the right click context menu items as well (explain, refactor, etc)
```
2024-09-11 10:11:34.384 [debug] telemetry: chat_roundTrip {
  Metadata: {
    duration: '12885',
    name: 'aws.amazonq.explainCode',
    child_metrics: 'initialRequestTime,webviewToDispatcher,amazonq_enterFocusConversation,amazonq_addMessage,finalRequestTime',
    child_metric_durations: '{"webviewToDispatcher":17,"amazonq_enterFocusConversation":1263,"amazonq_addMessage":11572,"finalRequestTime":33}',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}
```

</details>

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
