### PR TITLE
feat(amazonq): use detector library url from server

### DIFF
--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -74,10 +74,13 @@ export function createSecurityDiagnostic(securityIssue: CodeScanIssue) {
         vscode.DiagnosticSeverity.Warning
     )
     securityDiagnostic.source = codewhispererDiagnosticSourceLabel
-    securityDiagnostic.code = {
-        value: securityIssue.detectorId,
-        target: vscode.Uri.parse(securityIssue.recommendation.url),
-    }
+    const detectorUrl = securityIssue.recommendation.url
+    securityDiagnostic.code = detectorUrl
+        ? {
+              value: securityIssue.detectorId,
+              target: vscode.Uri.parse(detectorUrl),
+          }
+        : securityIssue.detectorId
     securityDiagnostic.findingId = securityIssue.findingId
     return securityDiagnostic
 }

--- a/packages/core/src/codewhisperer/views/securityIssue/vue/root.vue
+++ b/packages/core/src/codewhisperer/views/securityIssue/vue/root.vue
@@ -39,7 +39,8 @@
 
             <div>
                 <b>Detector library</b>
-                <p>
+                <p v-if="!detectorUrl || !detectorUrl.length">-</p>
+                <p v-else>
                     <a :href="detectorUrl">
                         {{ detectorName }} <span class="icon icon-sm icon-vscode-link-external"></span>
                     </a>
@@ -113,6 +114,7 @@ export default defineComponent({
             title: '',
             detectorId: '',
             detectorName: '',
+            detectorUrl: '',
             severity: '',
             recommendationText: '',
             suggestedFix: '',
@@ -140,6 +142,7 @@ export default defineComponent({
                 this.title = issue.title
                 this.detectorId = issue.detectorId
                 this.detectorName = issue.detectorName
+                this.detectorUrl = issue.recommendation.url
                 this.relatedVulnerabilities = issue.relatedVulnerabilities
                 this.severity = issue.severity
                 this.recommendationText = issue.recommendation.text
@@ -176,10 +179,6 @@ export default defineComponent({
     computed: {
         severityImage() {
             return severityImages[this.severity.toLowerCase()]
-        },
-        detectorUrl() {
-            const slug = this.detectorId.split('@').shift()
-            return `https://docs.aws.amazon.com/codeguru/detector-library/${slug}`
         },
         recommendationTextHtml() {
             return md.render(this.recommendationText)


### PR DESCRIPTION
## Problem

Dead links to detector library for some findings.


## Solution

Use detector library url from the server response instead of building it from the client.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
