### PR TITLE
refactor(logging): remove unused channels

### DIFF
--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -103,10 +103,8 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     globals.manifestPaths.endpoints = context.asAbsolutePath(join('resources', 'endpoints.json'))
     globals.regionProvider = RegionProvider.fromEndpointsProvider(makeEndpointsProvider())
 
-    const qOutputChannel = vscode.window.createOutputChannel('Amazon Q', { log: true })
     const qLogChannel = vscode.window.createOutputChannel('Amazon Q Logs', { log: true })
-    await activateLogger(context, amazonQContextPrefix, qOutputChannel, qLogChannel)
-    globals.outputChannel = qOutputChannel
+    await activateLogger(context, amazonQContextPrefix, qLogChannel)
     globals.logOutputChannel = qLogChannel
     globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
 

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -92,10 +92,8 @@ export async function activateCommon(
     })
 
     // Setup the logger
-    const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit', { log: true })
     const toolkitLogChannel = vscode.window.createOutputChannel('AWS Toolkit Logs', { log: true })
-    await activateLogger(context, contextPrefix, toolkitOutputChannel, toolkitLogChannel)
-    globals.outputChannel = toolkitOutputChannel
+    await activateLogger(context, contextPrefix, toolkitLogChannel)
     globals.logOutputChannel = toolkitLogChannel
 
     if (homeDirLogs.length > 0) {
@@ -103,7 +101,7 @@ export async function activateCommon(
     }
 
     if (isCloud9()) {
-        vscode.window.withProgress = wrapWithProgressForCloud9(globals.outputChannel)
+        vscode.window.withProgress = wrapWithProgressForCloud9(globals.logOutputChannel)
         context.subscriptions.push(
             Commands.register('aws.quickStart', async () => {
                 try {

--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -20,7 +20,6 @@ import { getUserAgent } from '../telemetry/util'
 export async function activate(
     extensionContext: vscode.ExtensionContext,
     contextPrefix: string,
-    outputChannel: vscode.LogOutputChannel,
     logChannel: vscode.LogOutputChannel
 ): Promise<void> {
     const settings = Settings.instance.getSection('aws')
@@ -50,7 +49,7 @@ export async function activate(
     setLogger(
         makeLogger({
             logLevel: chanLogLevel,
-            outputChannels: [outputChannel, logChannel],
+            outputChannels: [logChannel],
             useConsoleLog: true,
         }),
         'debugConsole'


### PR DESCRIPTION
## Problem
The `channel` logger was removed as part of: https://github.com/aws/aws-toolkit-vscode/pull/5564.
As a result the 'AWS toolkit' and 'Amazon Q' channels are no longer used, but they still show up in IDE output channels. They should be removed to maintain cleanliness. 

## Solution
Remove these two channels in `extension.ts` so they don't get initiated.  
Also remove input to logger activation since it's unused.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
