### PR TITLE
fix(amazonq): Use the correct state for Q in remote environment

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
@@ -233,7 +233,11 @@ describe('AuthUtil', async function () {
         // Switch to unsupported connection
         const cwAuthUpdatedConnection = captureEventOnce(authUtil.secondaryAuth.onDidChangeActiveConnection)
         await auth.useConnection(unsupportedConn)
+        // This is triggered when the main Auth connection is switched
         await cwAuthUpdatedConnection
+        // This is triggered by registerAuthListener() when it saves the previous active connection as a fallback.
+        // TODO in a refactor see if we can simplify multiple multiple triggers on the same event.
+        await captureEventOnce(authUtil.secondaryAuth.onDidChangeActiveConnection)
 
         // Is using the fallback connection
         assert.ok(authUtil.isConnected())

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -1022,9 +1022,20 @@ export class Auth implements AuthService, ConnectionManager {
         }
     }
 
+    /**
+     * Auth uses its own state, separate from the default {@link globalState}
+     * that is normally used throughout the codebase.
+     *
+     * IMPORTANT: Anything involving auth should ONLY use this state since the state
+     * can vary on certain conditions. So if you see something explicitly using
+     * globalState verify if it should actually be using that.
+     */
+    public getStateMemento: () => vscode.Memento = () => Auth._getStateMemento()
+    private static _getStateMemento = once(() => getEnvironmentSpecificMemento())
+
     static #instance: Auth | undefined
     public static get instance() {
-        return (this.#instance ??= new Auth(new ProfileStore(getEnvironmentSpecificMemento())))
+        return (this.#instance ??= new Auth(new ProfileStore(Auth._getStateMemento())))
     }
 
     private getSsoProfileLabel(profile: SsoProfile) {

--- a/packages/core/src/shared/utilities/mementos.ts
+++ b/packages/core/src/shared/utilities/mementos.ts
@@ -29,7 +29,14 @@ export function partition(memento: vscode.Memento, key: string): vscode.Memento 
     }
 }
 
-/** Avoids sharing globalState with remote vscode instances. */
+/**
+ * Resolves the appropriate memento/state for the current runtime environment.
+ *
+ * Why?
+ * - In remote instances where we ssh in to them, we do not always want to share
+ *   with the local globalState. We want certain functionality to be isolated to
+ *   the remote instance.
+ */
 export function getEnvironmentSpecificMemento(): vscode.Memento {
     if (!vscode.env.remoteName) {
         // local compute: no further partitioning


### PR DESCRIPTION
## Problem:

As part of our design we intentionally separate the Auth state between a local environment, versus a remote (ssh'd) one. We do this so that if the user has 2 IDE instances, one local and the other remote, if one changes its auth state the other one will not be affected.

The reason for separating auth that I can remember is due to how we store the actual tokens on disk. Because the remote does not have access to the disk of the local, we need to ensure the remote operates its auth independently of the local auth.

By design globalState is shared by both local and remote instances. So for local we need to ensure we do not use the base globalState, otherwise the same Auth state as the remote will be used.

The problem, SecondaryAuth is not doing this for all cases. It is using the globalState when it should be asking Auth which state it should use. The happy path was working though, but there can be potential issues with this bug at some other point.

## Solution:

Expose the state that Auth is using so that something like SecondaryAuth can ask Auth for the correct state object depending on the local vs remote.


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
