### PR TITLE
Most recently used file cache implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "src.gen/@amzn/codewhisperer-streaming"
             ],
             "dependencies": {
+                "lru-cache": "^11.0.1",
                 "vscode-nls": "^5.2.0",
                 "vscode-nls-dev": "^4.0.4"
             },
@@ -14059,6 +14060,19 @@
                 "node": ">=10"
             }
         },
+        "node_modules/hosted-git-info/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/hpack.js": {
             "version": "2.1.6",
             "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -15782,15 +15796,12 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
+            "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
+            "license": "ISC",
             "engines": {
-                "node": ">=10"
+                "node": "20 || >=22"
             }
         },
         "node_modules/lru-queue": {
@@ -21486,7 +21497,8 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/yaml": {
             "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "webpack-merge": "^5.10.0"
     },
     "dependencies": {
+        "lru-cache": "^11.0.1",
         "vscode-nls": "^5.2.0",
         "vscode-nls-dev": "^4.0.4"
     }

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -106,14 +106,6 @@
                         "amazonQWelcomePage": {
                             "type": "boolean",
                             "default": false
-                        },
-                        "amazonQSessionConfigurationMessage": {
-                            "type": "boolean",
-                            "default": false
-                        },
-                        "ssoCacheError": {
-                            "type": "boolean",
-                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -106,6 +106,14 @@
                         "amazonQWelcomePage": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "amazonQSessionConfigurationMessage": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "ssoCacheError": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/packages/core/src/codewhisperer/service/serviceContainer.ts
+++ b/packages/core/src/codewhisperer/service/serviceContainer.ts
@@ -7,6 +7,7 @@ import { AuthUtil } from '../util/authUtil'
 import { LineAnnotationController } from '../views/lineAnnotationController'
 import { ActiveStateController } from '../views/activeStateController'
 import { LineTracker } from '../tracker/lineTracker'
+import { RecentlyUsedFileTracker } from '../tracker/recentlyUsedFileTracker'
 
 /**
  * Container for CodeWhisperer sub-components
@@ -31,11 +32,13 @@ export class Container {
     readonly lineTracker: LineTracker
     readonly lineAnnotationController: LineAnnotationController
     readonly activeStateController: ActiveStateController
+    readonly recentlyUsedFileTracker: RecentlyUsedFileTracker
 
     protected constructor(readonly auth: AuthUtil) {
         this.lineTracker = new LineTracker()
         this.lineAnnotationController = new LineAnnotationController(this)
         this.activeStateController = new ActiveStateController(this)
+        this.recentlyUsedFileTracker = RecentlyUsedFileTracker.instance
     }
 
     ready() {

--- a/packages/core/src/codewhisperer/tracker/recentlyUsedFileTracker.ts
+++ b/packages/core/src/codewhisperer/tracker/recentlyUsedFileTracker.ts
@@ -8,7 +8,7 @@ import { LRUCache } from 'lru-cache'
 import { isTextDocument } from '../../shared/utilities/editorUtilities'
 
 /**
- * Naive most recently opened files as VSCode doesn't expose its API which is used when clicking [ctrl] + [tab]
+ * Naive most recently opened files cache as VSCode doesn't expose its API which is used when clicking [ctrl] + [tab]
  * Related feature request https://github.com/microsoft/vscode/issues/136878
  * VSCode src code https://github.com/microsoft/vscode/blob/298e7037f027bf5e6add0e0eecaeda10e0195411/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts#L265
  */

--- a/packages/core/src/codewhisperer/tracker/recentlyUsedFileTracker.ts
+++ b/packages/core/src/codewhisperer/tracker/recentlyUsedFileTracker.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { LRUCache } from 'lru-cache'
+import { isTextDocument } from '../../shared/utilities/editorUtilities'
+
+export class RecentlyUsedFileTracker implements vscode.Disposable {
+    static #instance: RecentlyUsedFileTracker
+    public static get instance() {
+        return (this.#instance ??= new RecentlyUsedFileTracker())
+    }
+
+    private _disposable: vscode.Disposable | undefined
+    private cache: LRUCache<string, vscode.TextDocument>
+
+    constructor() {
+        const tabgroup = vscode.window.tabGroups.activeTabGroup
+        const tabs = tabgroup.tabs
+        console.log('tabs', tabs)
+
+        this.cache = new LRUCache({
+            max: 20,
+        })
+
+        this._disposable = vscode.Disposable.from(
+            vscode.window.onDidChangeActiveTextEditor(async (e) => {
+                const doc = e?.document
+                if (!doc || !isTextDocument(doc)) {
+                    return
+                }
+
+                this.cache.set(doc.uri.fsPath, doc)
+            }),
+            vscode.workspace.onDidCloseTextDocument((e) => {
+                if (!isTextDocument(e)) {
+                    return
+                }
+
+                this.cache.delete(e.uri.fsPath)
+            }),
+            vscode.workspace.onDidOpenTextDocument((e) => {
+                if (!isTextDocument(e)) {
+                    return
+                }
+
+                // console.log('onDidOpenTextDocument', e)
+                // this.cache.set(e.uri.fsPath, e)
+            }),
+            vscode.window.onDidChangeTextEditorSelection(async (e) => {})
+        )
+
+        queueMicrotask(async () => await this.onActiveTextEditorChanged(vscode.window.activeTextEditor))
+    }
+
+    dispose() {
+        this._disposable?.dispose()
+    }
+
+    // @VisibleForTesting
+    async onActiveTextEditorChanged(editor: vscode.TextEditor | undefined) {}
+
+    // @VisibleForTesting
+    async onTextEditorSelectionChanged(e: vscode.TextEditorSelectionChangeEvent) {}
+
+    listFiles() {
+        const generator = this.cache.entries()
+        return [...generator]
+    }
+}

--- a/packages/core/src/codewhisperer/tracker/recentlyUsedFileTracker.ts
+++ b/packages/core/src/codewhisperer/tracker/recentlyUsedFileTracker.ts
@@ -7,6 +7,11 @@ import * as vscode from 'vscode'
 import { LRUCache } from 'lru-cache'
 import { isTextDocument } from '../../shared/utilities/editorUtilities'
 
+/**
+ * Naive most recently opened files as VSCode doesn't expose its API which is used when clicking [ctrl] + [tab]
+ * Related feature request https://github.com/microsoft/vscode/issues/136878
+ * VSCode src code https://github.com/microsoft/vscode/blob/298e7037f027bf5e6add0e0eecaeda10e0195411/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts#L265
+ */
 export class RecentlyUsedFileTracker implements vscode.Disposable {
     static #instance: RecentlyUsedFileTracker
     public static get instance() {
@@ -17,13 +22,14 @@ export class RecentlyUsedFileTracker implements vscode.Disposable {
     private cache: LRUCache<string, vscode.TextDocument>
 
     constructor() {
-        const tabgroup = vscode.window.tabGroups.activeTabGroup
-        const tabs = tabgroup.tabs
-        console.log('tabs', tabs)
-
         this.cache = new LRUCache({
             max: 20,
         })
+
+        const activeEditor = vscode.window.activeTextEditor
+        if (activeEditor) {
+            this.cache.set(activeEditor.document.uri.fsPath, activeEditor.document)
+        }
 
         this._disposable = vscode.Disposable.from(
             vscode.window.onDidChangeActiveTextEditor(async (e) => {
@@ -40,19 +46,8 @@ export class RecentlyUsedFileTracker implements vscode.Disposable {
                 }
 
                 this.cache.delete(e.uri.fsPath)
-            }),
-            vscode.workspace.onDidOpenTextDocument((e) => {
-                if (!isTextDocument(e)) {
-                    return
-                }
-
-                // console.log('onDidOpenTextDocument', e)
-                // this.cache.set(e.uri.fsPath, e)
-            }),
-            vscode.window.onDidChangeTextEditorSelection(async (e) => {})
+            })
         )
-
-        queueMicrotask(async () => await this.onActiveTextEditorChanged(vscode.window.activeTextEditor))
     }
 
     dispose() {

--- a/packages/core/src/shared/utilities/editorUtilities.ts
+++ b/packages/core/src/shared/utilities/editorUtilities.ts
@@ -14,6 +14,14 @@ export function isTextEditor(editor: vscode.TextEditor): boolean {
     return scheme !== 'debug' && scheme !== 'output' && scheme !== 'vscode-terminal'
 }
 
+export function isTextDocument(document: vscode.TextDocument): boolean {
+    if (!document) {
+        return false
+    }
+    const scheme = document.uri.scheme
+    return scheme !== 'git'
+}
+
 export function getTabSizeSetting(): number {
     return Settings.instance.getSection('editor').get('tabSize', defaultTabSize)
 }


### PR DESCRIPTION
## Problem

- Naive most recently opened files cache as VSCode doesn't expose its API (Previous Recently Used Editor)

- Related feature request https://github.com/microsoft/vscode/issues/136878
 - VSCode src code https://github.com/microsoft/vscode/blob/298e7037f027bf5e6add0e0eecaeda10e0195411/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts#L265


## Solution


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
