### PR TITLE
fix(amazonq): disable LSP in AL2

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-7bd6029d-04bc-4135-890a-1a8e4f70c18c.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-7bd6029d-04bc-4135-890a-1a8e4f70c18c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Disable LSP in AL2"
+}

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as fs from 'fs-extra'
 import * as crypto from 'crypto'
+import * as os from 'os'
 import { getLogger } from '../../shared/logger/logger'
 import { CurrentWsFolders, collectFilesForIndex } from '../../shared/utilities/workspaceUtils'
 import fetch from 'node-fetch'
@@ -363,9 +364,13 @@ export class LspController {
         }
     }
 
+    private isAmznLinux2(): boolean {
+        return os.release().includes('amzn2int') && process.platform === 'linux'
+    }
+
     async trySetupLsp(context: vscode.ExtensionContext) {
-        if (isCloud9() || isWeb()) {
-            // do not do anything if in Cloud9 or Web mode.
+        if (isCloud9() || isWeb() || this.isAmznLinux2()) {
+            // do not do anything if in Cloud9 or Web mode or in AL2 (AL2 does not support node v18+)
             return
         }
         setImmediate(async () => {


### PR DESCRIPTION
## Problem

In AL2, node js runtime v18 is not supported due to GLIBC <= 2.26.0. This LSP will show user facing error message, which is disturbing.

## Solution

Disable LSP in AL2. 

In the long run, we may downgrade node 18 to 16 if possible. Meanwhile, VS Code will soon require node v18. AL2 will migrate to AL2023 which has newer GLIBC. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
