### PR TITLE
refactor(logging): topicLogger for headers

### DIFF
--- a/packages/core/src/test/shared/logger/topicLogger.test.ts
+++ b/packages/core/src/test/shared/logger/topicLogger.test.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { stub, SinonStubbedInstance } from 'sinon'
+import { TopicLogger, Logger, LogLevel } from '../../../shared/logger/logger'
+
+describe('TopicLogger', () => {
+    let mockCoreLogger: SinonStubbedInstance<Logger>
+    let topicLogger: TopicLogger
+
+    beforeEach(() => {
+        mockCoreLogger = {
+            debug: stub(),
+            verbose: stub(),
+            info: stub(),
+            warn: stub(),
+            error: stub(),
+            setLogLevel: stub(),
+            logLevelEnabled: stub(),
+            getLogById: stub(),
+            enableDebugConsole: stub(),
+        } as SinonStubbedInstance<Logger>
+        topicLogger = new TopicLogger(mockCoreLogger as Logger, 'Test')
+    })
+
+    it('adds topic prefix to string type messages', () => {
+        topicLogger.info('Test message')
+        assert(mockCoreLogger.info.calledWith('Test: Test message'))
+    })
+
+    it('adds topic prefix to Error type messages', () => {
+        const testError = new Error('Test error')
+        topicLogger.error(testError)
+        assert(mockCoreLogger.error.calledOnce)
+        const calledArg = mockCoreLogger.error.firstCall.args[0]
+        assert(calledArg instanceof Error)
+        assert.strictEqual(calledArg.message, 'Test: Test error')
+        assert.strictEqual(calledArg.name, testError.name)
+        assert.strictEqual(calledArg.stack, testError.stack)
+    })
+
+    it('topic is "Unknown" when not specified', () => {
+        const defaultTopicLogger = new TopicLogger(mockCoreLogger as Logger)
+        defaultTopicLogger.debug('Verbose message')
+        assert(mockCoreLogger.debug.calledWith('Unknown: Verbose message'))
+    })
+
+    it('delegates setLogLevel to core logger', () => {
+        topicLogger.setLogLevel('debug' as LogLevel)
+        assert(mockCoreLogger.setLogLevel.calledWith('debug'))
+    })
+
+    it('delegates logLevelEnabled to core logger', () => {
+        topicLogger.logLevelEnabled('info' as LogLevel)
+        assert(mockCoreLogger.logLevelEnabled.calledWith('info'))
+    })
+
+    it('delegates getLogById to core logger', () => {
+        const mockUri = {} as any
+        topicLogger.getLogById(123, mockUri)
+        assert(mockCoreLogger.getLogById.calledWith(123, mockUri))
+    })
+
+    it('delegates enableDebugConsole to core logger', () => {
+        topicLogger.enableDebugConsole()
+        assert(mockCoreLogger.enableDebugConsole.called)
+    })
+})


### PR DESCRIPTION
## Problem
Log message can appear in output channels(such as Amazon Q Logs as shown), IDE Debug console, or write to pre-defined log file destinations. They come from all parts of our services and can amount to large and lengthy chunks quickly.

We don’t have a reliable way to identify log messages from various services and modules of our product. Some messages might have headers while others don’t, and the existing headers are hard-coded on a message by message basis, with no checks for consistency. 

1. It’s difficult to locate and trace unidentified log messages when the size of logs grow quickly.
2. Without regulation, the hard-coded custom headers can lead to legacy issues down-the-road and inconsistencies within the codebase.

## Solution
1. Make message topic identifiers a variable of the getLogger() function.
2. Define a set of topics to be used in message headers, covering all services and modules.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
