### PR TITLE
telemetry(core): implement tracing

### DIFF
--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -170,6 +170,7 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
         }
 
         this.metricId = randomUUID()
+        // forced to cast to any since apparently even though <T extends MetricBase>, Partial<T> doesn't guarentee that metricId is available
         this.record({ metricId: this.metricId } as any)
     }
 
@@ -278,9 +279,7 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
     }
 }
 
-type Attributes = Partial<MetricShapes[MetricName]> & {
-    traceId?: string
-}
+type Attributes = Partial<MetricShapes[MetricName]>
 
 interface TelemetryContext {
     readonly spans: TelemetrySpan[]

--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -146,7 +146,7 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
         passive: true,
         requiredMetadata: [],
     }
-    private readonly spanId: string
+    private readonly metricId: string
 
     /**
      * These fields appear on the base metric instead of the 'metadata' and
@@ -169,8 +169,8 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
             ),
         }
 
-        this.spanId = randomUUID()
-        this.record({ spanId: this.spanId } as any)
+        this.metricId = randomUUID()
+        this.record({ metricId: this.metricId } as any)
     }
 
     public get startTime(): Date | undefined {
@@ -266,8 +266,8 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> {
         }
     }
 
-    getSpanId() {
-        return this.spanId
+    getMetricId() {
+        return this.metricId
     }
 
     /**
@@ -465,7 +465,7 @@ export class TelemetryTracer extends TelemetryBase {
     private createSpan(name: string, options?: SpanOptions): TelemetrySpan {
         const span = new TelemetrySpan(name, options).record(this.attributes ?? {})
         if (this.activeSpan && this.activeSpan.name !== rootSpanName) {
-            return span.record({ parentId: this.activeSpan.getSpanId() })
+            return span.record({ parentId: this.activeSpan.getMetricId() })
         }
 
         return span

--- a/packages/core/src/shared/telemetry/telemetry.ts
+++ b/packages/core/src/shared/telemetry/telemetry.ts
@@ -25,5 +25,6 @@ declare module './telemetry.gen' {
     interface Metric<T extends MetricBase = MetricBase> {
         increment(data: { [P in NumericKeys<T>]+?: number }): void
         run<U>(fn: (span: this) => U, options?: SpanOptions): U
+        trace<U>(fn: (span: this) => U): U
     }
 }

--- a/packages/core/src/shared/telemetry/telemetry.ts
+++ b/packages/core/src/shared/telemetry/telemetry.ts
@@ -25,6 +25,5 @@ declare module './telemetry.gen' {
     interface Metric<T extends MetricBase = MetricBase> {
         increment(data: { [P in NumericKeys<T>]+?: number }): void
         run<U>(fn: (span: this) => U, options?: SpanOptions): U
-        trace<U>(fn: (span: this) => U): U
     }
 }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -315,6 +315,11 @@
             "name": "totalFiles",
             "type": "int",
             "description": "The total number of files being sent to Amazon Q"
+        },
+        {
+            "name": "traceId",
+            "type": "string",
+            "description": "The unique identifier of a trace"
         }
     ],
     "metrics": [
@@ -1175,6 +1180,20 @@
             "metadata": [
                 {
                     "type": "webviewName",
+                    "required": true
+                }
+            ]
+        },
+        {
+            "name": "trace_event",
+            "description": "Represents the root trace spanning multiple operations",
+            "metadata": [
+                {
+                    "type": "traceId",
+                    "required": true
+                },
+                {
+                    "type": "name",
                     "required": true
                 }
             ]

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1187,6 +1187,7 @@
         {
             "name": "trace_event",
             "description": "Represents the root trace spanning multiple operations",
+            "passive": true,
             "metadata": [
                 {
                     "type": "traceId",

--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -356,7 +356,7 @@ describe('TelemetryTracer', function () {
             it('should set trace id', function () {
                 telemetry.trace_event.run((span) => {
                     span.record({ name: flowName })
-                    assert.deepStrictEqual(telemetry.activeSpan?.getSpanId(), testId)
+                    assert.deepStrictEqual(telemetry.activeSpan?.getMetricId(), testId)
                 })
                 const event = getMetrics('trace_event')
                 assert.deepStrictEqual(event[0].traceId, testId)
@@ -364,39 +364,39 @@ describe('TelemetryTracer', function () {
             })
 
             it('trace id is propogated to children', function () {
-                const spanIds = {
+                const metricsIds = {
                     trace_event: {
-                        spanId: 'traceEvent',
+                        metricId: 'traceEvent',
                         traceId: testId,
                         parentId: undefined,
                     },
                     amazonq_startConversation: {
-                        spanId: 'amazonq_startConversation',
+                        metricId: 'amazonq_startConversation',
                         traceId: testId,
                         parentId: 'traceEvent',
                     },
                     amazonq_addMessage: {
-                        spanId: 'amazonq_addMessage',
+                        metricId: 'amazonq_addMessage',
                         traceId: testId,
                         parentId: 'amazonq_startConversation',
                     },
                     vscode_executeCommand: {
-                        spanId: 'vscode_executeCommand',
+                        metricId: 'vscode_executeCommand',
                         traceId: testId,
                         parentId: 'traceEvent',
                     },
                     amazonq_enterFocusConversation: {
-                        spanId: 'amazonq_enterFocusConversation',
+                        metricId: 'amazonq_enterFocusConversation',
                         traceId: testId,
                         parentId: 'vscode_executeCommand',
                     },
                     amazonq_exitFocusConversation: {
-                        spanId: 'amazonq_exitFocusConversation',
+                        metricId: 'amazonq_exitFocusConversation',
                         traceId: testId,
                         parentId: 'amazonq_enterFocusConversation',
                     },
                     amazonq_closeChat: {
-                        spanId: 'amazonq_closeChat',
+                        metricId: 'amazonq_closeChat',
                         traceId: testId,
                         parentId: 'traceEvent',
                     },
@@ -410,8 +410,8 @@ describe('TelemetryTracer', function () {
                  */
                 uuidStub.onCall(1).returns(testId)
                 let index = 2
-                for (const v of Object.values(spanIds)) {
-                    uuidStub.onCall(index).returns(v.spanId)
+                for (const v of Object.values(metricsIds)) {
+                    uuidStub.onCall(index).returns(v.metricId)
                     index++
                 }
 
@@ -429,12 +429,12 @@ describe('TelemetryTracer', function () {
                     })
                 })
 
-                const spanEntries = Object.entries(spanIds)
+                const spanEntries = Object.entries(metricsIds)
                 for (let x = 0; x < spanEntries.length; x++) {
-                    const [metricName, { spanId, traceId, parentId }] = spanEntries[x]
+                    const [metricName, { metricId, traceId, parentId }] = spanEntries[x]
                     const metric = getMetrics(metricName as keyof MetricShapes)[0] as any
                     assert.deepStrictEqual(metric.traceId, traceId)
-                    assert.deepStrictEqual(metric.spanId, spanId)
+                    assert.deepStrictEqual(metric.metricId, metricId)
                     assert.deepStrictEqual(metric.parentId, parentId)
                 }
             })

--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -292,7 +292,17 @@ describe('TelemetryTracer', function () {
         })
 
         describe('nested run()', function () {
+            let uuidStub: sinon.SinonStub
             const nestedName = 'nested_metric' as MetricName
+            const testId = 'foo-foo-foo-foo-foo'
+            const flowName = 'testTraceFlow'
+
+            beforeEach(() => {
+                uuidStub = sandbox.stub(crypto, 'randomUUID')
+
+                // in the first call we set the trace id in subsequent calls we get the span ids
+                uuidStub.returns(testId)
+            })
 
             it('can record metadata in nested spans', function () {
                 tracer.run(metricName, (span1) => {
@@ -311,18 +321,18 @@ describe('TelemetryTracer', function () {
             it('removes spans when exiting an execution context', function () {
                 tracer.run(metricName, () => {
                     tracer.run(nestedName, () => {
-                        assert.strictEqual(tracer.spans.length, 2)
+                        assert.strictEqual(tracer.spans.length, 3)
                     })
 
-                    assert.strictEqual(tracer.spans.length, 1)
+                    assert.strictEqual(tracer.spans.length, 2)
                 })
             })
 
             it('adds spans during a nested execution, closing them when after', function () {
                 tracer.run(metricName, () => {
-                    tracer.run(nestedName, () => assert.strictEqual(tracer.spans.length, 2))
-                    tracer.run(nestedName, () => assert.strictEqual(tracer.spans.length, 2))
-                    assert.strictEqual(tracer.spans.length, 1)
+                    tracer.run(nestedName, () => assert.strictEqual(tracer.spans.length, 3))
+                    tracer.run(nestedName, () => assert.strictEqual(tracer.spans.length, 3))
+                    assert.strictEqual(tracer.spans.length, 2)
                 })
 
                 assert.strictEqual(tracer.spans.length, 0)
@@ -331,18 +341,102 @@ describe('TelemetryTracer', function () {
             it('supports nesting the same event name', function () {
                 tracer.run(metricName, () => {
                     tracer.run(metricName, () => {
-                        assert.strictEqual(tracer.spans.length, 2)
-                        assert.ok(tracer.spans.every((s) => s.name === metricName))
+                        assert.strictEqual(tracer.spans.length, 3)
+                        assert.ok(tracer.spans.filter((m) => m.name !== 'root').every((s) => s.name === metricName))
                     })
                 })
             })
 
             it('attaches the parent id to the child span', function () {
-                const spanId = 'a-b-c-d-e-f'
-                sandbox.stub(crypto, 'randomUUID').returns(spanId)
                 tracer.run(metricName, () => tracer.run(nestedName, () => {}))
                 assertTelemetry(metricName, { result: 'Succeeded' })
-                assertTelemetry(nestedName, { result: 'Succeeded', parentId: spanId } as any)
+                assertTelemetry(nestedName, { result: 'Succeeded', parentId: testId } as any)
+            })
+
+            it('should set trace id', function () {
+                telemetry.trace_event.run((span) => {
+                    span.record({ name: flowName })
+                    assert.deepStrictEqual(telemetry.activeSpan?.getSpanId(), testId)
+                })
+                const event = getMetrics('trace_event')
+                assert.deepStrictEqual(event[0].traceId, testId)
+                assert.deepStrictEqual(event[0].name, 'testTraceFlow')
+            })
+
+            it('trace id is propogated to children', function () {
+                const spanIds = {
+                    trace_event: {
+                        spanId: 'traceEvent',
+                        traceId: testId,
+                        parentId: undefined,
+                    },
+                    amazonq_startConversation: {
+                        spanId: 'amazonq_startConversation',
+                        traceId: testId,
+                        parentId: 'traceEvent',
+                    },
+                    amazonq_addMessage: {
+                        spanId: 'amazonq_addMessage',
+                        traceId: testId,
+                        parentId: 'amazonq_startConversation',
+                    },
+                    vscode_executeCommand: {
+                        spanId: 'vscode_executeCommand',
+                        traceId: testId,
+                        parentId: 'traceEvent',
+                    },
+                    amazonq_enterFocusConversation: {
+                        spanId: 'amazonq_enterFocusConversation',
+                        traceId: testId,
+                        parentId: 'vscode_executeCommand',
+                    },
+                    amazonq_exitFocusConversation: {
+                        spanId: 'amazonq_exitFocusConversation',
+                        traceId: testId,
+                        parentId: 'amazonq_enterFocusConversation',
+                    },
+                    amazonq_closeChat: {
+                        spanId: 'amazonq_closeChat',
+                        traceId: testId,
+                        parentId: 'traceEvent',
+                    },
+                }
+
+                /**
+                 * randomUUID calls:
+                 * The first is called on the root event that never gets emitted
+                 * The second is called when generating the traceId
+                 * The rest are called when generating the spanIds
+                 */
+                uuidStub.onCall(1).returns(testId)
+                let index = 2
+                for (const v of Object.values(spanIds)) {
+                    uuidStub.onCall(index).returns(v.spanId)
+                    index++
+                }
+
+                telemetry.trace_event.run(() => {
+                    telemetry.amazonq_startConversation.run(() => {
+                        telemetry.amazonq_addMessage.run(() => {})
+                    })
+                    telemetry.vscode_executeCommand.run(() => {
+                        telemetry.amazonq_enterFocusConversation.run(() => {
+                            telemetry.amazonq_exitFocusConversation.run(() => {})
+                        })
+                    })
+                    telemetry.amazonq_closeChat.emit({
+                        result: 'Succeeded',
+                    })
+                })
+
+                const spanEntries = Object.entries(spanIds)
+                for (let x = 0; x < spanEntries.length; x++) {
+                    const [metricName, { spanId, traceId, parentId }] = spanEntries[x]
+                    const metric = getMetrics(metricName as keyof MetricShapes)[0] as any
+                    assert.deepStrictEqual(metric.traceId, traceId)
+                    assert.deepStrictEqual(metric.spanId, spanId)
+                    assert.deepStrictEqual(metric.parentId, parentId)
+                }
             })
         })
 
@@ -534,114 +628,6 @@ describe('TelemetryTracer', function () {
                 inst.doesNotEmit()
                 assertTelemetry('function_call', [])
             })
-        })
-    })
-
-    describe('trace()', function () {
-        let uuidStub: sinon.SinonStub
-        const traceId = 'foo-foo-foo-foo-foo'
-        const flowName = 'testTraceFlow'
-
-        beforeEach(() => {
-            uuidStub = sandbox.stub(crypto, 'randomUUID')
-
-            // in the first call we set the trace id in subsequent calls we get the span ids
-            uuidStub.returns(traceId)
-        })
-
-        it('one active trace at a time', function () {
-            const checkSpan = () => {
-                telemetry.trace_event.trace(() => {
-                    telemetry.trace_event.trace(() => {})
-                })
-            }
-            assert.throws(checkSpan)
-        })
-
-        it('should set trace id', function () {
-            telemetry.trace_event.trace((span) => {
-                span.record({ name: flowName })
-                assert.deepStrictEqual(telemetry.activeSpan?.getSpanId(), traceId)
-            })
-            const event = getMetrics('trace_event')
-            assert.deepStrictEqual(event[0].traceId, traceId)
-            assert.deepStrictEqual(event[0].name, 'testTraceFlow')
-        })
-
-        it('trace id is propogated to children', function () {
-            const spanIds = {
-                trace_event: {
-                    spanId: 'traceEvent',
-                    traceId,
-                    parentId: undefined,
-                },
-                amazonq_startConversation: {
-                    spanId: 'amazonq_startConversation',
-                    traceId,
-                    parentId: 'traceEvent',
-                },
-                amazonq_addMessage: {
-                    spanId: 'amazonq_addMessage',
-                    traceId,
-                    parentId: 'amazonq_startConversation',
-                },
-                vscode_executeCommand: {
-                    spanId: 'vscode_executeCommand',
-                    traceId,
-                    parentId: 'traceEvent',
-                },
-                amazonq_enterFocusConversation: {
-                    spanId: 'amazonq_enterFocusConversation',
-                    traceId,
-                    parentId: 'vscode_executeCommand',
-                },
-                amazonq_exitFocusConversation: {
-                    spanId: 'amazonq_exitFocusConversation',
-                    traceId,
-                    parentId: 'amazonq_enterFocusConversation',
-                },
-                amazonq_closeChat: {
-                    spanId: 'amazonq_closeChat',
-                    traceId,
-                    parentId: 'traceEvent',
-                },
-            }
-
-            /**
-             * randomUUID calls:
-             * The first is called on the root event that never gets emitted
-             * The second is called when generating the traceId
-             * The rest are called when generating the spanIds
-             */
-            uuidStub.onCall(1).returns(traceId)
-            let index = 2
-            for (const v of Object.values(spanIds)) {
-                uuidStub.onCall(index).returns(v.spanId)
-                index++
-            }
-
-            telemetry.trace_event.trace(() => {
-                telemetry.amazonq_startConversation.run(() => {
-                    telemetry.amazonq_addMessage.run(() => {})
-                })
-                telemetry.vscode_executeCommand.run(() => {
-                    telemetry.amazonq_enterFocusConversation.run(() => {
-                        telemetry.amazonq_exitFocusConversation.run(() => {})
-                    })
-                })
-                telemetry.amazonq_closeChat.emit({
-                    result: 'Succeeded',
-                })
-            })
-
-            const spanEntries = Object.entries(spanIds)
-            for (let x = 0; x < spanEntries.length; x++) {
-                const [metricName, { spanId, traceId, parentId }] = spanEntries[x]
-                const metric = getMetrics(metricName as keyof MetricShapes)[0] as any
-                assert.deepStrictEqual(metric.traceId, traceId)
-                assert.deepStrictEqual(metric.spanId, spanId)
-                assert.deepStrictEqual(metric.parentId, parentId)
-            }
         })
     })
 })


### PR DESCRIPTION
## Problem
- We can't see an e2e view of our events

## Solution
- Implement telemetry tracing using the opentelemetry idea of trace ids.
- A trace id helps create a collection of spans.
- Only one trace id can be active in an execution flow at a time.
- Additionally, it swaps parentMetric for parentId so that we can directly correlate one telemetry event to another

## Other details
- A trace is associated with a top level telemetry event. The top level can be either event_trace or any other of our metrics. 
---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
