### PR TITLE
fix(core): Add missing amazonq.supressPrompts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -269,6 +269,14 @@
                         "amazonQWelcomePage": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "amazonQSessionConfigurationMessage": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "ssoCacheError": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
## Problem
- When you build the project amazonQSessionConfigurationMessage and ssoCacheError get removed from the amazon q package.json

## Solution
- Add them into core, which makes sure they get copied to the package.json of amazonq


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
