### PR TITLE
feat(amazonq): Support @workspace queries for specific files like `@workspace what does test.ts do? `. 

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-3a97670a-e801-44a6-812e-37e2f68516fc.json
+++ b/packages/amazonq/.changes/next-release/Feature-3a97670a-e801-44a6-812e-37e2f68516fc.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Support @workspace queries for specific files like `@workspace what does test.ts do? `. Timely update @workspace index when files are added or deleted."
+}

--- a/packages/amazonq/.changes/next-release/Feature-3a97670a-e801-44a6-812e-37e2f68516fc.json
+++ b/packages/amazonq/.changes/next-release/Feature-3a97670a-e801-44a6-812e-37e2f68516fc.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Support @workspace queries for specific files like `@workspace what does test.ts do? `. Timely update @workspace index when files are added or deleted."
+	"description": "Support @workspace queries for specific files like `@workspace what does test.ts do? `. "
 }

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -67,7 +67,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.6']
+const supportedLspServerVersions = ['0.1.8']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 /*

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -67,7 +67,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.8']
+const supportedLspServerVersions = ['0.1.9']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 /*


### PR DESCRIPTION
## Problem
1. When filename is in the query, chat can not resolve to that file context.

## Solution

Upgrade LSP to 0.1.9 to fix above 2 use cases.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
