### PR TITLE
ci: make dependabot work on all projects except src.gen/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,9 @@
 version: 2
 updates:
     - package-ecosystem: 'npm'
-      directory: './packages/core/' # Location of package manifests.
+      directory: './' # Location of package manifests.
       target-branch: 'master' # Avoid updates to "staging".
+      versioning-strategy: 'increase'
       commit-message:
           prefix: 'deps'
       schedule:
@@ -24,8 +25,15 @@ updates:
               patterns:
                   - '@smithy*'
                   - 'smithy*'
+    - package-ecosystem: 'npm'
+      directory: './src.gen'
+      target-branch: 'master'
+      schedule:
+          interval: 'monthly'
+      ignore:
+          - dependency-name: '*' # roundabout way to ignore this entire directory, see https://github.com/dependabot/dependabot-core/issues/4364#issuecomment-2002406602
     - package-ecosystem: 'github-actions'
-      directory: './packages/core/'
+      directory: './'
       target-branch: 'master' # Avoid updates to "staging".
       commit-message:
           prefix: 'deps'


### PR DESCRIPTION
This attempts to fix our dependabot issue but I am not sure what the best way to test this is other than committing it and seeing what happens.

Problem (as I understand it, may be incorrect): Dependabot wants to update deps in src.gen/, but this is managed separately and can cause things to break. There is no exclude dirs option in dependabot. So, we limit the dependabot to packages/core only which doesn't paint the full picture of all of our dependencies AND since this is a monorepo where the package-lock.json lives in the root, it cannot be updated. This effectively bricks dependabot and makes the PRs nothing more than a reminder.

Solution: Use this 'workaround' to exclude a directory so that dependabot can update the deps of all of our subprojects and the root directory without touching src.gen/.
Hack from: https://github.com/dependabot/dependabot-core/issues/4364

MAY have to follow up with `versioning-strategy: 'increase'`, see https://github.com/dependabot/dependabot-core/issues/4993

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
