### PR TITLE
fix(amazonq): Release mynah-ui v4.15.10 with bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5829,11 +5829,10 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.15.9",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.9.tgz",
-            "integrity": "sha512-iiXEoQ30hugmk+28NVYUwuOwYVJM+zvHQT+rqs+f54mhGkjPIUpQc58L/w7ChCggUY3kXQEp/4lCQsocuSWJkw==",
+            "version": "4.15.10",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.10.tgz",
+            "integrity": "sha512-tnj2JXHmitm1toypJvdJPN6viNc+vFYO7+O5FlmtkJhG3HnhUy/HmAk1PxTegpqpPmmPzCCnq+1vlVXsz5Rqhw==",
             "hasInstallScript": true,
-            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
@@ -22035,7 +22034,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.15.9",
+                "@aws/mynah-ui": "^4.15.10",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-88f06153-eaf2-4d50-9934-e5d1044aa2e9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-88f06153-eaf2-4d50-9934-e5d1044aa2e9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Fix shifted chat contents when closing and opening chat panel back"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-b116896a-a7d1-445b-bd6a-5d2e82fe336a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b116896a-a7d1-445b-bd6a-5d2e82fe336a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Fix tooltip remaining on screen when closing and opening chat panel back"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4123,7 +4123,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.15.9",
+        "@aws/mynah-ui": "^4.15.10",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
New version of MynahUI requires release in vscode.

## Solution
Release new version of MynahUI with the following bug fixes:

- Fix shifted chat contents
- Fix tooltip remaining on screen after closing and opening chat panel: https://github.com/aws/aws-toolkit-vscode/issues/5535

MynahUI v4.15.10 release notes: https://github.com/aws/mynah-ui/releases/tag/v4.15.10

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
