### PR TITLE
feat(logging): topic header for logs

### DIFF
--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import { Logger, LogLevel, getLogger } from '.'
 import { fromVscodeLogLevel, setLogger } from './logger'
-import { WinstonToolkitLogger } from './winstonToolkitLogger'
+import { ToolkitLogger } from './toolkitLogger'
 import { Settings } from '../settings'
 import { Logging } from './commands'
 import { resolvePath } from '../utilities/pathUtils'
@@ -79,7 +79,7 @@ export function makeLogger(opts: {
     outputChannels?: vscode.OutputChannel[]
     useConsoleLog?: boolean
 }): Logger {
-    const logger = new WinstonToolkitLogger(opts.logLevel)
+    const logger = new ToolkitLogger(opts.logLevel)
     // debug console can show ANSI colors, output channels can not
     for (const logPath of opts.logPaths ?? []) {
         logger.logToFile(logPath)

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -7,23 +7,16 @@ import * as vscode from 'vscode'
 
 const toolkitLoggers: {
     main: Logger | undefined
-    channel: Logger | undefined
     debugConsole: Logger | undefined
-} = { main: undefined, channel: undefined, debugConsole: undefined }
+} = { main: undefined, debugConsole: undefined }
 
 export interface Logger {
-    debug(message: string, ...meta: any[]): number
-    debug(error: Error, ...meta: any[]): number
-    verbose(message: string, ...meta: any[]): number
-    verbose(error: Error, ...meta: any[]): number
-    info(message: string, ...meta: any[]): number
-    info(error: Error, ...meta: any[]): number
-    warn(message: string, ...meta: any[]): number
-    warn(error: Error, ...meta: any[]): number
-    error(message: string, ...meta: any[]): number
-    error(error: Error, ...meta: any[]): number
-    log(logLevel: LogLevel, message: string, ...meta: any[]): number
-    log(logLevel: LogLevel, error: Error, ...meta: any[]): number
+    debug(message: string | Error, ...meta: any[]): number
+    verbose(message: string | Error, ...meta: any[]): number
+    info(message: string | Error, ...meta: any[]): number
+    warn(message: string | Error, ...meta: any[]): number
+    error(message: string | Error, ...meta: any[]): number
+    log(logLevel: LogLevel, message: string | Error, ...meta: any[]): number
     setLogLevel(logLevel: LogLevel): void
     /** Returns true if the given log level is being logged.  */
     logLevelEnabled(logLevel: LogLevel): boolean

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -129,7 +129,7 @@ export function getLogger(topic?: LogTopic): Logger {
 }
 
 /**
- * check if the logger is of type `ToolkitLogger` while not causing dependency loop
+ * check if the logger is of type `ToolkitLogger`. This avoids Circular Dependencies, but `instanceof ToolkitLogger` is preferred.
  * @param logger
  * @returns bool, true if is `ToolkitLogger`
  */

--- a/packages/core/src/shared/logger/sharedFileTransport.ts
+++ b/packages/core/src/shared/logger/sharedFileTransport.ts
@@ -8,12 +8,12 @@ import fs from '../fs/fs'
 import * as vscode from 'vscode'
 import globals from '../extensionGlobals'
 import { MESSAGE } from './consoleLogTransport'
-import { WinstonToolkitLogger } from './winstonToolkitLogger'
+import { ToolkitLogger } from './toolkitLogger'
 
 interface LogEntry {
     level: string
     message: string
-    /** This is the formatted message from {@link WinstonToolkitLogger} in the winston.createLogger() call */
+    /** This is the formatted message from {@link ToolkitLogger} in the winston.createLogger() call */
     [MESSAGE]: string
 }
 

--- a/packages/core/src/shared/logger/toolkitLogger.ts
+++ b/packages/core/src/shared/logger/toolkitLogger.ts
@@ -15,7 +15,7 @@ import { ConsoleLogTransport } from './consoleLogTransport'
 import { isWeb } from '../extensionGlobals'
 
 /* define log topics */
-export type LogTopic = 'Unknown' | 'Test'
+export type LogTopic = 'unknown' | 'test'
 
 // Need to limit how many logs are actually tracked
 // LRU cache would work well, currently it just dumps the least recently added log
@@ -23,7 +23,7 @@ const logmapSize: number = 1000
 export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
     private readonly logger: winston.Logger
     /* topic is used for header in log messages, default is 'Unknown' */
-    private topic: LogTopic = 'Unknown'
+    private topic: LogTopic = 'unknown'
     private disposed: boolean = false
     private idCounter: number = 0
     private logMap: { [logID: number]: { [filePath: string]: string } } = {}
@@ -108,7 +108,7 @@ export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
               })
     }
 
-    public setTopic(topic: LogTopic = 'Unknown') {
+    public setTopic(topic: LogTopic = 'unknown') {
         this.topic = topic
     }
 
@@ -117,7 +117,7 @@ export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
         /*We shouldn't print unknow before current logging calls are migrated
          * TODO: remove this once migration of current calls is completed
          */
-        if (this.topic === 'Unknown') {
+        if (this.topic === 'unknown') {
             return message
         }
         const topicPrefix = `${this.topic}: `

--- a/packages/core/src/shared/logger/toolkitLogger.ts
+++ b/packages/core/src/shared/logger/toolkitLogger.ts
@@ -121,7 +121,6 @@ export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
 
     /* Format the message with topic header */
     private addTopicToMessage(message: string | Error): string | ErrorLog {
-        const topicPrefix = `${this.topic}: `
         if (typeof message === 'string') {
             /*We shouldn't print unknow before current logging calls are migrated
              * TODO: remove this once migration of current calls is completed
@@ -129,10 +128,9 @@ export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
             if (this.topic === 'unknown') {
                 return message
             }
-            return topicPrefix + message
+            return `${this.topic}: ` + message
         } else if (message instanceof Error) {
-            const topic = topicPrefix.split(':', 1)[0]
-            return new ErrorLog(topic, message)
+            return new ErrorLog(this.topic, message)
         }
         return message
     }

--- a/packages/core/src/shared/logger/toolkitLogger.ts
+++ b/packages/core/src/shared/logger/toolkitLogger.ts
@@ -113,22 +113,22 @@ export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
     }
 
     /* Format the message with topic header */
-    private addTopicToMessage(message: string | Error): string | Error {
+    private addTopicToMessage(message: string | Error): string | object {
         /*We shouldn't print unknow before current logging calls are migrated
          * TODO: remove this once migration of current calls is completed
          */
         if (this.topic === 'unknown') {
             return message
         }
-        const topicPrefix = `${this.topic}: `
+        const topic = `${this.topic}: `
         if (typeof message === 'string') {
-            return topicPrefix + message
+            return topic + message
         } else if (message instanceof Error) {
-            /* Create a new Error object to avoid modifying the original */
-            const topicError = new Error(topicPrefix + message.message)
-            topicError.name = message.name
-            topicError.stack = message.stack
-            return topicError
+            const errorWithTopic = {
+                topic,
+                message,
+            }
+            return errorWithTopic
         }
         return message
     }
@@ -156,7 +156,7 @@ export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
 
         meta = meta.map((o) => (o instanceof Error ? this.mapError(level, o) : o))
 
-        if (messageWithHeader instanceof Error) {
+        if (typeof messageWithHeader === 'object' && messageWithHeader !== null) {
             this.logger.log(level, '%O', messageWithHeader, ...meta, { logID: this.idCounter })
         } else {
             this.logger.log(level, messageWithHeader, ...meta, { logID: this.idCounter })

--- a/packages/core/src/shared/logger/toolkitLogger.ts
+++ b/packages/core/src/shared/logger/toolkitLogger.ts
@@ -6,7 +6,7 @@
 import { normalize } from 'path'
 import * as vscode from 'vscode'
 import winston from 'winston'
-import { baseLogger, LogLevel, compareLogLevel } from './logger'
+import { BaseLogger, LogLevel, compareLogLevel } from './logger'
 import { OutputChannelTransport } from './outputChannelTransport'
 import { isSourceMappingAvailable } from '../vscode/env'
 import { formatError, ToolkitError, UnknownError } from '../errors'
@@ -20,7 +20,7 @@ export type LogTopic = 'Unknown' | 'Test'
 // Need to limit how many logs are actually tracked
 // LRU cache would work well, currently it just dumps the least recently added log
 const logmapSize: number = 1000
-export class WinstonToolkitLogger extends baseLogger implements vscode.Disposable {
+export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
     private readonly logger: winston.Logger
     /* topic is used for header in log messages, default is 'Unknown' */
     private topic: LogTopic = 'Unknown'

--- a/packages/core/src/test/shared/logger/activation.test.ts
+++ b/packages/core/src/test/shared/logger/activation.test.ts
@@ -9,7 +9,7 @@ import vscode from 'vscode'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { Logger } from '../../../shared/logger'
 import { makeLogger } from '../../../shared/logger/activation'
-import { WinstonToolkitLogger } from '../../../shared/logger/winstonToolkitLogger'
+import { ToolkitLogger } from '../../../shared/logger/toolkitLogger'
 
 describe('makeLogger', function () {
     let tempFolder: string
@@ -22,7 +22,7 @@ describe('makeLogger', function () {
     })
 
     after(async function () {
-        if (testLogger && testLogger instanceof WinstonToolkitLogger) {
+        if (testLogger && testLogger instanceof ToolkitLogger) {
             await testLogger.dispose()
         }
 
@@ -32,6 +32,6 @@ describe('makeLogger', function () {
 
     it('creates a logger object', function () {
         assert.notStrictEqual(testLogger, undefined)
-        assert.ok(testLogger instanceof WinstonToolkitLogger)
+        assert.ok(testLogger instanceof ToolkitLogger)
     })
 })

--- a/packages/core/src/test/shared/logger/toolkitLogger.test.ts
+++ b/packages/core/src/test/shared/logger/toolkitLogger.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import * as fs from 'fs'
 import * as filesystemUtilities from '../../../shared/filesystemUtilities'
 import * as vscode from 'vscode'
-import { WinstonToolkitLogger } from '../../../shared/logger/winstonToolkitLogger'
+import { ToolkitLogger } from '../../../shared/logger/toolkitLogger'
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { sleep, waitUntil } from '../../../shared/utilities/timeoutUtils'
 
@@ -17,7 +17,7 @@ import { sleep, waitUntil } from '../../../shared/utilities/timeoutUtils'
  * were found.
  */
 async function checkFile(
-    logger: WinstonToolkitLogger,
+    logger: ToolkitLogger,
     logPath: vscode.Uri,
     expected: string[],
     unexpected: string[] = []
@@ -54,7 +54,7 @@ async function checkFile(
     return logger.dispose().then(() => check)
 }
 
-describe('WinstonToolkitLogger', function () {
+describe('ToolkitLogger', function () {
     let tempFolder: string
 
     before(async function () {
@@ -66,7 +66,7 @@ describe('WinstonToolkitLogger', function () {
     })
 
     it('logLevelEnabled()', function () {
-        const logger = new WinstonToolkitLogger('info')
+        const logger = new ToolkitLogger('info')
         // winston complains if we don't log to something
         logger.logToOutputChannel(new MockOutputChannel(), false)
 
@@ -92,11 +92,11 @@ describe('WinstonToolkitLogger', function () {
     })
 
     it('creates an object', function () {
-        assert.notStrictEqual(new WinstonToolkitLogger('info'), undefined)
+        assert.notStrictEqual(new ToolkitLogger('info'), undefined)
     })
 
     it('throws when logging to a disposed object', async function () {
-        const logger = new WinstonToolkitLogger('info')
+        const logger = new ToolkitLogger('info')
         await logger.dispose()
 
         assert.throws(() => logger.info('This should not log'))
@@ -105,31 +105,31 @@ describe('WinstonToolkitLogger', function () {
     const happyLogScenarios = [
         {
             name: 'logs debug',
-            logMessage: (logger: WinstonToolkitLogger, message: string) => {
+            logMessage: (logger: ToolkitLogger, message: string) => {
                 logger.debug(message)
             },
         },
         {
             name: 'logs verbose',
-            logMessage: (logger: WinstonToolkitLogger, message: string) => {
+            logMessage: (logger: ToolkitLogger, message: string) => {
                 logger.verbose(message)
             },
         },
         {
             name: 'logs info',
-            logMessage: (logger: WinstonToolkitLogger, message: string) => {
+            logMessage: (logger: ToolkitLogger, message: string) => {
                 logger.info(message)
             },
         },
         {
             name: 'logs warn',
-            logMessage: (logger: WinstonToolkitLogger, message: string) => {
+            logMessage: (logger: ToolkitLogger, message: string) => {
                 logger.warn(message)
             },
         },
         {
             name: 'logs error',
-            logMessage: (logger: WinstonToolkitLogger, message: string) => {
+            logMessage: (logger: ToolkitLogger, message: string) => {
                 logger.error(message)
             },
         },
@@ -138,7 +138,7 @@ describe('WinstonToolkitLogger', function () {
     describe('logs to a file', async function () {
         let tempLogPath: vscode.Uri
         let tempFileCounter = 0
-        let testLogger: WinstonToolkitLogger | undefined
+        let testLogger: ToolkitLogger | undefined
 
         beforeEach(async function () {
             tempLogPath = vscode.Uri.joinPath(vscode.Uri.file(tempFolder), `temp-${++tempFileCounter}.log`)
@@ -148,7 +148,7 @@ describe('WinstonToolkitLogger', function () {
             const debugMessage = 'debug message'
             const errorMessage = 'error message'
 
-            testLogger = new WinstonToolkitLogger('error')
+            testLogger = new ToolkitLogger('error')
             testLogger.logToFile(tempLogPath)
 
             testLogger.debug(debugMessage)
@@ -161,7 +161,7 @@ describe('WinstonToolkitLogger', function () {
             const nonLoggedVerboseEntry = 'verbose entry should not be logged'
             const loggedVerboseEntry = 'verbose entry should be logged'
 
-            testLogger = new WinstonToolkitLogger('info')
+            testLogger = new ToolkitLogger('info')
             testLogger.logToFile(tempLogPath)
 
             testLogger.verbose(nonLoggedVerboseEntry)
@@ -174,7 +174,7 @@ describe('WinstonToolkitLogger', function () {
         happyLogScenarios.forEach((scenario) => {
             it(scenario.name, async () => {
                 const message = `message for ${scenario.name}`
-                testLogger = new WinstonToolkitLogger('debug')
+                testLogger = new ToolkitLogger('debug')
                 testLogger.logToFile(tempLogPath)
 
                 scenario.logMessage(testLogger, message)
@@ -185,7 +185,7 @@ describe('WinstonToolkitLogger', function () {
     })
 
     describe('logs to an OutputChannel', async function () {
-        let testLogger: WinstonToolkitLogger | undefined
+        let testLogger: ToolkitLogger | undefined
         let outputChannel: MockOutputChannel
 
         beforeEach(async function () {
@@ -203,7 +203,7 @@ describe('WinstonToolkitLogger', function () {
             const debugMessage = 'debug message'
             const errorMessage = 'error message'
 
-            testLogger = new WinstonToolkitLogger('error')
+            testLogger = new ToolkitLogger('error')
             testLogger.logToOutputChannel(outputChannel, false)
 
             const waitForMessage = waitForLoggedTextByCount(1)
@@ -218,7 +218,7 @@ describe('WinstonToolkitLogger', function () {
             const nonLoggedVerboseEntry = 'verbose entry should not be logged'
             const loggedVerboseEntry = 'verbose entry should be logged'
 
-            testLogger = new WinstonToolkitLogger('info')
+            testLogger = new ToolkitLogger('info')
             testLogger.logToOutputChannel(outputChannel, false)
 
             testLogger.verbose(nonLoggedVerboseEntry)
@@ -233,7 +233,7 @@ describe('WinstonToolkitLogger', function () {
         happyLogScenarios.forEach((scenario) => {
             it(scenario.name, async () => {
                 const message = `message for ${scenario.name}`
-                testLogger = new WinstonToolkitLogger('debug')
+                testLogger = new ToolkitLogger('debug')
                 testLogger.logToOutputChannel(outputChannel, false)
 
                 const waitForMessage = waitForLoggedTextByCount(1)
@@ -283,10 +283,10 @@ describe('WinstonToolkitLogger', function () {
     describe('log tracking', function () {
         let tempLogPath: vscode.Uri
         let tempFileCounter: number = 0
-        let testLogger: WinstonToolkitLogger
+        let testLogger: ToolkitLogger
 
         beforeEach(async function () {
-            testLogger = new WinstonToolkitLogger('info')
+            testLogger = new ToolkitLogger('info')
             tempLogPath = vscode.Uri.joinPath(vscode.Uri.file(tempFolder), `temp-tracker-${tempFileCounter++}.log`)
             testLogger.logToFile(tempLogPath)
         })

--- a/packages/core/src/test/shared/logger/toolkitLogger.test.ts
+++ b/packages/core/src/test/shared/logger/toolkitLogger.test.ts
@@ -230,6 +230,50 @@ describe('ToolkitLogger', function () {
             assert.ok(!(await waitForMessage).includes(nonLoggedVerboseEntry), 'unexpected message in log')
         })
 
+        it('logs append topic header in message', async function () {
+            const testMessage = 'This is a test message'
+            const testMessageWithHeader = 'Test: This is a test message'
+
+            testLogger = new ToolkitLogger('info')
+            testLogger.logToOutputChannel(outputChannel, false)
+            testLogger.setTopic('Test')
+            testLogger.setLogLevel('verbose')
+            testLogger.verbose(testMessage)
+
+            const waitForMessage = waitForLoggedTextByContents(testMessageWithHeader)
+            assert.ok((await waitForMessage).includes(testMessageWithHeader), 'Expected header added')
+        })
+
+        it('unknown topic header ignored in message', async function () {
+            const testMessage = 'This is a test message'
+            const unknowntestMessage = 'Unknown: This is a test message'
+
+            testLogger = new ToolkitLogger('info')
+            testLogger.logToOutputChannel(outputChannel, false)
+            testLogger.setTopic('Unknown')
+            testLogger.setLogLevel('verbose')
+            testLogger.verbose(testMessage)
+
+            const waitForMessage = waitForLoggedTextByContents(testMessage)
+            assert.ok((await waitForMessage).includes(testMessage), 'Expected message logged')
+            assert.ok(!(await waitForMessage).includes(unknowntestMessage), 'unexpected header in log')
+        })
+
+        it('switch topic within same logger', async function () {
+            const testMessage = 'This is a test message'
+            const testMessageWithHeader = 'Test: This is a test message'
+
+            testLogger = new ToolkitLogger('info')
+            testLogger.logToOutputChannel(outputChannel, false)
+            testLogger.setTopic('Unknown')
+            testLogger.setTopic('Test')
+            testLogger.setLogLevel('verbose')
+            testLogger.verbose(testMessage)
+
+            const waitForMessage = waitForLoggedTextByContents(testMessageWithHeader)
+            assert.ok((await waitForMessage).includes(testMessageWithHeader), 'Expected header added')
+        })
+
         happyLogScenarios.forEach((scenario) => {
             it(scenario.name, async () => {
                 const message = `message for ${scenario.name}`

--- a/packages/core/src/test/shared/logger/toolkitLogger.test.ts
+++ b/packages/core/src/test/shared/logger/toolkitLogger.test.ts
@@ -236,7 +236,7 @@ describe('ToolkitLogger', function () {
 
             testLogger = new ToolkitLogger('info')
             testLogger.logToOutputChannel(outputChannel, false)
-            testLogger.setTopic('Test')
+            testLogger.setTopic('test')
             testLogger.setLogLevel('verbose')
             testLogger.verbose(testMessage)
 
@@ -250,7 +250,7 @@ describe('ToolkitLogger', function () {
 
             testLogger = new ToolkitLogger('info')
             testLogger.logToOutputChannel(outputChannel, false)
-            testLogger.setTopic('Unknown')
+            testLogger.setTopic('unknown')
             testLogger.setLogLevel('verbose')
             testLogger.verbose(testMessage)
 
@@ -265,8 +265,8 @@ describe('ToolkitLogger', function () {
 
             testLogger = new ToolkitLogger('info')
             testLogger.logToOutputChannel(outputChannel, false)
-            testLogger.setTopic('Unknown')
-            testLogger.setTopic('Test')
+            testLogger.setTopic('unknown')
+            testLogger.setTopic('test')
             testLogger.setLogLevel('verbose')
             testLogger.verbose(testMessage)
 

--- a/packages/core/src/test/shared/logger/toolkitLogger.test.ts
+++ b/packages/core/src/test/shared/logger/toolkitLogger.test.ts
@@ -247,7 +247,7 @@ describe('ToolkitLogger', function () {
 
         it('logs append topic header in errors', async function () {
             const testError = new ToolkitError('root error', { code: 'something went wrong' })
-            const testErrorWithHeader = "topic: 'test: '"
+            const testErrorWithHeader = "topic: 'test'"
 
             testLogger = new ToolkitLogger('info')
             testLogger.logToOutputChannel(outputChannel, false)

--- a/packages/core/src/test/shared/logger/toolkitLogger.test.ts
+++ b/packages/core/src/test/shared/logger/toolkitLogger.test.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode'
 import { ToolkitLogger } from '../../../shared/logger/toolkitLogger'
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { sleep, waitUntil } from '../../../shared/utilities/timeoutUtils'
+import { ToolkitError } from '../../../shared/errors'
 
 /**
  * Disposes the logger then waits for the write streams to flush. The `expected` and `unexpected` arrays just look
@@ -232,7 +233,7 @@ describe('ToolkitLogger', function () {
 
         it('logs append topic header in message', async function () {
             const testMessage = 'This is a test message'
-            const testMessageWithHeader = 'Test: This is a test message'
+            const testMessageWithHeader = 'test: This is a test message'
 
             testLogger = new ToolkitLogger('info')
             testLogger.logToOutputChannel(outputChannel, false)
@@ -244,9 +245,23 @@ describe('ToolkitLogger', function () {
             assert.ok((await waitForMessage).includes(testMessageWithHeader), 'Expected header added')
         })
 
+        it('logs append topic header in errors', async function () {
+            const testError = new ToolkitError('root error', { code: 'something went wrong' })
+            const testErrorWithHeader = "topic: 'test: '"
+
+            testLogger = new ToolkitLogger('info')
+            testLogger.logToOutputChannel(outputChannel, false)
+            testLogger.setTopic('test')
+            testLogger.setLogLevel('verbose')
+            testLogger.verbose(testError)
+
+            const waitForMessage = waitForLoggedTextByContents(testErrorWithHeader)
+            assert.ok((await waitForMessage).includes(testErrorWithHeader), 'Expected header added')
+        })
+
         it('unknown topic header ignored in message', async function () {
             const testMessage = 'This is a test message'
-            const unknowntestMessage = 'Unknown: This is a test message'
+            const unknowntestMessage = 'unknown: This is a test message'
 
             testLogger = new ToolkitLogger('info')
             testLogger.logToOutputChannel(outputChannel, false)
@@ -261,7 +276,7 @@ describe('ToolkitLogger', function () {
 
         it('switch topic within same logger', async function () {
             const testMessage = 'This is a test message'
-            const testMessageWithHeader = 'Test: This is a test message'
+            const testMessageWithHeader = 'test: This is a test message'
 
             testLogger = new ToolkitLogger('info')
             testLogger.logToOutputChannel(outputChannel, false)

--- a/packages/core/src/test/testLogger.ts
+++ b/packages/core/src/test/testLogger.ts
@@ -61,7 +61,7 @@ export class TestLogger implements Logger {
         return this.count++
     }
 
-    // No need to actually implement this. Log tracking is tested in winstonToolkitLogger.test.ts
+    // No need to actually implement this. Log tracking is tested in toolkitLogger.test.ts
     public getLogById(logID: number, file: Uri): string | undefined {
         return undefined
     }

--- a/packages/core/src/testInteg/globalSetup.test.ts
+++ b/packages/core/src/testInteg/globalSetup.test.ts
@@ -8,7 +8,7 @@
  */
 import vscode from 'vscode'
 import { getLogger } from '../shared/logger'
-import { WinstonToolkitLogger } from '../shared/logger/winstonToolkitLogger'
+import { ToolkitLogger } from '../shared/logger/toolkitLogger'
 import { mapTestErrors, normalizeError, patchObject, setRunnableTimeout } from '../test/setupUtil'
 import { getTestWindow, resetTestWindow } from '../test/shared/vscode/window'
 import * as sinon from 'sinon'
@@ -45,8 +45,8 @@ export async function mochaGlobalSetup(extensionId: string) {
 
         // Log as much as possible, useful for debugging integration tests.
         getLogger().setLogLevel('debug')
-        if (getLogger() instanceof WinstonToolkitLogger) {
-            ;(getLogger() as WinstonToolkitLogger).logToConsole()
+        if (getLogger() instanceof ToolkitLogger) {
+            ;(getLogger() as ToolkitLogger).logToConsole()
         }
     }
 }


### PR DESCRIPTION
## Problem
Log message can appear in output channels(such as Amazon Q Logs as shown), IDE Debug console, or write to pre-defined log file destinations. They come from all parts of our services and can amount to large and lengthy chunks quickly.

We don’t have a reliable way to identify log messages from various services and modules of our product. Some messages might have headers while others don’t, and the existing headers are hard-coded on a message by message basis, with no checks for consistency. 

1. It’s difficult to locate and trace unidentified log messages when the size of logs grow quickly.
2. Without regulation, the hard-coded custom headers can lead to legacy issues down-the-road and inconsistencies within the codebase.

## Solution
1. Make message topic identifiers an input variable of the getLogger() function.
2. Append the topic at the front of each message, for example:
`getLogger('S3').error('Something went wrong')`
Would print:
`S3: Something went wrong`
3. Define a set of topics to be used in message headers, covering all services and modules.


## Implementation notes:
1. The `WinstonToolkitLogger` is renamed to `ToolkitLogger` to avoid confusion, since its our own logger not winston's. The log topic feature is added here. 
2. A `baseLogger` abstract class is created to make the existing `NullLogger`, `ConsoleLogger`, and `ToolkitLogger` cleaner and their responsibilities more obvious and compact.
3. Currently the topics are optional, and the values are just `Test` and `Unknown`, this will be expanded during migration of existing logger calls.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
