### PR TITLE
feat(redshift): bug fix for regions which do not support serverless API

### DIFF
--- a/packages/core/src/awsService/redshift/explorer/redshiftNode.ts
+++ b/packages/core/src/awsService/redshift/explorer/redshiftNode.ts
@@ -16,6 +16,7 @@ import { RedshiftWarehouseType } from '../models/models'
 import { AWSResourceNode } from '../../../shared/treeview/nodes/awsResourceNode'
 import { LoadMoreNode } from '../../../shared/treeview/nodes/loadMoreNode'
 import { ChildNodeLoader, ChildNodePage } from '../../../awsexplorer/childNodeLoader'
+import { getLogger } from 'aws-core-vscode/shared'
 
 /**
  * An AWS Explorer node representing Redshift.
@@ -88,13 +89,13 @@ export class RedshiftNode extends AWSTreeNodeBase implements LoadMoreNode {
         const childNodes: RedshiftWarehouseNode[] = []
         let newServerlessToken: string = ''
         let newProvisionedToken: string = ''
-        // provisionedToken can be undefined (first time load) or non-empty (more results available). If it's empty, we've loaded all
+        // Handle provisioned clusters
         if (compositeContinuationToken === undefined || compositeContinuationToken.provisionedToken !== '') {
             const response = await this.redshiftClient.describeProvisionedClusters(
                 compositeContinuationToken?.provisionedToken
             )
             if (response.Clusters) {
-                const provisionedNodes = response.Clusters?.map((cluster) => {
+                const provisionedNodes = response.Clusters.map((cluster) => {
                     return new RedshiftWarehouseNode(
                         this,
                         {
@@ -108,21 +109,26 @@ export class RedshiftNode extends AWSTreeNodeBase implements LoadMoreNode {
                 newProvisionedToken = response.Marker ?? ''
             }
         }
-        // serverlessToken can be undefined (first time load) or non-empty (more results available). If it's empty, we've loaded all
+        // Handle serverless workgroups
         if (compositeContinuationToken === undefined || compositeContinuationToken.serverlessToken !== '') {
-            const response = await this.redshiftClient.listServerlessWorkgroups(
-                compositeContinuationToken?.serverlessToken
-            )
-            if (response.workgroups) {
-                const serverlessNodes: RedshiftWarehouseNode[] = response.workgroups?.map((workgroup) => {
-                    return new RedshiftWarehouseNode(
-                        this,
-                        { arn: workgroup.workgroupArn, name: workgroup.workgroupName } as AWSResourceNode,
-                        RedshiftWarehouseType.SERVERLESS
-                    )
-                })
-                childNodes.push(...serverlessNodes)
-                newServerlessToken = response.nextToken ?? ''
+            try {
+                const response = await this.redshiftClient.listServerlessWorkgroups(
+                    compositeContinuationToken?.serverlessToken
+                )
+                if (response.workgroups) {
+                    const serverlessNodes = response.workgroups.map((workgroup) => {
+                        return new RedshiftWarehouseNode(
+                            this,
+                            { arn: workgroup.workgroupArn, name: workgroup.workgroupName } as AWSResourceNode,
+                            RedshiftWarehouseType.SERVERLESS
+                        )
+                    })
+                    childNodes.push(...serverlessNodes)
+                    newServerlessToken = response.nextToken ?? ''
+                }
+            } catch (error) {
+                getLogger().error("Serverless workgroup operation isn't supported or failed:", error)
+                // Continue without interrupting the provisioned cluster loading
             }
         }
         return [childNodes, newProvisionedToken, newServerlessToken]

--- a/packages/core/src/awsService/redshift/explorer/redshiftNode.ts
+++ b/packages/core/src/awsService/redshift/explorer/redshiftNode.ts
@@ -16,7 +16,7 @@ import { RedshiftWarehouseType } from '../models/models'
 import { AWSResourceNode } from '../../../shared/treeview/nodes/awsResourceNode'
 import { LoadMoreNode } from '../../../shared/treeview/nodes/loadMoreNode'
 import { ChildNodeLoader, ChildNodePage } from '../../../awsexplorer/childNodeLoader'
-import { getLogger } from 'aws-core-vscode/shared'
+import { getLogger } from '../../../shared/logger/logger'
 
 /**
  * An AWS Explorer node representing Redshift.

--- a/packages/toolkit/.changes/next-release/Bug Fix-7abe66a9-111f-4507-8129-48b460819095.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-7abe66a9-111f-4507-8129-48b460819095.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Redshift: updated the list clusters and workgroups for regions which do not have serverless APIs"
+}


### PR DESCRIPTION
## Problem
Customer not able to list the provisioned clusters in region where serverless API's not present.
Solution


## Solution
Made a minor code change to fix the issue. Tested the change too.


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
