### PR TITLE
fix(amazonq): Replacing the loading icon in the status bar menu.

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-239f62a8-0e2a-42f8-a028-ef1639bac4c5.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-239f62a8-0e2a-42f8-a028-ef1639bac4c5.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q Scans: Replacing the loading icon in the status bar menu."
+	"description": "Security Scan: Fixed an issue where the wrong icon was used in the status bar menu."
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-239f62a8-0e2a-42f8-a028-ef1639bac4c5.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-239f62a8-0e2a-42f8-a028-ef1639bac4c5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Scans: Replacing the loading icon in the status bar menu."
+}

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -259,7 +259,7 @@ export class CodeScanState {
             case CodeScanStatus.Running:
                 return getIcon('vscode-stop-circle')
             case CodeScanStatus.Cancelling:
-                return getIcon('vscode-icons:loading~spin')
+                return getIcon('vscode-loading~spin')
         }
     }
 }


### PR DESCRIPTION
## Problem
- Issue with loading icon in the status bar menu.
![image](https://github.com/user-attachments/assets/94564f04-265d-49df-8a68-39745c7703b3)


## Solution
- Replaced previous icon with relevant loading icon.
![image](https://github.com/user-attachments/assets/72efac08-4a10-4cf4-9dbf-626793cc8fcb)
- Did not update any logic in the PR, its just a UI icon change so adding/updating tests is not considered.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
