### PR TITLE
ci: remove src.gen from workspaces to fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,6 @@
 version: 2
 updates:
     - package-ecosystem: 'npm'
-      directory: './src.gen'
-      target-branch: 'master'
-      schedule:
-          interval: 'monthly'
-      ignore:
-          - dependency-name: '*' # roundabout way to ignore this entire directory, see https://github.com/dependabot/dependabot-core/issues/4364#issuecomment-2002406602
-    - package-ecosystem: 'npm'
       directory: './' # Location of package manifests.
       target-branch: 'master' # Avoid updates to "staging".
       versioning-strategy: 'increase'
@@ -32,6 +25,13 @@ updates:
               patterns:
                   - '@smithy*'
                   - 'smithy*'
+    - package-ecosystem: 'npm'
+      directory: './src.gen'
+      target-branch: 'master'
+      schedule:
+          interval: 'monthly'
+      ignore:
+          - dependency-name: '*' # roundabout way to ignore this entire directory, see https://github.com/dependabot/dependabot-core/issues/4364#issuecomment-2002406602
     - package-ecosystem: 'github-actions'
       directory: './'
       target-branch: 'master' # Avoid updates to "staging".

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
             "workspaces": [
                 "packages/core/src/web",
                 "packages/*",
-                "plugins/*",
-                "src.gen/@amzn/codewhisperer-streaming"
+                "plugins/*"
             ],
             "dependencies": {
                 "vscode-nls": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
     "workspaces": [
         "packages/core/src/web",
         "packages/*",
-        "plugins/*",
-        "src.gen/@amzn/codewhisperer-streaming"
+        "plugins/*"
     ],
     "version": "0.0.1",
     "private": true,
@@ -21,8 +20,9 @@
     },
     "scripts": {
         "prepare": "ts-node ./scripts/prepare.ts",
-        "postinstall": "npm run buildCustomLintPlugin && npm run postinstall -ws --if-present",
+        "postinstall": "npm run buildCustomLintPlugin && npm run buildGenerated && npm run postinstall -ws --if-present",
         "buildCustomLintPlugin": "npm run build -w plugins/eslint-plugin-aws-toolkits",
+        "buildGenerated": "cd src.gen/@amzn/codewhisperer-streaming && npm i --silent",
         "compile": "npm run compile -w packages/",
         "testCompile": "npm run testCompile -w packages/ --if-present",
         "test": "npm run test -w packages/ --if-present",


### PR DESCRIPTION
Problem: I theorize that we are still getting dependabot for src.gen because it is a subworkspace of the root project.

Solution: Remove it and install/build separately on root `npm i`.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
