### PR TITLE
feat(amazonq): enable code actions for awesome lightbulb

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-b771fe9a-7f29-47b0-b39c-1282224069dd.json
+++ b/packages/amazonq/.changes/next-release/Feature-b771fe9a-7f29-47b0-b39c-1282224069dd.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "feat(amazonq): enable code actions for awesome lightbulb"
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -358,6 +358,10 @@
                 {
                     "submenu": "amazonqEditorContextSubmenu",
                     "group": "cw_chat"
+                },
+                {
+                    "command": "aws.amazonq.codeActions",
+                    "when": "editorHasSelection && !editorReadonly && aws.codewhisperer.connected"
                 }
             ],
             "aws.amazonq.submenu.feedback": [
@@ -560,6 +564,10 @@
                 "title": "%AWS.amazonq.toggleCodeScan%",
                 "category": "%AWS.amazonq.title%",
                 "enablement": "aws.codewhisperer.connected"
+            },
+            {
+                "command": "aws.amazonq.codeActions",
+                "title": "%AWS.command.amazonq.codeActions%"
             }
         ],
         "keybindings": [

--- a/packages/amazonq/src/codeActions.ts
+++ b/packages/amazonq/src/codeActions.ts
@@ -1,0 +1,67 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+
+export class CodeActions implements vscode.CodeActionProvider {
+    public static readonly providedCodeActionKinds = [
+        vscode.CodeActionKind.QuickFix,
+        vscode.CodeActionKind.RefactorRewrite,
+        vscode.CodeActionKind.Empty,
+    ]
+
+    private suffix: string = 'using Amazon Q'
+
+    private commands: Map<string, { title: string; kind: vscode.CodeActionKind }> = new Map<
+        string,
+        { title: string; kind: vscode.CodeActionKind }
+    >([
+        ['aws.amazonq.explainCode', { title: `Explain ${this.suffix}`, kind: vscode.CodeActionKind.Empty }],
+        ['aws.amazonq.refactorCode', { title: `Refactor ${this.suffix}`, kind: vscode.CodeActionKind.RefactorRewrite }],
+        ['aws.amazonq.fixCode', { title: `Fix ${this.suffix}`, kind: vscode.CodeActionKind.QuickFix }],
+        ['aws.amazonq.optimizeCode', { title: `Optimize ${this.suffix}`, kind: vscode.CodeActionKind.RefactorRewrite }],
+        [
+            'aws.amazonq.sendToPrompt',
+            { title: `Add selection to ${this.suffix} prompt`, kind: vscode.CodeActionKind.Empty },
+        ],
+    ])
+
+    provideCodeActions(): vscode.CodeAction[] {
+        const editor = vscode.window.activeTextEditor
+        if (!editor) {
+            return []
+        }
+
+        const selectedText = editor.document.getText(editor.selection)
+        if (!selectedText) {
+            return []
+        }
+
+        const codeActions: vscode.CodeAction[] = []
+
+        this.commands.forEach(({ title, kind }, command) => {
+            codeActions.push(this.createCodeAction(command, title, kind, selectedText))
+        })
+
+        return codeActions
+    }
+
+    private createCodeAction(
+        command: string,
+        title: string,
+        kind: vscode.CodeActionKind,
+        selectedText: string,
+        isPreferred = false
+    ): vscode.CodeAction {
+        const action = new vscode.CodeAction(title, kind)
+        action.command = {
+            command,
+            title,
+            arguments: [selectedText],
+        }
+        action.isPreferred = isPreferred
+        return action
+    }
+}

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -48,7 +48,7 @@ import * as semver from 'semver'
 import * as vscode from 'vscode'
 import { registerCommands } from './commands'
 import { focusAmazonQPanel } from 'aws-core-vscode/codewhispererChat'
-
+import { CodeActions } from './codeActions'
 export const amazonQContextPrefix = 'amazonq'
 
 /**
@@ -56,7 +56,7 @@ export const amazonQContextPrefix = 'amazonq'
  */
 export async function activateAmazonQCommon(context: vscode.ExtensionContext, isWeb: boolean) {
     initialize(context, isWeb)
-    const homeDirLogs = await fs.init(context, (homeDir) => {
+    const homeDirLogs = await fs.init(context, (homeDir: string) => {
         void messages.showViewLogsMessage(`Invalid home directory (check $HOME): "${homeDir}"`)
     })
     errors.init(fs.getUsername(), env.isAutomation())
@@ -193,6 +193,10 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
             })
         })
         .catch((err) => getLogger().error('Error collecting telemetry for auth_userState: %s', err))
+
+    vscode.languages.registerCodeActionsProvider({ scheme: 'file' }, new CodeActions(), {
+        providedCodeActionKinds: CodeActions.providedCodeActionKinds,
+    })
 }
 
 export async function deactivateCommon() {

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -112,6 +112,7 @@
     "AWS.command.amazonq.optimizeCode": "Optimize",
     "AWS.command.amazonq.sendToPrompt": "Send to prompt",
     "AWS.command.amazonq.security.scan": "Run Project Scan",
+    "AWS.command.amazonq.codeActions": "Code Actions",
     "AWS.command.deploySamApplication": "Deploy SAM Application",
     "AWS.command.aboutToolkit": "About",
     "AWS.command.downloadLambda": "Download...",


### PR DESCRIPTION
## Problem

The Amazon Q VS Code extension requires a more streamlined approach to handle various CodeAction scenarios such as quick fixes, refactoring, and code explanation for better user experience. 

## Solution
![codeActions](https://github.com/user-attachments/assets/fd971471-6df5-4f8e-89d5-f3e6c90aadf1)

1. **Enhanced Code Actions**: Introduced a `CodeActions` provider that dynamically generates and registers various actions (e.g., `QuickFix`, `RefactorRewrite`, `ExplainCode`) based on user selection.

### Key Changes:

- Refactored the activation logic in `extension.ts` to ensure proper extension initialization and handling for both the Node.js and web environments.
- Created `CodeActions` class to provide code actions like explaining, refactoring, and fixing code with a dynamic selection mechanism.


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
