### PR TITLE
fix(ec2): don't allow user to copy instance id from parent ec2 node. 

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1553,7 +1553,7 @@
                 },
                 {
                     "command": "aws.ec2.copyInstanceId",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsEc2(Parent|Running|Stopped)Node)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsEc2(Running|Stopped|Pending)Node)$/",
                     "group": "2@0"
                 },
                 {

--- a/packages/toolkit/.changes/next-release/Bug Fix-35f330d2-90f9-468c-8723-40ec8f4f1cfc.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-35f330d2-90f9-468c-8723-40ec8f4f1cfc.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "no longer gives option to copy instance id on ec2 parent node."
+}


### PR DESCRIPTION
## Problem
Gives option to copy instance id on non-instance node. 
<img width="487" alt="image" src="https://github.com/user-attachments/assets/3a203ff8-e31c-4c85-929b-4f0fb2fbc265">
Leads to error: 
<img width="523" alt="image" src="https://github.com/user-attachments/assets/edeb3edd-e59b-4465-8ee3-e81e6bee858d">

## Solution
Only give this option on ec2InstanceNodes

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
