### PR TITLE
telemetry(dev): add tracking for empty path file scenario

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-0d324321-bddd-4f93-80c4-80978930f157.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-0d324321-bddd-4f93-80c4-80978930f157.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /dev: include telemetry for workspace usage when generating new files"
+}

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -82,7 +82,8 @@ function registerNewFiles(
                       Object.values(workspaceFolderPrefixes).find((val) => val.index === 0)?.name ?? ''
                   ]
         if (folder === undefined) {
-            telemetry.amazonq_trackScenarioCountUsage.emit({
+            telemetry.toolkit_trackScenario.emit({
+                count: 1,
                 amazonqConversationId: conversationId,
                 credentialStartUrl: AuthUtil.instance.startUrl,
                 scenarioType: 'wsOrphanedDocuments',

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -82,9 +82,10 @@ function registerNewFiles(
                       Object.values(workspaceFolderPrefixes).find((val) => val.index === 0)?.name ?? ''
                   ]
         if (folder === undefined) {
-            telemetry.amazonq_wsOrphanedDocuments.emit({
+            telemetry.amazonq_trackScenarioCountUsage.emit({
                 amazonqConversationId: conversationId,
                 credentialStartUrl: AuthUtil.instance.startUrl,
+                scenarioType: 'wsOrphanedDocuments',
             })
             getLogger().error(`No workspace folder found for file: ${zipFilePath} and prefix: ${prefix}`)
             continue

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -86,7 +86,7 @@ function registerNewFiles(
                 count: 1,
                 amazonqConversationId: conversationId,
                 credentialStartUrl: AuthUtil.instance.startUrl,
-                scenarioType: 'wsOrphanedDocuments',
+                scenario: 'wsOrphanedDocuments',
             })
             getLogger().error(`No workspace folder found for file: ${zipFilePath} and prefix: ${prefix}`)
             continue

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1000,25 +1000,6 @@
             ]
         },
         {
-            "name": "amazonq_trackScenarioCountUsage",
-            "description": "Count how many times a scenario is reached.",
-            "unit": "Count",
-            "metadata": [
-                {
-                    "type": "amazonqConversationId",
-                    "required": true
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "scenarioType",
-                    "required": true
-                }
-            ]
-        },
-        {
             "name": "amazonq_approachThumbsUp",
             "description": "User clicked on the thumbs up button, to mention that they are satisfied",
             "unit": "Count",
@@ -1281,6 +1262,28 @@
                 {
                     "type": "proxiedSessionId",
                     "required": false
+                }
+            ]
+        },
+        {
+            "name": "toolkit_trackScenario",
+            "description": "Count how many times a scenario is reached.",
+            "unit": "Count",
+            "metadata": [
+                {
+                    "type": "count"
+                },
+                {
+                    "type": "amazonqConversationId",
+                    "required": true
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "scenarioType",
+                    "required": true
                 }
             ]
         }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -994,6 +994,20 @@
             ]
         },
         {
+            "name": "amazonq_wsOrphanedDocuments",
+            "description": "LLM generated orphaned documents for workspace scenario. This is useful to track how many times this is reached.",
+            "unit": "Count",
+            "metadata": [
+                {
+                    "type": "amazonqConversationId"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
+        },
+        {
             "name": "amazonq_approachThumbsUp",
             "description": "User clicked on the thumbs up button, to mention that they are satisfied",
             "unit": "Count",

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -356,11 +356,6 @@
             "name": "amazonqMessageDisplayedMs",
             "type": "int",
             "description": "Duration between the partner teams code receiving the message and when the message was finally displayed in ms"
-        },
-        {
-            "name": "scenario",
-            "type": "string",
-            "description": "Scenarios to count in telemetry"
         }
     ],
     "metrics": [
@@ -1261,28 +1256,6 @@
                 {
                     "type": "proxiedSessionId",
                     "required": false
-                }
-            ]
-        },
-        {
-            "name": "toolkit_trackScenario",
-            "description": "Count how many times a scenario is reached.",
-            "unit": "Count",
-            "metadata": [
-                {
-                    "type": "amazonqConversationId",
-                    "required": true
-                },
-                {
-                    "type": "count"
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "scenario",
-                    "required": true
                 }
             ]
         }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -356,6 +356,12 @@
             "name": "amazonqMessageDisplayedMs",
             "type": "int",
             "description": "Duration between the partner teams code receiving the message and when the message was finally displayed in ms"
+        },
+        {
+            "name": "scenarioType",
+            "type": "string",
+            "allowedValues": ["wsOrphanedDocuments"],
+            "description": "Scenarios to count in telemetry"
         }
     ],
     "metrics": [
@@ -994,16 +1000,21 @@
             ]
         },
         {
-            "name": "amazonq_wsOrphanedDocuments",
-            "description": "LLM generated orphaned documents for workspace scenario. This is useful to track how many times this is reached.",
+            "name": "amazonq_trackScenarioCountUsage",
+            "description": "Count how many times a scenario is reached.",
             "unit": "Count",
             "metadata": [
                 {
-                    "type": "amazonqConversationId"
+                    "type": "amazonqConversationId",
+                    "required": true
                 },
                 {
                     "type": "credentialStartUrl",
                     "required": false
+                },
+                {
+                    "type": "scenarioType",
+                    "required": true
                 }
             ]
         },

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -358,9 +358,8 @@
             "description": "Duration between the partner teams code receiving the message and when the message was finally displayed in ms"
         },
         {
-            "name": "scenarioType",
+            "name": "scenario",
             "type": "string",
-            "allowedValues": ["wsOrphanedDocuments"],
             "description": "Scenarios to count in telemetry"
         }
     ],
@@ -1282,7 +1281,7 @@
                     "required": false
                 },
                 {
-                    "type": "scenarioType",
+                    "type": "scenario",
                     "required": true
                 }
             ]

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1270,11 +1270,11 @@
             "unit": "Count",
             "metadata": [
                 {
-                    "type": "count"
-                },
-                {
                     "type": "amazonqConversationId",
                     "required": true
+                },
+                {
+                    "type": "count"
                 },
                 {
                     "type": "credentialStartUrl",


### PR DESCRIPTION
## Problem

When customer use workspaces to generate files, RTS and LLM cannot decide which folder to deliver the generated file. We're for now tracking how many times we reach for accountability and prioritization.

## Solution

Add telemetry to count and save the conversationIds that reach this specific workspace usage.

PS: This is should only be included in VS Code since the Workspaces capability its only used here.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
