### PR TITLE
fix(ec2): ssh config forces use of supplied keys

### DIFF
--- a/packages/core/src/shared/sshConfig.ts
+++ b/packages/core/src/shared/sshConfig.ts
@@ -170,7 +170,8 @@ export class SshConfig {
     private getBaseSSHConfig(proxyCommand: string): string {
         // "AddKeysToAgent" will automatically add keys used on the server to the local agent. If not set, then `ssh-add`
         // must be done locally. It's mostly a convenience thing; private keys are _not_ shared with the server.
-
+        // "IdentitiesOnly yes" forces agent to only use provided identity file.
+        // More details: https://www.ssh.com/academy/ssh/config
         return `
 # Created by AWS Toolkit for VSCode. https://github.com/aws/aws-toolkit-vscode
 Host ${this.configHostName}

--- a/packages/core/src/shared/sshConfig.ts
+++ b/packages/core/src/shared/sshConfig.ts
@@ -178,6 +178,8 @@ Host ${this.configHostName}
     AddKeysToAgent yes
     StrictHostKeyChecking accept-new
     ProxyCommand ${proxyCommand}
+    IdentitiesOnly yes
+    IdentityAgent none
     `
     }
 

--- a/packages/core/src/shared/sshConfig.ts
+++ b/packages/core/src/shared/sshConfig.ts
@@ -179,7 +179,6 @@ Host ${this.configHostName}
     StrictHostKeyChecking accept-new
     ProxyCommand ${proxyCommand}
     IdentitiesOnly yes
-    IdentityAgent none
     `
     }
 

--- a/packages/toolkit/.changes/next-release/Bug Fix-7e333959-58a0-48ff-9368-888735328bf2.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-7e333959-58a0-48ff-9368-888735328bf2.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "remote connection will no longer fail with 'too many authentication attempt'"
+	"description": "EC2 connect: remote connection will no longer fail with 'too many authentication attempt'"
 }

--- a/packages/toolkit/.changes/next-release/Bug Fix-7e333959-58a0-48ff-9368-888735328bf2.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-7e333959-58a0-48ff-9368-888735328bf2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "remote connection will no longer fail with 'too many authentication attempt'"
+}


### PR DESCRIPTION
## Problem
Occasionally this error pops up: 
![image](https://github.com/user-attachments/assets/28630fd3-569e-4307-914d-815669686ba4)

## Solution
Add one line to ssh config that force agent to use the provided key. 
- `IdentitiesOnly yes`: only use identity file provided. 

More info here: https://www.ssh.com/academy/ssh/config

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
