### PR TITLE
feat(ec2): default to ed25519 key type, but fall back on rsa

### DIFF
--- a/packages/core/src/awsService/ec2/sshKeyPair.ts
+++ b/packages/core/src/awsService/ec2/sshKeyPair.ts
@@ -9,7 +9,7 @@ import { tryRun } from '../../shared/utilities/pathFind'
 import { Timeout } from '../../shared/utilities/timeoutUtils'
 import { findAsync } from '../../shared/utilities/collectionUtils'
 
-type sshKeyType = 'rsa' | 'ed25519' | 'fake'
+type sshKeyType = 'rsa' | 'ed25519'
 
 export class SshKeyPair {
     private publicKeyPath: string

--- a/packages/core/src/awsService/ec2/sshKeyPair.ts
+++ b/packages/core/src/awsService/ec2/sshKeyPair.ts
@@ -5,6 +5,9 @@
 import * as fs from 'fs-extra'
 import { ToolkitError } from '../../shared/errors'
 import { ChildProcess } from '../../shared/utilities/childProcess'
+import { tryRun } from '../../shared/utilities/pathFind'
+
+type sshKeyType = 'ed25519' | 'rsa'
 
 export class SshKeyPair {
     private publicKeyPath: string
@@ -21,11 +24,19 @@ export class SshKeyPair {
     }
 
     public static async generateSshKeyPair(keyPath: string): Promise<void> {
-        const process = new ChildProcess(`ssh-keygen`, ['-t', 'ed25519', '-N', '', '-q', '-f', keyPath])
+        const process = new ChildProcess(`ssh-keygen`, ['-t', await this.getKeyType(), '-N', '', '-q', '-f', keyPath])
         const result = await process.run()
         if (result.exitCode !== 0) {
             throw new ToolkitError('ec2: Failed to generate ssh key', { details: { stdout: result.stdout } })
         }
+    }
+
+    private static async getKeyType(): Promise<sshKeyType> {
+        return (await this.isEd25519Supported()) ? 'ed25519' : 'rsa'
+    }
+
+    public static async isEd25519Supported(): Promise<boolean> {
+        return !(await tryRun('ssh-keygen', ['-t', 'ed25519', '-N', '', '-q'], 'yes', 'unknown key type'))
     }
 
     public getPublicKeyPath(): string {

--- a/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
+++ b/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
@@ -38,35 +38,36 @@ describe('SshKeyUtility', async function () {
         sinon.restore()
     })
 
-    describe('generateSshKeys', async function () {
-        it('generates key in target file', async function () {
-            const contents = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
-            assert.notStrictEqual(contents.length, 0)
-        })
+    it('generates key in target file', async function () {
+        const contents = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
+        assert.notStrictEqual(contents.length, 0)
+    })
 
-        it('generates unique key each time', async function () {
-            const beforeContent = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
-            keyPair = await SshKeyPair.getSshKeyPair(keyPath, 30000)
-            const afterContent = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
-            assert.notStrictEqual(beforeContent, afterContent)
-        })
+    it('generates unique key each time', async function () {
+        const beforeContent = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
+        keyPair = await SshKeyPair.getSshKeyPair(keyPath, 30000)
+        const afterContent = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
+        assert.notStrictEqual(beforeContent, afterContent)
+    })
 
-        it('defaults to ed25519 key type', async function () {
-            const process = new ChildProcess(`ssh-keygen`, ['-vvv', '-l', '-f', keyPath])
-            const result = await process.run()
-            // Check private key header for algorithm name
-            assert.strictEqual(result.stdout.includes('[ED25519 256]'), true)
-        })
+    it('defaults to ed25519 key type', async function () {
+        const process = new ChildProcess(`ssh-keygen`, ['-vvv', '-l', '-f', keyPath])
+        const result = await process.run()
+        // Check private key header for algorithm name
+        assert.strictEqual(result.stdout.includes('[ED25519 256]'), true)
+    })
 
-        it('uses rsa if ed25519 not available', async function () {
-            const stub = sinon.stub(SshKeyPair, 'isEd25519Supported').resolves(false)
-            keyPair = await SshKeyPair.getSshKeyPair(keyPath, 30000)
-            const process = new ChildProcess(`ssh-keygen`, ['-vvv', '-l', '-f', keyPath])
-            const result = await process.run()
-            // Check private key header for algorithm name
-            assert.strictEqual(result.stdout.includes('[RSA 256]'), true)
-            stub.restore()
-        })
+    it('falls back on rsa if ed25519 not available', async function () {
+        await keyPair.delete()
+        const stub = sinon.stub(SshKeyPair, 'tryKeyGen')
+        stub.onFirstCall().resolves(false)
+        stub.callThrough()
+        keyPair = await SshKeyPair.getSshKeyPair(keyPath, 30000)
+        const process = new ChildProcess(`ssh-keygen`, ['-vvv', '-l', '-f', keyPath])
+        const result = await process.run()
+        // Check private key header for algorithm name
+        assert.strictEqual(result.stdout.includes('[RSA 3072]'), true)
+        stub.restore()
     })
 
     it('properly names the public key', function () {

--- a/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
+++ b/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
@@ -66,7 +66,7 @@ describe('SshKeyUtility', async function () {
         const process = new ChildProcess(`ssh-keygen`, ['-vvv', '-l', '-f', keyPath])
         const result = await process.run()
         // Check private key header for algorithm name
-        assert.strictEqual(result.stdout.includes('[RSA 3072]'), true)
+        assert.strictEqual(result.stdout.includes('[RSA'), true)
         stub.restore()
     })
 

--- a/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
+++ b/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
@@ -39,14 +39,14 @@ describe('SshKeyUtility', async function () {
     })
 
     it('generates key in target file', async function () {
-        const contents = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
+        const contents = await fs.readFile(vscode.Uri.file(keyPath))
         assert.notStrictEqual(contents.length, 0)
     })
 
     it('generates unique key each time', async function () {
-        const beforeContent = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
+        const beforeContent = await fs.readFile(vscode.Uri.file(keyPath))
         keyPair = await SshKeyPair.getSshKeyPair(keyPath, 30000)
-        const afterContent = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
+        const afterContent = await fs.readFile(vscode.Uri.file(keyPath))
         assert.notStrictEqual(beforeContent, afterContent)
     })
 
@@ -81,10 +81,10 @@ describe('SshKeyUtility', async function () {
 
     it('does overwrite existing keys on get call', async function () {
         const generateStub = sinon.spy(SshKeyPair, 'generateSshKeyPair')
-        const keyBefore = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
+        const keyBefore = await fs.readFile(vscode.Uri.file(keyPath))
         keyPair = await SshKeyPair.getSshKeyPair(keyPath, 30000)
 
-        const keyAfter = await vscode.workspace.fs.readFile(vscode.Uri.file(keyPath))
+        const keyAfter = await fs.readFile(vscode.Uri.file(keyPath))
         sinon.assert.calledOnce(generateStub)
 
         assert.notStrictEqual(keyBefore, keyAfter)

--- a/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
+++ b/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
@@ -31,11 +31,21 @@ describe('SshKeyUtility', async function () {
             assert.notStrictEqual(contents.length, 0)
         })
 
-        it('uses ed25519 algorithm to generate the keys', async function () {
+        it('defaults to ed25519 key type', async function () {
             const process = new ChildProcess(`ssh-keygen`, ['-vvv', '-l', '-f', keyPath])
             const result = await process.run()
             // Check private key header for algorithm name
             assert.strictEqual(result.stdout.includes('[ED25519 256]'), true)
+        })
+
+        it('uses rsa if ed25519 not available', async function () {
+            const stub = sinon.stub(SshKeyPair, 'isEd25519Supported').resolves(false)
+            keyPair = await SshKeyPair.getSshKeyPair(keyPath)
+            const process = new ChildProcess(`ssh-keygen`, ['-vvv', '-l', '-f', keyPath])
+            const result = await process.run()
+            // Check private key header for algorithm name
+            assert.strictEqual(result.stdout.includes('[RSA 256]'), true)
+            stub.restore()
         })
     })
 

--- a/packages/toolkit/.changes/next-release/Feature-5ca56f55-9d01-40bd-86e8-bcb8a776c4d8.json
+++ b/packages/toolkit/.changes/next-release/Feature-5ca56f55-9d01-40bd-86e8-bcb8a776c4d8.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "EC2 connect: default to ed25519, but fall back on rsa if unsupported"
+}


### PR DESCRIPTION
## Problem
(title)

## Solution
Try to use `ed25519` first, if it fails use `rsa`. Alternatively, we could use the same code to check if version number of ssh, and then see if its above version 6.5 (https://www.openssh.com/releasenotes.html#6.5). However, doing an actual attempt at generating the keys felt more robust, as it could potentially fail for other reasons. Make use of the code here: 
https://github.com/aws/aws-toolkit-vscode/blob/791ae55021c0ee73dd84abaa57da46237d0fb0d5/packages/core/src/shared/utilities/pathFind.ts#L117-L134

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
