### PR TITLE
refactor(ec2): avoid unnecessary state in sshKeyPair

### DIFF
--- a/packages/core/src/awsService/ec2/sshKeyPair.ts
+++ b/packages/core/src/awsService/ec2/sshKeyPair.ts
@@ -11,7 +11,6 @@ import { Timeout } from '../../shared/utilities/timeoutUtils'
 export class SshKeyPair {
     private publicKeyPath: string
     private lifeTimeout: Timeout
-    private deleted: boolean = false
 
     private constructor(
         private keyPath: string,
@@ -63,12 +62,13 @@ export class SshKeyPair {
         if (!this.lifeTimeout.completed) {
             this.lifeTimeout.cancel()
         }
-
-        this.deleted = true
     }
 
-    public isDeleted(): boolean {
-        return this.deleted
+    public async isDeleted(): Promise<boolean> {
+        const privateKeyExists = await fs.existsFile(this.getPrivateKeyPath())
+        const publicKeyExists = await fs.existsFile(this.getPublicKeyPath())
+        const result = !(privateKeyExists || publicKeyExists)
+        return result
     }
 
     public timeAlive(): number {

--- a/packages/core/src/awsService/ec2/sshKeyPair.ts
+++ b/packages/core/src/awsService/ec2/sshKeyPair.ts
@@ -65,10 +65,9 @@ export class SshKeyPair {
     }
 
     public async isDeleted(): Promise<boolean> {
-        const privateKeyExists = await fs.existsFile(this.getPrivateKeyPath())
-        const publicKeyExists = await fs.existsFile(this.getPublicKeyPath())
-        const result = !(privateKeyExists || publicKeyExists)
-        return result
+        const privateKeyDeleted = !(await fs.existsFile(this.getPrivateKeyPath()))
+        const publicKeyDeleted = !(await fs.existsFile(this.getPublicKeyPath()))
+        return privateKeyDeleted || publicKeyDeleted
     }
 
     public timeAlive(): number {

--- a/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
+++ b/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
@@ -106,4 +106,32 @@ describe('SshKeyUtility', async function () {
         sinon.assert.calledOnce(deleteStub)
         sinon.restore()
     })
+
+    it('determines deleted status based on file system', async function () {
+        await fs.delete(keyPair.getPrivateKeyPath())
+        await fs.delete(keyPair.getPublicKeyPath())
+
+        assert(keyPair.isDeleted())
+    })
+
+    describe('isDeleted', async function () {
+        it('returns false if key files exist', async function () {
+            assert.strictEqual(await keyPair.isDeleted(), false)
+        })
+
+        it('returns true if key files do not exist', async function () {
+            await keyPair.delete()
+            assert.strictEqual(await keyPair.isDeleted(), true)
+        })
+
+        it('returns false if private key remains', async function () {
+            await fs.delete(keyPair.getPublicKeyPath())
+            assert.strictEqual(await keyPair.isDeleted(), false)
+        })
+
+        it('returns false if public key remains', async function () {
+            await fs.delete(keyPair.getPrivateKeyPath())
+            assert.strictEqual(await keyPair.isDeleted(), false)
+        })
+    })
 })

--- a/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
+++ b/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
@@ -124,14 +124,14 @@ describe('SshKeyUtility', async function () {
             assert.strictEqual(await keyPair.isDeleted(), true)
         })
 
-        it('returns false if private key remains', async function () {
+        it('returns true if private key remains', async function () {
             await fs.delete(keyPair.getPublicKeyPath())
-            assert.strictEqual(await keyPair.isDeleted(), false)
+            assert.strictEqual(await keyPair.isDeleted(), true)
         })
 
-        it('returns false if public key remains', async function () {
+        it('returns true if public key remains', async function () {
             await fs.delete(keyPair.getPrivateKeyPath())
-            assert.strictEqual(await keyPair.isDeleted(), false)
+            assert.strictEqual(await keyPair.isDeleted(), true)
         })
     })
 })


### PR DESCRIPTION
## Problem
Follow up: https://github.com/aws/aws-toolkit-vscode/pull/5578#discussion_r1769231182

## Solution
`isDeleted` status is determined by looking at the actual file system, rather than maintaining additional state

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
