### PR TITLE
fix(amazonq): issues with redacted code are hidden

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-385bc912-dc06-4b16-91ae-47fa1c586367.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-385bc912-dc06-4b16-91ae-47fa1c586367.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Security Scan: Fixes an issue that incorrectly removes hardcoded credentials detections from auto scans."
+}

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -180,5 +180,24 @@ describe('securityScanHandler', function () {
             assert.equal(codeScanIssueMap.size, 1)
             assert.equal(codeScanIssueMap.get('file1.ts')?.length, 2)
         })
+
+        it('should handle issue filtering with redacted code', () => {
+            const json = JSON.stringify([
+                {
+                    filePath: 'file1.ts',
+                    startLine: 1,
+                    endLine: 2,
+                    codeSnippet: [
+                        { number: 1, content: '**** *' },
+                        { number: 2, content: '**** *' },
+                    ],
+                },
+                { filePath: 'file1.ts', startLine: 3, endLine: 3, codeSnippet: [{ number: 3, content: '**** **' }] },
+            ])
+
+            mapToAggregatedList(codeScanIssueMap, json, editor, CodeAnalysisScope.FILE)
+            assert.strictEqual(codeScanIssueMap.size, 1)
+            assert.strictEqual(codeScanIssueMap.get('file1.ts')?.length, 1)
+        })
     })
 })

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -123,8 +123,11 @@ export function mapToAggregatedList(
             for (let lineNumber = issue.startLine; lineNumber <= issue.endLine; lineNumber++) {
                 const line = editor.document.lineAt(lineNumber - 1)?.text
                 const codeContent = issue.codeSnippet.find((codeIssue) => codeIssue.number === lineNumber)?.content
-                if (line !== codeContent) {
-                    return false
+                if (codeContent?.includes('***')) {
+                    // CodeSnippet contains redacted code so we can't do a direct comparison
+                    return line.length === codeContent.length
+                } else {
+                    return line === codeContent
                 }
             }
         }


### PR DESCRIPTION
## Problem
Hardcoded credentials detections are being removed from auto scan results due to line string comparison with the server response which contains redacted code.


## Solution
For redacted code, check only the line length instead of a full comparison.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
