### PR TITLE
refactor(test): toTextDocument, toTextEditor

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/service/telemetry.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/telemetry.test.ts
@@ -13,7 +13,7 @@ import {
     assertTelemetry,
     assertTextEditorContains,
     createTestWorkspaceFolder,
-    openATextEditorWithText,
+    toTextEditor,
 } from 'aws-core-vscode/test'
 import {
     DefaultCodeWhispererClient,
@@ -156,7 +156,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
     describe('tab and esc', function () {
         it('single accept', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await acceptByTab()
@@ -166,7 +166,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
 
         it('single reject', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await rejectByEsc()
@@ -179,7 +179,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
 
         it('accept - accept - accept', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await acceptByTab()
@@ -190,7 +190,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
             await acceptByTab()
             await assertTextEditorContains(`FooBaz${os.EOL}Baz`)
 
-            const anotherEditor = await openATextEditorWithText('', 'anotherTest.py')
+            const anotherEditor = await toTextEditor('', 'anotherTest.py')
             assertSessionClean()
             await manualTrigger(anotherEditor, client, config)
             await acceptByTab()
@@ -205,7 +205,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
 
         it('accept - reject - accept', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await acceptByTab()
@@ -216,7 +216,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
             await rejectByEsc()
             await assertTextEditorContains('Foo')
 
-            const anotherEditor = await openATextEditorWithText('', 'anotherTest.py')
+            const anotherEditor = await toTextEditor('', 'anotherTest.py')
             assertSessionClean()
             await manualTrigger(anotherEditor, client, config)
             await rejectByEsc()
@@ -231,7 +231,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
 
         it('reject - reject - reject', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await rejectByEsc()
@@ -256,7 +256,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
 
         it('reject - accept - reject', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await rejectByEsc()
@@ -302,7 +302,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
             }
 
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await navigateNext()
@@ -318,7 +318,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
             }
 
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await navigateNext()
@@ -336,7 +336,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
             }
 
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await navigateNext()
@@ -351,7 +351,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
     describe('typing', function () {
         it('typeahead match accept', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await typing(editor, 'F')
@@ -365,7 +365,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
 
         it('typeahead match, backspace and accept', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await typing(editor, 'F')
@@ -385,7 +385,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
             // the solution is to waitUntil VSCode InlineSuggestion to resolve the "typeahead" but currently no easy way to know if the InlinSuggestion is shown visible again
             this.skip()
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await typing(editor, 'F')
@@ -398,7 +398,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
             await rejectByEsc()
             await assertTextEditorContains('Foo')
 
-            const anotherEditor = await openATextEditorWithText('', 'anotherTest.py')
+            const anotherEditor = await toTextEditor('', 'anotherTest.py')
             await manualTrigger(anotherEditor, client, config)
             await typing(anotherEditor, 'Qo')
             await assertTextEditorContains('Qo')
@@ -415,7 +415,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
 
         it('typeahead not match after suggestion is shown and reject', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await typing(editor, 'H')
@@ -441,13 +441,13 @@ describe.skip('CodeWhisperer telemetry', async function () {
 
         it('reject - typeahead not matching after suggestion is shown then invoke another round and accept', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await typing(editor, 'H')
             await assertTextEditorContains('H')
 
-            const anotherEditor = await openATextEditorWithText('', 'anotherTest.py')
+            const anotherEditor = await toTextEditor('', 'anotherTest.py')
             await manualTrigger(anotherEditor, client, config)
             await acceptByTab()
             await assertTextEditorContains(`Baz${os.EOL}Baz`)
@@ -462,14 +462,14 @@ describe.skip('CodeWhisperer telemetry', async function () {
     describe('on editor change, focus change', function () {
         it('reject: trigger then open another editor', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py', tempFolder, { preview: false })
+            const editor = await toTextEditor('', 'test.py', tempFolder, { preview: false })
 
             await manualTrigger(editor, client, config)
 
-            await openATextEditorWithText('text in 2nd editor', 'another1.py', tempFolder, {
+            await toTextEditor('text in 2nd editor', 'another1.py', tempFolder, {
                 preview: false,
             })
-            const anotherEditor = await openATextEditorWithText('text in 3rd editor', 'another2.py', tempFolder, {
+            const anotherEditor = await toTextEditor('text in 3rd editor', 'another2.py', tempFolder, {
                 preview: false,
             })
 
@@ -483,7 +483,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
 
         it('reject: trigger then close editor', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await closeActiveEditor()
@@ -496,7 +496,7 @@ describe.skip('CodeWhisperer telemetry', async function () {
 
         it('reject: onFocusChange', async function () {
             assertSessionClean()
-            const editor = await openATextEditorWithText('', 'test.py')
+            const editor = await toTextEditor('', 'test.py')
 
             await manualTrigger(editor, client, config)
             await assertTextEditorContains('')

--- a/packages/amazonq/test/unit/codewhisperer/tracker/lineTracker.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/tracker/lineTracker.test.ts
@@ -6,7 +6,7 @@
 import { LineSelection, LineTracker, AuthUtil } from 'aws-core-vscode/codewhisperer'
 import sinon from 'sinon'
 import { Disposable, TextEditor, Position, Range, Selection } from 'vscode'
-import { openATextEditorWithText } from 'aws-core-vscode/test'
+import { toTextEditor } from 'aws-core-vscode/test'
 import assert from 'assert'
 import { waitUntil } from 'aws-core-vscode/shared'
 
@@ -82,7 +82,7 @@ describe('LineTracker class', function () {
     describe('includes', function () {
         // util function to help set up LineTracker.selections
         async function setEditorSelection(selections: LineSelection[]): Promise<TextEditor> {
-            const editor = await openATextEditorWithText('\n\n\n\n\n\n\n\n\n\n', 'foo.py', undefined, {
+            const editor = await toTextEditor('\n\n\n\n\n\n\n\n\n\n', 'foo.py', undefined, {
                 preview: false,
             })
 
@@ -200,7 +200,7 @@ describe('LineTracker class', function () {
 
     describe('onContentChanged', function () {
         it('should fire lineChangedEvent and set current line selection', async function () {
-            editor = await openATextEditorWithText('\n\n\n\n\n', 'foo.py', undefined, { preview: false })
+            editor = await toTextEditor('\n\n\n\n\n', 'foo.py', undefined, { preview: false })
             editor.selection = new Selection(new Position(5, 0), new Position(5, 0))
             assertEmptyCounts()
 
@@ -222,7 +222,7 @@ describe('LineTracker class', function () {
 
     describe('onTextEditorSelectionChanged', function () {
         it('should fire lineChangedEvent if selection changes and set current line selection', async function () {
-            editor = await openATextEditorWithText('\n\n\n\n\n', 'foo.py', undefined, { preview: false })
+            editor = await toTextEditor('\n\n\n\n\n', 'foo.py', undefined, { preview: false })
             editor.selection = new Selection(new Position(3, 0), new Position(3, 0))
             assertEmptyCounts()
 
@@ -259,7 +259,7 @@ describe('LineTracker class', function () {
         it('should not fire lineChangedEvent if uri scheme is debug || output', async function () {
             // if the editor is not a text editor, won't emit an event and selection will be set to undefined
             async function assertLineChanged(schema: string) {
-                const anotherEditor = await openATextEditorWithText('', 'bar.log', undefined, { preview: false })
+                const anotherEditor = await toTextEditor('', 'bar.log', undefined, { preview: false })
                 const uri = anotherEditor.document.uri
                 sandbox.stub(uri, 'scheme').get(() => schema)
 

--- a/packages/amazonq/test/unit/codewhisperer/util/closingBracketUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/closingBracketUtil.test.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import assert from 'assert'
 import { handleExtraBrackets } from 'aws-core-vscode/codewhisperer'
-import { openATextEditorWithText } from 'aws-core-vscode/test'
+import { toTextEditor } from 'aws-core-vscode/test'
 
 describe('closingBracketUtil', function () {
     /**
@@ -20,7 +20,7 @@ describe('closingBracketUtil', function () {
             recommendation: string,
             expected: string
         ) {
-            const editor = await openATextEditorWithText(leftContext + recommendation + rightContext, 'test.txt')
+            const editor = await toTextEditor(leftContext + recommendation + rightContext, 'test.txt')
             const document = editor.document
 
             const startStart = document.positionAt(0)

--- a/packages/amazonq/test/unit/codewhisperer/util/codeParsingUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/codeParsingUtil.test.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
 import {
     PlatformLanguageId,
     extractClasses,
@@ -11,9 +10,8 @@ import {
     isTestFile,
     utgLanguageConfigs,
 } from 'aws-core-vscode/codewhisperer'
-import * as path from 'path'
 import assert from 'assert'
-import { createTestWorkspaceFolder, toFile } from 'aws-core-vscode/test'
+import { createTestWorkspaceFolder, toTextDocument } from 'aws-core-vscode/test'
 
 describe('RegexValidationForPython', () => {
     it('should extract all function names from a python file content', () => {
@@ -119,9 +117,7 @@ describe('isTestFile', () => {
         expected: boolean
     ) {
         for (const fileName of fileNames) {
-            const p = path.join(testWsFolder, fileName)
-            await toFile('', p)
-            const document = await vscode.workspace.openTextDocument(p)
+            const document = await toTextDocument('', fileName, testWsFolder)
             const actual = await isTestFile(document.uri.fsPath, { languageId: config.languageId })
             assert.strictEqual(actual, expected)
         }

--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -13,7 +13,7 @@ import {
     assertTabCount,
     closeAllEditors,
     createTestWorkspaceFolder,
-    openATextEditorWithText,
+    toTextEditor,
     shuffleList,
     toFile,
 } from 'aws-core-vscode/test'
@@ -38,8 +38,8 @@ describe('crossFileContextUtil', function () {
 
         describe('should fetch 3 chunks and each chunk should contains 10 lines', function () {
             async function assertCorrectCodeChunk() {
-                await openATextEditorWithText(sampleFileOf60Lines, 'CrossFile.java', tempFolder, { preview: false })
-                const myCurrentEditor = await openATextEditorWithText('', 'TargetFile.java', tempFolder, {
+                await toTextEditor(sampleFileOf60Lines, 'CrossFile.java', tempFolder, { preview: false })
+                const myCurrentEditor = await toTextEditor('', 'TargetFile.java', tempFolder, {
                     preview: false,
                 })
                 const actual = await crossFile.fetchSupplementalContextForSrc(myCurrentEditor, fakeCancellationToken)
@@ -120,12 +120,12 @@ describe('crossFileContextUtil', function () {
             const shuffledFilePaths = shuffleList(expectedFilePaths)
 
             for (const filePath of shuffledFilePaths) {
-                await openATextEditorWithText('', filePath, tempFolder, { preview: false })
+                await toTextEditor('', filePath, tempFolder, { preview: false })
             }
 
-            await openATextEditorWithText('', testFile1, tempFolder, { preview: false })
-            await openATextEditorWithText('', testFile2, tempFolder, { preview: false })
-            const editor = await openATextEditorWithText('', targetFile, tempFolder, { preview: false })
+            await toTextEditor('', testFile1, tempFolder, { preview: false })
+            await toTextEditor('', testFile2, tempFolder, { preview: false })
+            const editor = await toTextEditor('', targetFile, tempFolder, { preview: false })
 
             await assertTabCount(shuffledFilePaths.length + 3)
 
@@ -158,10 +158,10 @@ describe('crossFileContextUtil', function () {
 
         fileExtLists.forEach((fileExt) => {
             it('should be empty if userGroup is control', async function () {
-                const editor = await openATextEditorWithText('content-1', `file-1.${fileExt}`, tempFolder)
-                await openATextEditorWithText('content-2', `file-2.${fileExt}`, tempFolder, { preview: false })
-                await openATextEditorWithText('content-3', `file-3.${fileExt}`, tempFolder, { preview: false })
-                await openATextEditorWithText('content-4', `file-4.${fileExt}`, tempFolder, { preview: false })
+                const editor = await toTextEditor('content-1', `file-1.${fileExt}`, tempFolder)
+                await toTextEditor('content-2', `file-2.${fileExt}`, tempFolder, { preview: false })
+                await toTextEditor('content-3', `file-3.${fileExt}`, tempFolder, { preview: false })
+                await toTextEditor('content-4', `file-4.${fileExt}`, tempFolder, { preview: false })
 
                 await assertTabCount(4)
 
@@ -190,10 +190,10 @@ describe('crossFileContextUtil', function () {
 
         fileExtLists.forEach((fileExt) => {
             it('should be non empty if usergroup is Crossfile', async function () {
-                const editor = await openATextEditorWithText('content-1', `file-1.${fileExt}`, tempFolder)
-                await openATextEditorWithText('content-2', `file-2.${fileExt}`, tempFolder, { preview: false })
-                await openATextEditorWithText('content-3', `file-3.${fileExt}`, tempFolder, { preview: false })
-                await openATextEditorWithText('content-4', `file-4.${fileExt}`, tempFolder, { preview: false })
+                const editor = await toTextEditor('content-1', `file-1.${fileExt}`, tempFolder)
+                await toTextEditor('content-2', `file-2.${fileExt}`, tempFolder, { preview: false })
+                await toTextEditor('content-3', `file-3.${fileExt}`, tempFolder, { preview: false })
+                await toTextEditor('content-4', `file-4.${fileExt}`, tempFolder, { preview: false })
 
                 await assertTabCount(4)
 
@@ -222,10 +222,10 @@ describe('crossFileContextUtil', function () {
 
         fileExtLists.forEach((fileExt) => {
             it('should be non empty', async function () {
-                const editor = await openATextEditorWithText('content-1', `file-1.${fileExt}`, tempFolder)
-                await openATextEditorWithText('content-2', `file-2.${fileExt}`, tempFolder, { preview: false })
-                await openATextEditorWithText('content-3', `file-3.${fileExt}`, tempFolder, { preview: false })
-                await openATextEditorWithText('content-4', `file-4.${fileExt}`, tempFolder, { preview: false })
+                const editor = await toTextEditor('content-1', `file-1.${fileExt}`, tempFolder)
+                await toTextEditor('content-2', `file-2.${fileExt}`, tempFolder, { preview: false })
+                await toTextEditor('content-3', `file-3.${fileExt}`, tempFolder, { preview: false })
+                await toTextEditor('content-4', `file-4.${fileExt}`, tempFolder, { preview: false })
 
                 await assertTabCount(4)
 

--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -9,7 +9,7 @@ import {
     createMockTextEditor,
     createMockClientRequest,
     resetCodeWhispererGlobalVariables,
-    openATextEditorWithText,
+    toTextEditor,
     createTestWorkspaceFolder,
     closeAllEditors,
 } from 'aws-core-vscode/test'
@@ -104,7 +104,7 @@ describe('editorContext', function () {
         })
 
         it('Should return relative path', async function () {
-            const editor = await openATextEditorWithText('tttt', 'test.py', tempFolder)
+            const editor = await toTextEditor('tttt', 'test.py', tempFolder)
             const actual = EditorContext.getFileRelativePath(editor)
             const expected = 'test.py'
             assert.strictEqual(actual, expected)

--- a/packages/core/src/test/amazonq/common/contentController.test.ts
+++ b/packages/core/src/test/amazonq/common/contentController.test.ts
@@ -5,7 +5,7 @@
 import * as vscode from 'vscode'
 import assert from 'assert'
 import { EditorContentController } from '../../../amazonq/commons/controllers/contentController'
-import { openATextEditorWithText } from '../../testUtil'
+import { toTextEditor } from '../../testUtil'
 
 describe('contentController', () => {
     let controller: EditorContentController
@@ -16,7 +16,7 @@ describe('contentController', () => {
 
     describe('insertTextAtCursorPosition', () => {
         it('insert code when left hand size has no non empty character', async () => {
-            const editor = await openATextEditorWithText('def hello_world():\n    ', 'test.py')
+            const editor = await toTextEditor('def hello_world():\n    ', 'test.py')
             if (editor) {
                 const pos = new vscode.Position(1, 4)
                 editor.selection = new vscode.Selection(pos, pos)
@@ -32,7 +32,7 @@ describe('contentController', () => {
         })
 
         it('insert code when left hand size has non empty character', async () => {
-            const editor = await openATextEditorWithText('def hello_world():\n    ', 'test.py')
+            const editor = await toTextEditor('def hello_world():\n    ', 'test.py')
             if (editor) {
                 const pos = new vscode.Position(0, 4)
                 editor.selection = new vscode.Selection(pos, pos)

--- a/packages/core/src/test/shared/utilities/editorUtilities.test.ts
+++ b/packages/core/src/test/shared/utilities/editorUtilities.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import * as path from 'path'
 import sinon from 'sinon'
-import { closeAllEditors, assertTabCount, createTestWorkspaceFolder, openATextEditorWithText } from '../../testUtil'
+import { closeAllEditors, assertTabCount, createTestWorkspaceFolder, toTextEditor } from '../../testUtil'
 import { getOpenFilesInWindow, isTextEditor } from '../../../shared/utilities/editorUtilities'
 
 describe('supplementalContextUtil', function () {
@@ -27,7 +27,7 @@ describe('supplementalContextUtil', function () {
         })
 
         it('isTextEditor returns false if scheme is debug, output or vscode-terminal', async function () {
-            const editor = await openATextEditorWithText('content', 'file.java', tempFolder, { preview: false })
+            const editor = await toTextEditor('content', 'file.java', tempFolder, { preview: false })
             const uri = editor.document.uri
 
             sinon.stub(uri, 'scheme').get(() => 'debug')
@@ -41,10 +41,10 @@ describe('supplementalContextUtil', function () {
         })
 
         it('no filter provided as argument, should return all files opened', async function () {
-            await openATextEditorWithText('content-1', 'file-1.java', tempFolder, { preview: false })
-            await openATextEditorWithText('content-2', 'file-2.java', tempFolder, { preview: false })
-            await openATextEditorWithText('content-3', 'file-3.java', tempFolder, { preview: false })
-            await openATextEditorWithText('content-4', 'file-4.java', tempFolder, { preview: false })
+            await toTextEditor('content-1', 'file-1.java', tempFolder, { preview: false })
+            await toTextEditor('content-2', 'file-2.java', tempFolder, { preview: false })
+            await toTextEditor('content-3', 'file-3.java', tempFolder, { preview: false })
+            await toTextEditor('content-4', 'file-4.java', tempFolder, { preview: false })
 
             await assertTabCount(4)
 
@@ -57,10 +57,10 @@ describe('supplementalContextUtil', function () {
         })
 
         it('filter argument provided, should return only files matching the predicate', async function () {
-            await openATextEditorWithText('content-1', 'file-1.java', tempFolder, { preview: false })
-            await openATextEditorWithText('content-2', 'file-2.java', tempFolder, { preview: false })
-            await openATextEditorWithText('content-3', 'file-3.txt', tempFolder, { preview: false })
-            await openATextEditorWithText('content-4', 'file-4.txt', tempFolder, { preview: false })
+            await toTextEditor('content-1', 'file-1.java', tempFolder, { preview: false })
+            await toTextEditor('content-2', 'file-2.java', tempFolder, { preview: false })
+            await toTextEditor('content-3', 'file-3.txt', tempFolder, { preview: false })
+            await toTextEditor('content-4', 'file-4.txt', tempFolder, { preview: false })
 
             await assertTabCount(4)
 

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -326,24 +326,45 @@ export async function assertTextEditorContains(contents: string, exact: boolean 
 }
 
 /**
- * Create and open an editor with provided fileText, fileName and options. If folder is not provided,
- * will create a temp worksapce folder which will be automatically deleted in testing environment
- * @param fileText The supplied text to fill this file with
- * @param fileName The name of the file to save it as. Include the file extension here.
+ * Saves `fileText` to `fileName` relative to `folder` (or an auto-created temp workspace folder,
+ * which will be automatically deleted after tests finish), and opens it as a `TextDocument` (not
+ * a `TextEditor`, which is *slow*; use {@link toTextEditor} for that).
+ *
+ * @param fileText Text content
+ * @param fileName Name of the file (including extension) to save it as.
+ * @param folder?  Optional workspace folder where the file will be written to.
+ *
+ * @returns TextDocument that was just opened
+ */
+export async function toTextDocument(
+    fileText: string,
+    fileName: string,
+    folder?: string
+): Promise<ReturnType<typeof vscode.workspace.openTextDocument>> {
+    const myWorkspaceFolder = folder ? folder : (await createTestWorkspaceFolder()).uri.fsPath
+    const filePath = path.join(myWorkspaceFolder, fileName)
+    await toFile(fileText, filePath)
+
+    return await vscode.workspace.openTextDocument(filePath)
+}
+
+/**
+ * Same as {@link toTextDocument}, but opens the result in a TextEditor. This is *much* slower, use
+ * `toTextDocument` if you don't need a text editor.
+ *
+ * @param fileText Text content
+ * @param fileName Name of the file (including extension) to save it as.
+ * @param folder?  Optional workspace folder where the file will be written to.
  *
  * @returns TextEditor that was just opened
  */
-export async function openATextEditorWithText(
+export async function toTextEditor(
     fileText: string,
     fileName: string,
     folder?: string,
     options?: vscode.TextDocumentShowOptions
 ): Promise<vscode.TextEditor> {
-    const myWorkspaceFolder = folder ? folder : (await createTestWorkspaceFolder()).uri.fsPath
-    const filePath = path.join(myWorkspaceFolder, fileName)
-    await toFile(fileText, filePath)
-
-    const textDocument = await vscode.workspace.openTextDocument(filePath)
+    const textDocument = await toTextDocument(fileText, fileName, folder)
 
     return await vscode.window.showTextDocument(textDocument, options)
 }

--- a/packages/core/src/testInteg/stepFunctions/init.test.ts
+++ b/packages/core/src/testInteg/stepFunctions/init.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { createTestWorkspaceFolder, openATextEditorWithText } from '../../test/testUtil'
+import { createTestWorkspaceFolder, toTextEditor } from '../../test/testUtil'
 import vscode from 'vscode'
 import { ASLLanguageClient } from '../../stepFunctions/asl/client'
 import { waitUntil } from '../../shared'
@@ -23,7 +23,7 @@ describe('stepFunctions ASL LSP', async function () {
 
 }`
         const fileName = 'stepfunction.asl'
-        const editor = await openATextEditorWithText(stateMachineFileText, fileName, tempFolder)
+        const editor = await toTextEditor(stateMachineFileText, fileName, tempFolder)
         await waitUntil(async () => ASLLanguageClient.isReady, {
             timeout: 30000,
             interval: 500,

--- a/packages/core/src/testInteg/stepFunctions/visualizeStateMachine.test.ts
+++ b/packages/core/src/testInteg/stepFunctions/visualizeStateMachine.test.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import { MessageObject } from '../../stepFunctions/commands/visualizeStateMachine/aslVisualization'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
-import { closeAllEditors, openATextEditorWithText } from '../../test/testUtil'
+import { closeAllEditors, toTextEditor } from '../../test/testUtil'
 import { previewStateMachineCommand } from '../../stepFunctions/activation'
 
 const sampleStateMachine = `
@@ -101,7 +101,7 @@ describe('visualizeStateMachine', async function () {
     it('opens up a webview when there is an active text editor', async function () {
         const stateMachineFileText = '{}'
         const fileName = 'mysamplestatemachine.json'
-        await openATextEditorWithText(stateMachineFileText, fileName, tempFolder)
+        await toTextEditor(stateMachineFileText, fileName, tempFolder)
 
         const result = await previewStateMachineCommand.execute()
 
@@ -110,7 +110,7 @@ describe('visualizeStateMachine', async function () {
 
     it('correctly displays content when given a sample state machine', async function () {
         const fileName = 'mysamplestatemachine.json'
-        const textEditor = await openATextEditorWithText(sampleStateMachine, fileName, tempFolder)
+        const textEditor = await toTextEditor(sampleStateMachine, fileName, tempFolder)
 
         const result = await previewStateMachineCommand.execute()
 
@@ -133,7 +133,7 @@ describe('visualizeStateMachine', async function () {
 
     it('correctly displays content when given a sample state machine in yaml', async function () {
         const fileName = 'mysamplestatemachine.asl.yaml'
-        const textEditor = await openATextEditorWithText(samleStateMachineYaml, fileName, tempFolder)
+        const textEditor = await toTextEditor(samleStateMachineYaml, fileName, tempFolder)
 
         const result = await previewStateMachineCommand.execute()
 
@@ -157,7 +157,7 @@ describe('visualizeStateMachine', async function () {
     it('update webview is triggered when user saves correct text editor', async function () {
         const stateMachineFileText = '{}'
         const fileName = 'mysamplestatemachine.json'
-        const textEditor = await openATextEditorWithText(stateMachineFileText, fileName, tempFolder)
+        const textEditor = await toTextEditor(stateMachineFileText, fileName, tempFolder)
 
         const result = await previewStateMachineCommand.execute()
 
@@ -191,7 +191,7 @@ describe('visualizeStateMachine', async function () {
     it('doesnt update the graph if a seperate file is opened or modified', async function () {
         const stateMachineFileText = '{}'
         const stateMachineDefinitionFile = 'mystatemachine.json'
-        await openATextEditorWithText(stateMachineFileText, stateMachineDefinitionFile, tempFolder)
+        await toTextEditor(stateMachineFileText, stateMachineDefinitionFile, tempFolder)
 
         const result = await previewStateMachineCommand.execute()
         assert.ok(result)
@@ -202,7 +202,7 @@ describe('visualizeStateMachine', async function () {
         const someOtherFileText = 'Some other file that is not related to state machine.'
         const someOtherFileName = 'fileTwo'
 
-        const textEditor2 = await openATextEditorWithText(someOtherFileText, someOtherFileName, tempFolder)
+        const textEditor2 = await toTextEditor(someOtherFileText, someOtherFileName, tempFolder)
 
         const updatedText = 'updated text'
 


### PR DESCRIPTION
Problem:
Redundant code, suboptimal names and docstrings.

Solution:
- Introduce `toTextDocument` for tests such as `codeParsingUtil.test.ts` which don't need a TextEditor.
- Rename `openATextEditorWithText` => `toTextEditor`.




---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
