### PR TITLE
fix(amazonq): Remove automatic focus on prompt input field after response

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-ecd96a79-8bb7-4411-ae6b-8952381dc86d.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-ecd96a79-8bb7-4411-ae6b-8952381dc86d.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "Amazon Q Chat: Remove automatic focus on prompt input field after chat response"
+}

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -466,6 +466,7 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
             maxTabs: 10,
             feedbackOptions: feedbackOptions,
             texts: uiComponentsTexts,
+            autoFocus: false,
         },
     })
 


### PR DESCRIPTION
## Problem
When a request completes in amazon q the chat is automatically focused, pulling focus away from anything a user is doing in the editor

## Solution
Disable automatic prompt focus

Mynah UI docs: https://github.com/aws/mynah-ui/blob/b7f9807b4aa984dda9200286a9d0d9e083dd39fa/docs/CONFIG.md#autofocus

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
