### PR TITLE
fix(dev): When using workspace, define first folder if LLM created file doesn't have a defined root path

### DIFF
--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -68,7 +68,13 @@ function registerNewFiles(
         fs.registerProvider(uri, new VirtualMemoryFile(contents))
         const prefix =
             workspaceFolderPrefixes === undefined ? '' : zipFilePath.substring(0, zipFilePath.indexOf(path.sep))
-        const folder = workspaceFolderPrefixes === undefined ? workspaceFolders[0] : workspaceFolderPrefixes[prefix]
+        const folder =
+            workspaceFolderPrefixes === undefined
+                ? workspaceFolders[0]
+                : workspaceFolderPrefixes[prefix] ??
+                  workspaceFolderPrefixes[
+                      Object.values(workspaceFolderPrefixes).find((val) => val.index === 0)?.name ?? ''
+                  ]
         if (folder === undefined) {
             getLogger().error(`No workspace folder found for file: ${zipFilePath} and prefix: ${prefix}`)
             continue
@@ -78,7 +84,9 @@ function registerNewFiles(
             fileContent,
             virtualMemoryUri: uri,
             workspaceFolder: folder,
-            relativePath: zipFilePath.substring(workspaceFolderPrefixes === undefined ? 0 : prefix.length + 1),
+            relativePath: zipFilePath.substring(
+                workspaceFolderPrefixes === undefined ? 0 : prefix.length > 0 ? prefix.length + 1 : 0
+            ),
             rejected: false,
         })
     }

--- a/packages/core/src/amazonqFeatureDev/util/files.ts
+++ b/packages/core/src/amazonqFeatureDev/util/files.ts
@@ -63,15 +63,18 @@ export async function prepareRepoData(
         const iterator = ignoredExtensionMap.entries()
 
         for (let i = 0; i < ignoredExtensionMap.size; i++) {
-            const [key, value] = iterator.next().value
-            await amznTelemetry.amazonq_bundleExtensionIgnored.run(async (bundleSpan) => {
-                const event = {
-                    filenameExt: key,
-                    count: value,
-                }
+            const iteratorValue = iterator.next().value
+            if (iteratorValue) {
+                const [key, value] = iteratorValue
+                await amznTelemetry.amazonq_bundleExtensionIgnored.run(async (bundleSpan) => {
+                    const event = {
+                        filenameExt: key,
+                        count: value,
+                    }
 
-                bundleSpan.record(event)
-            })
+                    bundleSpan.record(event)
+                })
+            }
         }
 
         telemetry.setRepositorySize(totalBytes)
@@ -116,8 +119,10 @@ export function getPathsFromZipFilePath(
         }
     }
     // otherwise the first part of the zipPath is the prefix
-    const prefix = zipFilePath.substring(0, zipFilePath.indexOf(path.sep)) || '.'
-    const workspaceFolder = workspacesByPrefix[prefix]
+    const prefix = zipFilePath.substring(0, zipFilePath.indexOf(path.sep))
+    const workspaceFolder =
+        workspacesByPrefix[prefix] ??
+        (workspacesByPrefix[Object.values(workspacesByPrefix).find((val) => val.index === 0)?.name ?? ''] || undefined)
     if (workspaceFolder === undefined) {
         throw new ToolkitError(`Could not find workspace folder for prefix ${prefix}`)
     }

--- a/packages/core/src/amazonqFeatureDev/util/files.ts
+++ b/packages/core/src/amazonqFeatureDev/util/files.ts
@@ -116,7 +116,7 @@ export function getPathsFromZipFilePath(
         }
     }
     // otherwise the first part of the zipPath is the prefix
-    const prefix = zipFilePath.substring(0, zipFilePath.indexOf(path.sep))
+    const prefix = zipFilePath.substring(0, zipFilePath.indexOf(path.sep)) || '.'
     const workspaceFolder = workspacesByPrefix[prefix]
     if (workspaceFolder === undefined) {
         throw new ToolkitError(`Could not find workspace folder for prefix ${prefix}`)


### PR DESCRIPTION
## Problem

In VS Code, when user add 2 different folders in the workspace which contain different root paths, RTS/LLM cannot decide where to place a generated file.

![recording](https://github.com/user-attachments/assets/f435648c-8375-41e2-99ef-da9b8d6811f3)


## Solution

This fix add the default first folder selected as its default for orphaned root created files, not blocking user to receive an empty patch but also support better the workspace usage.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
