### PR TITLE
fix(amazonq): do not trigger uninstall when extension auto-updates

### DIFF
--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -131,7 +131,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     registerCommands(context)
 
     // Handle Amazon Q Extension un-installation.
-    setupUninstallHandler(VSCODE_EXTENSION_ID.amazonq, context)
+    setupUninstallHandler(VSCODE_EXTENSION_ID.amazonq, context.extension.packageJSON.version, context)
 
     // Hide the Amazon Q tree in toolkit explorer
     await setContext('aws.toolkit.amazonq.dismissed', true)

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -155,7 +155,7 @@ export async function activateCommon(
     )
 
     // Handle AWS Toolkit un-installation.
-    setupUninstallHandler(VSCODE_EXTENSION_ID.awstoolkit, context)
+    setupUninstallHandler(VSCODE_EXTENSION_ID.awstoolkit, context.extension.id, context)
 
     // auth
     await initializeAuth(globals.loginManager)

--- a/packages/core/src/shared/handleUninstall.ts
+++ b/packages/core/src/shared/handleUninstall.ts
@@ -7,57 +7,103 @@
 
 import * as vscode from 'vscode'
 import { existsSync } from 'fs'
+import * as semver from 'semver'
 import { join } from 'path'
 import { getLogger } from './logger/logger'
 import { telemetry } from './telemetry'
 import { VSCODE_EXTENSION_ID } from './extensions'
-import { extensionVersion } from './vscode/env'
 
 /**
- * Checks if the extension has been uninstalled by reading the .obsolete file
- * and comparing the number of obsolete extensions with the installed extensions.
+ * Checks if an extension has been uninstalled and performs a callback if so.
+ * This function differentiates between an uninstall and an auto-update.
  *
- * @param {string} extensionName - The name of the extension.
- * @param {string} extensionsDirPath - The path to the extensions directory.
- * @param {string} obsoleteFilePath - The path to the .obsolete file.
- * @param {function} callback - Action performed when extension is uninstalled.
- * @returns {void}
+ * @param extensionId - The ID of the extension to check (e.g., VSCODE_EXTENSION_ID.awstoolkit)
+ * @param extensionsPath - The file system path to the VS Code extensions directory
+ * @param obsoletePath - The file system path to the .obsolete file
+ * @param onUninstallCallback - A callback function to execute if the extension is uninstalled
  */
 async function checkExtensionUninstall(
-    extensionName: typeof VSCODE_EXTENSION_ID.awstoolkit | typeof VSCODE_EXTENSION_ID.amazonq,
-    extensionsDirPath: string,
-    obsoleteFilePath: string,
-    callback: () => Promise<void>
+    extensionId: typeof VSCODE_EXTENSION_ID.awstoolkit | typeof VSCODE_EXTENSION_ID.amazonq,
+    extensionVersion: string,
+    extensionsPath: string,
+    obsoletePath: string,
+    onUninstallCallback: () => Promise<void>
 ): Promise<void> {
-    /**
-     * Users can have multiple profiles with different versions of the extensions.
-     *
-     * This makes sure the callback is triggered only when an explicit extension with specific version is uninstalled.
-     */
-    const extension = `${extensionName}-${extensionVersion}`
+    const extensionFullName = `${extensionId}-${extensionVersion}`
+
     try {
-        const [obsoleteFileContent, extensionsDirContent] = await Promise.all([
-            vscode.workspace.fs.readFile(vscode.Uri.file(obsoleteFilePath)),
-            vscode.workspace.fs.readDirectory(vscode.Uri.file(extensionsDirPath)),
+        const [obsoleteFileContent, extensionDirEntries] = await Promise.all([
+            vscode.workspace.fs.readFile(vscode.Uri.file(obsoletePath)),
+            vscode.workspace.fs.readDirectory(vscode.Uri.file(extensionsPath)),
         ])
 
-        const installedExtensionsCount = extensionsDirContent
-            .map(([name]) => name)
-            .filter((name) => name.includes(extension)).length
-
         const obsoleteExtensions = JSON.parse(obsoleteFileContent.toString())
-        const obsoleteExtensionsCount = Object.keys(obsoleteExtensions).filter((id) => id.includes(extension)).length
+        const currentExtension = vscode.extensions.getExtension(extensionId)
 
-        if (installedExtensionsCount === obsoleteExtensionsCount) {
-            await callback()
-            telemetry.aws_extensionUninstalled.run((span) => {
-                span.record({})
-            })
-            getLogger().info(`UninstallExtension: ${extension} uninstalled successfully`)
+        if (!currentExtension) {
+            // Check if the extension was previously installed and is now in the obsolete list
+            const wasObsolete = Object.keys(obsoleteExtensions).some((id) => id.startsWith(extensionId))
+            if (wasObsolete) {
+                await handleUninstall(extensionFullName, onUninstallCallback)
+            }
+        } else {
+            // Check if there's a newer version in the extensions directory
+            const newerVersionExists = checkForNewerVersion(extensionDirEntries, extensionId, extensionVersion)
+
+            if (!newerVersionExists) {
+                // No newer version exists, so this is likely an uninstall
+                await handleUninstall(extensionFullName, onUninstallCallback)
+            } else {
+                getLogger().info(`UpdateExtension: ${extensionFullName} is being updated - not an uninstall`)
+            }
         }
     } catch (error) {
         getLogger().error(`UninstallExtension: Failed to check .obsolete: ${error}`)
     }
+}
+
+/**
+ * Checks if a newer version of the extension exists in the extensions directory.
+ * The isExtensionInstalled fn is used to determine if the extension is installed using the vscode API
+ * whereas this function checks for the newer version in the extension directory for scenarios where
+ * the old extension is un-installed and the new extension in downloaded but not installed.
+ *
+ * @param dirEntries - The entries in the extensions directory
+ * @param extensionId - The ID of the extension to check
+ * @param currentVersion - The current version of the extension
+ * @returns True if a newer version exists, false otherwise
+ */
+
+function checkForNewerVersion(
+    dirEntries: [string, vscode.FileType][],
+    extensionId: string,
+    currentVersion: string
+): boolean {
+    const versionRegex = new RegExp(`^${extensionId}-(.+)$`)
+
+    return dirEntries
+        .map(([name]) => name)
+        .filter((name) => name.startsWith(extensionId))
+        .some((name) => {
+            const match = name.match(versionRegex)
+            if (match && match[1]) {
+                const version = semver.valid(semver.coerce(match[1]))
+                return version !== null && semver.gt(version, currentVersion)
+            }
+            return false
+        })
+}
+
+/**
+ * Handles the uninstall process by calling the callback and logging the event.
+ *
+ * @param extensionFullName - The full name of the extension including version
+ * @param callback - The callback function to execute on uninstall
+ */
+async function handleUninstall(extensionFullName: string, callback: () => Promise<void>): Promise<void> {
+    await callback()
+    telemetry.aws_extensionUninstalled.run(() => {})
+    getLogger().info(`UninstallExtension: ${extensionFullName} uninstalled successfully`)
 }
 
 /**
@@ -71,6 +117,7 @@ async function checkExtensionUninstall(
  */
 export function setupUninstallHandler(
     extensionName: typeof VSCODE_EXTENSION_ID.awstoolkit | typeof VSCODE_EXTENSION_ID.amazonq,
+    extensionVersion: string,
     context: vscode.ExtensionContext,
     callback: () => Promise<void> = async () => {}
 ): void {
@@ -86,7 +133,7 @@ export function setupUninstallHandler(
             const fileWatcher = vscode.workspace.createFileSystemWatcher(watchPattern)
 
             const checkUninstallHandler = () =>
-                checkExtensionUninstall(extensionName, extensionsDirPath, obsoleteFilePath, callback)
+                checkExtensionUninstall(extensionName, extensionVersion, extensionsDirPath, obsoleteFilePath, callback)
             fileWatcher.onDidCreate(checkUninstallHandler)
             fileWatcher.onDidChange(checkUninstallHandler)
 


### PR DESCRIPTION
Do not trigger uninstall when extension auto-updates

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
