### PR TITLE
tests(amazonq): performance test for LSP setup. 

### DIFF
--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -5,8 +5,8 @@
 
 import * as vscode from 'vscode'
 import * as path from 'path'
-import * as fs from 'fs-extra'
 import * as crypto from 'crypto'
+import { chmodSync, createWriteStream } from 'fs'
 import { getLogger } from '../../shared/logger/logger'
 import { CurrentWsFolders, collectFilesForIndex } from '../../shared/utilities/workspaceUtils'
 import fetch from 'node-fetch'
@@ -19,7 +19,7 @@ import { CodeWhispererSettings } from '../../codewhisperer/util/codewhispererSet
 import { activate as activateLsp } from './lspClient'
 import { telemetry } from '../../shared/telemetry'
 import { isCloud9 } from '../../shared/extensionUtilities'
-import { globals, ToolkitError } from '../../shared'
+import { fs, globals, ToolkitError } from '../../shared'
 import { AuthUtil } from '../../codewhisperer'
 import { isWeb } from '../../shared/extensionGlobals'
 import { getUserAgent } from '../../shared/telemetry/util'
@@ -105,7 +105,7 @@ export class LspController {
             throw new ToolkitError(`Failed to download. Error: ${JSON.stringify(res)}`)
         }
         return new Promise((resolve, reject) => {
-            const file = fs.createWriteStream(localFile)
+            const file = createWriteStream(localFile)
             res.body.pipe(file)
             res.body.on('error', (err) => {
                 reject(err)
@@ -133,16 +133,16 @@ export class LspController {
     }
 
     async getFileSha384(filePath: string): Promise<string> {
-        const fileBuffer = await fs.promises.readFile(filePath)
+        const fileBuffer = await fs.readFile(filePath)
         const hash = crypto.createHash('sha384')
         hash.update(fileBuffer)
         return hash.digest('hex')
     }
 
-    isLspInstalled(context: vscode.ExtensionContext) {
+    async isLspInstalled(context: vscode.ExtensionContext) {
         const localQServer = context.asAbsolutePath(path.join('resources', 'qserver'))
         const localNodeRuntime = context.asAbsolutePath(path.join('resources', nodeBinName))
-        return fs.existsSync(localQServer) && fs.existsSync(localNodeRuntime)
+        return (await fs.exists(localQServer)) && (await fs.exists(localNodeRuntime))
     }
 
     getQserverFromManifest(manifest: Manifest): Content | undefined {
@@ -207,7 +207,7 @@ export class LspController {
             getLogger().error(
                 `LspController: Downloaded file sha ${sha384} does not match manifest ${content.hashes[0]}.`
             )
-            fs.removeSync(filePath)
+            await fs.delete(filePath)
             return false
         }
         return true
@@ -225,19 +225,19 @@ export class LspController {
     async tryInstallLsp(context: vscode.ExtensionContext): Promise<boolean> {
         let tempFolder = undefined
         try {
-            if (this.isLspInstalled(context)) {
+            if (await this.isLspInstalled(context)) {
                 getLogger().info(`LspController: LSP already installed`)
                 return true
             }
             // clean up previous downloaded LSP
             const qserverPath = context.asAbsolutePath(path.join('resources', 'qserver'))
-            if (fs.existsSync(qserverPath)) {
+            if (await fs.exists(qserverPath)) {
                 await tryRemoveFolder(qserverPath)
             }
             // clean up previous downloaded node runtime
             const nodeRuntimePath = context.asAbsolutePath(path.join('resources', nodeBinName))
-            if (fs.existsSync(nodeRuntimePath)) {
-                fs.rmSync(nodeRuntimePath)
+            if (await fs.exists(nodeRuntimePath)) {
+                await fs.delete(nodeRuntimePath)
             }
             // fetch download url for qserver and node runtime
             const manifest: Manifest = (await this.fetchManifest()) as Manifest
@@ -258,7 +258,7 @@ export class LspController {
             }
             const zip = new AdmZip(qserverZipTempPath)
             zip.extractAllTo(tempFolder)
-            fs.moveSync(path.join(tempFolder, 'qserver'), qserverPath)
+            await fs.rename(path.join(tempFolder, 'qserver'), qserverPath)
 
             // download node runtime to temp folder
             const nodeRuntimeTempPath = path.join(tempFolder, nodeBinName)
@@ -266,8 +266,8 @@ export class LspController {
             if (!downloadNodeOk) {
                 return false
             }
-            fs.chmodSync(nodeRuntimeTempPath, 0o755)
-            fs.moveSync(nodeRuntimeTempPath, nodeRuntimePath)
+            chmodSync(nodeRuntimeTempPath, 0o755)
+            await fs.rename(nodeRuntimeTempPath, nodeRuntimePath)
             return true
         } catch (e) {
             getLogger().error(`LspController: Failed to setup LSP server ${e}`)

--- a/packages/core/src/test/amazonq/common/tryInstallLsp.test.ts
+++ b/packages/core/src/test/amazonq/common/tryInstallLsp.test.ts
@@ -1,0 +1,81 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import assert from 'assert'
+import { performanceTest } from '../../../shared/performance/performance'
+import { LspController } from '../../../amazonq'
+import { fs, globals } from '../../../shared'
+import sinon from 'sinon'
+import { Content } from 'aws-sdk/clients/codecommit'
+import { createTestWorkspace } from '../../testUtil'
+import AdmZip from 'adm-zip'
+import path from 'path'
+
+// fakeFileContent is matched to fakeQServerContent based on hash.
+const fakeHash = '4eb2865c8f40a322aa04e17d8d83bdaa605d6f1cb363af615240a5442a010e0aef66e21bcf4c88f20fabff06efe8a214'
+
+const fakeQServerContent = {
+    filename: 'qserver-fake.zip',
+    url: 'https://aws-language-servers/fake.zip',
+    hashes: [`sha384:${fakeHash}`],
+    bytes: 93610849,
+    serverVersion: '1.1.1',
+}
+
+const fakeNodeContent = {
+    filename: 'fake-file',
+    url: 'https://aws-language-servers.fake-file',
+    hashes: [`sha384:${fakeHash}`],
+    bytes: 94144448,
+    serverVersion: '1.1.1',
+}
+
+/**
+ * Creates a fake zip with some files in it.
+ * @param filepath where to write the zip to.
+ * @param _content unused parameter, for compatability with real function.
+ */
+const fakeDownload = async (filepath: string, _content: Content) => {
+    const dummyFilesPath = (
+        await createTestWorkspace(100, {
+            fileNamePrefix: 'fakeFile',
+            fileContent: 'emptyContent',
+            workspaceName: 'workspace',
+        })
+    ).uri.fsPath
+    await fs.writeFile(path.join(dummyFilesPath, 'qserver'), 'this value shouldnt matter')
+    const zip = new AdmZip()
+    zip.addLocalFolder(dummyFilesPath)
+    zip.writeZip(filepath)
+}
+
+describe('tryInstallLsp performance test', function () {
+    afterEach(function () {
+        sinon.restore()
+    })
+
+    performanceTest({}, 'sets up', function () {
+        return {
+            setup: async () => {
+                // Avoid making HTTP request or mocking giant manifest, stub what we need directly from request.
+                sinon.stub(LspController.prototype, 'fetchManifest')
+                // Directly feed the runtime specifications.
+                sinon.stub(LspController.prototype, 'getQserverFromManifest').returns(fakeQServerContent)
+                sinon.stub(LspController.prototype, 'getNodeRuntimeFromManifest').returns(fakeNodeContent)
+                // avoid fetch call.
+                sinon.stub(LspController.prototype, '_download').callsFake(fakeDownload)
+                // Hard code the hash since we are creating files on the spot, whose hashes can't be predicted.
+                sinon.stub(LspController.prototype, 'getFileSha384').resolves(fakeHash)
+                // Don't allow tryInstallLsp to move runtimes out of temporary folder.
+                sinon.stub(fs, 'rename')
+            },
+            execute: async () => {
+                return await LspController.instance.tryInstallLsp(globals.context)
+            },
+            verify: async (setup: any, result: boolean) => {
+                assert.ok(result)
+            },
+        }
+    })
+})

--- a/packages/core/src/test/amazonq/common/tryInstallLsp.test.ts
+++ b/packages/core/src/test/amazonq/common/tryInstallLsp.test.ts
@@ -70,7 +70,9 @@ describe('tryInstallLsp performance test', function () {
     afterEach(function () {
         sinon.restore()
     })
-
+    /**
+     * Test setting up LSP when fetched zip is many (250) small (10B) files.
+     */
     performanceTest(
         {
             testRuns: 10,
@@ -105,7 +107,9 @@ describe('tryInstallLsp performance test', function () {
             }
         }
     )
-
+    /**
+     * Test setting up LSP when fetched zip is few (10) large (1000B) files.
+     */
     performanceTest(
         {
             testRuns: 10,


### PR DESCRIPTION
## Problem
continuation of reliability work

## Solution
`tryInstallLsp` in `src/amazonq/lsp/lspController.ts` captures many potentially high risk paths in a single function, such as some I/O operations, and heavy use of the `admZip` dependency. 

Two performance tests were added, one for handling zipping and maniupulating many small files, and one with few large files. Thresholds determined by running in CI a few times and multiplying the observed median by 1.5 to 2.0 depending on variance. 

The "many files" test does 250 files w/ 10 bytes each. The "large files" does 10 files w/ 1000 bytes each. These values were chosen to avoid flakiness in CI. 
