### PR TITLE
revert(amazonq): skip showing users unit test form

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-cd5797a0-6460-4fc6-b3f7-47f55f9bf163.json
+++ b/packages/amazonq/.changes/next-release/Feature-cd5797a0-6460-4fc6-b3f7-47f55f9bf163.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "Amazon Q Code Transformation: allow users to skip running tests"
-}

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -389,7 +389,11 @@ export class GumbyController {
 
             await processTransformFormInput(pathToProject, fromJDKVersion, toJDKVersion)
 
-            await this.messenger.sendSkipTestsPrompt(message.tabID)
+            // TODO: delete this line when backend issue is fixed
+            await this.validateBuildWithPromptOnError(message)
+
+            // TODO: un-comment this line when backend issue is fixed
+            // await this.messenger.sendSkipTestsPrompt(message.tabID)
         })
     }
 


### PR DESCRIPTION
## Problem

Revert https://github.com/aws/aws-toolkit-vscode/pull/5607 by not showing users the skip tests form


## Solution

Above


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
