### PR TITLE
telemetry(amazonq): change code percentage event to not consider modification for toolkit telemetry

### DIFF
--- a/packages/core/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/packages/core/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -120,7 +120,7 @@ export class CodeWhispererCodeCoverageTracker {
                 }
             })
         }
-        const percentCount = ((unmodifiedAcceptedTokens / totalTokens) * 100).toFixed(2)
+        const percentCount = ((acceptedTokens / totalTokens) * 100).toFixed(2)
         const percentage = Math.round(parseInt(percentCount))
         const selectedCustomization = getSelectedCustomization()
         if (this._serviceInvocationCount <= 0) {


### PR DESCRIPTION
## Problem
Product thinks that code percentage event should not consider user modification

## Solution
use raw accepted token count (without considering modification) for the percentage field in toolkit telemetry
there is no change to STE

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
