### PR TITLE
test(ec2): fix flaky tests regarding child node updates. 

### DIFF
--- a/packages/core/src/awsService/ec2/explorer/ec2ParentNode.ts
+++ b/packages/core/src/awsService/ec2/explorer/ec2ParentNode.ts
@@ -52,15 +52,19 @@ export class Ec2ParentNode extends AWSTreeNodeBase {
         )
     }
 
-    private updatePendingNodes() {
-        this.pollingSet.forEach(async (instanceId) => {
+    private async updatePendingNodes() {
+        for (const instanceId of this.pollingSet.values()) {
             const childNode = this.ec2InstanceNodes.get(instanceId)!
-            await childNode.updateStatus()
-            if (!childNode.isPending()) {
-                this.pollingSet.delete(instanceId)
-                await childNode.refreshNode()
-            }
-        })
+            await this.updatePendingNode(childNode)
+        }
+    }
+
+    private async updatePendingNode(node: Ec2InstanceNode) {
+        await node.updateStatus()
+        if (!node.isPending()) {
+            this.pollingSet.delete(node.InstanceId)
+            await node.refreshNode()
+        }
     }
 
     public async clearChildren() {

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -53,6 +53,6 @@ describe('tech debt', function () {
         // Monitor telemtry to determine removal or snooze
         // toolkit_showNotification.id = sessionSeparation
         // auth_modifyConnection.action = deleteProfile OR auth_modifyConnection.source contains CodeCatalyst
-        fixByDate('2024-9-30', 'Remove the edge case code from the commit that this test is a part of.')
+        fixByDate('2024-10-30', 'Remove the edge case code from the commit that this test is a part of.')
     })
 })


### PR DESCRIPTION
## Problem
The issue is here: https://github.com/aws/aws-toolkit-vscode/blob/9eea1f3700930df79620ef26ff6a43450e593580/packages/core/src/awsService/ec2/explorer/ec2ParentNode.ts#L55-L64
This fires off multiple asynchronous calls on each child, with the function returning before any are resolved. Thus, the child node could be deleted from the set after this function returned (potentially when another piece of code is using it). This leads to `undefined` errors within that function. 
## Solution
Refactor the code to make use of a `for...of` with `await` pattern. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
