### PR TITLE
feat(amazonq): Re-enable generate unit tests command and context menu item

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -352,7 +352,7 @@
                 {
                     "command": "aws.amazonq.generateUnitTests",
                     "group": "cw_chat@5",
-                    "when": "false"
+                    "when": "aws.codewhisperer.connected && aws.isInternalUser"
                 },
                 {
                     "command": "aws.amazonq.sendToPrompt",
@@ -432,7 +432,7 @@
                 "command": "aws.amazonq.generateUnitTests",
                 "title": "%AWS.command.amazonq.generateUnitTests%",
                 "category": "%AWS.amazonq.title%",
-                "enablement": "false"
+                "enablement": "aws.codewhisperer.connected && aws.isInternalUser"
             },
             {
                 "command": "aws.amazonq.reconnect",
@@ -615,7 +615,7 @@
                 "key": "win+alt+t",
                 "mac": "cmd+alt+t",
                 "linux": "meta+alt+t",
-                "when": "false"
+                "when": "aws.codewhisperer.connected && aws.isInternalUser"
             },
             {
                 "command": "aws.amazonq.invokeInlineCompletion",

--- a/packages/core/src/codewhispererChat/controllers/chat/userIntent/userIntentRecognizer.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/userIntent/userIntentRecognizer.ts
@@ -6,6 +6,7 @@
 import { UserIntent } from '@amzn/codewhisperer-streaming'
 import { EditorContextCommand } from '../../../commands/registerCommands'
 import { PromptMessage } from '../model'
+import { Auth } from '../../../../auth'
 
 export class UserIntentRecognizer {
     public getFromContextMenuCommand(command: EditorContextCommand): UserIntent | undefined {
@@ -38,6 +39,8 @@ export class UserIntentRecognizer {
             return UserIntent.APPLY_COMMON_BEST_PRACTICES
         } else if (prompt.message.startsWith('Optimize')) {
             return UserIntent.IMPROVE_CODE
+        } else if (prompt.message.startsWith('Generate unit tests') && Auth.instance.isInternalAmazonUser()) {
+            return UserIntent.GENERATE_UNIT_TESTS
         }
         return undefined
     }


### PR DESCRIPTION
## Problem

Command and context menu item for unit test generation was disabled for internal users before last release. We are ready to enable now.

## Solution

This PR enables the context menu item and commands for unit test generation.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
