### PR TITLE
feat(amazonq): Decouple LSP from vector index creation; start LSP by default

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-5576420e-6db2-4045-a99f-afced496da0f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-5576420e-6db2-4045-a99f-afced496da0f.json
@@ -1,4 +1,4 @@
 {
-	"type": "Feature",
+	"type": "Bug Fix",
 	"description": "Start language server by default"
 }

--- a/packages/amazonq/.changes/next-release/Feature-5576420e-6db2-4045-a99f-afced496da0f.json
+++ b/packages/amazonq/.changes/next-release/Feature-5576420e-6db2-4045-a99f-afced496da0f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Start language server by default"
+}

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -305,7 +305,7 @@ export class LspController {
     }
 
     async buildIndex() {
-        getLogger().info(`LspController: Starting to build vector index of project`)
+        getLogger().info(`LspController: Starting to build index of project`)
         const start = performance.now()
         const projPaths = getProjectPaths()
         projPaths.sort()
@@ -332,7 +332,7 @@ export class LspController {
                 false
             )
             if (resp) {
-                getLogger().debug(`LspController: Finish building vector index of project`)
+                getLogger().debug(`LspController: Finish building index of project`)
                 const usage = await LspClient.instance.getLspServerUsage()
                 telemetry.amazonq_indexWorkspace.emit({
                     duration: performance.now() - start,
@@ -344,7 +344,7 @@ export class LspController {
                     credentialStartUrl: AuthUtil.instance.startUrl,
                 })
             } else {
-                getLogger().error(`LspController: Failed to build vector index of project`)
+                getLogger().error(`LspController: Failed to build index of project`)
                 telemetry.amazonq_indexWorkspace.emit({
                     duration: performance.now() - start,
                     result: 'Failed',
@@ -353,7 +353,7 @@ export class LspController {
                 })
             }
         } catch (e) {
-            getLogger().error(`LspController: Failed to build vector index of project`)
+            getLogger().error(`LspController: Failed to build index of project`)
             telemetry.amazonq_indexWorkspace.emit({
                 duration: performance.now() - start,
                 result: 'Failed',
@@ -372,12 +372,6 @@ export class LspController {
             return
         }
         setImmediate(async () => {
-            if (!CodeWhispererSettings.instance.isLocalIndexEnabled()) {
-                // only download LSP for users who did not turn on this feature
-                // do not start LSP server
-                await LspController.instance.tryInstallLsp(context)
-                return
-            }
             const ok = await LspController.instance.tryInstallLsp(context)
             if (!ok) {
                 return
@@ -385,7 +379,9 @@ export class LspController {
             try {
                 await activateLsp(context)
                 getLogger().info('LspController: LSP activated')
-                void LspController.instance.buildIndex()
+                if (CodeWhispererSettings.instance.isLocalIndexEnabled()) {
+                    void LspController.instance.buildIndex()
+                }
                 // log the LSP server CPU and Memory usage per 30 minutes.
                 globals.clock.setInterval(
                     async () => {


### PR DESCRIPTION
## Problem

Current LSP start is coupled with vector index creation, this should be decoupled. We will be having new releases in the LSP to build some other indexes for everyone very soon ( not computation expensive as vector index), therefore we need to start LSP by default. The vector indexing, as a computational expensive index, will be only enabled if opt-in.

## Solution
Decouple LSP from vector index creation; start LSP by default

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
