### PR TITLE
telemetry(amazonq): Add client latency metrics for amazon q chat

### DIFF
--- a/packages/core/src/amazonq/messages/chatMessageDuration.ts
+++ b/packages/core/src/amazonq/messages/chatMessageDuration.ts
@@ -43,10 +43,11 @@ export class AmazonQChatMessageDuration {
     /**
      * Stop listening to all incoming events and emit what we've found
      */
-    static stopChatMessageTelemetry(msg: { tabID: string; time: number }) {
-        const { tabID, time } = msg
+    static stopChatMessageTelemetry(msg: { tabID: string; time: number; tabType: TabType }) {
+        const { tabID, time, tabType } = msg
+
         // We can't figure out what trace this event was associated with
-        if (!tabID) {
+        if (!tabID || tabType !== 'cwc') {
             return
         }
 

--- a/packages/core/src/amazonq/messages/chatMessageDuration.ts
+++ b/packages/core/src/amazonq/messages/chatMessageDuration.ts
@@ -3,91 +3,110 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import AsyncLock from 'async-lock'
 import { globals } from '../../shared'
 import { telemetry } from '../../shared/telemetry'
 import { Event, uiEventRecorder } from '../util/eventRecorder'
+import { CWCTelemetryHelper } from '../../codewhispererChat/controllers/chat/telemetryHelper'
+import { TabType } from '../webview/ui/storages/tabsStorage'
 
 export class AmazonQChatMessageDuration {
+    private static _asyncLock = new AsyncLock()
+    private static getAsyncLock() {
+        if (!AmazonQChatMessageDuration._asyncLock) {
+            AmazonQChatMessageDuration._asyncLock = new AsyncLock()
+        }
+        return AmazonQChatMessageDuration._asyncLock
+    }
+
     /**
      * Record the initial requests in the chat message flow
      */
-    static startChatMessageTelemetry(msg: { traceId: string; startTime: number; trigger?: string }) {
-        const { traceId, startTime, trigger } = msg
+    static startChatMessageTelemetry(msg: { traceId: string; startTime: number; tabID: string; trigger?: string }) {
+        const { traceId, startTime, tabID, trigger } = msg
 
-        uiEventRecorder.set(traceId, {
+        uiEventRecorder.set(tabID, {
+            traceId,
             events: {
                 chatMessageSent: startTime,
-            },
-        })
-        uiEventRecorder.set(traceId, {
-            events: {
                 editorReceivedMessage: globals.clock.Date.now(),
             },
         })
         if (trigger) {
-            uiEventRecorder.set(traceId, {
+            uiEventRecorder.set(tabID, {
                 trigger,
             })
         }
+        CWCTelemetryHelper.instance.setDisplayTimeForChunks(tabID, startTime)
     }
 
     /**
      * Stop listening to all incoming events and emit what we've found
      */
-    static stopChatMessageTelemetry(msg: { traceId: string }) {
-        const { traceId } = msg
-
+    static stopChatMessageTelemetry(msg: { tabID: string; time: number }) {
+        const { tabID, time } = msg
         // We can't figure out what trace this event was associated with
-        if (!traceId) {
+        if (!tabID) {
             return
         }
 
-        uiEventRecorder.set(traceId, {
-            events: {
-                messageDisplayed: globals.clock.Date.now(),
-            },
-        })
+        // Lock the tab id just in case another event tries to trigger this
+        void AmazonQChatMessageDuration.getAsyncLock().acquire(tabID, () => {
+            const metrics = uiEventRecorder.get(tabID)
+            if (!metrics) {
+                return
+            }
 
-        const metrics = uiEventRecorder.get(traceId)
-
-        // get events sorted by the time they were created
-        const events = Object.entries(metrics.events)
-            .map((x) => ({
-                event: x[0],
-                duration: x[1],
-            }))
-            .sort((a, b) => {
-                return a.duration - b.duration
+            uiEventRecorder.set(tabID, {
+                events: {
+                    messageDisplayed: time,
+                },
             })
 
-        const chatMessageSentTime = events[events.length - 1].duration
-        // Get the total duration by subtracting when the message was displayed and when the chat message was first sent
-        const totalDuration = events[events.length - 1].duration - events[0].duration
+            const displayTime = metrics.events.messageDisplayed
+            const sentTime = metrics.events.chatMessageSent
+            if (!displayTime || !sentTime) {
+                return
+            }
 
-        /**
-         * Find the time it took to get between two metric events
-         */
-        const timings = new Map<Event, number>()
-        for (let i = 1; i < events.length; i++) {
-            const currentEvent = events[i]
-            const previousEvent = events[i - 1]
+            const totalDuration = displayTime - sentTime
 
-            const timeDifference = currentEvent.duration - previousEvent.duration
+            function durationFrom(start: Event, end: Event) {
+                const startEvent = metrics.events[start]
+                const endEvent = metrics.events[end]
+                if (!startEvent || !endEvent) {
+                    return -1
+                }
+                return endEvent - startEvent
+            }
 
-            timings.set(currentEvent.event as Event, timeDifference)
+            // TODO: handle onContextCommand round trip time
+            if (metrics.trigger !== 'onContextCommand') {
+                telemetry.amazonq_chatRoundTrip.emit({
+                    amazonqChatMessageSentTime: metrics.events.chatMessageSent ?? -1,
+                    amazonqEditorReceivedMessageMs: durationFrom('chatMessageSent', 'editorReceivedMessage') ?? -1,
+                    amazonqFeatureReceivedMessageMs:
+                        durationFrom('editorReceivedMessage', 'featureReceivedMessage') ?? -1,
+                    amazonqMessageDisplayedMs: durationFrom('featureReceivedMessage', 'messageDisplayed') ?? -1,
+                    source: metrics.trigger,
+                    duration: totalDuration,
+                    result: 'Succeeded',
+                    traceId: metrics.traceId,
+                })
+            }
+
+            CWCTelemetryHelper.instance.emitAddMessage(tabID, totalDuration, metrics.events.chatMessageSent)
+
+            uiEventRecorder.delete(tabID)
+        })
+    }
+
+    static updateChatMessageTelemetry(msg: { tabID: string; time: number; tabType: TabType }) {
+        const { tabID, time, tabType } = msg
+        if (!tabID || tabType !== 'cwc') {
+            return
         }
 
-        telemetry.amazonq_chatRoundTrip.emit({
-            amazonqChatMessageSentTime: chatMessageSentTime,
-            amazonqEditorReceivedMessageMs: timings.get('editorReceivedMessage') ?? -1,
-            amazonqFeatureReceivedMessageMs: timings.get('featureReceivedMessage') ?? -1,
-            amazonqMessageDisplayedMs: timings.get('messageDisplayed') ?? -1,
-            source: metrics.trigger,
-            duration: totalDuration,
-            result: 'Succeeded',
-            traceId,
-        })
-
-        uiEventRecorder.delete(traceId)
+        CWCTelemetryHelper.instance.setDisplayTimeForChunks(tabID, time)
     }
 }

--- a/packages/core/src/amazonq/util/eventRecorder.ts
+++ b/packages/core/src/amazonq/util/eventRecorder.ts
@@ -9,10 +9,10 @@ export type Event =
     | 'chatMessageSent' // initial on chat prompt event in the ui
     | 'editorReceivedMessage' // message gets from the chat prompt to VSCode
     | 'featureReceivedMessage' // message gets redirected from VSCode -> Partner team features implementation
-    | 'messageDisplayed' // message gets received in the UI
+    | 'messageDisplayed' // message gets shown in the UI
 
 /**
- * For a given traceID, map an event to a time
+ * For a given tabId, map an event to a time
  *
  * This is used to correlated disjoint events that are happening in different
  * parts of Q Chat.
@@ -22,8 +22,14 @@ export type Event =
  *  - when the feature starts processing the message
  *  - final message rendering
  * and emit those as a final result, rather than having to emit each event individually
+ *
+ * Event timings are generated using Date.now() instead of performance.now() for cross-context consistency.
+ * performance.now() provides timestamps relative to the context's time origin (when the webview or VS Code was opened),
+ * which can lead to inconsistent measurements between the webview and vscode.
+ * Date.now() is more consistent across both contexts
  */
 export const uiEventRecorder = new RecordMap<{
     trigger: string
+    traceId: string
     events: Partial<Record<Event, number>>
 }>()

--- a/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
+++ b/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
@@ -17,29 +17,35 @@ export function dispatchWebViewMessagesToApps(
     webViewToAppsMessagePublishers: Map<TabType, MessagePublisher<any>>
 ) {
     webview.onDidReceiveMessage((msg) => {
-        if (msg.command === 'ui-is-ready') {
-            /**
-             * ui-is-ready isn't associated to any tab so just record the telemetry event and continue.
-             * This would be equivalent of the duration between "user clicked open q" and "ui has become available"
-             * NOTE: Amazon Q UI is only loaded ONCE. The state is saved between each hide/show of the webview.
-             */
+        switch (msg.command) {
+            case 'ui-is-ready': {
+                /**
+                 * ui-is-ready isn't associated to any tab so just record the telemetry event and continue.
+                 * This would be equivalent of the duration between "user clicked open q" and "ui has become available"
+                 * NOTE: Amazon Q UI is only loaded ONCE. The state is saved between each hide/show of the webview.
+                 */
 
-            telemetry.webview_load.emit({
-                webviewName: 'amazonq',
-                duration: performance.measure(amazonqMark.uiReady, amazonqMark.open).duration,
-                result: 'Succeeded',
-            })
-            performance.clearMarks(amazonqMark.uiReady)
-            performance.clearMarks(amazonqMark.open)
-            return
-        }
-
-        if (msg.type === 'startChatMessageTelemetry') {
-            AmazonQChatMessageDuration.startChatMessageTelemetry(msg)
-            return
-        } else if (msg.type === 'stopChatMessageTelemetry') {
-            AmazonQChatMessageDuration.stopChatMessageTelemetry(msg)
-            return
+                telemetry.webview_load.emit({
+                    webviewName: 'amazonq',
+                    duration: performance.measure(amazonqMark.uiReady, amazonqMark.open).duration,
+                    result: 'Succeeded',
+                })
+                performance.clearMarks(amazonqMark.uiReady)
+                performance.clearMarks(amazonqMark.open)
+                return
+            }
+            case 'start-chat-message-telemetry': {
+                AmazonQChatMessageDuration.startChatMessageTelemetry(msg)
+                return
+            }
+            case 'update-chat-message-telemetry': {
+                AmazonQChatMessageDuration.updateChatMessageTelemetry(msg)
+                return
+            }
+            case 'stop-chat-message-telemetry': {
+                AmazonQChatMessageDuration.stopChatMessageTelemetry(msg)
+                return
+            }
         }
 
         if (msg.type === 'error') {

--- a/packages/core/src/amazonq/webview/ui/commands.ts
+++ b/packages/core/src/amazonq/webview/ui/commands.ts
@@ -31,5 +31,7 @@ type MessageCommand =
     | 'file-click'
     | 'form-action-click'
     | 'open-settings'
+    | 'start-chat-message-telemetry'
+    | 'stop-chat-message-telemetry'
 
 export type ExtensionMessage = Record<string, any> & { command: MessageCommand }

--- a/packages/core/src/amazonq/webview/ui/followUps/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/followUps/handler.ts
@@ -60,7 +60,7 @@ export class FollowUpInteractionHandler {
             this.tabsStorage.resetTabTimer(tabID)
 
             if (followUp.type !== undefined && followUp.type === 'init-prompt') {
-                void this.connector.requestGenerativeAIAnswer(tabID, {
+                void this.connector.requestGenerativeAIAnswer(tabID, messageId, {
                     chatMessage: followUp.prompt,
                 })
                 return

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Connector, TracedChatItem } from './connector'
+import { Connector } from './connector'
 import { ChatItem, ChatItemType, MynahIcons, MynahUI, MynahUIDataModel, NotificationType } from '@aws/mynah-ui'
 import { ChatPrompt } from '@aws/mynah-ui/dist/static'
 import { TabsStorage, TabType } from './storages/tabsStorage'
@@ -125,7 +125,17 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
             if (command === 'aws.amazonq.sendToPrompt') {
                 return messageController.sendSelectedCodeToTab(message)
             } else {
-                return messageController.sendMessageToTab(message, 'cwc')
+                const tabID = messageController.sendMessageToTab(message, 'cwc')
+                if (tabID) {
+                    ideApi.postMessage({
+                        command: 'start-chat-message-telemetry',
+                        trigger: 'onContextCommand',
+                        tabID,
+                        tabType: 'cwc',
+                        startTime: Date.now(),
+                    })
+                }
+                return tabID
             }
         },
         onWelcomeFollowUpClicked: (tabID: string, welcomeFollowUpType: WelcomeFollowupType) => {
@@ -189,7 +199,7 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
                 } as ChatItem)
             }
         },
-        onChatAnswerReceived: (tabID: string, item: TracedChatItem) => {
+        onChatAnswerReceived: (tabID: string, item: ChatItem) => {
             if (item.type === ChatItemType.ANSWER_PART || item.type === ChatItemType.CODE_RESULT) {
                 mynahUI.updateLastChatAnswer(tabID, {
                     ...(item.messageId !== undefined ? { messageId: item.messageId } : {}),
@@ -200,6 +210,12 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
                     ...(item.type === ChatItemType.CODE_RESULT
                         ? { type: ChatItemType.CODE_RESULT, fileList: item.fileList }
                         : {}),
+                })
+                ideApi.postMessage({
+                    command: 'update-chat-message-telemetry',
+                    tabID,
+                    tabType: tabsStorage.getTab(tabID)?.type,
+                    time: Date.now(),
                 })
                 return
             }
@@ -235,19 +251,17 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
                 })
                 tabsStorage.updateTabStatus(tabID, 'free')
 
-                if (item.traceId) {
-                    /**
-                     * We've received an answer for a traceId and this message has
-                     * completed its round trip. Send that information back to
-                     * VSCode so we can emit a round trip event
-                     **/
-                    ideApi.postMessage({
-                        type: 'stopChatMessageTelemetry',
-                        tabID,
-                        traceId: item.traceId,
-                        tabType: tabsStorage.getTab(tabID)?.type,
-                    })
-                }
+                /**
+                 * We've received an answer for a tabID and this message has
+                 * completed its round trip. Send that information back to
+                 * VSCode so we can emit a round trip event
+                 **/
+                ideApi.postMessage({
+                    command: 'stop-chat-message-telemetry',
+                    tabID,
+                    tabType: tabsStorage.getTab(tabID)?.type,
+                    time: Date.now(),
+                })
             }
         },
         onMessageReceived: (tabID: string, messageData: MynahUIDataModel) => {
@@ -389,7 +403,6 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
             } else if (tabsStorage.getTab(tabID)?.type === 'gumby') {
                 connector.requestAnswer(tabID, {
                     chatMessage: prompt.prompt ?? '',
-                    traceId: eventId as string,
                 })
                 return
             }
@@ -398,19 +411,6 @@ export const createMynahUI = (ideApi: any, amazonQEnabled: boolean) => {
                 quickActionHandler.handle(prompt, tabID, eventId)
                 return
             }
-
-            /**
-             * When a user presses "enter" send an event that indicates
-             * we should start tracking the round trip time for this message
-             **/
-            ideApi.postMessage({
-                type: 'startChatMessageTelemetry',
-                trigger: 'onChatPrompt',
-                tabID,
-                traceId: eventId,
-                tabType: tabsStorage.getTab(tabID)?.type,
-                startTime: Date.now(),
-            })
 
             textMessageHandler.handle(prompt, tabID, eventId as string)
         },

--- a/packages/core/src/amazonq/webview/ui/messages/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/messages/handler.ts
@@ -41,10 +41,9 @@ export class TextMessageHandler {
         this.tabsStorage.updateTabStatus(tabID, 'busy')
 
         void this.connector
-            .requestGenerativeAIAnswer(tabID, {
+            .requestGenerativeAIAnswer(tabID, eventID, {
                 chatMessage: chatPrompt.prompt ?? '',
                 chatCommand: chatPrompt.command,
-                traceId: eventID,
             })
             .then(() => {})
     }

--- a/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
@@ -163,7 +163,7 @@ export class QuickActionHandler {
                     promptInputDisabledState: true,
                 })
 
-                void this.connector.requestGenerativeAIAnswer(affectedTabId, {
+                void this.connector.requestGenerativeAIAnswer(affectedTabId, '', {
                     chatMessage: realPromptText,
                 })
             }

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -106,7 +106,7 @@ export class ChatController {
     ) {
         this.sessionStorage = new ChatSessionStorage()
         this.triggerEventsStorage = new TriggerEventsStorage()
-        this.telemetryHelper = new CWCTelemetryHelper(this.sessionStorage, this.triggerEventsStorage)
+        this.telemetryHelper = CWCTelemetryHelper.init(this.sessionStorage, this.triggerEventsStorage)
         this.messenger = new Messenger(
             new AppToWebViewMessageDispatcher(appsToWebViewMessagePublisher),
             this.telemetryHelper
@@ -125,8 +125,9 @@ export class ChatController {
         })
 
         this.chatControllerMessageListeners.processPromptChatMessage.onMessage((data) => {
-            if (data.traceId) {
-                uiEventRecorder.set(data.traceId, {
+            const uiEvents = uiEventRecorder.get(data.tabID)
+            if (uiEvents) {
+                uiEventRecorder.set(data.tabID, {
                     events: {
                         featureReceivedMessage: globals.clock.Date.now(),
                     },
@@ -139,7 +140,7 @@ export class ChatController {
              **/
             return telemetry.withTraceId(() => {
                 return this.processPromptChatMessage(data)
-            }, data.traceId ?? randomUUID())
+            }, uiEvents?.traceId ?? randomUUID())
         })
 
         this.chatControllerMessageListeners.processTabCreatedMessage.onMessage((data) => {
@@ -503,7 +504,6 @@ export class ChatController {
                         codeQuery: context?.focusAreaContext?.names,
                         userIntent: this.userIntentRecognizer.getFromPromptChatMessage(message),
                         customization: getSelectedCustomization(),
-                        traceId: message.traceId,
                     },
                     triggerID
                 )

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -293,7 +293,6 @@ export class Messenger {
                             relatedSuggestions: undefined,
                             triggerID,
                             messageID,
-                            traceId: triggerPayload.traceId,
                         },
                         tabID
                     )

--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -72,7 +72,6 @@ export type ChatPromptCommandType =
 export interface PromptMessage {
     message: string | undefined
     messageId: string
-    traceId?: string
     command: ChatPromptCommandType | undefined
     userIntent: UserIntent | undefined
     tabID: string

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -58,6 +58,7 @@ export function recordTelemetryChatRunCommand(type: CwsprChatCommandType, comman
 }
 
 export class CWCTelemetryHelper {
+    static instance: CWCTelemetryHelper
     private sessionStorage: ChatSessionStorage
     private triggerEventsStorage: TriggerEventsStorage
     private responseStreamStartTime: Map<string, number> = new Map()
@@ -65,9 +66,37 @@ export class CWCTelemetryHelper {
     private responseStreamTimeForChunks: Map<string, number[]> = new Map()
     private responseWithProjectContext: Map<string, boolean> = new Map()
 
+    // Keeps track of when chunks of data were displayed in a tab
+    private displayTimeForChunks: Map<string, number[]> = new Map()
+
+    /**
+     * Stores payload information about a message response until
+     * the full round trip time finishes and addMessage telemetry
+     * is sent
+     */
+    private messageStorage: Map<
+        string,
+        {
+            triggerPayload: TriggerPayload
+            message: PromptAnswer
+        }
+    > = new Map()
+
     constructor(sessionStorage: ChatSessionStorage, triggerEventsStorage: TriggerEventsStorage) {
         this.sessionStorage = sessionStorage
         this.triggerEventsStorage = triggerEventsStorage
+    }
+
+    public static init(sessionStorage: ChatSessionStorage, triggerEventsStorage: TriggerEventsStorage) {
+        const lastInstance = CWCTelemetryHelper.instance
+        if (lastInstance !== undefined) {
+            return lastInstance
+        }
+
+        getLogger().debug('CWCTelemetryHelper: Initialized new telemetry helper')
+        const instance = new CWCTelemetryHelper(sessionStorage, triggerEventsStorage)
+        CWCTelemetryHelper.instance = instance
+        return instance
     }
 
     private getUserIntentForTelemetry(userIntent: UserIntent | undefined): CwsprChatUserIntent | undefined {
@@ -334,7 +363,26 @@ export class CWCTelemetryHelper {
         })
     }
 
+    /**
+     * Store the trigger payload and message until the full message round trip finishes
+     *
+     * @calls emitAddMessage when the full message round trip finishes
+     */
     public recordAddMessage(triggerPayload: TriggerPayload, message: PromptAnswer) {
+        this.messageStorage.set(message.tabID, {
+            triggerPayload,
+            message,
+        })
+    }
+
+    public emitAddMessage(tabID: string, fullDisplayLatency: number, startTime?: number) {
+        const payload = this.messageStorage.get(tabID)
+        if (!payload) {
+            return
+        }
+
+        const { triggerPayload, message } = payload
+
         const triggerEvent = this.triggerEventsStorage.getLastTriggerEventByTabID(message.tabID)
         const hasProjectLevelContext =
             triggerPayload.relevantTextDocuments &&
@@ -356,8 +404,13 @@ export class CWCTelemetryHelper {
             cwsprChatReferencesCount: message.codeReferenceCount,
             cwsprChatFollowUpCount: message.followUpCount,
             cwsprChatTimeToFirstChunk: this.getResponseStreamTimeToFirstChunk(message.tabID),
-            cwsprChatTimeBetweenChunks: JSON.stringify(this.getResponseStreamTimeBetweenChunks(message.tabID)),
+            cwsprChatTimeBetweenChunks: JSON.stringify(
+                this.getTimeBetweenChunks(message.tabID, this.responseStreamTimeForChunks)
+            ),
             cwsprChatFullResponseLatency: this.responseStreamTotalTime.get(message.tabID) ?? 0,
+            cwsprTimeToFirstDisplay: this.getFirstDisplayTime(tabID, startTime),
+            cwsprChatTimeBetweenDisplays: JSON.stringify(this.getTimeBetweenChunks(tabID, this.displayTimeForChunks)),
+            cwsprChatFullDisplayLatency: fullDisplayLatency,
             cwsprChatRequestLength: triggerPayload.message?.length ?? 0,
             cwsprChatResponseLength: message.messageLength,
             cwsprChatConversationType: 'Chat',
@@ -382,7 +435,7 @@ export class CWCTelemetryHelper {
                         ...(language !== undefined ? { programmingLanguage: language } : {}),
                         activeEditorTotalCharacters: event.cwsprChatActiveEditorTotalCharacters,
                         timeToFirstChunkMilliseconds: event.cwsprChatTimeToFirstChunk,
-                        timeBetweenChunks: this.getResponseStreamTimeBetweenChunks(message.tabID),
+                        timeBetweenChunks: this.getTimeBetweenChunks(message.tabID, this.responseStreamTimeForChunks),
                         fullResponselatency: event.cwsprChatFullResponseLatency,
                         requestLength: event.cwsprChatRequestLength,
                         responseLength: event.cwsprChatResponseLength,
@@ -394,6 +447,8 @@ export class CWCTelemetryHelper {
             })
             .then()
             .catch(logSendTelemetryEventFailure)
+
+        this.messageStorage.delete(tabID)
     }
 
     public recordMessageResponseError(triggerPayload: TriggerPayload, tabID: string, responseCode: number) {
@@ -436,13 +491,19 @@ export class CWCTelemetryHelper {
     }
 
     public setResponseStreamStartTime(tabID: string) {
-        this.responseStreamStartTime.set(tabID, performance.now())
+        this.responseStreamStartTime.set(tabID, globals.clock.Date.now())
         this.responseStreamTimeForChunks.set(tabID, [performance.now()])
+        this.displayTimeForChunks.set(tabID, [])
     }
 
     public setResponseStreamTimeForChunks(tabID: string) {
         const chunkTimes = this.responseStreamTimeForChunks.get(tabID) ?? []
         this.responseStreamTimeForChunks.set(tabID, [...chunkTimes, performance.now()])
+    }
+
+    public setDisplayTimeForChunks(tabID: string, time: number) {
+        const chunkTimes = this.displayTimeForChunks.get(tabID) ?? []
+        this.displayTimeForChunks.set(tabID, [...chunkTimes, time])
     }
 
     public setResponseFromProjectContext(messageId: string) {
@@ -457,10 +518,21 @@ export class CWCTelemetryHelper {
         return Math.round(chunkTimes[1] - chunkTimes[0])
     }
 
-    private getResponseStreamTimeBetweenChunks(tabID: string): number[] {
+    /**
+     * Finds the time between when a user pressed enter and the first chunk appears in the UI
+     */
+    private getFirstDisplayTime(tabID: string, startTime?: number) {
+        if (!startTime) {
+            return 0
+        }
+        const chunkTimes = this.displayTimeForChunks.get(tabID) ?? [0]
+        return Math.round(chunkTimes[0] - startTime)
+    }
+
+    private getTimeBetweenChunks(tabID: string, chunks: Map<string, number[]>): number[] {
         try {
             const chunkDeltaTimes: number[] = []
-            const chunkTimes = this.responseStreamTimeForChunks.get(tabID) ?? [0]
+            const chunkTimes = chunks.get(tabID) ?? [0]
             for (let idx = 0; idx < chunkTimes.length - 1; idx++) {
                 chunkDeltaTimes.push(Math.round(chunkTimes[idx + 1] - chunkTimes[idx]))
             }
@@ -473,7 +545,7 @@ export class CWCTelemetryHelper {
     }
 
     public setResponseStreamTotalTime(tabID: string) {
-        const totalTime = performance.now() - (this.responseStreamStartTime.get(tabID) ?? 0)
+        const totalTime = globals.clock.Date.now() - (this.responseStreamStartTime.get(tabID) ?? 0)
         this.responseStreamTotalTime.set(tabID, Math.round(totalTime))
     }
 

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -491,7 +491,7 @@ export class CWCTelemetryHelper {
     }
 
     public setResponseStreamStartTime(tabID: string) {
-        this.responseStreamStartTime.set(tabID, globals.clock.Date.now())
+        this.responseStreamStartTime.set(tabID, performance.now())
         this.responseStreamTimeForChunks.set(tabID, [performance.now()])
         this.displayTimeForChunks.set(tabID, [])
     }
@@ -545,7 +545,7 @@ export class CWCTelemetryHelper {
     }
 
     public setResponseStreamTotalTime(tabID: string) {
-        const totalTime = globals.clock.Date.now() - (this.responseStreamStartTime.get(tabID) ?? 0)
+        const totalTime = performance.now() - (this.responseStreamStartTime.get(tabID) ?? 0)
         this.responseStreamTotalTime.set(tabID, Math.round(totalTime))
     }
 

--- a/packages/core/src/codewhispererChat/view/connector/connector.ts
+++ b/packages/core/src/codewhispererChat/view/connector/connector.ts
@@ -141,7 +141,6 @@ export interface ChatMessageProps {
     readonly codeReference?: CodeReference[]
     readonly triggerID: string
     readonly messageID: string
-    readonly traceId?: string
 }
 
 export class ChatMessage extends UiMessage {
@@ -154,7 +153,6 @@ export class ChatMessage extends UiMessage {
     readonly followUpsHeader: string | undefined
     readonly triggerID: string
     readonly messageID: string | undefined
-    readonly traceId?: string
     override type = 'chatMessage'
 
     constructor(props: ChatMessageProps, tabID: string) {
@@ -167,7 +165,6 @@ export class ChatMessage extends UiMessage {
         this.codeReference = props.codeReference
         this.triggerID = props.triggerID
         this.messageID = props.messageID
-        this.traceId = props.traceId
     }
 }
 

--- a/packages/core/src/codewhispererChat/view/messages/messageListener.ts
+++ b/packages/core/src/codewhispererChat/view/messages/messageListener.ts
@@ -204,7 +204,6 @@ export class UIMessageListener {
             tabID: msg.tabID,
             messageId: msg.messageId,
             userIntent: msg.userIntent !== '' ? msg.userIntent : undefined,
-            traceId: msg.traceId,
         })
     }
 

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -157,17 +157,32 @@
         {
             "name": "cwsprChatTimeToFirstChunk",
             "type": "int",
-            "description": "Time taken in ms to get back the first chunk"
+            "description": "The time between the initial server request and when we got back the first usable result"
         },
         {
             "name": "cwsprChatTimeBetweenChunks",
             "type": "string",
-            "description": "Time (list of int) taken in ms between chunks"
+            "description": "An array of time when successive chunks of data are received from the server"
         },
         {
             "name": "cwsprChatFullResponseLatency",
             "type": "int",
-            "description": "Time taken to get the full response in ms"
+            "description": "The time between the initial server request and the final response from the server"
+        },
+        {
+            "name": "cwsprTimeToFirstDisplay",
+            "type": "int",
+            "description": "The time between the user pressing enter and when the first chunk of data is displayed to the user"
+        },
+        {
+            "name": "cwsprChatTimeBetweenDisplays",
+            "type": "string",
+            "description": "An array of time when successive chunks of server responses are displayed to the user"
+        },
+        {
+            "name": "cwsprChatFullDisplayLatency",
+            "type": "int",
+            "description": "The time between the user pressing enter and the entire response being rendered"
         },
         {
             "name": "cwsprChatResponseLength",
@@ -757,6 +772,15 @@
                 },
                 {
                     "type": "cwsprChatFullResponseLatency"
+                },
+                {
+                    "type": "cwsprTimeToFirstDisplay"
+                },
+                {
+                    "type": "cwsprChatFullDisplayLatency"
+                },
+                {
+                    "type": "cwsprChatTimeBetweenDisplays"
                 },
                 {
                     "type": "cwsprChatRequestLength"


### PR DESCRIPTION
## Problem:
- It's not clear what's meant by cwsprChatTimeToFirstChunk, cwsprChatTimeBetweenChunks, cwsprChatFullResponseLatency
- We don't have any client latency metrics

## Solution:
- Clarify the descriptions of cwsprChatTimeToFirstChunk, cwsprChatTimeBetweenChunks, cwsprChatFullResponseLatency
- Implement cwsprTimeToFirstDisplay, cwsprChatTimeBetweenDisplay, cwsprChatFullDisplayLatency metrics

## Other changes:
- Instead of instrumenting everything via a traceId instead use the tabId as the unique identifier and store a traceId when we get it inside of the uiEventRecorder. That way we can associate events from a tab to the trace without needing to pass the trace around the entire application.
- Lock stopChatMessageTelemetry on the tabId just in case something calls that twice for the same event

## Risks:
- All flows from start of chat message -> end of chat message need to be instrumented otherwise an addChatMessage event wont be sent.
- RIght now:
   - Right click context menu works
   - Normal chat message work
   - Follow up button works
   - Are there any other flows that we need to know about?
---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
