### PR TITLE
config(dev): re-enable Q dev API retry for read APIs

### DIFF
--- a/packages/core/src/amazonqFeatureDev/client/featureDev.ts
+++ b/packages/core/src/amazonqFeatureDev/client/featureDev.ts
@@ -26,8 +26,17 @@ import { createCodeWhispererChatStreamingClient } from '../../shared/clients/cod
 import { getClientId, getOptOutPreference, getOperatingSystem } from '../../shared/telemetry/util'
 import { extensionVersion } from '../../shared/vscode/env'
 
+// Re-enable once BE is able to handle retries.
+const writeAPIRetryOptions = {
+    maxRetries: 0,
+    retryDelayOptions: {
+        // The default number of milliseconds to use in the exponential backoff
+        base: 500,
+    },
+}
+
 // Create a client for featureDev proxy client based off of aws sdk v2
-export async function createFeatureDevProxyClient(): Promise<FeatureDevProxyClient> {
+export async function createFeatureDevProxyClient(options?: Partial<ServiceOptions>): Promise<FeatureDevProxyClient> {
     const bearerToken = await AuthUtil.instance.getBearerToken()
     const cwsprConfig = getCodewhispererConfig()
     return (await globals.sdkClientBuilder.createAwsService(
@@ -37,27 +46,22 @@ export async function createFeatureDevProxyClient(): Promise<FeatureDevProxyClie
             region: cwsprConfig.region,
             endpoint: cwsprConfig.endpoint,
             token: new Token({ token: bearerToken }),
-            // SETTING TO 0 FOR BETA. RE-ENABLE FOR RE-INVENT
-            maxRetries: 0,
-            retryDelayOptions: {
-                // The default number of milliseconds to use in the exponential backoff
-                base: 500,
-            },
+            ...options,
         } as ServiceOptions,
         undefined
     )) as FeatureDevProxyClient
 }
 
 export class FeatureDevClient {
-    public async getClient() {
+    public async getClient(options?: Partial<ServiceOptions>) {
         // Should not be stored for the whole session.
         // Client has to be reinitialized for each request so we always have a fresh bearerToken
-        return await createFeatureDevProxyClient()
+        return await createFeatureDevProxyClient(options)
     }
 
     public async createConversation() {
         try {
-            const client = await this.getClient()
+            const client = await this.getClient(writeAPIRetryOptions)
             getLogger().debug(`Executing createTaskAssistConversation with {}`)
             const { conversationId, $response } = await client.createTaskAssistConversation().promise()
             getLogger().debug(`${featureName}: Created conversation: %O`, {
@@ -82,7 +86,7 @@ export class FeatureDevClient {
 
     public async createUploadUrl(conversationId: string, contentChecksumSha256: string, contentLength: number) {
         try {
-            const client = await this.getClient()
+            const client = await this.getClient(writeAPIRetryOptions)
             const params = {
                 uploadContext: {
                     taskAssistPlanningUploadContext: {
@@ -119,7 +123,7 @@ export class FeatureDevClient {
 
     public async startCodeGeneration(conversationId: string, uploadId: string, message: string) {
         try {
-            const client = await this.getClient()
+            const client = await this.getClient(writeAPIRetryOptions)
             const params = {
                 conversationState: {
                     conversationId,


### PR DESCRIPTION
## Problem

- `/dev` conversation would got terminated by retry-able errors, since we disabled the default retry.

## Solution

- Re-enable the default to prevent `/dev` from terminated by transient/retry-able errors.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
