### PR TITLE
refactor(core): Remove trackPerformance from telemetry

### DIFF
--- a/packages/core/src/shared/performance/performance.ts
+++ b/packages/core/src/shared/performance/performance.ts
@@ -5,7 +5,6 @@
 
 import assert from 'assert'
 import { getLogger } from '../logger'
-import { isWeb } from '../extensionGlobals'
 
 interface PerformanceMetrics {
     /**
@@ -45,10 +44,6 @@ export class PerformanceTracker {
         | undefined
 
     constructor(private readonly name: string) {}
-
-    static enabled(name: string, trackPerformance: boolean): boolean {
-        return name === 'function_call' && trackPerformance && !isWeb()
-    }
 
     start() {
         this.#startPerformance = {

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -308,16 +308,6 @@
             "description": "The CPU architecture"
         },
         {
-            "name": "totalFileSizeInMB",
-            "type": "int",
-            "description": "The total size of all files being sent to Amazon Q"
-        },
-        {
-            "name": "totalFiles",
-            "type": "int",
-            "description": "The total number of files being sent to Amazon Q"
-        },
-        {
             "name": "traceId",
             "type": "string",
             "description": "The unique identifier of a trace"
@@ -1166,14 +1156,6 @@
                     "required": false
                 },
                 {
-                    "type": "totalFiles",
-                    "required": false
-                },
-                {
-                    "type": "totalFileSizeInMB",
-                    "required": false
-                },
-                {
                     "type": "architecture",
                     "required": false
                 },
@@ -1186,8 +1168,7 @@
                     "required": true
                 }
             ],
-            "passive": true,
-            "trackPerformance": true
+            "passive": true
         },
         {
             "name": "webview_load",

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -344,7 +344,6 @@ export async function collectFiles(
             }
 
             let totalSizeBytes = 0
-            let totalFiles = 0
             for (const rootPath of sourcePaths) {
                 const allFiles = await vscode.workspace.findFiles(
                     new vscode.RelativePattern(rootPath, '**'),
@@ -352,7 +351,6 @@ export async function collectFiles(
                 )
 
                 const files = respectGitIgnore ? await filterOutGitignoredFiles(rootPath, allFiles) : allFiles
-                totalFiles += files.length
 
                 for (const file of files) {
                     const relativePath = getWorkspaceRelativePath(file.fsPath, { workspaceFolders })
@@ -385,7 +383,6 @@ export async function collectFiles(
                     })
                 }
             }
-            span.record({ totalFiles, totalFileSizeInMB: totalSizeBytes / (1024 * 1024) })
             return storage
         },
         {

--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -14,7 +14,6 @@ import { sleep } from '../../../shared'
 import { withTelemetryContext } from '../../../shared/telemetry/util'
 import { SinonSandbox } from 'sinon'
 import sinon from 'sinon'
-import { stubPerformance } from '../../utilities/performance'
 import * as crypto from '../../../shared/crypto'
 
 describe('TelemetrySpan', function () {

--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -77,23 +77,6 @@ describe('TelemetrySpan', function () {
             { result: 'Succeeded', duration: 100 },
         ])
     })
-
-    it('records performance', function () {
-        const { expectedUserCpuUsage, expectedSystemCpuUsage, expectedHeapTotal } = stubPerformance(sandbox)
-        const span = new TelemetrySpan('function_call', {
-            emit: true,
-        })
-        span.start()
-        clock.tick(90)
-        span.stop()
-        assertTelemetry('function_call', {
-            userCpuUsage: expectedUserCpuUsage,
-            systemCpuUsage: expectedSystemCpuUsage,
-            heapTotal: expectedHeapTotal,
-            duration: 90,
-            result: 'Succeeded',
-        })
-    })
 })
 
 describe('TelemetryTracer', function () {
@@ -267,28 +250,6 @@ describe('TelemetryTracer', function () {
             assert.match(metric.awsRegion ?? '', /not-set|\w+-\w+-\d+/)
             assert.match(String(metric.duration) ?? '', /\d+/)
             assert.match(metric.requestId ?? '', /[a-z0-9-]+/)
-        })
-
-        it('records performance', function () {
-            clock = installFakeClock()
-            const { expectedUserCpuUsage, expectedSystemCpuUsage, expectedHeapTotal } = stubPerformance(sandbox)
-            tracer.run(
-                'function_call',
-                () => {
-                    clock?.tick(90)
-                },
-                {
-                    emit: true,
-                }
-            )
-
-            assertTelemetry('function_call', {
-                userCpuUsage: expectedUserCpuUsage,
-                systemCpuUsage: expectedSystemCpuUsage,
-                heapTotal: expectedHeapTotal,
-                duration: 90,
-                result: 'Succeeded',
-            })
         })
 
         describe('nested run()', function () {

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -301,8 +301,6 @@ describe('collectFiles', function () {
         )
 
         assertTelemetry('function_call', {
-            totalFiles: 8,
-            totalFileSizeInMB: 0.0002593994140625,
             functionName: 'collectFiles',
         })
     })


### PR DESCRIPTION
## Problem
- withPerformance was an experiment to see if we could correlate cpu/memory with number of files


## Solution
- Cpu usage/memory usage in the extension host is way too volitile so we might as well clean up this code


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
