### PR TITLE
fix(test): fix failing IAMPolicy check test

### DIFF
--- a/packages/core/src/test/awsService/accessanalyzer/iamPolicyChecks.test.ts
+++ b/packages/core/src/test/awsService/accessanalyzer/iamPolicyChecks.test.ts
@@ -19,6 +19,7 @@ import * as iamPolicyChecks from '../../../awsService/accessanalyzer/vue/iamPoli
 import * as vscode from 'vscode'
 import { IamPolicyChecksConstants } from '../../../awsService/accessanalyzer/vue/constants'
 import { FileSystem } from '../../../shared/fs/fs'
+import path from 'path'
 
 const defaultTerraformConfigPath = 'resources/policychecks-tf-default.yaml'
 let sandbox: sinon.SinonSandbox
@@ -29,7 +30,10 @@ describe('iamPolicyChecks', function () {
     it('IamPolicyChecksWebview built .vue source file path exists', async function () {
         assert.ok(
             await vscodeFs.existsFile(
-                globals.context.asAbsolutePath(`src/awsService/accessanalyzer/vue/iamPolicyChecks.vue`)
+                path.join(
+                    path.dirname(globals.context.extensionPath),
+                    `core/src/awsService/accessanalyzer/vue/iamPolicyChecks.vue`
+                )
             )
         )
     })


### PR DESCRIPTION
## Problem
There is a test from recent PR that is incorrect given current structure. Ex. https://github.com/aws/aws-toolkit-vscode/actions/runs/11149044046/job/30987024464

Using `globals.context.asAbsolutePath` will prepend `toolkit` to the path, whereas we want to look in `core` for this file. 

## Solution
- Manually construct the path to be checked. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
