### PR TITLE
refactor(urls): Remove isCloud9 from constants file

### DIFF
--- a/packages/core/src/awsService/apprunner/wizards/apprunnerCreateServiceWizard.ts
+++ b/packages/core/src/awsService/apprunner/wizards/apprunnerCreateServiceWizard.ts
@@ -14,11 +14,11 @@ import { AppRunnerImageRepositoryWizard } from './imageRepositoryWizard'
 import { AppRunnerCodeRepositoryWizard } from './codeRepositoryWizard'
 import { GitExtension } from '../../../shared/extensions/git'
 import { makeDeploymentButton } from './deploymentButton'
-import { apprunnerCreateServiceDocsUrl } from '../../../shared/constants'
 import { createExitPrompter } from '../../../shared/ui/common/exitPrompter'
 import { DefaultIamClient } from '../../../shared/clients/iamClient'
 import { DefaultEcrClient } from '../../../shared/clients/ecrClient'
 import { DefaultAppRunnerClient } from '../../../shared/clients/apprunnerClient'
+import { getAppRunnerCreateServiceDocUrl } from '../../../shared/extensionUtilities'
 
 const localize = nls.loadMessageBundle()
 
@@ -68,7 +68,7 @@ function createInstanceStep(): Prompter<AppRunner.InstanceConfiguration> {
 
     return picker.createQuickPick(items, {
         title: localize('AWS.apprunner.createService.selectInstanceConfig.title', 'Select instance configuration'),
-        buttons: createCommonButtons(apprunnerCreateServiceDocsUrl),
+        buttons: createCommonButtons(getAppRunnerCreateServiceDocUrl()),
     })
 }
 
@@ -92,7 +92,7 @@ function createSourcePrompter(
 
     return picker.createQuickPick([ecrPath, repositoryPath], {
         title: localize('AWS.apprunner.createService.sourceType.title', 'Select a source code location type'),
-        buttons: [autoDeployButton, ...createCommonButtons(apprunnerCreateServiceDocsUrl)],
+        buttons: [autoDeployButton, ...createCommonButtons(getAppRunnerCreateServiceDocUrl())],
     })
 }
 
@@ -137,7 +137,7 @@ export class CreateAppRunnerServiceWizard extends Wizard<AppRunner.CreateService
             input.createInputBox({
                 title: localize('AWS.apprunner.createService.name.title', 'Name your service'),
                 validateInput: validateName, // TODO: we can check if names match any already made services
-                buttons: createCommonButtons(apprunnerCreateServiceDocsUrl),
+                buttons: createCommonButtons(getAppRunnerCreateServiceDocUrl()),
             })
         )
 

--- a/packages/core/src/awsService/apprunner/wizards/codeRepositoryWizard.ts
+++ b/packages/core/src/awsService/apprunner/wizards/codeRepositoryWizard.ts
@@ -15,14 +15,10 @@ import { AppRunnerClient } from '../../../shared/clients/apprunnerClient'
 import { makeDeploymentButton } from './deploymentButton'
 import { createLabelQuickPick, createQuickPick, QuickPickPrompter } from '../../../shared/ui/pickerPrompter'
 import { createInputBox, InputBoxPrompter } from '../../../shared/ui/inputPrompter'
-import {
-    apprunnerConnectionHelpUrl,
-    apprunnerConfigHelpUrl,
-    apprunnerRuntimeHelpUrl,
-    apprunnerCreateServiceDocsUrl,
-} from '../../../shared/constants'
+import { apprunnerConnectionHelpUrl, apprunnerConfigHelpUrl, apprunnerRuntimeHelpUrl } from '../../../shared/constants'
 import { Wizard, WIZARD_BACK } from '../../../shared/wizards/wizard'
 import { openUrl } from '../../../shared/utilities/vsCodeUtils'
+import { getAppRunnerCreateServiceDocUrl } from '../../../shared/extensionUtilities'
 
 const localize = nls.loadMessageBundle()
 
@@ -140,7 +136,7 @@ function createPortPrompter(): InputBoxPrompter {
         validateInput: validatePort,
         title: localize('AWS.apprunner.createService.selectPort.title', 'Enter a port for the new service'),
         placeholder: 'Enter a port',
-        buttons: createCommonButtons(apprunnerCreateServiceDocsUrl),
+        buttons: createCommonButtons(getAppRunnerCreateServiceDocUrl()),
     })
 }
 
@@ -220,7 +216,7 @@ function createCodeRepositorySubForm(git: GitExtension): WizardForm<AppRunner.Co
     codeConfigForm.body.StartCommand.bindPrompter((state) => createStartCommandPrompter(state.Runtime!))
     codeConfigForm.body.Port.bindPrompter(createPortPrompter)
     codeConfigForm.body.RuntimeEnvironmentVariables.bindPrompter(() =>
-        createVariablesPrompter(createCommonButtons(apprunnerCreateServiceDocsUrl))
+        createVariablesPrompter(createCommonButtons(getAppRunnerCreateServiceDocUrl()))
     )
     // TODO: ask user if they would like to save their parameters into an App Runner config file
 

--- a/packages/core/src/awsService/apprunner/wizards/imageRepositoryWizard.ts
+++ b/packages/core/src/awsService/apprunner/wizards/imageRepositoryWizard.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
 import { AppRunner, IAM } from 'aws-sdk'
 import { createCommonButtons, QuickInputButton, QuickInputToggleButton } from '../../../shared/ui/buttons'
 import { toArrayAsync } from '../../../shared/utilities/collectionUtils'
@@ -21,8 +20,7 @@ import { makeDeploymentButton } from './deploymentButton'
 import { IamClient } from '../../../shared/clients/iamClient'
 import { createRolePrompter } from '../../../shared/ui/common/roles'
 import { getLogger } from '../../../shared/logger/logger'
-import { isCloud9 } from '../../../shared/extensionUtilities'
-import { apprunnerCreateServiceDocsUrl } from '../../../shared/constants'
+import { getAppRunnerCreateServiceDocUrl, isCloud9 } from '../../../shared/extensionUtilities'
 import { createExitPrompter } from '../../../shared/ui/common/exitPrompter'
 
 const localize = nls.loadMessageBundle()
@@ -162,7 +160,7 @@ function createPortPrompter(): Prompter<string> {
         validateInput: validatePort,
         title: localize('AWS.apprunner.createService.selectPort.title', 'Enter a port for the new service'),
         placeholder: 'Enter a port',
-        buttons: createCommonButtons(apprunnerCreateServiceDocsUrl),
+        buttons: createCommonButtons(getAppRunnerCreateServiceDocUrl()),
     })
 }
 
@@ -249,7 +247,7 @@ function createImageRepositorySubForm(
 
     form.ImageConfiguration.Port.bindPrompter(() => createPortPrompter())
     form.ImageConfiguration.RuntimeEnvironmentVariables.bindPrompter(() =>
-        createVariablesPrompter(createCommonButtons(apprunnerCreateServiceDocsUrl))
+        createVariablesPrompter(createCommonButtons(getAppRunnerCreateServiceDocUrl()))
     )
 
     return subform
@@ -262,7 +260,7 @@ export class AppRunnerImageRepositoryWizard extends Wizard<AppRunner.SourceConfi
         const createAccessRolePrompter = () => {
             return createRolePrompter(iamClient, {
                 title: localize('AWS.apprunner.createService.selectRole.title', 'Select a role to pull from ECR'),
-                helpUrl: vscode.Uri.parse(apprunnerCreateServiceDocsUrl),
+                helpUrl: getAppRunnerCreateServiceDocUrl(),
                 roleFilter: (role) => (role.AssumeRolePolicyDocument ?? '').includes(appRunnerEcrEntity),
                 createRole: createEcrRole.bind(undefined, iamClient),
             }).transform((resp) => resp.Arn)

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -16,8 +16,8 @@ import * as nls from 'vscode-nls'
 import globals, { initialize, isWeb } from './shared/extensionGlobals'
 import { join } from 'path'
 import { Commands } from './shared/vscode/commands2'
-import { documentationUrl, endpointsFileUrl, githubCreateIssueUrl, githubUrl } from './shared/constants'
-import { getIdeProperties, aboutExtension, isCloud9 } from './shared/extensionUtilities'
+import { endpointsFileUrl, githubCreateIssueUrl, githubUrl } from './shared/constants'
+import { getIdeProperties, aboutExtension, isCloud9, getDocUrl } from './shared/extensionUtilities'
 import { logAndShowError, logAndShowWebviewError } from './shared/utilities/logAndShowUtils'
 import { AuthStatus, telemetry } from './shared/telemetry/telemetry'
 import { openUrl } from './shared/utilities/vsCodeUtils'
@@ -149,7 +149,7 @@ export async function activateCommon(
         ),
         // register URLs in extension menu
         Commands.register(`aws.toolkit.help`, async () => {
-            void openUrl(vscode.Uri.parse(documentationUrl))
+            void openUrl(getDocUrl())
             telemetry.aws_help.emit()
         })
     )

--- a/packages/core/src/lambda/commands/createNewSamApp.ts
+++ b/packages/core/src/lambda/commands/createNewSamApp.ts
@@ -39,8 +39,12 @@ import { isTemplateTargetProperties } from '../../shared/sam/debugger/awsSamDebu
 import { TemplateTargetProperties } from '../../shared/sam/debugger/awsSamDebugConfiguration'
 import { openLaunchJsonFile } from '../../shared/sam/debugger/commands/addSamDebugConfiguration'
 import { waitUntil } from '../../shared/utilities/timeoutUtils'
-import { debugNewSamAppUrl, launchConfigDocUrl } from '../../shared/constants'
-import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
+import {
+    getIdeProperties,
+    getDebugNewSamAppDocUrl,
+    isCloud9,
+    getLaunchConfigDocUrl,
+} from '../../shared/extensionUtilities'
 import { execFileSync } from 'child_process'
 import { writeFile } from 'fs-extra'
 import { checklogs } from '../../shared/localizedText'
@@ -316,7 +320,7 @@ export async function createNewSamApplication(
                 )
                 .then(async (buttonText) => {
                     if (buttonText === helpText) {
-                        void openUrl(vscode.Uri.parse(launchConfigDocUrl))
+                        void openUrl(getLaunchConfigDocUrl())
                     }
                 })
         }
@@ -441,7 +445,7 @@ async function showCompletionNotification(appName: string, configs: string): Pro
     if (action === openJson) {
         await openLaunchJsonFile()
     } else if (action === learnMore) {
-        void openUrl(vscode.Uri.parse(debugNewSamAppUrl))
+        void openUrl(getDebugNewSamAppDocUrl())
     }
 }
 

--- a/packages/core/src/lambda/wizards/samDeployWizard.ts
+++ b/packages/core/src/lambda/wizards/samDeployWizard.ts
@@ -10,7 +10,6 @@ const localize = nls.loadMessageBundle()
 
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { samDeployDocUrl } from '../../shared/constants'
 import * as localizedText from '../../shared/localizedText'
 import { getLogger } from '../../shared/logger'
 import { createHelpButton } from '../../shared/ui/buttons'
@@ -35,7 +34,7 @@ import { minSamCliVersionForImageSupport } from '../../shared/sam/cli/samCliVali
 import { ExtContext } from '../../shared/extensions'
 import { validateBucketName } from '../../awsService/s3/util'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
-import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
+import { getIdeProperties, getSamDeployDocUrl, isCloud9 } from '../../shared/extensionUtilities'
 import { recentlyUsed } from '../../shared/localizedText'
 import globals from '../../shared/extensionGlobals'
 import { SamCliSettings } from '../../shared/sam/cli/samCliSettings'
@@ -252,7 +251,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
                 if (button === vscode.QuickInputButtons.Back) {
                     resolve(undefined)
                 } else if (button === this.helpButton) {
-                    void openUrl(vscode.Uri.parse(samDeployDocUrl))
+                    void openUrl(getSamDeployDocUrl())
                 }
             },
         })
@@ -292,7 +291,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
                         if (button === vscode.QuickInputButtons.Back) {
                             resolve(undefined)
                         } else if (button === this.helpButton) {
-                            void openUrl(vscode.Uri.parse(samDeployDocUrl))
+                            void openUrl(getSamDeployDocUrl())
                         }
                     },
                 })
@@ -336,7 +335,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
                         if (button === vscode.QuickInputButtons.Back) {
                             resolve(undefined)
                         } else if (button === this.helpButton) {
-                            void openUrl(vscode.Uri.parse(samDeployDocUrl))
+                            void openUrl(getSamDeployDocUrl())
                         }
                     },
                 })
@@ -385,7 +384,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
                 if (button === vscode.QuickInputButtons.Back) {
                     resolve(undefined)
                 } else if (button === this.helpButton) {
-                    void openUrl(vscode.Uri.parse(samDeployDocUrl))
+                    void openUrl(getSamDeployDocUrl())
                 }
             },
         })
@@ -459,7 +458,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
                 if (button === vscode.QuickInputButtons.Back) {
                     resolve(undefined)
                 } else if (button === this.helpButton) {
-                    void openUrl(vscode.Uri.parse(samDeployDocUrl))
+                    void openUrl(getSamDeployDocUrl())
                 } else if (button === createBucket) {
                     resolve([{ label: CREATE_NEW_BUCKET }])
                 } else if (button === enterBucket) {
@@ -515,7 +514,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
                 if (button === vscode.QuickInputButtons.Back) {
                     resolve(undefined)
                 } else if (button === this.helpButton) {
-                    void openUrl(vscode.Uri.parse(samDeployDocUrl))
+                    void openUrl(getSamDeployDocUrl())
                 } else if (bucketProps.buttonHandler) {
                     bucketProps.buttonHandler(button, inputBox, resolve, reject)
                 }
@@ -559,7 +558,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
                 if (button === vscode.QuickInputButtons.Back) {
                     resolve(undefined)
                 } else if (button === this.helpButton) {
-                    void openUrl(vscode.Uri.parse(samDeployDocUrl))
+                    void openUrl(getSamDeployDocUrl())
                 }
             },
         })
@@ -612,7 +611,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
                 if (button === vscode.QuickInputButtons.Back) {
                     resolve(undefined)
                 } else if (button === this.helpButton) {
-                    void openUrl(vscode.Uri.parse(samDeployDocUrl))
+                    void openUrl(getSamDeployDocUrl())
                 }
             },
         })

--- a/packages/core/src/lambda/wizards/samInitWizard.ts
+++ b/packages/core/src/lambda/wizards/samInitWizard.ts
@@ -10,7 +10,7 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import { SchemasDataProvider } from '../../eventSchemas/providers/schemasDataProvider'
 import { DefaultSchemaClient } from '../../shared/clients/schemaClient'
-import { eventBridgeSchemasDocUrl, samInitDocUrl } from '../../shared/constants'
+import { eventBridgeSchemasDocUrl } from '../../shared/constants'
 import {
     Architecture,
     createRuntimeQuickPick,
@@ -37,6 +37,7 @@ import { Region } from '../../shared/regions/endpoints'
 import { createCommonButtons } from '../../shared/ui/buttons'
 import { createExitPrompter } from '../../shared/ui/common/exitPrompter'
 import { getNonexistentFilename } from '../../shared/filesystemUtilities'
+import { getSamInitDocUrl } from '../../shared/extensionUtilities'
 
 const localize = nls.loadMessageBundle()
 
@@ -55,7 +56,7 @@ export interface CreateNewSamAppWizardForm {
 function createRuntimePrompter(samCliVersion: string): QuickPickPrompter<RuntimeAndPackage> {
     return createRuntimeQuickPick({
         showImageRuntimes: semver.gte(samCliVersion, minSamCliVersionForImageSupport),
-        buttons: createCommonButtons(samInitDocUrl),
+        buttons: createCommonButtons(getSamInitDocUrl()),
     })
 }
 
@@ -73,7 +74,7 @@ function createSamTemplatePrompter(
 
     return createQuickPick(items, {
         title: localize('AWS.samcli.initWizard.template.prompt', 'Select a SAM Application Template'),
-        buttons: createCommonButtons(samInitDocUrl),
+        buttons: createCommonButtons(getSamInitDocUrl()),
     })
 }
 
@@ -91,7 +92,7 @@ function createDependencyPrompter(currRuntime: Runtime): QuickPickPrompter<Depen
 
     return createLabelQuickPick(items, {
         title: localize('AWS.samcli.initWizard.dependencyManager.prompt', 'Select a Dependency Manager'),
-        buttons: createCommonButtons(samInitDocUrl),
+        buttons: createCommonButtons(getSamInitDocUrl()),
     })
 }
 
@@ -117,7 +118,7 @@ function createRegistryPrompter(region: string, credentials?: AWS.Credentials): 
 
     return createLabelQuickPick(items, {
         title: localize('AWS.samcli.initWizard.schemas.registry.prompt', 'Select a Registry'),
-        buttons: createCommonButtons(samInitDocUrl),
+        buttons: createCommonButtons(getSamInitDocUrl()),
     })
 }
 
@@ -179,7 +180,7 @@ function createNamePrompter(defaultValue: string): InputBoxPrompter {
     return createInputBox({
         value: defaultValue,
         title: localize('AWS.samcli.initWizard.name.prompt', 'Enter a name for your new application'),
-        buttons: createCommonButtons(samInitDocUrl),
+        buttons: createCommonButtons(getSamInitDocUrl()),
         validateInput: validateName,
     })
 }
@@ -187,7 +188,7 @@ function createNamePrompter(defaultValue: string): InputBoxPrompter {
 function createArchitecturePrompter(): QuickPickPrompter<Architecture> {
     return createLabelQuickPick<Architecture>([{ label: 'x86_64' }, { label: 'arm64' }], {
         title: localize('AWS.samcli.initWizard.architecture.prompt', 'Select an Architecture'),
-        buttons: createCommonButtons(samInitDocUrl),
+        buttons: createCommonButtons(getSamInitDocUrl()),
     })
 }
 
@@ -266,7 +267,7 @@ export class CreateNewSamAppWizard extends Wizard<CreateNewSamAppWizardForm> {
 
         this.form.location.bindPrompter(() =>
             createFolderPrompt(vscode.workspace.workspaceFolders ?? [], {
-                buttons: createCommonButtons(samInitDocUrl),
+                buttons: createCommonButtons(getSamInitDocUrl()),
                 title: localize('AWS.samInit.location.title', 'Select the folder for your new SAM application'),
                 browseFolderDetail: localize(
                     'AWS.samInit.location.detail',

--- a/packages/core/src/shared/constants.ts
+++ b/packages/core/src/shared/constants.ts
@@ -5,8 +5,6 @@
 
 import * as vscode from 'vscode'
 
-import { isCloud9 } from './extensionUtilities'
-
 export const profileSettingKey = 'profile'
 export const productName: string = 'aws-toolkit-vscode'
 
@@ -25,9 +23,12 @@ export const samTroubleshootingUrl = vscode.Uri.parse(
 )
 export const githubUrl: string = 'https://github.com/aws/aws-toolkit-vscode'
 export const githubCreateIssueUrl = `${githubUrl}/issues/new/choose`
-export const documentationUrl: string = isCloud9()
-    ? 'https://docs.aws.amazon.com/cloud9/latest/user-guide/toolkit-welcome.html'
-    : 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html'
+
+export const documentationUrl = {
+    cloud9: vscode.Uri.parse('https://docs.aws.amazon.com/cloud9/latest/user-guide/toolkit-welcome.html'),
+    toolkit: vscode.Uri.parse('https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html'),
+} as const
+
 /**
  * General help page to help users understand the different ways of connecting to AWS (AWS ID, IAM credentials, SSO).
  *
@@ -46,18 +47,29 @@ export const supportedLambdaRuntimesUrl: string =
     'https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html'
 export const createUrlForLambdaFunctionUrl = 'https://docs.aws.amazon.com/lambda/latest/dg/urls-configuration.html'
 // URLs for samInitWizard
-export const samInitDocUrl = vscode.Uri.parse(
-    isCloud9()
-        ? 'https://docs.aws.amazon.com/cloud9/latest/user-guide/serverless-apps-toolkit.html#sam-create'
-        : 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html#serverless-apps-create'
-)
-export const launchConfigDocUrl: string = isCloud9()
-    ? 'https://docs.aws.amazon.com/cloud9/latest/user-guide/sam-debug-config-ref.html'
-    : 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps-run-debug-config-ref.html'
+export const samInitDocUrl = {
+    cloud9: vscode.Uri.parse(
+        'https://docs.aws.amazon.com/cloud9/latest/user-guide/serverless-apps-toolkit.html#sam-create'
+    ),
+    toolkit: vscode.Uri.parse(
+        'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html#serverless-apps-create'
+    ),
+} as const
+export const launchConfigDocUrl = {
+    cloud9: vscode.Uri.parse('https://docs.aws.amazon.com/cloud9/latest/user-guide/sam-debug-config-ref.html'),
+    toolkit: vscode.Uri.parse(
+        'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps-run-debug-config-ref.html'
+    ),
+} as const
 // URLs for samDeployWizard
-export const samDeployDocUrl: string = isCloud9()
-    ? 'https://docs.aws.amazon.com/cloud9/latest/user-guide/serverless-apps-toolkit.html#deploy-serverless-app'
-    : 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html#serverless-apps-deploy'
+export const samDeployDocUrl = {
+    cloud9: vscode.Uri.parse(
+        'https://docs.aws.amazon.com/cloud9/latest/user-guide/serverless-apps-toolkit.html#deploy-serverless-app'
+    ),
+    toolkit: vscode.Uri.parse(
+        'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html#serverless-apps-deploy'
+    ),
+} as const
 export const lambdaFunctionUrlConfigUrl: string = 'https://docs.aws.amazon.com/lambda/latest/dg/urls-configuration.html'
 // URLs for "sam sync" wizard.
 export const samSyncUrl = vscode.Uri.parse(
@@ -92,9 +104,14 @@ export const ssmJson: string = 'ssm-json'
 export const ssmYaml: string = 'ssm-yaml'
 
 // URL for post-Create SAM App
-export const debugNewSamAppUrl: string = isCloud9()
-    ? 'https://docs.aws.amazon.com/cloud9/latest/user-guide/serverless-apps-toolkit.html#sam-run-debug'
-    : 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html#serverless-apps-debug'
+export const debugNewSamAppDocUrl = {
+    cloud9: vscode.Uri.parse(
+        'https://docs.aws.amazon.com/cloud9/latest/user-guide/serverless-apps-toolkit.html#sam-run-debug'
+    ),
+    toolkit: vscode.Uri.parse(
+        'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html#serverless-apps-debug'
+    ),
+} as const
 
 // URLs for ECS Exec
 export const ecsDocumentationUrl: string = 'https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html'
@@ -121,10 +138,12 @@ export const apprunnerConnectionHelpUrl =
 export const apprunnerConfigHelpUrl = 'https://docs.aws.amazon.com/apprunner/latest/dg/manage-configure.html'
 export const apprunnerRuntimeHelpUrl = 'https://docs.aws.amazon.com/apprunner/latest/dg/service-source-code.html'
 export const apprunnerPricingUrl = 'https://aws.amazon.com/apprunner/pricing/'
-export const apprunnerCreateServiceDocsUrl: string = isCloud9()
-    ? 'https://docs.aws.amazon.com/cloud9/latest/user-guide/creating-service-apprunner.html'
-    : 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/creating-service-apprunner.html'
-
+export const apprunnerCreateServiceDocUrl = {
+    cloud9: vscode.Uri.parse('https://docs.aws.amazon.com/cloud9/latest/user-guide/creating-service-apprunner.html'),
+    toolkit: vscode.Uri.parse(
+        'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/creating-service-apprunner.html'
+    ),
+} as const
 // URLs for S3
 // TODO: update docs to add the file viewer feature
 export const s3FileViewerHelpUrl = 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/s3.html'

--- a/packages/core/src/shared/debug/launchConfiguration.ts
+++ b/packages/core/src/shared/debug/launchConfiguration.ts
@@ -24,9 +24,9 @@ import * as pathutils from '../utilities/pathUtils'
 import { tryGetAbsolutePath } from '../utilities/workspaceUtils'
 import { getLogger } from '../logger'
 import { makeFailedWriteMessage, showViewLogsMessage } from '../utilities/messages'
-import { launchConfigDocUrl } from '../constants'
 import { openUrl } from '../utilities/vsCodeUtils'
 import globals from '../extensionGlobals'
+import { getLaunchConfigDocUrl } from '../extensionUtilities'
 
 const localize = nls.loadMessageBundle()
 
@@ -130,7 +130,7 @@ class DefaultDebugConfigSource implements DebugConfigurationSource {
             await showViewLogsMessage(makeFailedWriteMessage('launch.json'), 'error', [helpText]).then(
                 async (buttonText) => {
                     if (buttonText === helpText) {
-                        await openUrl(vscode.Uri.parse(launchConfigDocUrl))
+                        await openUrl(getLaunchConfigDocUrl())
                     }
                 }
             )

--- a/packages/core/src/shared/extensionUtilities.ts
+++ b/packages/core/src/shared/extensionUtilities.ts
@@ -15,6 +15,14 @@ import { extensionVersion, getCodeCatalystDevEnvId } from './vscode/env'
 import { DevSettings } from './settings'
 import globals from './extensionGlobals'
 import { once } from './utilities/functionUtils'
+import {
+    apprunnerCreateServiceDocUrl,
+    debugNewSamAppDocUrl,
+    documentationUrl,
+    launchConfigDocUrl,
+    samDeployDocUrl,
+    samInitDocUrl,
+} from './constants'
 
 const localize = nls.loadMessageBundle()
 
@@ -252,6 +260,28 @@ export function showWelcomeMessage(context: vscode.ExtensionContext): void {
         // swallow error and don't block extension load
         getLogger().error(err as Error)
     }
+}
+
+function _getDocumentationUrl(urls: { cloud9: vscode.Uri; toolkit: vscode.Uri }): vscode.Uri {
+    return isCloud9() ? urls.cloud9 : urls.toolkit
+}
+export function getDocUrl() {
+    return _getDocumentationUrl(documentationUrl)
+}
+export function getSamInitDocUrl() {
+    return _getDocumentationUrl(samInitDocUrl)
+}
+export function getLaunchConfigDocUrl() {
+    return _getDocumentationUrl(launchConfigDocUrl)
+}
+export function getSamDeployDocUrl() {
+    return _getDocumentationUrl(samDeployDocUrl)
+}
+export function getDebugNewSamAppDocUrl() {
+    return _getDocumentationUrl(debugNewSamAppDocUrl)
+}
+export function getAppRunnerCreateServiceDocUrl() {
+    return _getDocumentationUrl(apprunnerCreateServiceDocUrl)
 }
 
 /**

--- a/packages/core/src/shared/sam/sync.ts
+++ b/packages/core/src/shared/sam/sync.ts
@@ -26,7 +26,7 @@ import { telemetry } from '../telemetry/telemetry'
 import { createCommonButtons } from '../ui/buttons'
 import { ToolkitPromptSettings } from '../settings'
 import { getLogger } from '../logger'
-import { isCloud9 } from '../extensionUtilities'
+import { getSamInitDocUrl, isCloud9 } from '../extensionUtilities'
 import { removeAnsi } from '../utilities/textUtilities'
 import { createExitPrompter } from '../ui/common/exitPrompter'
 import { StackSummary } from 'aws-sdk/clients/cloudformation'
@@ -41,7 +41,7 @@ import { parse } from 'semver'
 import { isAutomation } from '../vscode/env'
 import { getOverriddenParameters } from '../../lambda/config/parameterUtils'
 import { addTelemetryEnvVar } from './cli/samCliInvokerUtils'
-import { samSyncUrl, samInitDocUrl, samUpgradeUrl, credentialHelpUrl } from '../constants'
+import { samSyncUrl, samUpgradeUrl, credentialHelpUrl } from '../constants'
 import { getAwsConsoleUrl } from '../awsConsole'
 import { openUrl } from '../utilities/vsCodeUtils'
 import { showMessageWithUrl, showOnce } from '../utilities/messages'
@@ -212,7 +212,7 @@ function createTemplatePrompter(registry: CloudFormationTemplateRegistry) {
         noItemsFoundItem: {
             label: localize('aws.sam.noWorkspace', 'No SAM template.yaml file(s) found. Select for help'),
             data: undefined,
-            onClick: () => openUrl(samInitDocUrl),
+            onClick: () => openUrl(getSamInitDocUrl()),
         },
     })
 }

--- a/packages/core/src/shared/ui/buttons.ts
+++ b/packages/core/src/shared/ui/buttons.ts
@@ -5,10 +5,9 @@
 
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
-import { documentationUrl } from '../constants'
 import { getIcon } from '../icons'
 import { WizardControl, WIZARD_EXIT, WIZARD_RETRY } from '../wizards/wizard'
-import { getIdeProperties } from '../extensionUtilities'
+import { getDocUrl, getIdeProperties } from '../extensionUtilities'
 import { openUrl } from '../utilities/vsCodeUtils'
 
 const localize = nls.loadMessageBundle()
@@ -32,7 +31,7 @@ export interface QuickInputButton<T> extends vscode.QuickInputButton {
  * @param tooltip Optional tooltip for button
  */
 export function createHelpButton(
-    uri: string | vscode.Uri = documentationUrl,
+    uri: string | vscode.Uri = getDocUrl(),
     tooltip: string = helpTooltip
 ): QuickInputLinkButton {
     const iconPath = getIcon('vscode-help')


### PR DESCRIPTION
We have some strings that need to resolve a url depending on c9 vs toolkit.

The isCloud9() function is causing issues in the constants file. Due to some sort of module import order, isCloud9() did not resolve appropriately when expected. I think we used the constants file before all the dependencies of the isCloud9() function were available

The constants file should be a minimal module with as little external dependencies as possible.

## Solution:

Move the resolution of c9 vs toolkit docs to an external function. Update uses everywhere.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
