### PR TITLE
feat(cwl): Initialize TailLogGroup command with Wizard

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/activation.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/activation.ts
@@ -91,13 +91,13 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
         Commands.register('aws.cwl.changeFilterPattern', async () => changeLogSearchParams(registry, 'filterPattern')),
 
         Commands.register('aws.cwl.changeTimeFilter', async () => changeLogSearchParams(registry, 'timeFilter')),
-    
+
         Commands.register('aws.cwl.tailLogGroup', async (node: LogGroupNode | CloudWatchLogsNode) => {
             const logGroupInfo =
                 node instanceof LogGroupNode
                     ? { regionName: node.regionCode, groupName: node.logGroup.logGroupName! }
                     : undefined
             await tailLogGroup(logGroupInfo)
-        }),
+        })
     )
 }

--- a/packages/core/src/awsService/cloudWatchLogs/activation.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/activation.ts
@@ -19,6 +19,7 @@ import { searchLogGroup } from './commands/searchLogGroup'
 import { changeLogSearchParams } from './changeLogSearch'
 import { CloudWatchLogsNode } from './explorer/cloudWatchLogsNode'
 import { loadAndOpenInitialLogStreamFile, LogStreamCodeLensProvider } from './document/logStreamsCodeLensProvider'
+import { tailLogGroup } from './commands/tailLogGroup'
 
 export async function activate(context: vscode.ExtensionContext, configuration: Settings): Promise<void> {
     const registry = LogDataRegistry.instance
@@ -89,6 +90,14 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
 
         Commands.register('aws.cwl.changeFilterPattern', async () => changeLogSearchParams(registry, 'filterPattern')),
 
-        Commands.register('aws.cwl.changeTimeFilter', async () => changeLogSearchParams(registry, 'timeFilter'))
+        Commands.register('aws.cwl.changeTimeFilter', async () => changeLogSearchParams(registry, 'timeFilter')),
+    
+        Commands.register('aws.cwl.tailLogGroup', async (node: LogGroupNode | CloudWatchLogsNode) => {
+            const logGroupInfo =
+                node instanceof LogGroupNode
+                    ? { regionName: node.regionCode, groupName: node.logGroup.logGroupName! }
+                    : undefined
+            await tailLogGroup(logGroupInfo)
+        }),
     )
 }

--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -1,0 +1,107 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+import { DefaultCloudWatchLogsClient } from '../../../shared/clients/cloudWatchLogsClient'
+import { createBackButton, createExitButton, createHelpButton } from '../../../shared/ui/buttons'
+import { createInputBox } from '../../../shared/ui/inputPrompter'
+import { DataQuickPickItem } from '../../../shared/ui/pickerPrompter'
+import { Wizard } from '../../../shared/wizards/wizard'
+import { CloudWatchLogsGroupInfo } from '../registry/logDataRegistry'
+import { RegionSubmenu, RegionSubmenuResponse } from '../../../shared/ui/common/regionSubmenu'
+import { CancellationError } from '../../../shared/utilities/timeoutUtils'
+import { LogStreamFilterResponse, LogStreamFilterSubmenu } from '../liveTailLogStreamSubmenu'
+import { getLogger } from '../../../shared'
+
+const localize = nls.loadMessageBundle()
+
+export interface TailLogGroupWizardResponse {
+    regionLogGroupSubmenuResponse: RegionSubmenuResponse<string>
+    logStreamFilter: LogStreamFilterResponse
+    filterPattern: string
+}
+
+export async function tailLogGroup(logData?: { regionName: string; groupName: string }): Promise<void> {
+    const wizard = new TailLogGroupWizard(logData)
+    const wizardResponse = await wizard.run()
+    if (!wizardResponse) {
+        throw new CancellationError('user')
+    }
+
+    //TODO: Remove Log. For testing while we aren't yet consuming the wizardResponse.
+    getLogger().info(JSON.stringify(wizardResponse))
+}
+
+export class TailLogGroupWizard extends Wizard<TailLogGroupWizardResponse> {
+    public constructor(logGroupInfo?: CloudWatchLogsGroupInfo) {
+        super({
+            initState: {
+                regionLogGroupSubmenuResponse: logGroupInfo
+                    ? {
+                          data: logGroupInfo.groupName,
+                          region: logGroupInfo.regionName,
+                      }
+                    : undefined,
+            },
+        })
+        this.form.regionLogGroupSubmenuResponse.bindPrompter(createRegionLogGroupSubmenu)
+        this.form.logStreamFilter.bindPrompter((state) => {
+            if (!state.regionLogGroupSubmenuResponse?.data) {
+                throw Error('LogGroupName is null')
+            }
+            return new LogStreamFilterSubmenu(
+                state.regionLogGroupSubmenuResponse.data,
+                state.regionLogGroupSubmenuResponse.region
+            )
+        })
+        this.form.filterPattern.bindPrompter((state) => createFilterPatternPrompter())
+    }
+}
+
+export function createRegionLogGroupSubmenu(): RegionSubmenu<string> {
+    return new RegionSubmenu(
+        getLogGroupQuickPickOptions,
+        {
+            title: localize('AWS.cwl.tailLogGroup.logGroupPromptTitle', 'Select Log Group to tail'),
+            buttons: [createExitButton()],
+        },
+        { title: localize('AWS.cwl.tailLogGroup.regionPromptTitle', 'Select Region for Log Group') },
+        'LogGroups'
+    )
+}
+
+async function getLogGroupQuickPickOptions(regionCode: string): Promise<DataQuickPickItem<string>[]> {
+    const client = new DefaultCloudWatchLogsClient(regionCode)
+    const logGroups = client.describeLogGroups()
+
+    const logGroupsOptions: DataQuickPickItem<string>[] = []
+
+    for await (const logGroupObject of logGroups) {
+        if (!logGroupObject.arn || !logGroupObject.logGroupName) {
+            throw Error('LogGroupObject name or arn undefined')
+        }
+
+        logGroupsOptions.push({
+            label: logGroupObject.logGroupName,
+            data: formatLogGroupArn(logGroupObject.arn),
+        })
+    }
+
+    return logGroupsOptions
+}
+
+function formatLogGroupArn(logGroupArn: string): string {
+    return logGroupArn.endsWith(':*') ? logGroupArn.substring(0, logGroupArn.length - 2) : logGroupArn
+}
+
+export function createFilterPatternPrompter() {
+    const helpUri = 'https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html'
+    return createInputBox({
+        title: 'Provide log event filter pattern',
+        placeholder: 'filter pattern (case sensitive; empty matches all)',
+        prompt: 'Optional pattern to use to filter the results to include only log events that match the pattern.',
+        buttons: [createHelpButton(helpUri), createBackButton(), createExitButton()],
+    })
+}

--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -13,7 +13,8 @@ import { CloudWatchLogsGroupInfo } from '../registry/logDataRegistry'
 import { RegionSubmenu, RegionSubmenuResponse } from '../../../shared/ui/common/regionSubmenu'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import { LogStreamFilterResponse, LogStreamFilterSubmenu } from '../liveTailLogStreamSubmenu'
-import { getLogger } from '../../../shared'
+import { getLogger, ToolkitError } from '../../../shared'
+import { cwlFilterPatternHelpUrl } from '../../../shared/constants'
 
 const localize = nls.loadMessageBundle()
 
@@ -49,7 +50,7 @@ export class TailLogGroupWizard extends Wizard<TailLogGroupWizardResponse> {
         this.form.regionLogGroupSubmenuResponse.bindPrompter(createRegionLogGroupSubmenu)
         this.form.logStreamFilter.bindPrompter((state) => {
             if (!state.regionLogGroupSubmenuResponse?.data) {
-                throw Error('LogGroupName is null')
+                throw new ToolkitError('LogGroupName is null')
             }
             return new LogStreamFilterSubmenu(
                 state.regionLogGroupSubmenuResponse.data,
@@ -80,7 +81,7 @@ async function getLogGroupQuickPickOptions(regionCode: string): Promise<DataQuic
 
     for await (const logGroupObject of logGroups) {
         if (!logGroupObject.arn || !logGroupObject.logGroupName) {
-            throw Error('LogGroupObject name or arn undefined')
+            throw new ToolkitError('LogGroupObject name or arn undefined')
         }
 
         logGroupsOptions.push({
@@ -97,7 +98,7 @@ function formatLogGroupArn(logGroupArn: string): string {
 }
 
 export function createFilterPatternPrompter() {
-    const helpUri = 'https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html'
+    const helpUri = cwlFilterPatternHelpUrl
     return createInputBox({
         title: 'Provide log event filter pattern',
         placeholder: 'filter pattern (case sensitive; empty matches all)',

--- a/packages/core/src/awsService/cloudWatchLogs/liveTailLogStreamSubmenu.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/liveTailLogStreamSubmenu.ts
@@ -1,0 +1,168 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Prompter, PromptResult } from '../../shared/ui/prompter'
+import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogsClient'
+import { createCommonButtons } from '../../shared/ui/buttons'
+import { createInputBox, InputBoxPrompter } from '../../shared/ui/inputPrompter'
+import { createQuickPick, DataQuickPickItem, QuickPickPrompter } from '../../shared/ui/pickerPrompter'
+import { pageableToCollection } from '../../shared/utilities/collectionUtils'
+import { CloudWatchLogs } from 'aws-sdk'
+import { isValidResponse, StepEstimator } from '../../shared/wizards/wizard'
+import { isNonNullable } from '../../shared/utilities/tsUtils'
+
+export enum LogStreamFilterType {
+    MENU = 'menu',
+    PREFIX = 'prefix',
+    SPECIFIC = 'specific',
+    ALL = 'all',
+}
+
+export interface LogStreamFilterResponse {
+    readonly filter?: string
+    readonly type: LogStreamFilterType
+}
+
+export class LogStreamFilterSubmenu extends Prompter<LogStreamFilterResponse> {
+    private logStreamPrefixRegEx = /^[^:*]*$/
+    private currentState: LogStreamFilterType = LogStreamFilterType.MENU
+    private steps?: [current: number, total: number]
+    private region: string
+    private logGroupArn: string
+    public defaultPrompter: QuickPickPrompter<LogStreamFilterType> = this.createMenuPrompter()
+
+    public constructor(logGroupArn: string, region: string) {
+        super()
+        this.region = region
+        this.logGroupArn = logGroupArn
+    }
+
+    public createMenuPrompter() {
+        const helpUri = 'https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartLiveTail.html'
+        const prompter = createQuickPick(this.menuOptions, {
+            title: 'Select LogStream filter type',
+            buttons: createCommonButtons(helpUri),
+        })
+        return prompter
+    }
+
+    private get menuOptions(): DataQuickPickItem<LogStreamFilterType>[] {
+        const options: DataQuickPickItem<LogStreamFilterType>[] = []
+        options.push({
+            label: 'All',
+            detail: 'Include log events from all LogStreams in the selected LogGroup',
+            data: LogStreamFilterType.ALL,
+        })
+        options.push({
+            label: 'Specific',
+            detail: 'Include log events from only a specific LogStream',
+            data: LogStreamFilterType.SPECIFIC,
+        })
+        options.push({
+            label: 'Prefix',
+            detail: 'Include log events from LogStreams that begin with a provided prefix',
+            data: LogStreamFilterType.PREFIX,
+        })
+        return options
+    }
+
+    public createLogStreamPrefixBox(): InputBoxPrompter {
+        const helpUri =
+            'https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartLiveTail.html#CWL-StartLiveTail-request-logStreamNamePrefixes'
+        return createInputBox({
+            title: 'Enter LogStream prefix',
+            placeholder: 'logStream prefix (case sensitive; empty matches all)',
+            prompt: 'Only log events in the LogStreams that have names that start with the prefix that you specify here are included in the Live Tail session',
+            validateInput: (input) => this.validateLogStreamPrefix(input),
+            buttons: createCommonButtons(helpUri),
+        })
+    }
+
+    public validateLogStreamPrefix(prefix: string) {
+        if (prefix.length > 512) {
+            return 'LogStream prefix cannot be longer than 512 characters'
+        }
+
+        if (!this.logStreamPrefixRegEx.test(prefix)) {
+            return 'LogStream prefix must match pattern: [^:*]*'
+        }
+    }
+
+    public createLogStreamSelector(): QuickPickPrompter<string> {
+        const helpUri =
+            'https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartLiveTail.html#CWL-StartLiveTail-request-logStreamNames'
+        const client = new DefaultCloudWatchLogsClient(this.region)
+        const request: CloudWatchLogs.DescribeLogStreamsRequest = {
+            logGroupIdentifier: this.logGroupArn,
+            orderBy: 'LastEventTime',
+            descending: true,
+        }
+        const requester = (request: CloudWatchLogs.DescribeLogStreamsRequest) => client.describeLogStreams(request)
+        const collection = pageableToCollection(requester, request, 'nextToken', 'logStreams')
+
+        const items = collection
+            .filter(isNonNullable)
+            .map((streams) => streams!.map((stream) => ({ data: stream.logStreamName!, label: stream.logStreamName! })))
+
+        return createQuickPick(items, {
+            title: 'Select LogStream',
+            buttons: createCommonButtons(helpUri),
+        })
+    }
+
+    private switchState(newState: LogStreamFilterType) {
+        this.currentState = newState
+    }
+
+    protected async promptUser(): Promise<PromptResult<LogStreamFilterResponse>> {
+        while (true) {
+            switch (this.currentState) {
+                case LogStreamFilterType.MENU: {
+                    const prompter = this.createMenuPrompter()
+                    this.steps && prompter.setSteps(this.steps[0], this.steps[1])
+
+                    const resp = await prompter.prompt()
+                    if (resp === LogStreamFilterType.PREFIX) {
+                        this.switchState(LogStreamFilterType.PREFIX)
+                    } else if (resp === LogStreamFilterType.SPECIFIC) {
+                        this.switchState(LogStreamFilterType.SPECIFIC)
+                    } else if (resp === LogStreamFilterType.ALL) {
+                        return { filter: undefined, type: resp }
+                    } else {
+                        return undefined
+                    }
+
+                    break
+                }
+                case LogStreamFilterType.PREFIX: {
+                    const resp = await this.createLogStreamPrefixBox().prompt()
+                    if (isValidResponse(resp)) {
+                        return { filter: resp, type: LogStreamFilterType.PREFIX }
+                    }
+                    this.switchState(LogStreamFilterType.MENU)
+                    break
+                }
+                case LogStreamFilterType.SPECIFIC: {
+                    const resp = await this.createLogStreamSelector().prompt()
+                    if (isValidResponse(resp)) {
+                        return { filter: resp, type: LogStreamFilterType.SPECIFIC }
+                    }
+                    this.switchState(LogStreamFilterType.MENU)
+                    break
+                }
+            }
+        }
+    }
+
+    public setSteps(current: number, total: number): void {
+        this.steps = [current, total]
+    }
+
+    // Unused
+    public get recentItem(): any {
+        return
+    }
+    public set recentItem(response: any) {}
+    public setStepEstimator(estimator: StepEstimator<LogStreamFilterResponse>): void {}
+}

--- a/packages/core/src/shared/constants.ts
+++ b/packages/core/src/shared/constants.ts
@@ -113,6 +113,14 @@ export const ecsIamPermissionsUrl = vscode.Uri.parse(
 export const CLOUDWATCH_LOGS_SCHEME = 'aws-cwl' // eslint-disable-line @typescript-eslint/naming-convention
 export const AWS_SCHEME = 'aws' // eslint-disable-line @typescript-eslint/naming-convention
 
+export const startLiveTailHelpUrl =
+    'https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartLiveTail.html'
+export const startLiveTailLogStreamPrefixHelpUrl = `${startLiveTailHelpUrl}#CWL-StartLiveTail-request-logStreamNamePrefixes`
+export const startLiveTailLogStreamNamesHelpUrl = `${startLiveTailHelpUrl}#CWL-StartLiveTail-request-logStreamNames`
+
+export const cwlFilterPatternHelpUrl =
+    'https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html'
+
 export const lambdaPackageTypeImage = 'Image'
 
 // URLs for App Runner

--- a/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TailLogGroupWizard } from '../../../../awsService/cloudWatchLogs/commands/tailLogGroup'
+import { createWizardTester } from '../../../shared/wizards/wizardTestUtils'
+
+describe('TailLogGroupWizard', async function () {
+    it('prompts regionLogGroup submenu first if context not provided', async function () {
+        const wizard = new TailLogGroupWizard()
+        const tester = await createWizardTester(wizard)
+        tester.regionLogGroupSubmenuResponse.assertShowFirst()
+        tester.logStreamFilter.assertShowSecond()
+        tester.filterPattern.assertShowThird()
+    })
+
+    it('skips regionLogGroup submenu if context provided', async function () {
+        const wizard = new TailLogGroupWizard({
+            groupName: 'test-groupName',
+            regionName: 'test-regionName',
+        })
+        const tester = await createWizardTester(wizard)
+        tester.regionLogGroupSubmenuResponse.assertDoesNotShow()
+        tester.logStreamFilter.assertShowFirst()
+        tester.filterPattern.assertShowSecond()
+    })
+})

--- a/packages/core/src/test/awsService/cloudWatchLogs/liveTailLogStreamSubmenu.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/liveTailLogStreamSubmenu.test.ts
@@ -1,0 +1,74 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { LogStreamFilterSubmenu } from '../../../awsService/cloudWatchLogs/liveTailLogStreamSubmenu'
+import { createQuickPickPrompterTester, QuickPickPrompterTester } from '../../shared/ui/testUtils'
+import { getTestWindow } from '../../shared/vscode/window'
+
+describe('liveTailLogStreamSubmenu', async function () {
+    let logStreamFilterSubmenu: LogStreamFilterSubmenu
+    let logStreamMenuPrompter: QuickPickPrompterTester<any>
+    const testRegion = 'us-east-1'
+    const testLogGroupArn = 'my-log-group-arn'
+
+    beforeEach(async function () {
+        logStreamFilterSubmenu = new LogStreamFilterSubmenu(testRegion, testLogGroupArn)
+        logStreamMenuPrompter = createQuickPickPrompterTester(logStreamFilterSubmenu.defaultPrompter)
+    })
+
+    describe('Menu prompter', async function () {
+        it('gives option for each filter type', async function () {
+            logStreamMenuPrompter.assertContainsItems('All', 'Specific', 'Prefix')
+            logStreamMenuPrompter.acceptItem('All')
+            await logStreamMenuPrompter.result()
+        })
+    })
+
+    describe('LogStream Prefix Submenu', function () {
+        it('accepts valid input', async function () {
+            const validInput = 'my-log-stream'
+            getTestWindow().onDidShowInputBox((input) => {
+                input.acceptValue(validInput)
+            })
+            const inputBox = logStreamFilterSubmenu.createLogStreamPrefixBox()
+            const result = inputBox.prompt()
+            assert.strictEqual(await result, validInput)
+        })
+
+        it('rejects invalid input (:)', async function () {
+            const invalidInput = 'my-log-stream:'
+            getTestWindow().onDidShowInputBox((input) => {
+                input.acceptValue(invalidInput)
+                assert.deepEqual(input.validationMessage, 'LogStream prefix must match pattern: [^:*]*')
+                input.hide()
+            })
+            const inputBox = logStreamFilterSubmenu.createLogStreamPrefixBox()
+            await inputBox.prompt()
+        })
+
+        it('rejects invalid input (*)', async function () {
+            const invalidInput = 'my-log-stream*'
+            getTestWindow().onDidShowInputBox((input) => {
+                input.acceptValue(invalidInput)
+                assert.deepEqual(input.validationMessage, 'LogStream prefix must match pattern: [^:*]*')
+                input.hide()
+            })
+            const inputBox = logStreamFilterSubmenu.createLogStreamPrefixBox()
+            await inputBox.prompt()
+        })
+
+        it('rejects invalid input (length)', async function () {
+            const invalidInput = 'a'.repeat(520)
+            getTestWindow().onDidShowInputBox((input) => {
+                input.acceptValue(invalidInput)
+                assert.deepEqual(input.validationMessage, 'LogStream prefix cannot be longer than 512 characters')
+                input.hide()
+            })
+            const inputBox = logStreamFilterSubmenu.createLogStreamPrefixBox()
+            await inputBox.prompt()
+        })
+    })
+})

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1731,6 +1731,16 @@
                     "when": "view == aws.explorer && viewItem =~ /^awsCloudWatchLogNode|awsCloudWatchLogParentNode$/"
                 },
                 {
+                    "command": "aws.cwl.tailLogGroup",
+                    "group": "0@1",
+                    "when": "view == aws.explorer && viewItem =~ /^awsCloudWatchLogNode|awsCloudWatchLogParentNode$/"
+                },
+                {
+                    "command": "aws.cwl.tailLogGroup",
+                    "group": "inline@1",
+                    "when": "view == aws.explorer && viewItem =~ /^awsCloudWatchLogNode|awsCloudWatchLogParentNode$/"
+                },
+                {
                     "command": "aws.apig.copyUrl",
                     "when": "view == aws.explorer && viewItem =~ /^(awsApiGatewayNode)$/",
                     "group": "2@0"
@@ -3117,6 +3127,18 @@
                 "category": "%AWS.title%",
                 "enablement": "isCloud9 || !aws.isWebExtHost",
                 "icon": "$(search-view-icon)",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.cwl.tailLogGroup",
+                "title": "%AWS.command.cloudWatchLogs.tailLogGroup%",
+                "category": "%AWS.title%",
+                "enablement": "isCloud9 || !aws.isWebExtHost",
+                "icon": "$(notebook-execute)",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"


### PR DESCRIPTION
## Problem
CWL is planning on supporting a LiveTail experience in AWSToolkit for VSCode

## Solution
Registers `aws.cwl.tailLogGroup` as a recognized command in AWS Toolkit. 
In this PR, running this command will simply take the user through a Wizard to collect the configuration for the tailing session, and logs it.

In follow up PRs, I will take this Wizard input and use it to call CWL APIs and output streamed LogEvents to a TextDocument. 

This command will be able to be executed in the command pallet, or by pressing a "play button" icon when viewing LogGroups in the CloudWatch Logs explorer menu. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
