### PR TITLE
fix(test): fix failing integ tests. 

### DIFF
--- a/packages/core/src/stepFunctions/utils.ts
+++ b/packages/core/src/stepFunctions/utils.ts
@@ -69,8 +69,8 @@ export class StateMachineGraphCache {
             })
         this.writeFile =
             writeFileCustom ??
-            (async (path: string, data: string, encoding: string) => {
-                await fs.writeFile(path, data, { mode: encoding })
+            (async (path: string, data: string, _encoding: string) => {
+                await fs.writeFile(path, data)
             })
         this.logger = getLogger()
         this.getFileData = getFileData ?? httpsGetRequestWrapper


### PR DESCRIPTION
## Problem
In the recent refactor (https://github.com/aws/aws-toolkit-vscode/pull/5689), there is a mismatch in args between our fs and fs-extra. Not caught until integ tests were run. 

## Solution
have default write file method ignores encoding since it uses utf8 anyway. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
