### PR TITLE
refactor(amazonq): Remove collectFiles instrumentation

### DIFF
--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1158,22 +1158,6 @@
             "description": "Represents a function call. In most cases this should wrap code with a run(), then you can add context.",
             "metadata": [
                 {
-                    "type": "userCpuUsage",
-                    "required": false
-                },
-                {
-                    "type": "systemCpuUsage",
-                    "required": false
-                },
-                {
-                    "type": "architecture",
-                    "required": false
-                },
-                {
-                    "type": "heapTotal",
-                    "required": false
-                },
-                {
                     "type": "functionName",
                     "required": true
                 },

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -18,7 +18,7 @@ import {
 import { getTestWorkspaceFolder } from '../../integrationTestsUtilities'
 import globals from '../../../shared/extensionGlobals'
 import { CodelensRootRegistry } from '../../../shared/fs/codelensRootRegistry'
-import { assertTelemetry, createTestWorkspace, createTestWorkspaceFolder, toFile } from '../../../test/testUtil'
+import { createTestWorkspace, createTestWorkspaceFolder, toFile } from '../../../test/testUtil'
 import sinon from 'sinon'
 import { performanceTest } from '../../../shared/performance/performance'
 import { randomUUID } from '../../../shared/crypto'
@@ -299,10 +299,6 @@ describe('collectFiles', function () {
             ] satisfies typeof result,
             result
         )
-
-        assertTelemetry('function_call', {
-            functionName: 'collectFiles',
-        })
     })
 
     it('does not return license files', async function () {


### PR DESCRIPTION
## Problem
- Follow up on the previous remove trackPerformance PR, we no longer need collectFiles telemetry since the data isn't reliable in the extension host
- integ tests are failing because of this


## Solution
- Remove the instrumentation

