### PR TITLE
fix(test): rebase test w/ new telemetry

### DIFF
--- a/packages/core/src/test/amazonqFeatureDev/prepareRepoData.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/prepareRepoData.test.ts
@@ -7,7 +7,8 @@ import { WorkspaceFolder } from 'vscode'
 import { performanceTest } from '../../shared/performance/performance'
 import { createTestWorkspace } from '../testUtil'
 import { prepareRepoData, TelemetryHelper } from '../../amazonqFeatureDev'
-import { AmazonqCreateUpload, getRandomString, Metric } from '../../shared'
+import { AmazonqCreateUpload, getRandomString } from '../../shared'
+import { Span } from '../../shared/telemetry'
 
 type resultType = {
     zipFileBuffer: Buffer
@@ -48,7 +49,7 @@ function performanceTestWrapper(numFiles: number, fileSize: number) {
                 execute: async (workspace: WorkspaceFolder) => {
                     return await prepareRepoData([workspace.uri.fsPath], [workspace], telemetry, {
                         record: () => {},
-                    } as unknown as Metric<AmazonqCreateUpload>)
+                    } as unknown as Span<AmazonqCreateUpload>)
                 },
                 verify: async (_w: WorkspaceFolder, result: resultType) => {
                     verifyResult(result, telemetry, numFiles * fileSize)


### PR DESCRIPTION
## Problem
Last PR: https://github.com/aws/aws-toolkit-vscode/pull/5670 was not rebased onto https://github.com/aws/aws-toolkit-vscode/commit/a386cc389787e385db82924b4fa8ce94b04dfe4a, so did not include relevant telemetry changes. Therefore tests passed until the merge happened. 

## Solution
change type signature to reflect telemetry changes. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
