### PR TITLE
fix(startup): Q may fail if Toolkit fails

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-3f76aff8-1622-4647-aafe-3210cf0c3b74.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-3f76aff8-1622-4647-aafe-3210cf0c3b74.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q extension may fail to start if AWS Toolkit extension fails to start"
+}

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -462,7 +462,7 @@ export const registerToolkitApiCallback = Commands.declare(
             } else if (isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)) {
                 // when this command is executed by Amazon Q activation
                 const toolkitExt = vscode.extensions.getExtension(VSCODE_EXTENSION_ID.awstoolkit)
-                _toolkitApi = toolkitExt?.exports.getApi(VSCODE_EXTENSION_ID.amazonq)
+                _toolkitApi = toolkitExt?.exports?.getApi(VSCODE_EXTENSION_ID.amazonq)
             }
             if (_toolkitApi) {
                 registerToolkitApiCallbackOnce()

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -45,7 +45,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
         }
         await activateExtension(VSCODE_EXTENSION_ID.awstoolkit)
         const toolkitExt = vscode.extensions.getExtension(VSCODE_EXTENSION_ID.awstoolkit)
-        const importedApi = toolkitExt?.exports.getApi(VSCODE_EXTENSION_ID.amazonq)
+        const importedApi = toolkitExt?.exports?.getApi(VSCODE_EXTENSION_ID.amazonq)
         if (importedApi && 'listConnections' in importedApi) {
             return ((await importedApi?.listConnections()) as AwsConnection[]).filter(
                 // No need to display Builder ID as an existing connection,

--- a/packages/core/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/packages/core/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -21,15 +21,6 @@ import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { getConfigFilename, getCredentialsFilename } from '../../../auth/credentials/sharedCredentialsFile'
 import { fs } from '../../../shared'
 
-/** Async version of "doesNotThrow" */
-async function assertDoesNotThrow(fn: () => Promise<void>): Promise<void> {
-    try {
-        await fn()
-    } catch (err) {
-        assert.fail(`Provided function threw error ${err}`)
-    }
-}
-
 describe('UserCredentialsUtils', function () {
     let tempFolder: string
     let defaultConfigFileName: string
@@ -151,8 +142,8 @@ describe('UserCredentialsUtils', function () {
                 `creds.secretKey: "${profile.aws_access_key_id}" !== "${creds.secretKey}"`
             )
 
-            await assertDoesNotThrow(async () => await fs.checkPerms(credentialsFilename, 'r--'))
-            await assertDoesNotThrow(async () => await fs.checkPerms(credentialsFilename, '-w-'))
+            await assert.doesNotReject(async () => await fs.checkPerms(credentialsFilename, 'r--'))
+            await assert.doesNotReject(async () => await fs.checkPerms(credentialsFilename, '-w-'))
         })
     })
 


### PR DESCRIPTION
Problem:
If Toolkit fails to start, then Q will also fail to start:

    2024-10-01 09:56:13.188 [error] aws.amazonq.refreshConnectionCallback: [
      [TypeError: Cannot read properties of undefined (reading 'getApi')
      at c:\…\dist\src\extensionNode.js:6093:284

Solution:
Check for undefined `exports`.