### PR TITLE
fix(telemetry): Crash monitoring fixes

### DIFF
--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -32,7 +32,7 @@ export async function activate(context: vscode.ExtensionContext) {
  * the code compatible with web and move it to {@link activateAmazonQCommon}.
  */
 async function activateAmazonQNode(context: vscode.ExtensionContext) {
-    await (await CrashMonitoring.instance()).start()
+    await (await CrashMonitoring.instance())?.start()
 
     const extContext = {
         extensionContext: context,
@@ -96,5 +96,5 @@ async function setupDevMode(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
     // Run concurrently to speed up execution. stop() does not throw so it is safe
-    await Promise.all([(await CrashMonitoring.instance()).stop(), deactivateCommon()])
+    await Promise.all([(await CrashMonitoring.instance())?.stop(), deactivateCommon()])
 }

--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -32,7 +32,8 @@ export async function activate(context: vscode.ExtensionContext) {
  * the code compatible with web and move it to {@link activateAmazonQCommon}.
  */
 async function activateAmazonQNode(context: vscode.ExtensionContext) {
-    await (await CrashMonitoring.instance())?.start()
+    // Intentionally do not await since this is slow and non-critical
+    void (await CrashMonitoring.instance())?.start()
 
     const extContext = {
         extensionContext: context,

--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -97,5 +97,5 @@ async function setupDevMode(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
     // Run concurrently to speed up execution. stop() does not throw so it is safe
-    await Promise.all([(await CrashMonitoring.instance())?.stop(), deactivateCommon()])
+    await Promise.all([(await CrashMonitoring.instance())?.shutdown(), deactivateCommon()])
 }

--- a/packages/core/src/extensionNode.ts
+++ b/packages/core/src/extensionNode.ts
@@ -255,7 +255,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
     // Run concurrently to speed up execution. stop() does not throw so it is safe
-    await Promise.all([await (await CrashMonitoring.instance())?.stop(), deactivateCommon()])
+    await Promise.all([await (await CrashMonitoring.instance())?.shutdown(), deactivateCommon()])
     await globals.resourceManager.dispose()
 }
 

--- a/packages/core/src/extensionNode.ts
+++ b/packages/core/src/extensionNode.ts
@@ -78,7 +78,7 @@ export async function activate(context: vscode.ExtensionContext) {
         // IMPORTANT: If you are doing setup that should also work in web mode (browser), it should be done in the function below
         const extContext = await activateCommon(context, contextPrefix, false)
 
-        await (await CrashMonitoring.instance()).start()
+        await (await CrashMonitoring.instance())?.start()
 
         initializeCredentialsProviderManager()
 
@@ -254,7 +254,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
     // Run concurrently to speed up execution. stop() does not throw so it is safe
-    await Promise.all([await (await CrashMonitoring.instance()).stop(), deactivateCommon()])
+    await Promise.all([await (await CrashMonitoring.instance())?.stop(), deactivateCommon()])
     await globals.resourceManager.dispose()
 }
 

--- a/packages/core/src/extensionNode.ts
+++ b/packages/core/src/extensionNode.ts
@@ -78,7 +78,8 @@ export async function activate(context: vscode.ExtensionContext) {
         // IMPORTANT: If you are doing setup that should also work in web mode (browser), it should be done in the function below
         const extContext = await activateCommon(context, contextPrefix, false)
 
-        await (await CrashMonitoring.instance())?.start()
+        // Intentionally do not await since this can be slow and non-critical
+        void (await CrashMonitoring.instance())?.start()
 
         initializeCredentialsProviderManager()
 

--- a/packages/core/src/shared/crashMonitoring.ts
+++ b/packages/core/src/shared/crashMonitoring.ts
@@ -205,6 +205,11 @@ class Heartbeat {
             await this.state.clearHeartbeat()
         } catch {}
     }
+
+    /** Mimics a crash, only for testing */
+    public testCrash() {
+        globals.clock.clearInterval(this.intervalRef)
+    }
 }
 
 /**
@@ -312,8 +317,13 @@ class CrashChecker {
         }
     }
 
-    /** Use this on failures */
+    /** Use this on failures to terminate the crash checker */
     public cleanup() {
+        globals.clock.clearInterval(this.intervalRef)
+    }
+
+    /** Mimics a crash, only for testing */
+    public testCrash() {
         globals.clock.clearInterval(this.intervalRef)
     }
 }

--- a/packages/core/src/shared/crashMonitoring.ts
+++ b/packages/core/src/shared/crashMonitoring.ts
@@ -492,7 +492,11 @@ export class FileSystemState {
         return p
     }
     public async clearState(): Promise<void> {
-        await withFailCtx('clearState', async () => fs.delete(this.stateDirPath, { force: true }))
+        this.deps.devLogger?.debug('crashMonitoring: CLEAR_STATE: Started')
+        await withFailCtx('clearState', async () => {
+            await fs.delete(this.stateDirPath, { force: true, recursive: true })
+            this.deps.devLogger?.debug('crashMonitoring: CLEAR_STATE: Succeeded')
+        })
     }
     public async getAllExts(): Promise<ExtInstanceHeartbeat[]> {
         const res = await withFailCtx('getAllExts', async () => {

--- a/packages/core/src/shared/filesystemUtilities.ts
+++ b/packages/core/src/shared/filesystemUtilities.ts
@@ -11,6 +11,7 @@ import { getLogger } from './logger'
 import * as pathutils from './utilities/pathUtils'
 import globals from '../shared/extensionGlobals'
 import fs from '../shared/fs/fs'
+import { ToolkitError } from './errors'
 
 export const tempDirPath = path.join(
     // https://github.com/aws/aws-toolkit-vscode/issues/240
@@ -244,5 +245,119 @@ export async function setDefaultDownloadPath(downloadPath: string) {
         }
     } catch (err) {
         getLogger().error('Error while setting "aws.downloadPath"', err as Error)
+    }
+}
+
+const FileSystemStabilityExceptionId = 'FileSystemStabilityException'
+const FileSystemStabilityException = ToolkitError.named(FileSystemStabilityExceptionId)
+
+/**
+ * Run this function to validate common file system calls/flows, ensuring they work
+ * as expected.
+ *
+ * The intent of this function is to catch potential fs issues early,
+ * testing common cases of fs usage. We need this since each machine can behave
+ * differently depending on things like OS, permissions, disk speed, ...
+ *
+ * @throws a {@link FileSystemStabilityException} which wraps the underlying failed fs operation error.
+ */
+export async function throwOnUnstableFileSystem(tmpRoot: string) {
+    const tmpFolder = path.join(tmpRoot, `validateStableFS-${crypto.randomBytes(4).toString('hex')}`)
+    const tmpFile = path.join(tmpFolder, 'file.txt')
+
+    try {
+        // test basic folder operations
+        await withFailCtx('mkdirInitial', () => fs.mkdir(tmpFolder))
+        // Verifies that we do not throw if the dir exists and we try to make it again
+        await withFailCtx('mkdirButAlreadyExists', () => fs.mkdir(tmpFolder))
+        await withFailCtx('mkdirSubfolder', () => fs.mkdir(path.join(tmpFolder, 'subfolder')))
+        await withFailCtx('rmdirInitial', () => fs.delete(tmpFolder, { recursive: true }))
+
+        // test basic file operations
+        await withFailCtx('mkdirForFileOpsTest', () => fs.mkdir(tmpFolder))
+        await withFailCtx('writeFile1', () => fs.writeFile(tmpFile, 'test1'))
+        await withFailCtx('readFile1', async () => {
+            const text = await fs.readFileText(tmpFile)
+            if (text !== 'test1') {
+                throw new Error(`Unexpected file contents: "${text}"`)
+            }
+        })
+        // overwrite the file content multiple times
+        await withFailCtx('writeFile2', () => fs.writeFile(tmpFile, 'test2'))
+        await withFailCtx('writeFile3', () => fs.writeFile(tmpFile, 'test3'))
+        await withFailCtx('writeFile4', () => fs.writeFile(tmpFile, 'test4'))
+        await withFailCtx('writeFile5', () => fs.writeFile(tmpFile, 'test5'))
+        await withFailCtx('readFile5', async () => {
+            const text = await fs.readFileText(tmpFile)
+            if (text !== 'test5') {
+                throw new Error(`Unexpected file contents after multiple writes: "${text}"`)
+            }
+        })
+        // test concurrent reads on a file
+        await withFailCtx('writeFileConcurrencyTest', () => fs.writeFile(tmpFile, 'concurrencyTest'))
+        const result = await Promise.all([
+            withFailCtx('readFileConcurrent1', () => fs.readFileText(tmpFile)),
+            withFailCtx('readFileConcurrent2', () => fs.readFileText(tmpFile)),
+            withFailCtx('readFileConcurrent3', () => fs.readFileText(tmpFile)),
+            withFailCtx('readFileConcurrent4', () => fs.readFileText(tmpFile)),
+            withFailCtx('readFileConcurrent5', () => fs.readFileText(tmpFile)),
+        ])
+        if (result.some((text) => text !== 'concurrencyTest')) {
+            throw new Error(`Unexpected concurrent file reads: ${result}`)
+        }
+        // test deleting a file
+        await withFailCtx('deleteFileInitial', () => fs.delete(tmpFile))
+        await withFailCtx('writeFileAfterDelete', () => fs.writeFile(tmpFile, 'afterDelete'))
+        await withFailCtx('readNewFileAfterDelete', async () => {
+            const text = await fs.readFileText(tmpFile)
+            if (text !== 'afterDelete') {
+                throw new Error(`Unexpected file content after writing to deleted file: "${text}"`)
+            }
+        })
+        await withFailCtx('deleteFileFully', () => fs.delete(tmpFile))
+        await withFailCtx('notExistsFileAfterDelete', async () => {
+            const res = await fs.exists(tmpFile)
+            if (res) {
+                throw new Error(`Expected file to NOT exist: "${tmpFile}"`)
+            }
+        })
+
+        // test rename
+        await withFailCtx('writeFileForRename', () => fs.writeFile(tmpFile, 'TestingRename'))
+        const tmpFileRenamed = tmpFile + '.renamed'
+        await withFailCtx('renameFile', () => fs.rename(tmpFile, tmpFileRenamed))
+        await withFailCtx('existsRenamedFile', async () => {
+            const res = await fs.exists(tmpFileRenamed)
+            if (!res) {
+                throw new Error(`Expected RENAMED file to exist: "${tmpFileRenamed}"`)
+            }
+        })
+        await withFailCtx('writeToRenamedFile', async () => fs.writeFile(tmpFileRenamed, 'hello'))
+        await withFailCtx('readFromRenamedFile', async () => {
+            const res = await fs.readFileText(tmpFileRenamed)
+            if (res !== 'hello') {
+                throw new Error(`Expected RENAMED file to be writable: "${tmpFileRenamed}"`)
+            }
+        })
+        await withFailCtx('renameFileReset', () => fs.rename(tmpFileRenamed, tmpFile))
+        await withFailCtx('renameFileResetExists', async () => {
+            const res = await fs.exists(tmpFile)
+            if (!res) {
+                throw new Error(`Expected reverted renamed file to exist: "${tmpFile}"`)
+            }
+        })
+    } finally {
+        await fs.delete(tmpFolder, { recursive: true, force: true })
+    }
+
+    async function withFailCtx<T>(ctx: string, fn: () => Promise<T>): Promise<T> {
+        try {
+            return await fn()
+        } catch (e) {
+            if (!(e instanceof Error)) {
+                throw e
+            }
+            throw FileSystemStabilityException.chain(e, `context: "${ctx}"`, { code: FileSystemStabilityExceptionId })
+        }
     }
 }

--- a/packages/core/src/shared/utilities/osUtils.ts
+++ b/packages/core/src/shared/utilities/osUtils.ts
@@ -15,12 +15,13 @@ import * as os from 'os'
  * Use this function to perform one-time initialization tasks that should only happen
  * once per OS session, regardless of how many extension instances are running.
  */
-export async function isNewOsSession(now = () => globals.clock.Date.now(), uptime = () => os.uptime()) {
+export async function isNewOsSession(now = () => globals.clock.Date.now(), uptimeMillis = () => os.uptime() * 1000) {
     // Windows does not have an ephemeral /tmp/ folder that deletes on shutdown, while unix-like os's do.
     // So in Windows we calculate the start time and see if it changed from the previous known start time.
     const lastStartTime = globals.globalState.tryGet('lastOsStartTime', Number)
-    // uptime() returns seconds, convert to ms
-    const currentOsStartTime = now() - uptime() * 1000 * 60
+
+    const uptime = uptimeMillis()
+    const currentOsStartTime = now() - uptime
 
     if (lastStartTime === undefined) {
         await globals.globalState.update('lastOsStartTime', currentOsStartTime)
@@ -28,7 +29,7 @@ export async function isNewOsSession(now = () => globals.clock.Date.now(), uptim
     }
 
     // If the current start time is later than the last, it means we are in a new session since they should be the same value.
-    // But to account for small differences in how the current time is calculate, we add in a 5 second buffer.
+    // But to account for minor millisecond differnces, we add in a 5 second buffer.
     if (currentOsStartTime - 1000 * 5 > lastStartTime) {
         await globals.globalState.update('lastOsStartTime', currentOsStartTime)
         return true

--- a/packages/core/src/test/shared/crashMonitoring.test.ts
+++ b/packages/core/src/test/shared/crashMonitoring.test.ts
@@ -15,8 +15,9 @@ class TestCrashMonitoring extends CrashMonitoring {
         super(...deps)
     }
     /** Immitates an extension crash */
-    public crash() {
-        super.cleanup()
+    public async crash() {
+        this.crashChecker?.cleanup()
+        await this.heartbeat?.cleanup()
     }
 }
 
@@ -88,7 +89,7 @@ export const crashMonitoringTest = async () => {
 
         // Ext 1 does a graceful shutdown
         await exts[1].ext.start()
-        await exts[1].ext.stop()
+        await exts[1].ext.shutdown()
         await awaitIntervals(oneInterval)
         // Ext 1 did a graceful shutdown so no metric emitted
         assertTelemetry('session_end', [])
@@ -100,7 +101,7 @@ export const crashMonitoringTest = async () => {
         const exts = await makeTestExtensions(2)
 
         await exts[0].ext.start()
-        exts[0].ext.crash()
+        await exts[0].ext.crash()
         await awaitIntervals(oneInterval)
         // There is no other active instance to report the issue
         assertTelemetry('session_end', [])
@@ -122,7 +123,7 @@ export const crashMonitoringTest = async () => {
         }
 
         for (let i = 1; i < extCount; i++) {
-            exts[i].ext.crash()
+            await exts[i].ext.crash()
             latestCrashedExts.push(exts[i])
         }
 
@@ -143,7 +144,7 @@ export const crashMonitoringTest = async () => {
 
         // start Ext 1 then crash it, Ext 0 finds the crash
         await exts[1].ext.start()
-        exts[1].ext.crash()
+        await exts[1].ext.crash()
         latestCrashedExts.push(exts[1])
         await awaitIntervals(oneInterval * 1)
 
@@ -151,14 +152,14 @@ export const crashMonitoringTest = async () => {
 
         // start Ext 2 and crash Ext 0, Ext 2 is promoted to Primary checker
         await exts[2].ext.start()
-        exts[0].ext.crash()
+        await exts[0].ext.crash()
         latestCrashedExts.push(exts[0])
         await awaitIntervals(oneInterval * 1)
         assertCrashedExtensions(latestCrashedExts)
 
         // Ext 3 starts, then crashes. Ext 2 reports the crash since it is the Primary checker
         await exts[3].ext.start()
-        exts[3].ext.crash()
+        await exts[3].ext.crash()
         latestCrashedExts.push(exts[3])
         await awaitIntervals(oneInterval * 1)
         assertCrashedExtensions(latestCrashedExts)

--- a/packages/core/src/test/shared/crashMonitoring.test.ts
+++ b/packages/core/src/test/shared/crashMonitoring.test.ts
@@ -14,10 +14,10 @@ class TestCrashMonitoring extends CrashMonitoring {
     public constructor(...deps: ConstructorParameters<typeof CrashMonitoring>) {
         super(...deps)
     }
-    /** Immitates an extension crash */
+    /** Imitates an extension crash */
     public async crash() {
-        this.crashChecker?.cleanup()
-        await this.heartbeat?.cleanup()
+        this.crashChecker?.testCrash()
+        this.heartbeat?.testCrash()
     }
 }
 

--- a/packages/core/src/test/shared/crashMonitoring.test.ts
+++ b/packages/core/src/test/shared/crashMonitoring.test.ts
@@ -14,8 +14,9 @@ class TestCrashMonitoring extends CrashMonitoring {
     public constructor(...deps: ConstructorParameters<typeof CrashMonitoring>) {
         super(...deps)
     }
-    public override crash() {
-        super.crash()
+    /** Immitates an extension crash */
+    public crash() {
+        super.cleanup()
     }
 }
 

--- a/packages/core/src/test/shared/filesystemUtilities.test.ts
+++ b/packages/core/src/test/shared/filesystemUtilities.test.ts
@@ -13,8 +13,10 @@ import {
     isInDirectory,
     makeTemporaryToolkitFolder,
     tempDirPath,
+    throwOnUnstableFileSystem,
 } from '../../shared/filesystemUtilities'
 import { fs } from '../../shared'
+import { TestFolder } from '../testUtil'
 
 describe('filesystemUtilities', function () {
     const targetFilename = 'findThisFile12345.txt'
@@ -189,6 +191,13 @@ describe('filesystemUtilities', function () {
             fileB = 'C:\\FOO\\BAR\\B.txt'
             const actual = getFileDistance(fileA, fileB)
             assert.strictEqual(actual, 3)
+        })
+    })
+
+    describe('throwOnUnstableFileSystem', async function () {
+        it('does not throw on stable filesystem', async function () {
+            const testFolder = await TestFolder.create()
+            await throwOnUnstableFileSystem(testFolder.path)
         })
     })
 })

--- a/packages/core/src/test/shared/fs/fs.test.ts
+++ b/packages/core/src/test/shared/fs/fs.test.ts
@@ -340,6 +340,7 @@ describe('FileSystem', function () {
 
         it('deletes directory with recursive:true', async function () {
             const dir = await testFolder.mkdir()
+            await testFolder.write('testfile.txt', 'testText')
             await fs.delete(dir, { recursive: true })
             assert(!existsSync(dir))
         })
@@ -348,7 +349,7 @@ describe('FileSystem', function () {
             const dir = await testFolder.mkdir()
             const f = path.join(dir, 'missingfile.txt')
             assert(!existsSync(f))
-            await fs.delete(f, { recursive: true })
+            await fs.delete(f)
         })
 
         it('error if file *and* its parent dir not found', async function () {

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -75,7 +75,7 @@ export function getWorkspaceFolder(dir: string): vscode.WorkspaceFolder {
  * But if the day comes that we need it for web, we should be able to add some agnostic FS methods in here.
  */
 export class TestFolder {
-    protected constructor(private readonly rootFolder: string) {}
+    protected constructor(public readonly path: string) {}
 
     /** Creates a folder that deletes itself once all tests are done running. */
     static async create() {
@@ -117,10 +117,6 @@ export class TestFolder {
     /** Returns an absolute path compose of the test folder path and the given relative path. */
     pathFrom(relativePath: string): string {
         return path.join(this.path, relativePath)
-    }
-
-    get path(): string {
-        return path.join(this.rootFolder)
     }
 }
 


### PR DESCRIPTION
## Problem

Crash monitoring is reporting incorrect crash metrics.
This seems to be due to various filesystem errors such as eperm (even though we were doing an operation on a file we created), enospc (the user ran out of space on their machine, and other errors.

Because of this we ran in to situations where our state did not reflect reality, and due to this certain extension
instances were seen as crashed.

## Solution

- Determine if a filesystem is reliable on a machine (try a bunch of different filesystem flows and ensure nothing throws), if it is THEN we start the crash monitoring process. Otherwise we do not run it since we cannot rely it will be accurate.
  - We added a `function_call` metric to allow us to determine the ratio of successes to failures
- Add retries to critical filesystem operations such as the heartbeats and deleting a crashed extension instance from the state.
- Other various fixes


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
