### PR TITLE
fix(dev):  add error messages for upload URL expiry

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-55ef93ff-1589-41bc-a482-ed09002f1fd9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-55ef93ff-1589-41bc-a482-ed09002f1fd9.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Q dev add error messages for upload URL expiry"
+	"description": "Amazon Q Feature Dev: Add error messages when the upload URL expires"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-55ef93ff-1589-41bc-a482-ed09002f1fd9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-55ef93ff-1589-41bc-a482-ed09002f1fd9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Q dev add error messages for upload URL expiry"
+}

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -280,6 +280,7 @@
     "AWS.amazonq.featureDev.error.codeGen.denyListedError": "I'm sorry, I'm having trouble generating your code and can't continue at the moment. Please try again later, and share feedback to help me improve.",
     "AWS.amazonq.featureDev.error.codeGen.default": "I'm sorry, I ran into an issue while trying to generate your code. Please try again.",
     "AWS.amazonq.featureDev.error.codeGen.timeout": "Code generation did not finish within the expected time",
+    "AWS.amazonq.featureDev.error.uploadURLExpired": "I’m sorry, I wasn’t able to generate code. A connection timed out or became unavailable. Please try again or check the following:\n\n- Exclude non-essential files in your workspace’s `.gitignore.`\n\n- Check that your network connection is stable.",
     "AWS.amazonq.featureDev.error.workspaceFolderNotFoundError": "I couldn't find a workspace folder. Open a workspace, and then open a new chat tab and enter /dev to start discussing your code task with me.",
     "AWS.amazonq.featureDev.error.selectedFolderNotInWorkspaceFolderError": "The folder you chose isn't in your open workspace folder. You can add this folder to your workspace, or choose a folder in your open workspace.",
     "AWS.amazonq.featureDev.error.userMessageNotFoundError": "It looks like you didn't provide an input. Please enter your message in the text bar.",

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -20,6 +20,7 @@ import {
     SelectedFolderNotInWorkspaceFolderError,
     TabIdNotFoundError,
     UploadCodeError,
+    UploadURLExpired,
     UserMessageNotFoundError,
     WorkspaceFolderNotFoundError,
     ZipFileError,
@@ -278,6 +279,14 @@ export class FeatureDevController {
                             status: 'success',
                         },
                     ],
+                })
+                break
+            case UploadURLExpired.errorName:
+                this.messenger.sendAnswer({
+                    type: 'answer',
+                    tabID: message.tabID,
+                    message: err.message,
+                    canBeVoted: true,
                 })
                 break
             default:

--- a/packages/core/src/amazonqFeatureDev/errors.ts
+++ b/packages/core/src/amazonqFeatureDev/errors.ts
@@ -98,6 +98,13 @@ export class UploadCodeError extends ToolkitError {
     }
 }
 
+export class UploadURLExpired extends ToolkitError {
+    static errorName = 'UploadURLExpired'
+    constructor() {
+        super(i18n('AWS.amazonq.featureDev.error.uploadURLExpired'), { code: 'UploadURLExpired' })
+    }
+}
+
 export class IllegalStateTransition extends ToolkitError {
     constructor() {
         super(i18n('AWS.amazonq.featureDev.error.illegalStateTransition'), { code: 'IllegalStateTransition' })

--- a/packages/core/src/amazonqFeatureDev/util/upload.ts
+++ b/packages/core/src/amazonqFeatureDev/util/upload.ts
@@ -42,6 +42,6 @@ export async function uploadCode(url: string, buffer: Buffer, checksumSha256: st
                     )
             }
         }
-        throw new ToolkitError(i18n('AWS.amazonq.featureDev.error.codeGen.default'))
+        throw ToolkitError.chain(e, i18n('AWS.amazonq.featureDev.error.codeGen.default'))
     }
 }

--- a/packages/core/src/amazonqFeatureDev/util/upload.ts
+++ b/packages/core/src/amazonqFeatureDev/util/upload.ts
@@ -7,7 +7,9 @@ import request, { RequestError } from '../../shared/request'
 import { getLogger } from '../../shared/logger/logger'
 import { featureName } from '../constants'
 
-import { UploadCodeError } from '../errors'
+import { UploadCodeError, UploadURLExpired } from '../errors'
+import { ToolkitError } from '../../shared'
+import { i18n } from '../../shared/i18n-helper'
 
 /**
  * uploadCode
@@ -30,8 +32,16 @@ export async function uploadCode(url: string, buffer: Buffer, checksumSha256: st
         }).response
     } catch (e: any) {
         getLogger().error(`${featureName}: failed to upload code to s3: ${(e as Error).message}`)
-        throw new UploadCodeError(
-            e instanceof RequestError ? `${e.response.status}: ${e.response.statusText}` : 'Unknown'
-        )
+        if (e instanceof RequestError) {
+            switch (e.response.status) {
+                case 403:
+                    throw new UploadURLExpired()
+                default:
+                    throw new UploadCodeError(
+                        e instanceof RequestError ? `${e.response.status}: ${e.response.statusText}` : 'Unknown'
+                    )
+            }
+        }
+        throw new ToolkitError(i18n('AWS.amazonq.featureDev.error.codeGen.default'))
     }
 }


### PR DESCRIPTION
## Problem

- Upload url would expire in a given time. The original error message is not clear for users what to do next.

## Solution

- Handle URL expiry explicitly.
- Add a clear error message.
<img width="648" alt="URLExpired" src="https://github.com/user-attachments/assets/b8552cf9-37a3-465d-85c2-392a6649a1fb">


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
