### PR TITLE
config(dev): adjust API connection timeout

### DIFF
--- a/packages/core/src/amazonqFeatureDev/client/featureDev.ts
+++ b/packages/core/src/amazonqFeatureDev/client/featureDev.ts
@@ -46,6 +46,9 @@ export async function createFeatureDevProxyClient(options?: Partial<ServiceOptio
             region: cwsprConfig.region,
             endpoint: cwsprConfig.endpoint,
             token: new Token({ token: bearerToken }),
+            httpOptions: {
+                connectTimeout: 10000, // 10 seconds, 3 times P99 API latency
+            },
             ...options,
         } as ServiceOptions,
         undefined


### PR DESCRIPTION
## Problem

- The API connection was timing out after 120 seconds, leading to a poor customer experience (CX). Users were waiting for 2 minutes before receiving a timeout error, which is an unacceptably long wait time.

## Solution

- Adjust the API connection timeout to 10 seconds, which is approximately 3 times the high band of the API's P99 latency.
- This change should improve the user experience by failing fast in case of connection issues.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
