### PR TITLE
refactor(filesystem): prefer our fs wrapper to node's with lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -180,6 +180,10 @@ module.exports = {
                         message:
                             'Avoid fs-extra, use shared/fs/fs.ts. Notify the Toolkit team if your required functionality is not available.',
                     },
+                    {
+                        name: 'fs',
+                        message: 'Avoid fs and use shared/fs/fs.ts when possible.',
+                    },
                 ],
             },
         ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -182,7 +182,7 @@ module.exports = {
                     },
                     {
                         name: 'fs',
-                        message: 'Avoid fs and use shared/fs/fs.ts when possible.',
+                        message: 'Avoid node:fs and use shared/fs/fs.ts when possible.',
                     },
                 ],
             },

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -17,7 +17,7 @@ import {
 import assert from 'assert'
 import sinon from 'sinon'
 import * as vscode from 'vscode'
-import fs from 'fs'
+import fs from 'fs' // eslint-disable-line no-restricted-imports
 
 const mockCodeScanFindings = JSON.stringify([
     {

--- a/packages/core/scripts/build/generateServiceClient.ts
+++ b/packages/core/scripts/build/generateServiceClient.ts
@@ -4,7 +4,7 @@
  */
 
 import * as proc from 'child_process'
-import * as nodefs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 
 const repoRoot = path.join(process.cwd(), '../../') // root/packages/toolkit -> root/

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
 import * as crypto from 'crypto'
-import { createWriteStream } from 'fs'
+import { createWriteStream } from 'fs' // eslint-disable-line no-restricted-imports
 import { getLogger } from '../../shared/logger/logger'
 import { CurrentWsFolders, collectFilesForIndex } from '../../shared/utilities/workspaceUtils'
 import fetch from 'node-fetch'

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -5,7 +5,7 @@
  * This class is responsible for responding to UI events by calling
  * the Gumby extension.
  */
-import nodefs from 'fs'
+import nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import path from 'path'
 import * as vscode from 'vscode'
 import { GumbyNamedMessages, Messenger } from './messenger/messenger'

--- a/packages/core/src/awsService/accessanalyzer/vue/iamPolicyChecks.ts
+++ b/packages/core/src/awsService/accessanalyzer/vue/iamPolicyChecks.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 import { getLogger, Logger } from '../../../shared/logger'
 import { localize } from '../../../shared/utilities/vsCodeUtils'

--- a/packages/core/src/awsService/s3/commands/uploadFile.ts
+++ b/packages/core/src/awsService/s3/commands/uploadFile.ts
@@ -6,7 +6,7 @@
 import * as path from 'path'
 import * as mime from 'mime-types'
 import * as vscode from 'vscode'
-import { statSync } from 'fs'
+import { statSync } from 'fs' // eslint-disable-line no-restricted-imports
 import { S3 } from 'aws-sdk'
 import { getLogger } from '../../../shared/logger'
 import { S3Node } from '../explorer/s3Nodes'

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import * as os from 'os'
 import path from 'path'
 import { getLogger } from '../../shared/logger'

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -16,7 +16,7 @@ import {
 import { sleep } from '../../shared/utilities/timeoutUtils'
 import * as codewhispererClient from '../client/codewhisperer'
 import * as CodeWhispererConstants from '../models/constants'
-import { existsSync, statSync, readFileSync } from 'fs'
+import { existsSync, statSync, readFileSync } from 'fs' // eslint-disable-line no-restricted-imports
 import { RawCodeScanIssue } from '../models/model'
 import * as crypto from 'crypto'
 import path = require('path')

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode'
-import * as nodefs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 import * as os from 'os'
 import * as codeWhisperer from '../../client/codewhisperer'

--- a/packages/core/src/codewhisperer/service/transformByQ/transformFileHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformFileHandler.ts
@@ -8,7 +8,7 @@ import * as path from 'path'
 import * as os from 'os'
 import xml2js = require('xml2js')
 import * as CodeWhispererConstants from '../../models/constants'
-import { existsSync, writeFileSync } from 'fs'
+import { existsSync, writeFileSync } from 'fs' // eslint-disable-line no-restricted-imports
 import { BuildSystem, FolderInfo, transformByQState } from '../../models/model'
 import { IManifestFile } from '../../../amazonqFeatureDev/models'
 import fs from '../../../shared/fs/fs'

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -5,7 +5,7 @@
 
 import AdmZip from 'adm-zip'
 import os from 'os'
-import fs from 'fs'
+import fs from 'fs' // eslint-disable-line no-restricted-imports
 import { parsePatch, applyPatches, ParsedDiff } from 'diff'
 import path from 'path'
 import vscode from 'vscode'

--- a/packages/core/src/dynamicResources/awsResourceManager.ts
+++ b/packages/core/src/dynamicResources/awsResourceManager.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { writeFileSync } from 'fs'
+import { writeFileSync } from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { CloudFormationClient } from '../shared/clients/cloudFormationClient'

--- a/packages/core/src/lambda/vue/remoteInvoke/invokeLambda.ts
+++ b/packages/core/src/lambda/vue/remoteInvoke/invokeLambda.ts
@@ -4,7 +4,7 @@
  */
 
 import { _Blob } from 'aws-sdk/clients/lambda'
-import { readFileSync } from 'fs'
+import { readFileSync } from 'fs' // eslint-disable-line no-restricted-imports
 import * as _ from 'lodash'
 import * as vscode from 'vscode'
 import { DefaultLambdaClient, LambdaClient } from '../../../shared/clients/lambdaClient'

--- a/packages/core/src/shared/cloudformation/cloudformation.ts
+++ b/packages/core/src/shared/cloudformation/cloudformation.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { promises as nodefs } from 'fs'
+import { promises as nodefs } from 'fs' // eslint-disable-line no-restricted-imports
 import * as vscode from 'vscode'
 import { schema } from 'yaml-cfn'
 import * as yaml from 'js-yaml'

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -10,7 +10,7 @@ import { isThrottlingError, isTransientError } from '@smithy/service-error-class
 import { Result } from './telemetry/telemetry'
 import { CancellationError } from './utilities/timeoutUtils'
 import { hasKey, isNonNullable } from './utilities/tsUtils'
-import type * as nodefs from 'fs'
+import type * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import type * as os from 'os'
 import { CodeWhispererStreamingServiceException } from '@amzn/codewhisperer-streaming'
 import { driveLetterRegex } from './utilities/pathUtils'

--- a/packages/core/src/shared/extensions/yaml.ts
+++ b/packages/core/src/shared/extensions/yaml.ts
@@ -9,7 +9,7 @@ import { getLogger } from '../logger/logger'
 import { getIdeProperties } from '../extensionUtilities'
 import { activateExtension } from '../utilities/vsCodeUtils'
 import { AWS_SCHEME } from '../constants'
-import * as nodefs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 
 // sourced from https://github.com/redhat-developer/vscode-yaml/blob/3d82d61ea63d3e3a9848fe6b432f8f1f452c1bec/src/schema-extension-api.ts
 // removed everything that is not currently being used

--- a/packages/core/src/shared/fs/fs.ts
+++ b/packages/core/src/shared/fs/fs.ts
@@ -4,7 +4,7 @@
  */
 import vscode from 'vscode'
 import os from 'os'
-import { promises as nodefs, constants as nodeConstants, WriteFileOptions } from 'fs'
+import { promises as nodefs, constants as nodeConstants, WriteFileOptions } from 'fs' // eslint-disable-line no-restricted-imports
 import { chmod } from 'fs/promises'
 import { isCloud9 } from '../extensionUtilities'
 import _path from 'path'

--- a/packages/core/src/shared/fs/templateRegistry.ts
+++ b/packages/core/src/shared/fs/templateRegistry.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import { readFileSync } from 'fs'
+import { readFileSync } from 'fs' // eslint-disable-line no-restricted-imports
 import * as CloudFormation from '../cloudformation/cloudformation'
 import * as pathutils from '../utilities/pathUtils'
 import * as path from 'path'

--- a/packages/core/src/shared/handleUninstall.ts
+++ b/packages/core/src/shared/handleUninstall.ts
@@ -6,7 +6,7 @@
 // Implementation inspired by https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/c864f15af264f0f456a6d8a83290b5c940715349/client/vscode/src/settings/uninstall.ts#L2
 
 import * as vscode from 'vscode'
-import { existsSync } from 'fs'
+import { existsSync } from 'fs' // eslint-disable-line no-restricted-imports
 import * as semver from 'semver'
 import { join } from 'path'
 import { getLogger } from './logger/logger'

--- a/packages/core/src/shared/icons.ts
+++ b/packages/core/src/shared/icons.ts
@@ -6,7 +6,7 @@
 import globals, { isWeb } from './extensionGlobals'
 
 import type * as packageJson from '../../package.json'
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 import { Uri, ThemeIcon, ThemeColor } from 'vscode'
 import { isCloud9 } from './extensionUtilities'

--- a/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import * as http from 'http'
 import * as https from 'https'
 import * as stream from 'stream'

--- a/packages/core/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/packages/core/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 import { samImageLambdaRuntimes, samZipLambdaRuntimes } from '../../../lambda/models/samLambdaRuntime'
 import * as CloudFormation from '../../cloudformation/cloudformation'

--- a/packages/core/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/packages/core/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { existsSync, PathLike, readFileSync } from 'fs'
+import { existsSync, PathLike, readFileSync } from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { isImageLambdaConfig, NodejsDebugConfiguration } from '../../../lambda/local/debugConfiguration'

--- a/packages/core/src/shared/sshConfig.ts
+++ b/packages/core/src/shared/sshConfig.ts
@@ -16,7 +16,7 @@ import { CancellationError } from './utilities/timeoutUtils'
 import { getSshConfigPath } from './extensions/ssh'
 import globals from './extensionGlobals'
 import { fileExists, readFileAsString } from './filesystemUtilities'
-import { chmodSync } from 'fs'
+import { chmodSync } from 'fs' // eslint-disable-line no-restricted-imports
 import fs from './fs/fs'
 
 const localize = nls.loadMessageBundle()

--- a/packages/core/src/shared/utilities/streamUtilities.ts
+++ b/packages/core/src/shared/utilities/streamUtilities.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import { Readable, Writable, pipeline } from 'stream'
 import * as vscode from 'vscode'
 

--- a/packages/core/src/shared/utilities/textUtilities.ts
+++ b/packages/core/src/shared/utilities/textUtilities.ts
@@ -4,7 +4,7 @@
  */
 
 import * as crypto from 'crypto'
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import { default as stripAnsi } from 'strip-ansi'
 import { isCloud9 } from '../extensionUtilities'
 import { getLogger } from '../logger'

--- a/packages/core/src/stepFunctions/commands/visualizeStateMachine/getStateMachineDefinitionFromCfnTemplate.ts
+++ b/packages/core/src/stepFunctions/commands/visualizeStateMachine/getStateMachineDefinitionFromCfnTemplate.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import { getLogger, Logger } from '../../../shared/logger'
 
 /**

--- a/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
+++ b/packages/core/src/test/awsService/ec2/sshKeyPair.test.ts
@@ -4,7 +4,7 @@
  */
 import * as vscode from 'vscode'
 import assert from 'assert'
-import nodefs from 'fs'
+import nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import * as sinon from 'sinon'
 import * as path from 'path'
 import * as os from 'os'

--- a/packages/core/src/test/codewhisperer/testUtil.ts
+++ b/packages/core/src/test/codewhisperer/testUtil.ts
@@ -17,7 +17,6 @@ import { getLogger } from '../../shared/logger'
 import { CodeWhispererCodeCoverageTracker } from '../../codewhisperer/tracker/codewhispererCodeCoverageTracker'
 import globals from '../../shared/extensionGlobals'
 import { session } from '../../codewhisperer/util/codeWhispererSession'
-import fs from 'fs'
 import { DefaultAWSClientBuilder, ServiceOptions } from '../../shared/awsClientBuilder'
 import { FakeAwsContext } from '../utilities/fakeAwsContext'
 import { Service } from 'aws-sdk'
@@ -25,6 +24,7 @@ import userApiConfig = require('./../../codewhisperer/client/user-service-2.json
 import CodeWhispererUserClient = require('../../codewhisperer/client/codewhispereruserclient')
 import { codeWhispererClient } from '../../codewhisperer/client/codewhisperer'
 import { RecommendationHandler } from '../../codewhisperer/service/recommendationHandler'
+import { Dirent } from 'fs' // eslint-disable-line no-restricted-imports
 
 export async function resetCodeWhispererGlobalVariables() {
     vsCodeState.isIntelliSenseActive = false
@@ -201,8 +201,8 @@ export function createCodeActionContext(): vscode.CodeActionContext {
     }
 }
 
-export function createMockDirentFile(fileName: string): fs.Dirent {
-    const dirent = new fs.Dirent()
+export function createMockDirentFile(fileName: string): Dirent {
+    const dirent = new Dirent()
     dirent.isFile = () => true
     dirent.name = fileName
     return dirent

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -24,7 +24,7 @@ import { getOpenExternalStub } from '../../globalSetup.test'
 import { getTestWindow } from '../../shared/vscode/window'
 import { SeverityLevel } from '../../shared/vscode/message'
 import { ToolkitError } from '../../../shared/errors'
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 import { Stub, stub } from '../../utilities/stubber'
 

--- a/packages/core/src/test/dynamicResources/awsResourceManager.test.ts
+++ b/packages/core/src/test/dynamicResources/awsResourceManager.test.ts
@@ -16,7 +16,7 @@ import { CloudControlClient, DefaultCloudControlClient } from '../../shared/clie
 import { CloudFormationClient, DefaultCloudFormationClient } from '../../shared/clients/cloudFormationClient'
 import { makeTemporaryToolkitFolder, readFileAsString } from '../../shared/filesystemUtilities'
 import { FakeExtensionContext } from '../fakeExtensionContext'
-import { existsSync } from 'fs'
+import { existsSync } from 'fs' // eslint-disable-line no-restricted-imports
 import { ResourceTypeMetadata } from '../../dynamicResources/model/resources'
 import globals from '../../shared/extensionGlobals'
 import { Stub, stub } from '../utilities/stubber'

--- a/packages/core/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
+++ b/packages/core/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
@@ -25,7 +25,7 @@ import admZip from 'adm-zip'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { DefaultSchemaClient } from '../../../shared/clients/schemaClient'
 import { fs } from '../../../shared'
-import * as nodefs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 
 describe('CodeDownloader', function () {
     let tempFolder: string

--- a/packages/core/src/test/shared/fs/fs.test.ts
+++ b/packages/core/src/test/shared/fs/fs.test.ts
@@ -7,9 +7,9 @@ import assert from 'assert'
 import vscode from 'vscode'
 import * as path from 'path'
 import * as utils from 'util'
-import { existsSync, mkdirSync, promises as nodefs, readFileSync } from 'fs'
+import { existsSync, mkdirSync, promises as nodefs, readFileSync } from 'fs' // eslint-disable-line no-restricted-imports
 import { stat } from 'fs/promises'
-import nodeFs from 'fs'
+import nodeFs from 'fs' // eslint-disable-line no-restricted-imports
 import fs, { FileSystem } from '../../../shared/fs/fs'
 import * as os from 'os'
 import { isMinVscode, isWin } from '../../../shared/vscode/env'

--- a/packages/core/src/test/shared/logger/sharedFileTransport.test.ts
+++ b/packages/core/src/test/shared/logger/sharedFileTransport.test.ts
@@ -10,7 +10,7 @@ import fs from '../../../shared/fs/fs'
 import { stub, SinonStub } from 'sinon'
 import { MESSAGE } from '../../../shared/logger/consoleLogTransport'
 import { createTestFile } from '../../testUtil'
-import { readFileSync } from 'fs'
+import { readFileSync } from 'fs' // eslint-disable-line no-restricted-imports
 import { sleep } from '../../../shared/utilities/timeoutUtils'
 
 describe('SharedFileTransport', function () {

--- a/packages/core/src/test/shared/logger/toolkitLogger.test.ts
+++ b/packages/core/src/test/shared/logger/toolkitLogger.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import * as filesystemUtilities from '../../../shared/filesystemUtilities'
 import * as vscode from 'vscode'
 import { ToolkitLogger } from '../../../shared/logger/toolkitLogger'

--- a/packages/core/src/test/shared/vscode/runCommand.test.ts
+++ b/packages/core/src/test/shared/vscode/runCommand.test.ts
@@ -6,7 +6,7 @@
 import globals from '../../../shared/extensionGlobals'
 
 import os from 'os'
-import { promises as fsPromises } from 'fs'
+import { promises as fsPromises } from 'fs' // eslint-disable-line no-restricted-imports
 import fs from '../../../shared/fs/fs'
 import * as sinon from 'sinon'
 import assert from 'assert'

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -15,7 +15,7 @@ import { MetricName, MetricShapes } from '../shared/telemetry/telemetry'
 import { keys, selectFrom } from '../shared/utilities/tsUtils'
 import fs from '../shared/fs/fs'
 import { DeclaredCommand } from '../shared/vscode/commands2'
-import { mkdirSync, existsSync } from 'fs'
+import { mkdirSync, existsSync } from 'fs' // eslint-disable-line no-restricted-imports
 import { randomBytes } from 'crypto'
 import request from '../shared/request'
 import { stub } from 'sinon'

--- a/packages/core/src/testInteg/sam.test.ts
+++ b/packages/core/src/testInteg/sam.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert'
 import { Runtime } from 'aws-sdk/clients/lambda'
-import { mkdtempSync } from 'fs'
+import { mkdtempSync } from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 import * as semver from 'semver'
 import * as vscode from 'vscode'

--- a/packages/core/src/testInteg/shared/extensions/git.test.ts
+++ b/packages/core/src/testInteg/shared/extensions/git.test.ts
@@ -9,7 +9,7 @@ import vscode from 'vscode'
 import * as GitTypes from '../../../../types/git'
 import { GitExtension, Repository } from '../../../shared/extensions/git'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
-import { realpathSync } from 'fs'
+import { realpathSync } from 'fs' // eslint-disable-line no-restricted-imports
 import { execFileSync } from 'child_process'
 import { sleep } from '../../../shared/utilities/timeoutUtils'
 import { getLogger } from '../../../shared/logger/logger'

--- a/packages/core/src/testLint/gitSecrets.test.ts
+++ b/packages/core/src/testLint/gitSecrets.test.ts
@@ -8,7 +8,7 @@ import { describe } from 'mocha'
 import assert from 'assert'
 import * as path from 'path'
 import { platform } from 'os'
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs' // eslint-disable-line no-restricted-imports
 import { runCmd } from './testUtils'
 
 /**

--- a/packages/toolkit/scripts/build/generateConfigurationAttributes.ts
+++ b/packages/toolkit/scripts/build/generateConfigurationAttributes.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'fs'
+import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 import { JSONSchema4 } from 'json-schema'
 import { compile } from 'json-schema-to-typescript'

--- a/scripts/createRelease.ts
+++ b/scripts/createRelease.ts
@@ -8,7 +8,7 @@
 //
 
 import * as child_process from 'child_process'
-import * as nodefs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 
 // Must run from a subproject root folder, e.g packages/toolkit

--- a/scripts/generateIcons.ts
+++ b/scripts/generateIcons.ts
@@ -5,7 +5,7 @@
 
 import webfont from 'webfont'
 import * as path from 'path'
-import * as nodefs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 
 const fontId = 'aws-toolkit-icons'
 const projectDir = process.cwd() // root/packages/toolkit

--- a/scripts/generateNonCodeFiles.ts
+++ b/scripts/generateNonCodeFiles.ts
@@ -4,7 +4,7 @@
  */
 
 import * as child_process from 'child_process'
-import * as nodefs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import { marked } from 'marked'
 import * as path from 'path'
 

--- a/scripts/generateSettings.ts
+++ b/scripts/generateSettings.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as nodefs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 
 /**

--- a/scripts/newChange.ts
+++ b/scripts/newChange.ts
@@ -4,7 +4,7 @@
  */
 
 import * as child_process from 'child_process'
-import * as nodefs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import { join } from 'path'
 import * as readlineSync from 'readline-sync'
 import * as crypto from 'crypto'

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -18,7 +18,7 @@
 //
 
 import * as child_process from 'child_process'
-import * as nodefs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
 
 function parseArgs() {


### PR DESCRIPTION
## Problem
We want to avoid future unnecessary use of `fs` module and maximize usage of our wrapper fs. Benefits include:
- more control over interfacing with fs. 
- increased web compatibility. 
- minimizing dependencies. 

## Solution
- add a lint rule to discourage future imports of `fs`. 
- leave current uses as exceptions. 
- Planning follow up PR to migrate some of the easy uses of fs to our wrapper. 


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
