### PR TITLE
fix(dev): Allow user access history diff generated along iterations

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-dd58d9cb-4fb4-4cb3-a9a2-dc5c5462e529.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-dd58d9cb-4fb4-4cb3-a9a2-dc5c5462e529.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q (/dev): Allow end-user access history diff generated along iterations"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-dd58d9cb-4fb4-4cb3-a9a2-dc5c5462e529.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-dd58d9cb-4fb4-4cb3-a9a2-dc5c5462e529.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q (/dev): Allow end-user access history diff generated along iterations"
+	"description": "Amazon Q (/dev): view diffs of previous /dev iterations"
 }

--- a/packages/amazonq/test/unit/amazonqFeatureDev/session/session.test.ts
+++ b/packages/amazonq/test/unit/amazonqFeatureDev/session/session.test.ts
@@ -96,7 +96,8 @@ describe('session', () => {
                 [],
                 [],
                 tabID,
-                0
+                0,
+                {}
             )
             const session = await createSession({ messenger, sessionState: codeGenState, conversationID })
             encodedContent = new TextEncoder().encode(notRejectedFileContent)

--- a/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
@@ -94,12 +94,13 @@ export class Connector {
         })
     }
 
-    onOpenDiff = (tabID: string, filePath: string, deleted: boolean): void => {
+    onOpenDiff = (tabID: string, filePath: string, deleted: boolean, messageId?: string): void => {
         this.sendMessageToExtension({
             command: 'open-diff',
             tabID,
             filePath,
             deleted,
+            messageId,
             tabType: 'featuredev',
         })
     }
@@ -167,7 +168,11 @@ export class Connector {
                 canBeVoted: true,
                 codeReference: messageData.references,
                 // TODO get the backend to store a message id in addition to conversationID
-                messageId: messageData.messageID ?? messageData.triggerID ?? messageData.conversationID,
+                messageId:
+                    messageData.codeGenerationId ??
+                    messageData.messageID ??
+                    messageData.triggerID ??
+                    messageData.conversationID,
                 fileList: {
                     rootFolderTitle: 'Changes',
                     filePaths: messageData.filePaths.map((f: DiffTreeFileInfo) => f.zipFilePath),

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -24,6 +24,16 @@ export interface CodeReference {
     }
 }
 
+export interface UploadHistory {
+    [key: string]: {
+        uploadId: string
+        timestamp: number
+        tabId: string
+        filePaths: DiffTreeFileInfo[]
+        deletedFiles: DiffTreeFileInfo[]
+    }
+}
+
 export interface ChatPayload {
     chatMessage: string
     chatCommand?: string
@@ -355,10 +365,10 @@ export class Connector {
         }
     }
 
-    onOpenDiff = (tabID: string, filePath: string, deleted: boolean): void => {
+    onOpenDiff = (tabID: string, filePath: string, deleted: boolean, messageId?: string): void => {
         switch (this.tabsStorage.getTab(tabID)?.type) {
             case 'featuredev':
-                this.featureDevChatConnector.onOpenDiff(tabID, filePath, deleted)
+                this.featureDevChatConnector.onOpenDiff(tabID, filePath, deleted, messageId)
                 break
         }
     }

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -67,6 +67,7 @@ type OpenDiffMessage = {
     // currently the zip file path
     filePath: string
     deleted: boolean
+    codeGenerationId: string
 }
 
 type fileClickedMessage = {
@@ -400,7 +401,8 @@ export class FeatureDevController {
                 deletedFiles,
                 session.state.references ?? [],
                 tabID,
-                session.uploadId
+                session.uploadId,
+                session.state.codeGenerationId ?? ''
             )
 
             const remainingIterations = session.state.codeGenerationRemainingIterationCount
@@ -686,6 +688,7 @@ export class FeatureDevController {
 
     private async openDiff(message: OpenDiffMessage) {
         const tabId: string = message.tabID
+        const codeGenerationId: string = message.messageId
         const zipFilePath: string = message.filePath
         const session = await this.sessionStorage.getSession(tabId)
         telemetry.amazonq_isReviewedChanges.emit({
@@ -702,7 +705,11 @@ export class FeatureDevController {
             const name = path.basename(pathInfos.relativePath)
             await openDeletedDiff(pathInfos.absolutePath, name, tabId)
         } else {
-            const rightPath = path.join(session.uploadId, zipFilePath)
+            let uploadId = session.uploadId
+            if (session?.state?.uploadHistory && session.state.uploadHistory[codeGenerationId]) {
+                uploadId = session?.state?.uploadHistory[codeGenerationId].uploadId
+            }
+            const rightPath = path.join(uploadId, zipFilePath)
             await openDiff(pathInfos.absolutePath, rightPath, tabId)
         }
     }

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -115,9 +115,12 @@ export class Messenger {
         deletedFiles: DeletedFileInfo[],
         references: CodeReference[],
         tabID: string,
-        uploadId: string
+        uploadId: string,
+        codeGenerationId: string
     ) {
-        this.dispatcher.sendCodeResult(new CodeResultMessage(filePaths, deletedFiles, references, tabID, uploadId))
+        this.dispatcher.sendCodeResult(
+            new CodeResultMessage(filePaths, deletedFiles, references, tabID, uploadId, codeGenerationId)
+        )
     }
 
     public sendAsyncEventProgress(tabID: string, inProgress: boolean, message: string | undefined) {

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -130,6 +130,7 @@ export class Session {
             fs: this.config.fs,
             messenger: this.messenger,
             telemetry: this.telemetry,
+            uploadHistory: this.state.uploadHistory,
         })
 
         if (resp.nextState) {

--- a/packages/core/src/amazonqFeatureDev/types.ts
+++ b/packages/core/src/amazonqFeatureDev/types.ts
@@ -9,7 +9,7 @@ import type { CancellationTokenSource } from 'vscode'
 import { Messenger } from './controllers/chat/messenger/messenger'
 import { FeatureDevClient } from './client/featureDev'
 import { TelemetryHelper } from './util/telemetryHelper'
-import { CodeReference } from '../amazonq/webview/ui/connector'
+import { CodeReference, UploadHistory } from '../amazonq/webview/ui/connector'
 import { DiffTreeFileInfo } from '../amazonq/webview/ui/diffTree/types'
 
 export type Interaction = {
@@ -61,11 +61,13 @@ export interface SessionState {
     readonly phase?: SessionStatePhase
     readonly uploadId: string
     readonly tokenSource: CancellationTokenSource
+    readonly codeGenerationId?: string
     readonly tabID: string
     interact(action: SessionStateAction): Promise<SessionStateInteraction>
     updateWorkspaceRoot?: (workspaceRoot: string) => void
     codeGenerationRemainingIterationCount?: number
     codeGenerationTotalIterationCount?: number
+    uploadHistory?: UploadHistory
 }
 
 export interface SessionStateConfig {
@@ -82,6 +84,7 @@ export interface SessionStateAction {
     messenger: Messenger
     fs: VirtualFileSystem
     telemetry: TelemetryHelper
+    uploadHistory?: UploadHistory
 }
 
 export type NewFileZipContents = { zipFilePath: string; fileContent: string }

--- a/packages/core/src/amazonqFeatureDev/views/actions/uiMessageListener.ts
+++ b/packages/core/src/amazonqFeatureDev/views/actions/uiMessageListener.ts
@@ -108,6 +108,7 @@ export class UIMessageListener {
             tabID: msg.tabID,
             filePath: msg.filePath,
             deleted: msg.deleted,
+            messageId: msg.messageId,
         })
     }
 

--- a/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
+++ b/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
@@ -33,6 +33,7 @@ export class ErrorMessage extends UiMessage {
 
 export class CodeResultMessage extends UiMessage {
     readonly message!: string
+    readonly codeGenerationId!: string
     readonly references!: {
         information: string
         recommendationContentSpan: {
@@ -48,7 +49,8 @@ export class CodeResultMessage extends UiMessage {
         readonly deletedFiles: DeletedFileInfo[],
         references: CodeReference[],
         tabID: string,
-        conversationID: string
+        conversationID: string,
+        codeGenerationId: string
     ) {
         super(tabID)
         this.references = references
@@ -64,6 +66,7 @@ export class CodeResultMessage extends UiMessage {
                     },
                 }
             })
+        this.codeGenerationId = codeGenerationId
         this.conversationID = conversationID
     }
 }

--- a/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -263,7 +263,7 @@ describe('Controller', () => {
                 workspaceFolders,
             }
 
-            const codeGenState = new CodeGenState(testConfig, getFilePaths(controllerSetup), [], [], tabID, 0)
+            const codeGenState = new CodeGenState(testConfig, getFilePaths(controllerSetup), [], [], tabID, 0, {})
             const newSession = await createSession({
                 messenger: controllerSetup.messenger,
                 sessionState: codeGenState,

--- a/packages/core/src/test/amazonqFeatureDev/session/sessionState.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/session/sessionState.test.ts
@@ -27,10 +27,10 @@ const mockSessionStateAction = (msg?: string): SessionStateAction => {
             new AppToWebViewMessageDispatcher(new MessagePublisher<any>(new vscode.EventEmitter<any>()))
         ),
         telemetry: new TelemetryHelper(),
+        uploadHistory: {},
     }
 }
 
-let mockGeneratePlan: sinon.SinonStub
 let mockGetCodeGeneration: sinon.SinonStub
 let mockExportResultArchive: sinon.SinonStub
 let mockCreateUploadUrl: sinon.SinonStub
@@ -49,7 +49,6 @@ const mockSessionStateConfig = ({
     proxyClient: {
         createConversation: () => sinon.stub(),
         createUploadUrl: () => mockCreateUploadUrl(),
-        generatePlan: () => mockGeneratePlan(),
         startCodeGeneration: () => sinon.stub(),
         getCodeGeneration: () => mockGetCodeGeneration(),
         exportResultArchive: () => mockExportResultArchive(),
@@ -111,7 +110,7 @@ describe('sessionState', () => {
             mockExportResultArchive = sinon.stub().resolves({ newFileContents: [], deletedFiles: [], references: [] })
 
             const testAction = mockSessionStateAction()
-            const state = new CodeGenState(testConfig, [], [], [], tabId, 0, 2, 3)
+            const state = new CodeGenState(testConfig, [], [], [], tabId, 0, {}, 2, 3)
             const result = await state.interact(testAction)
 
             const nextState = new PrepareCodeGenState(testConfig, [], [], [], tabId, 1, 2, 3)
@@ -125,7 +124,7 @@ describe('sessionState', () => {
         it('fails when codeGenerationStatus failed ', async () => {
             mockGetCodeGeneration = sinon.stub().rejects(new ToolkitError('Code generation failed'))
             const testAction = mockSessionStateAction()
-            const state = new CodeGenState(testConfig, [], [], [], tabId, 0)
+            const state = new CodeGenState(testConfig, [], [], [], tabId, 0, {})
             try {
                 await state.interact(testAction)
                 assert.fail('failed code generations should throw an error')


### PR DESCRIPTION
## Problem


We currently only support accessing the last code generated (by the Tree view). If you try open the diff view in past history, will thrown an error. This happens because when we click on past history Tree we actually send a "newer" uploadId and didn't keep track of all the past ones.


![Screenshot 2024-10-09 at 11 07 58 AM](https://github.com/user-attachments/assets/9f604eb5-c09b-4ce2-a762-de21d7383162)


## Solution

Cache those uploadIds based on codeGenerationId which can be easily accessible while clicking in past views.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.

