### PR TITLE
feat(amazonq): Automatically pause and resume @workspace indexing when OS CPU load is high

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-294f0da4-1fb4-43c9-90f2-e066d7351c3c.json
+++ b/packages/amazonq/.changes/next-release/Feature-294f0da4-1fb4-43c9-90f2-e066d7351c3c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Automatically pause and resume @workspace indexing when OS CPU load is high"
+}

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -68,7 +68,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.9']
+const supportedLspServerVersions = ['0.1.13']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 /*
@@ -285,7 +285,7 @@ export class LspController {
         const resp: RelevantTextDocument[] = []
         chunks?.forEach((chunk) => {
             const text = chunk.context ? chunk.context : chunk.content
-            if (chunk.programmingLanguage) {
+            if (chunk.programmingLanguage && chunk.programmingLanguage !== 'unknown') {
                 resp.push({
                     text: text,
                     relativeFilePath: chunk.relativePath ? chunk.relativePath : path.basename(chunk.filePath),


### PR DESCRIPTION
## Problem
If the customer machine is already under heavy CPU load, the @ workspace indexing can cause slowness.

## Solution
When the user's OS is under heavy load, we pause the @ workspace  indexing and resumes when it is low. This is to avoid slowing down customer's device. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
