### PR TITLE
fix(infracomposer): update animate graph for infraComposer in toolkit README

### DIFF
--- a/packages/toolkit/.changes/next-release/Bug Fix-d8111f1d-c5f8-48ee-9b25-6d64a98bc3c2.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-d8111f1d-c5f8-48ee-9b25-6d64a98bc3c2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "update animate graph for infraComposer in toolkit README"
+}

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -33,7 +33,7 @@ AWS Infrastructure Composer maintains a real-time visual representation of your 
 -   Use the right tool for the task, including visual, code, or generative AI powered code suggestions in your IDE.
 -   Integrate with Workflow Studio to visually orchestrate over 220 AWS services or public http endpoints with Step Functions workflows.
 
-![Infrastructure Composer](https://raw.githubusercontent.com/aws/aws-toolkit-vscode/HEAD/docs/marketplace/vscode/appComposer.gif)
+![Infrastructure Composer](https://raw.githubusercontent.com/aws/aws-toolkit-vscode/HEAD/docs/marketplace/vscode/infraComposer.webp)
 
 ## [Amazon CodeCatalyst](https://codecatalyst.aws/explore)
 


### PR DESCRIPTION
## Problem
After renaming Application Composer to Infrastructure Composer, we need to update the animate graph in Toolkit/README

## Solution
update the animate graph in Toolkit/README

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
