### PR TITLE
telemetry(messages): maybeShowMinVscodeWarning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19394,7 +19394,7 @@
             },
             "engines": {
                 "npm": "^10.1.0",
-                "vscode": "^1.83.0"
+                "vscode": "^1.68.0"
             }
         },
         "packages/core/node_modules/@types/node": {

--- a/packages/core/src/shared/utilities/messages.ts
+++ b/packages/core/src/shared/utilities/messages.ts
@@ -16,8 +16,9 @@ import { getIcon, codicon } from '../icons'
 import globals from '../extensionGlobals'
 import { openUrl } from './vsCodeUtils'
 import { AmazonQPromptSettings, ToolkitPromptSettings } from '../../shared/settings'
-import { telemetry } from '../telemetry/telemetry'
+import { telemetry, ToolkitShowNotification } from '../telemetry/telemetry'
 import { vscodeComponent } from '../vscode/commands2'
+import { getTelemetryReasonDesc } from '../errors'
 
 export const messages = {
     editCredentials(icon: boolean) {
@@ -35,21 +36,31 @@ export function makeFailedWriteMessage(filename: string): string {
     return message
 }
 
-function showMessageWithItems(
-    message: string,
+export function showMessage(
     kind: 'info' | 'warn' | 'error' = 'error',
+    message: string,
     items: string[] = [],
-    useModal: boolean = false
+    options: vscode.MessageOptions & { telemetry?: boolean } = {},
+    metric: Partial<ToolkitShowNotification> = {}
 ): Thenable<string | undefined> {
-    switch (kind) {
-        case 'info':
-            return vscode.window.showInformationMessage(message, { modal: useModal }, ...items)
-        case 'warn':
-            return vscode.window.showWarningMessage(message, { modal: useModal }, ...items)
-        case 'error':
-        default:
-            return vscode.window.showErrorMessage(message, { modal: useModal }, ...items)
-    }
+    return telemetry.toolkit_showNotification.run(async (span) => {
+        span.record({
+            passive: true,
+            id: 'unknown',
+            component: 'editor',
+            ...metric,
+        })
+
+        switch (kind) {
+            case 'info':
+                return vscode.window.showInformationMessage(message, options, ...items)
+            case 'warn':
+                return vscode.window.showWarningMessage(message, options, ...items)
+            case 'error':
+            default:
+                return vscode.window.showErrorMessage(message, options, ...items)
+        }
+    })
 }
 
 /**
@@ -75,7 +86,16 @@ export async function showMessageWithUrl(
     const uri = typeof url === 'string' ? vscode.Uri.parse(url) : url
     const items = [...extraItems, urlItem]
 
-    const p = showMessageWithItems(message, kind, items, useModal)
+    const p = showMessage(
+        kind,
+        message,
+        items,
+        { modal: useModal },
+        {
+            id: 'showMessageWithUrl',
+            reasonDesc: getTelemetryReasonDesc(message),
+        }
+    )
     return p.then<string | undefined>((selection) => {
         if (selection === urlItem) {
             void openUrl(uri)
@@ -102,7 +122,16 @@ export async function showViewLogsMessage(
     const logsItem = localize('AWS.generic.message.viewLogs', 'View Logs...')
     const items = [...extraItems, logsItem]
 
-    const p = showMessageWithItems(message, kind, items)
+    const p = showMessage(
+        kind,
+        message,
+        items,
+        {},
+        {
+            id: 'showViewLogsMessage',
+            reasonDesc: getTelemetryReasonDesc(message),
+        }
+    )
     return p.then<string | undefined>((selection) => {
         if (selection === logsItem) {
             globals.logOutputChannel.show(true)

--- a/packages/core/src/test/shared/extensionUtilities.test.ts
+++ b/packages/core/src/test/shared/extensionUtilities.test.ts
@@ -21,6 +21,7 @@ import globals from '../../shared/extensionGlobals'
 import { createQuickStartWebview, maybeShowMinVscodeWarning } from '../../shared/extensionStartup'
 import { fs } from '../../shared'
 import { getTestWindow } from './vscode/window'
+import { assertTelemetry } from '../testUtil'
 
 describe('extensionUtilities', function () {
     it('maybeShowMinVscodeWarning', async () => {
@@ -30,6 +31,7 @@ describe('extensionUtilities', function () {
             /will soon require .* 99\.0\.0 or newer. The currently running version .* will no longer receive updates./
         const msg = await getTestWindow().waitForMessage(expectedMsg)
         msg.close()
+        assertTelemetry('toolkit_showNotification', [])
     })
 
     describe('createQuickStartWebview', async function () {


### PR DESCRIPTION
## Problem

no metrics for notifications.

## Solution

add `toolkit_showNotification` to `showMessage` and use it in `maybeShowMinVscodeWarning`.


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
