### PR TITLE
refactor(amazonq): move getIndentedCode to textDocumentUtilities and use cwsprChatInteractionType

### DIFF
--- a/packages/core/src/amazonq/commons/controllers/contentController.ts
+++ b/packages/core/src/amazonq/commons/controllers/contentController.ts
@@ -12,9 +12,10 @@ import { disposeOnEditorClose } from '../../../shared/utilities/editorUtilities'
 import {
     applyChanges,
     createTempFileForDiff,
+    getIndentedCode,
     getSelectionFromRange,
 } from '../../../shared/utilities/textDocumentUtilities'
-import { extractFileAndCodeSelectionFromMessage, fs, getErrorMsg, getIndentedCode, ToolkitError } from '../../../shared'
+import { extractFileAndCodeSelectionFromMessage, fs, getErrorMsg, ToolkitError } from '../../../shared'
 
 class ContentProvider implements vscode.TextDocumentContentProvider {
     constructor(private uri: vscode.Uri) {}

--- a/packages/core/src/amazonq/util/functionUtils.ts
+++ b/packages/core/src/amazonq/util/functionUtils.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * Converts an array of key-value pairs into a Map object.
+ * Tries to create map and returns empty map if failed.
  *
  * @param {[unknown, unknown][]} arr - An array of tuples, where each tuple represents a key-value pair.
  * @returns {Map<unknown, unknown>} A new Map object created from the input array.

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -200,24 +200,6 @@
             "description": "Number of characters in request"
         },
         {
-            "name": "cwsprChatInteractionType",
-            "allowedValues": [
-                "acceptDiff",
-                "insertAtCursor",
-                "copySnippet",
-                "copy",
-                "clickLink",
-                "clickFollowUp",
-                "hoverReference",
-                "upvote",
-                "downvote",
-                "clickBodyLink",
-                "viewDiff"
-            ],
-            "type": "string",
-            "description": "Indicates the specific interaction type with a message in a conversation"
-        },
-        {
             "name": "cwsprChatInteractionTarget",
             "type": "string",
             "description": "Identifies the entity within the message that user interacts with."

--- a/packages/core/src/shared/utilities/textDocumentUtilities.ts
+++ b/packages/core/src/shared/utilities/textDocumentUtilities.ts
@@ -7,7 +7,7 @@ import * as _path from 'path'
 import * as vscode from 'vscode'
 import { getTabSizeSetting } from './editorUtilities'
 import { tempDirPath } from '../filesystemUtilities'
-import { fs, getIndentedCode, ToolkitError } from '../index'
+import { fs, indent, ToolkitError } from '../index'
 import { getLogger } from '../logger'
 
 /**
@@ -164,4 +164,23 @@ export async function createTempFileForDiff(
 
     await applyChanges(doc, range, code)
     return tempFileUri
+}
+
+/**
+ * Indents the given code based on the current document's indentation at the selection start.
+ *
+ * @param message The message object containing the code.
+ * @param doc The VSCode document where the code is applied.
+ * @param selection The selection range in the document.
+ * @returns The processed code to be applied to the document.
+ */
+export function getIndentedCode(message: any, doc: vscode.TextDocument, selection: vscode.Selection) {
+    const indentRange = new vscode.Range(new vscode.Position(selection.start.line, 0), selection.active)
+    let indentation = doc.getText(indentRange)
+
+    if (indentation.trim().length !== 0) {
+        indentation = ' '.repeat(indentation.length - indentation.trimStart().length)
+    }
+
+    return indent(message.code, indentation.length)
 }

--- a/packages/core/src/shared/utilities/textUtilities.ts
+++ b/packages/core/src/shared/utilities/textUtilities.ts
@@ -417,22 +417,3 @@ export function extractFileAndCodeSelectionFromMessage(message: any) {
     const selection = message?.context?.focusAreaContext?.selectionInsideExtendedCodeBlock as vscode.Selection
     return { filePath, selection }
 }
-
-/**
- * Indents the given code based on the current document's indentation at the selection start.
- *
- * @param {any} message - The message object containing the code.
- * @param {vscode.TextDocument} doc - The VSCode document where the code is applied.
- * @param {vscode.Selection} selection - The selection range in the document.
- * @returns {string} - The processed code to be applied to the document.
- */
-export function getIndentedCode(message: any, doc: vscode.TextDocument, selection: vscode.Selection) {
-    const indentRange = new vscode.Range(new vscode.Position(selection.start.line, 0), selection.active)
-    let indentation = doc.getText(indentRange)
-
-    if (indentation.trim().length !== 0) {
-        indentation = ' '.repeat(indentation.length - indentation.trimStart().length)
-    }
-
-    return indent(message.code, indentation.length)
-}


### PR DESCRIPTION
move getIndentedCode to textDocumentUtilities and use cwsprChatInteractionType from aws-toolkit-common

---

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
