### PR TITLE
fix(tests): avoid using our fs before globals initialized

### DIFF
--- a/packages/core/src/test/globalSetup.test.ts
+++ b/packages/core/src/test/globalSetup.test.ts
@@ -26,9 +26,9 @@ import { GlobalState } from '../shared/globalState'
 import { FeatureConfigProvider } from '../shared/featureConfig'
 import { mockFeatureConfigsData } from './fake/mockFeatureConfigData'
 import { fs } from '../shared'
+import { rm, mkdir } from 'fs/promises' //eslint-disable-line no-restricted-imports
 
 disableAwsSdkWarning()
-
 const testReportDir = join(__dirname, '../../../../../.test-reports') // Root project, not subproject
 const testLogOutput = join(testReportDir, 'testLog.log')
 const globalSandbox = sinon.createSandbox()
@@ -42,10 +42,11 @@ let openExternalStub: sinon.SinonStub<Parameters<(typeof vscode)['env']['openExt
 export async function mochaGlobalSetup(extensionId: string) {
     return async function (this: Mocha.Runner) {
         // Clean up and set up test logs
+        // Use nodefs over our fs since globals may not be initialized yet and our fs checks isWeb via globals.
         try {
-            await fs.delete(testLogOutput)
+            await rm(testLogOutput)
         } catch (e) {}
-        await fs.mkdir(testReportDir)
+        await mkdir(testReportDir, { recursive: true })
 
         sinon.stub(FeatureConfigProvider.prototype, 'listFeatureEvaluations').resolves({
             featureEvaluations: mockFeatureConfigsData,

--- a/packages/core/src/test/globalSetup.test.ts
+++ b/packages/core/src/test/globalSetup.test.ts
@@ -26,7 +26,7 @@ import { GlobalState } from '../shared/globalState'
 import { FeatureConfigProvider } from '../shared/featureConfig'
 import { mockFeatureConfigsData } from './fake/mockFeatureConfigData'
 import { fs } from '../shared'
-import { rm, mkdir } from 'fs/promises' //eslint-disable-line no-restricted-imports
+import { promises as nodefs } from 'fs' //eslint-disable-line no-restricted-imports
 
 disableAwsSdkWarning()
 const testReportDir = join(__dirname, '../../../../../.test-reports') // Root project, not subproject
@@ -43,8 +43,8 @@ export async function mochaGlobalSetup(extensionId: string) {
     return async function (this: Mocha.Runner) {
         // Clean up and set up test logs
         // Use nodefs over our fs since globals may not be initialized yet and our fs checks isWeb via globals.
-        await rm(testLogOutput, { force: true })
-        await mkdir(testReportDir, { recursive: true })
+        await nodefs.rm(testLogOutput, { force: true })
+        await nodefs.mkdir(testReportDir, { recursive: true })
 
         sinon.stub(FeatureConfigProvider.prototype, 'listFeatureEvaluations').resolves({
             featureEvaluations: mockFeatureConfigsData,

--- a/packages/core/src/test/globalSetup.test.ts
+++ b/packages/core/src/test/globalSetup.test.ts
@@ -43,9 +43,7 @@ export async function mochaGlobalSetup(extensionId: string) {
     return async function (this: Mocha.Runner) {
         // Clean up and set up test logs
         // Use nodefs over our fs since globals may not be initialized yet and our fs checks isWeb via globals.
-        try {
-            await rm(testLogOutput)
-        } catch (e) {}
+        await rm(testLogOutput, { force: true })
         await mkdir(testReportDir, { recursive: true })
 
         sinon.stub(FeatureConfigProvider.prototype, 'listFeatureEvaluations').resolves({

--- a/packages/core/src/test/globalSetup.test.ts
+++ b/packages/core/src/test/globalSetup.test.ts
@@ -42,7 +42,7 @@ let openExternalStub: sinon.SinonStub<Parameters<(typeof vscode)['env']['openExt
 export async function mochaGlobalSetup(extensionId: string) {
     return async function (this: Mocha.Runner) {
         // Clean up and set up test logs
-        // Use nodefs over our fs since globals may not be initialized yet and our fs checks isWeb via globals.
+        // Use nodefs instead of our fs module (which uses globals.isWeb, which is not initialized yet).
         await nodefs.rm(testLogOutput, { force: true })
         await nodefs.mkdir(testReportDir, { recursive: true })
 


### PR DESCRIPTION
## Problem
In https://github.com/aws/aws-toolkit-vscode/blob/16aa3684f479566bfcf6a9e33f88e70039831e9a/packages/core/src/test/globalSetup.test.ts#L48, we use our fs wrapper, but global context hasn't been initialized yet. When we check `isWeb` in our fs module, we get the following: 
```
Exception has occurred: Error: ToolkitGlobals accessed before initialize()
  at Object.get (/Volumes/workplace/aws-toolkit-vscode/packages/core/src/shared/extensionGlobals.ts:109:23)
    at FileSystem.get isWeb [as isWeb] (/Volumes/workplace/aws-toolkit-vscode/packages/core/src/shared/fs/fs.ts:689:24)
    at FileSystem.mkdir (/Volumes/workplace/aws-toolkit-vscode/packages/core/src/shared/fs/fs.ts:94:63)
    at Runner.<anonymous> (/Volumes/workplace/aws-toolkit-vscode/packages/core/src/test/globalSetup.test.ts:48:18)
    at async Mocha._runGlobalFixtures (/Volumes/workplace/aws-toolkit-vscode/node_modules/mocha/lib/mocha.js:1214:5)
    at async Mocha.runGlobalSetup (/Volumes/workplace/aws-toolkit-vscode/node_modules/mocha/lib/mocha.js:1174:5)
    at async runAsync (/Volumes/workplace/aws-toolkit-vscode/node_modules/mocha/lib/mocha.js:1016:11)
```

To reproduce, go into master, run any test file individually with "Extension Tests (current file) (amazonq)". 

## Solution
Use node's fs when setting up tests since we must wait for global context to be initialized to use our fs. 

## Open Question 
Why does it work when we do  "Extension Tests (current file) (toolkit)"  for q related tests? Does the toolkit do additional setup that might initialize the globals?

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
