### PR TITLE
feat(stepfunctions): Implement bi-directional sync between local file and WFS

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -23,6 +23,7 @@
     "AWS.stepFunctions.asl.format.enable.desc": "Enables the default formatter used with Amazon States Language files",
     "AWS.stepFunctions.asl.maxItemsComputed.desc": "The maximum number of outline symbols and folding regions computed (limited for performance reasons).",
     "AWS.stepFunctions.workflowStudio.actions.progressMessage": "Opening asl file in Workflow Studio",
+    "AWS.stepFunctions.workflowStudio.actions.saveSuccessMessage": "{0} has been saved",
     "AWS.configuration.description.awssam.debug.api": "API Gateway configuration",
     "AWS.configuration.description.awssam.debug.api.clientCertId": "The API Gateway client certificate ID",
     "AWS.configuration.description.awssam.debug.api.headers": "Additional HTTP headers",

--- a/packages/core/src/feedback/vue/submitFeedback.ts
+++ b/packages/core/src/feedback/vue/submitFeedback.ts
@@ -71,7 +71,7 @@ export class FeedbackWebview extends VueWebview {
     }
 }
 
-type FeedbackId = 'AWS Toolkit' | 'Amazon Q' | 'Application Composer' | 'Threat Composer'
+type FeedbackId = 'AWS Toolkit' | 'Amazon Q' | 'Application Composer' | 'Threat Composer' | 'Workflow Studio'
 
 let _submitFeedback:
     | RegisteredCommand<(_: VsCodeCommandArg, id: FeedbackId, commentData?: string) => Promise<void>>

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -517,6 +517,24 @@
             ]
         },
         {
+            "name": "stepfunctions_saveFile",
+            "description": "Called after the user saves local ASL file (inlcuding autosave) from VSCode editor or Workflow Studio",
+            "metadata": [
+                {
+                    "type": "id",
+                    "required": true
+                },
+                {
+                    "type": "saveType",
+                    "required": true
+                },
+                {
+                    "type": "source",
+                    "required": true
+                }
+            ]
+        },
+        {
             "name": "vscode_activeRegions",
             "description": "Record the number of active regions at startup and when regions are added/removed",
             "unit": "Count",

--- a/packages/core/src/stepFunctions/workflowStudio/handleMessage.ts
+++ b/packages/core/src/stepFunctions/workflowStudio/handleMessage.ts
@@ -1,0 +1,172 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    Command,
+    Message,
+    MessageType,
+    SaveFileRequestMessage,
+    WebviewContext,
+    InitResponseMessage,
+    FileChangedMessage,
+    FileChangeEventTrigger,
+} from './types'
+import { submitFeedback } from '../../feedback/vue/submitFeedback'
+import { placeholder } from '../../shared/vscode/commands2'
+import * as nls from 'vscode-nls'
+import vscode from 'vscode'
+import { telemetry } from '../../shared/telemetry/telemetry'
+import { ToolkitError } from '../../shared/errors'
+const localize = nls.loadMessageBundle()
+
+/**
+ * Handles messages received from the webview. Depending on the message type and command,
+ * calls the appropriate handler function
+ * @param message The message received from the webview
+ * @param context The context object containing information about the webview environment
+ */
+export async function handleMessage(message: Message, context: WebviewContext) {
+    const { command, messageType } = message
+
+    if (messageType === MessageType.REQUEST) {
+        switch (command) {
+            case Command.INIT:
+                void initMessageHandler(context)
+                break
+            case Command.SAVE_FILE:
+                void saveFileMessageHandler(message as SaveFileRequestMessage, context)
+                break
+            case Command.AUTO_SAVE_FILE:
+                void autoSaveFileMessageHandler(message as SaveFileRequestMessage, context)
+                break
+            case Command.OPEN_FEEDBACK:
+                void submitFeedback(placeholder, 'Workflow Studio')
+                break
+        }
+    } else if (messageType === MessageType.BROADCAST) {
+        switch (command) {
+            case Command.LOAD_STAGE:
+                void loadStageMessageHandler(context)
+                break
+        }
+    }
+}
+
+/**
+ * Handler for when the webview is ready.
+ * This handler is used to initialize the webview with the contents of the asl file selected.
+ * @param context The context object containing the necessary information for the webview.
+ */
+async function initMessageHandler(context: WebviewContext) {
+    const filePath = context.defaultTemplatePath
+
+    try {
+        const fileContents = context.textDocument.getText().toString()
+        context.fileStates[filePath] = { fileContents }
+
+        await broadcastFileChange(context, 'INITIAL_RENDER')
+        context.loaderNotification?.progress.report({ increment: 25 })
+    } catch (e) {
+        await context.panel.webview.postMessage({
+            messageType: MessageType.RESPONSE,
+            command: Command.INIT,
+            filePath,
+            isSuccess: false,
+            failureReason: (e as Error).message,
+        } as InitResponseMessage)
+    }
+}
+
+/**
+ * Helper Function to broadcast the local file change to the Workflow Studio view
+ * @param context: The context of the webview
+ * @param trigger: The action that triggered the change (either initial render or user saving the file)
+ */
+export async function broadcastFileChange(context: WebviewContext, trigger: FileChangeEventTrigger) {
+    await context.panel.webview.postMessage({
+        messageType: MessageType.BROADCAST,
+        command: Command.FILE_CHANGED,
+        fileName: context.defaultTemplateName,
+        fileContents: context.textDocument.getText().toString(),
+        filePath: context.defaultTemplatePath,
+        trigger,
+    } as FileChangedMessage)
+}
+
+/**
+ * Handler for managing webview stage load, which updates load notifications.
+ * @param message The message containing the load stage.
+ * @param context The context object containing the necessary information for the webview.
+ */
+async function loadStageMessageHandler(context: WebviewContext) {
+    context.loaderNotification?.progress.report({ increment: 25 })
+    setTimeout(() => {
+        context.loaderNotification?.resolve()
+    }, 100)
+}
+
+/**
+ * Handler for saving a file from the webview which updates the workspace and saves the file.
+ * Triggered when the user explicitly applies save action in WFS
+ * @param request The request message containing the file contents.
+ * @param context The webview context containing the necessary information for saving the file.
+ */
+async function saveFileMessageHandler(request: SaveFileRequestMessage, context: WebviewContext) {
+    await telemetry.stepfunctions_saveFile.run(async (span) => {
+        span.record({
+            id: context.fileId,
+            saveType: 'MANUAL_SAVE',
+            source: 'WORKFLOW_STUDIO',
+        })
+
+        try {
+            await saveWorkspace(context, request.fileContents)
+            await context.textDocument.save()
+
+            void vscode.window.showInformationMessage(
+                localize(
+                    'AWS.stepFunctions.workflowStudio.actions.saveSuccessMessage',
+                    '{0} has been saved',
+                    context.defaultTemplateName
+                )
+            )
+        } catch (err) {
+            throw ToolkitError.chain(err, 'Could not save asl file.', { code: 'SaveFailed' })
+        }
+    })
+}
+
+/**
+ * Handler for auto saving a file from the webview which updates the workspace but does not save the file.
+ * Triggered on every code change from WFS.
+ * @param request The request message containing the file contents.
+ * @param context The webview context containing the necessary information for saving the file.
+ */
+async function autoSaveFileMessageHandler(request: SaveFileRequestMessage, context: WebviewContext) {
+    await telemetry.stepfunctions_saveFile.run(async (span) => {
+        span.record({
+            id: context.fileId,
+            saveType: 'AUTO_SAVE',
+            source: 'WORKFLOW_STUDIO',
+        })
+
+        try {
+            await saveWorkspace(context, request.fileContents)
+        } catch (err) {
+            throw ToolkitError.chain(err, 'Could not autosave asl file.', { code: 'AutoSaveFailed' })
+        }
+    })
+}
+
+/**
+ * Saves to the workspace with the provided file contents.
+ * @param context The webview context containing the necessary information for saving the file.
+ * @param fileContents The file contents to save.
+ */
+async function saveWorkspace(context: WebviewContext, fileContents: string) {
+    const edit = new vscode.WorkspaceEdit()
+    edit.replace(context.textDocument.uri, new vscode.Range(0, 0, context.textDocument.lineCount, 0), fileContents)
+    await vscode.workspace.applyEdit(edit)
+}

--- a/packages/core/src/stepFunctions/workflowStudio/types.ts
+++ b/packages/core/src/stepFunctions/workflowStudio/types.ts
@@ -11,6 +11,7 @@ export type WebviewContext = {
     workSpacePath: string
     defaultTemplatePath: string
     defaultTemplateName: string
+    fileStates: Record<string, FileWatchInfo>
     loaderNotification: undefined | LoaderNotification
     fileId: string
 }
@@ -22,4 +23,52 @@ export type LoaderNotification = {
     }>
     cancellationToken: vscode.CancellationToken
     resolve: () => void
+}
+
+export enum MessageType {
+    REQUEST = 'REQUEST',
+    RESPONSE = 'RESPONSE',
+    BROADCAST = 'BROADCAST',
+}
+
+export enum Command {
+    INIT = 'INIT',
+    SAVE_FILE = 'SAVE_FILE',
+    AUTO_SAVE_FILE = 'AUTO_SAVE_FILE',
+    FILE_CHANGED = 'FILE_CHANGED',
+    LOAD_STAGE = 'LOAD_STAGE',
+    OPEN_FEEDBACK = 'OPEN_FEEDBACK',
+}
+
+export type FileWatchInfo = {
+    fileContents: string
+}
+
+export enum SaveCompleteSubType {
+    SAVED = 'SAVED',
+    SAVE_SKIPPED_SAME_CONTENT = 'SAVE_SKIPPED_SAME_CONTENT',
+    SAVE_FAILED = 'SAVE_FAILED',
+}
+
+export interface Message {
+    command: Command
+    messageType: MessageType
+}
+
+export type FileChangeEventTrigger = 'INITIAL_RENDER' | 'MANUAL_SAVE'
+
+export interface FileChangedMessage extends Message {
+    fileName: string
+    fileContents: string
+    filePath: string
+    trigger: FileChangeEventTrigger
+}
+
+export interface InitResponseMessage extends Omit<FileChangedMessage, 'trigger'> {
+    isSuccess: boolean
+    failureReason?: string
+}
+
+export interface SaveFileRequestMessage extends Message {
+    fileContents: string
 }

--- a/packages/core/src/stepFunctions/workflowStudio/workflowStudioEditorProvider.ts
+++ b/packages/core/src/stepFunctions/workflowStudio/workflowStudioEditorProvider.ts
@@ -140,7 +140,9 @@ export class WorkflowStudioEditorProvider implements vscode.CustomTextEditorProv
                     )
                     this.handleNewVisualization(document.uri.fsPath, newVisualization)
                 } catch (err) {
-                    throw new ToolkitError((err as Error).message, { code: 'OpenWorkflowStudioFailed' })
+                    throw ToolkitError.chain(err, 'Could not open Workflow Studio editor', {
+                        code: 'OpenWorkflowStudioFailed',
+                    })
                 }
             }
         })


### PR DESCRIPTION
## Problem
Workflow Studio custom editor does not communicate bi-directly with local asl file

## Solution
Adding bi-directional sync between local file and Workflow Studio custom editor
- On local file save, the change is sent and applied to WFS
- On every WFS action the change is synced with local file (without saving)
- On save action from WFS (Save button or Crtl+S) the local file is saved


Additionally, adding send feedback functionality + handling webview loading indicator

[Demo gif](https://maxis-file-service-prod-iad.iad.proxy.amazon.com/issues/bccf68da-2515-47fd-b549-65d7f7de39fe/attachments/4c11f37d32d60190aba363c20716f554045326d9381107c403f741c0496cd7b4_cb34c843-ee3b-42a3-b725-a7e87856741a)


---


License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
