### PR TITLE
fix(dev): add UserAgent in Q feature development requests

### DIFF
--- a/packages/core/src/amazonqFeatureDev/client/featureDev.ts
+++ b/packages/core/src/amazonqFeatureDev/client/featureDev.ts
@@ -23,7 +23,7 @@ import {
 import { ToolkitError, isAwsError } from '../../shared/errors'
 import { getCodewhispererConfig } from '../../codewhisperer/client/codewhisperer'
 import { createCodeWhispererChatStreamingClient } from '../../shared/clients/codewhispererChatClient'
-import { getClientId, getOptOutPreference, getOperatingSystem } from '../../shared/telemetry/util'
+import { getClientId, getOptOutPreference, getOperatingSystem, getUserAgent } from '../../shared/telemetry/util'
 import { extensionVersion } from '../../shared/vscode/env'
 
 // Re-enable once BE is able to handle retries.
@@ -46,6 +46,7 @@ export async function createFeatureDevProxyClient(options?: Partial<ServiceOptio
             region: cwsprConfig.region,
             endpoint: cwsprConfig.endpoint,
             token: new Token({ token: bearerToken }),
+            customUserAgent: getUserAgent(),
             httpOptions: {
                 connectTimeout: 10000, // 10 seconds, 3 times P99 API latency
             },


### PR DESCRIPTION
## Problem

Missing user agent in Amazon Q feature development requests.
Observed errors with proxy settings.

```
2024-10-07 15:23:33.084 [error] Amazon Q Developer Agent for software development: failed to start get code generation results: Client network socket disconnected before secure TLS connection was established RequestId: undefined

```

## Solution

- set customUserAgent in the Amazon Q feature development client.

refers to https://github.com/aws/aws-toolkit-vscode/pull/5158

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
