### PR TITLE
fix(test): unreliable test "AuthUtil CodeWhisperer uses fallback connection"

### DIFF
--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -565,9 +565,18 @@ export function captureEvent<T>(event: vscode.Event<T>): EventCapturer<T> {
  * Captures the first value emitted by an event, optionally with a timeout
  */
 export function captureEventOnce<T>(event: vscode.Event<T>, timeout?: number): Promise<T> {
+    return captureEventNTimes(event, 1, timeout)
+}
+
+export function captureEventNTimes<T>(event: vscode.Event<T>, amount: number, timeout?: number): Promise<T> {
     return new Promise<T>((resolve, reject) => {
         const stop = () => reject(new Error('Timed out waiting for event'))
-        event((data) => resolve(data))
+        let count = 0
+        event((data) => {
+            if (++count === amount) {
+                resolve(data)
+            }
+        })
 
         if (timeout !== undefined) {
             setTimeout(stop, timeout)


### PR DESCRIPTION
## Problem:

This test was flaky due to the event emitter and the test expecting 2 of the same event to come in, but sometimes the second one was not capture.

This looks to be due to the second `captureEventOnce` call needing to do some initial setup before it could capture an event. And I think there was a race condition between it being setup in time and the event being emitted before it could start listening.

## Solution:

Make a new function which does the event capture once and then listens N amount of times. This is reliable.

fix https://github.com/aws/aws-toolkit-vscode/issues/5681

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
