### PR TITLE
refactor(cwl): Change implementation of LiveTailRegistry to standard map

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSessionRegistry.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSessionRegistry.ts
@@ -5,10 +5,8 @@
 import * as vscode from 'vscode'
 import { CLOUDWATCH_LOGS_LIVETAIL_SCHEME } from '../../../shared/constants'
 import { LiveTailSession, LiveTailSessionConfiguration } from './liveTailSession'
-import { ToolkitError } from '../../../shared'
-import { NestedMap } from '../../../shared/utilities/map'
 
-export class LiveTailSessionRegistry extends NestedMap<vscode.Uri, LiveTailSession> {
+export class LiveTailSessionRegistry extends Map<vscode.Uri, LiveTailSession> {
     static #instance: LiveTailSessionRegistry
 
     public static get instance() {
@@ -17,18 +15,6 @@ export class LiveTailSessionRegistry extends NestedMap<vscode.Uri, LiveTailSessi
 
     public constructor() {
         super()
-    }
-
-    protected override hash(uri: vscode.Uri): string {
-        return uri.toString()
-    }
-
-    protected override get name(): string {
-        return LiveTailSessionRegistry.name
-    }
-
-    protected override get default(): LiveTailSession {
-        throw new ToolkitError('No LiveTailSession found for provided uri.')
     }
 }
 

--- a/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailRegistry.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailRegistry.test.ts
@@ -4,53 +4,9 @@
  */
 import * as vscode from 'vscode'
 import assert from 'assert'
-import {
-    LiveTailSession,
-    LiveTailSessionConfiguration,
-} from '../../../../awsService/cloudWatchLogs/registry/liveTailSession'
-import {
-    createLiveTailURIFromArgs,
-    LiveTailSessionRegistry,
-} from '../../../../awsService/cloudWatchLogs/registry/liveTailSessionRegistry'
+import { LiveTailSessionConfiguration } from '../../../../awsService/cloudWatchLogs/registry/liveTailSession'
+import { createLiveTailURIFromArgs } from '../../../../awsService/cloudWatchLogs/registry/liveTailSessionRegistry'
 import { CLOUDWATCH_LOGS_LIVETAIL_SCHEME } from '../../../../shared/constants'
-
-/**
- * Exposes protected methods so we can test them
- */
-class TestLiveTailSessionRegistry extends LiveTailSessionRegistry {
-    constructor() {
-        super()
-    }
-
-    override hash(uri: vscode.Uri): string {
-        return super.hash(uri)
-    }
-
-    override get default(): LiveTailSession {
-        return super.default
-    }
-}
-
-describe('LiveTailRegistry', async function () {
-    const session = new LiveTailSession({
-        logGroupName: 'test-log-group',
-        region: 'test-region',
-    })
-
-    let liveTailSessionRegistry: TestLiveTailSessionRegistry
-
-    beforeEach(function () {
-        liveTailSessionRegistry = new TestLiveTailSessionRegistry()
-    })
-
-    it('hash()', function () {
-        assert.deepStrictEqual(liveTailSessionRegistry.hash(session.uri), session.uri.toString())
-    })
-
-    it('default()', function () {
-        assert.throws(() => liveTailSessionRegistry.default)
-    })
-})
 
 describe('LiveTailSession URI', async function () {
     const testLogGroupName = 'test-log-group'


### PR DESCRIPTION
## Problem
The nestedMap implementation of the registry was forcing a defined Default item. This doesn't fit the usecase I am aiming to provide by this registry. There is no default object to be returned. If an item doesn't exist in the registry, we should handle an undefined object, and not a placeholder. In other words, there is no concept of a placeholder/default value for a LiveTailSession.

Additionally, `set` on the NestedMap would perform a deep merge. I am wanting to replace the object. 

Originally I defined the default object to an exception, but the NestedMap `set` operation calls `get`. And if there isn't already a value in the map, it would throw the exception defined as the default object. This means we could never add any item to the map. 

## Solution
Swap the underlying implementation of the registry to a basic Map. 
I am still defining a `LiveTailSessionRegistry` class so we can statically initialize a registry singleton, as well as leaving the possibility open to override or extend the `Map` class. Also so we can pass around the type `LiveTailSessionRegistry` instead of `Map<Foo, Bar>`.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
