### PR TITLE
fix(credentials): fix credential test so it won't remove real aws config

### DIFF
--- a/packages/core/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/packages/core/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -52,8 +52,8 @@ describe('UserCredentialsUtils', function () {
     after(async function () {
         await fs.delete(tempFolder, { recursive: true })
         // restore envs
-        process.env['AWS_SHARED_CREDENTIALS_FILE'] = credEnv
-        process.env['AWS_CONFIG_FILE'] = configEnv
+        process.env.AWS_SHARED_CREDENTIALS_FILE = credEnv
+        process.env.AWS_CONFIG_FILE = configEnv
     })
 
     describe('findExistingCredentialsFilenames', function () {

--- a/packages/core/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/packages/core/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -18,42 +18,20 @@ import {
 import { UserCredentialsUtils } from '../../../shared/credentials/userCredentialsUtils'
 import { EnvironmentVariables } from '../../../shared/environmentVariables'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
-import { getConfigFilename, getCredentialsFilename } from '../../../auth/credentials/sharedCredentialsFile'
 import { fs } from '../../../shared'
 
 describe('UserCredentialsUtils', function () {
     let tempFolder: string
-    let defaultConfigFileName: string
-    let defaultCredentialsFilename: string
-    // preserve envs
-    const credEnv = process.env['AWS_SHARED_CREDENTIALS_FILE']
-    const configEnv = process.env['AWS_CONFIG_FILE']
 
-    before(async function () {
+    beforeEach(async function () {
         // Make a temp folder for all these tests
         // Stick some temp credentials files in there to load from
         tempFolder = await makeTemporaryToolkitFolder()
-
-        // Set env to fake cred/config to avoid the actual aws config being deleted by test
-        process.env.AWS_SHARED_CREDENTIALS_FILE = path.join(tempFolder, 'aws-credentials-tmp')
-        process.env.AWS_CONFIG_FILE = path.join(tempFolder, 'aws-config-tmp')
-
-        defaultConfigFileName = getConfigFilename()
-        defaultCredentialsFilename = getCredentialsFilename()
     })
 
     afterEach(async function () {
-        await fs.delete(defaultConfigFileName, { recursive: true })
-        await fs.delete(defaultCredentialsFilename, { recursive: true })
-
-        sinon.restore()
-    })
-
-    after(async function () {
         await fs.delete(tempFolder, { recursive: true })
-        // restore envs
-        process.env.AWS_SHARED_CREDENTIALS_FILE = credEnv
-        process.env.AWS_CONFIG_FILE = configEnv
+        sinon.restore()
     })
 
     describe('findExistingCredentialsFilenames', function () {

--- a/packages/core/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/packages/core/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -25,13 +25,21 @@ describe('UserCredentialsUtils', function () {
     let tempFolder: string
     let defaultConfigFileName: string
     let defaultCredentialsFilename: string
+    // preserve envs
+    const credEnv = process.env['AWS_SHARED_CREDENTIALS_FILE']
+    const configEnv = process.env['AWS_CONFIG_FILE']
 
     before(async function () {
-        defaultConfigFileName = getConfigFilename()
-        defaultCredentialsFilename = getCredentialsFilename()
         // Make a temp folder for all these tests
         // Stick some temp credentials files in there to load from
         tempFolder = await makeTemporaryToolkitFolder()
+
+        // Set env to fake cred/config to avoid the actual aws config being deleted by test
+        process.env.AWS_SHARED_CREDENTIALS_FILE = path.join(tempFolder, 'aws-credentials-tmp')
+        process.env.AWS_CONFIG_FILE = path.join(tempFolder, 'aws-config-tmp')
+
+        defaultConfigFileName = getConfigFilename()
+        defaultCredentialsFilename = getCredentialsFilename()
     })
 
     afterEach(async function () {
@@ -43,6 +51,9 @@ describe('UserCredentialsUtils', function () {
 
     after(async function () {
         await fs.delete(tempFolder, { recursive: true })
+        // restore envs
+        process.env['AWS_SHARED_CREDENTIALS_FILE'] = credEnv
+        process.env['AWS_CONFIG_FILE'] = configEnv
     })
 
     describe('findExistingCredentialsFilenames', function () {

--- a/packages/toolkit/.changes/next-release/Bug Fix-a0acdaa1-7356-4f58-bc9b-fb7b708fe831.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-a0acdaa1-7356-4f58-bc9b-fb7b708fe831.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix userCredentialsUtils.test.ts so it won't remove the actual aws config"
+}


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/blob/0164d4145e58ae036ddf3815455ea12a159d491d/packages/core/src/test/shared/credentials/userCredentialsUtils.test.ts#L38-L39

This test is deleting my actual aws config file


## Solution
Update the environment variable to point to a fake location before test
Then recover them after test

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
