### PR TITLE
feat(amazonq): create context menu for agents

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-045e06c9-093c-44df-aec2-a55239ce2cb5.json
+++ b/packages/amazonq/.changes/next-release/Feature-045e06c9-093c-44df-aec2-a55239ce2cb5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Create a new group for Q Developer Agents in the Context Menu"
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -355,13 +355,21 @@
                     "group": "cw_chat@4"
                 },
                 {
-                    "command": "aws.amazonq.generateUnitTests",
-                    "group": "cw_chat@5",
-                    "when": "aws.codewhisperer.connected && aws.isInternalUser"
+                    "command": "aws.amazonq.sendToPrompt",
+                    "group": "cw_chat@5"
                 },
                 {
-                    "command": "aws.amazonq.sendToPrompt",
-                    "group": "cw_chat@6"
+                    "command": "aws.amazonq.contextMenu.Agent.title",
+                    "group": "cw_chat_agents@1"
+                },
+                {
+                    "command": "aws.amazonq.security.scan",
+                    "group": "cw_chat_agents@1"
+                },
+                {
+                    "command": "aws.amazonq.generateUnitTests",
+                    "group": "cw_chat_agents@2",
+                    "when": "aws.codewhisperer.connected && aws.isInternalUser"
                 }
             ],
             "editor/context": [
@@ -576,6 +584,11 @@
                 "title": "%AWS.amazonq.toggleCodeScan%",
                 "category": "%AWS.amazonq.title%",
                 "enablement": "aws.codewhisperer.connected"
+            },
+            {
+                "command": "aws.amazonq.contextMenu.Agent.title",
+                "title": "%AWS.amazonq.contextMenu.Agent.title%",
+                "enablement": "false"
             }
         ],
         "keybindings": [

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -317,5 +317,6 @@
     "AWS.amazonq.featureDev.placeholder.additionalImprovements": "Choose an option to proceed",
     "AWS.amazonq.featureDev.placeholder.feedback": "Provide feedback or comments",
     "AWS.amazonq.featureDev.placeholder.describe": "Describe your task or issue in detail",
-    "AWS.amazonq.featureDev.placeholder.sessionClosed": "Open a new chat tab to continue"
+    "AWS.amazonq.featureDev.placeholder.sessionClosed": "Open a new chat tab to continue",
+    "AWS.amazonq.contextMenu.Agent.title": "Q Developer Agents"
 }


### PR DESCRIPTION
Create a new Group in the Amazon Q Context Menu for Q Software Developer Agents. 

The Group has a title - `Q Developer Agents`. As VSCode doesn't support title/label for Groupings in context menu, we have created a command which is always disabled. As this command is not enabled
- It doesn't show up in the command palette
- It doesn't have a hover state or is clickable.

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
