### PR TITLE
refactor(telemetry): add functionality to @withTelemetryContext

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -229,8 +229,6 @@ thisThrows()
 
 ### Important Notes
 
--   You can avoid redundancy when repeating fields like `class` in `@withTelemetryContext` by using `withTelemetryContextFactory()`. It builds a new decorator with pre-defined values that you choose.
-
 -   If a nested function does not use a `run()` then it will not be part of the call stack.
 
     ```typescript

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -170,7 +170,7 @@ function failsDependingOnInput(num: number) {
 
 ### Solution
 
-On class methods use the `@withTelemetryContext()` decorator add context to the execution. Depending on the args set, it provides features like emitting the result, or adding it's context to errors.
+On class methods, use the `@withTelemetryContext()` decorator to add context to the execution. Depending on the args set, it provides features like emitting the result, or adding it's context to errors.
 
 > NOTE: Decorators are currently only supported for methods and not functions
 

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -438,7 +438,7 @@ export function withTelemetryContext(opts: TelemetryContextArgs) {
                 },
                 {
                     emit: opts.emit !== undefined ? opts.emit : false,
-                    functionId: opts,
+                    functionId: { name: opts.name, class: opts.class },
                 }
             )
         }

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -452,11 +452,3 @@ export function withTelemetryContext(opts: TelemetryContextArgs) {
         })
     }
 }
-
-/**
- * Returns a custom {@link withTelemetryContext} decorator, but with some values predefined
- * to deduplicate boilerplate for a class that will use this decorator multiple times.
- */
-export function withTelemetryContextFactory(predefinedOpts: Omit<TelemetryContextArgs, 'name'>) {
-    return (opts: TelemetryContextArgs) => withTelemetryContext({ ...predefinedOpts, ...opts })
-}

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -452,3 +452,11 @@ export function withTelemetryContext(opts: TelemetryContextArgs) {
         })
     }
 }
+
+/**
+ * Returns a custom {@link withTelemetryContext} decorator, but with some values predefined
+ * to deduplicate boilerplate for a class that will use this decorator multiple times.
+ */
+export function withTelemetryContextFactory(predefinedOpts: Omit<TelemetryContextArgs, 'name'>) {
+    return (opts: TelemetryContextArgs) => withTelemetryContext({ ...predefinedOpts, ...opts })
+}

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1137,6 +1137,10 @@
                 {
                     "type": "className",
                     "required": false
+                },
+                {
+                    "type": "source",
+                    "required": false
                 }
             ],
             "passive": true

--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -642,37 +642,34 @@ describe('TelemetryTracer', function () {
             assert.throws(
                 () => inst.throwsError(),
                 (e) => {
-                    if (!(e instanceof ToolkitError)) {
-                        return false
-                    }
-                    const id = getErrorId(e)
-                    const message = e.message
-                    const cause = e.cause
-                    return id === 'TestThrows' && message === 'ctx: throwsError' && cause === arbitraryError
+                    return (
+                        e instanceof ToolkitError &&
+                        getErrorId(e) === 'TestThrows' &&
+                        e.message === 'ctx: throwsError' &&
+                        e.cause === arbitraryError
+                    )
                 }
             )
             assert.throws(
                 () => inst.throwsErrorButNoClass(),
                 (e) => {
-                    if (!(e instanceof ToolkitError)) {
-                        return false
-                    }
-                    const id = getErrorId(e)
-                    const message = e.message
-                    const cause = e.cause
-                    return id === 'Error' && message === 'ctx: throwsError' && cause === arbitraryError
+                    return (
+                        e instanceof ToolkitError &&
+                        getErrorId(e) === 'Error' &&
+                        e.message === 'ctx: throwsError' &&
+                        e.cause === arbitraryError
+                    )
                 }
             )
             await assert.rejects(
                 () => inst.throwsAsyncError(),
                 (e) => {
-                    if (!(e instanceof ToolkitError)) {
-                        return false
-                    }
-                    const id = getErrorId(e)
-                    const message = e.message
-                    const cause = e.cause
-                    return id === 'Error' && message === 'ctx: throwsError' && cause === arbitraryError
+                    return (
+                        e instanceof ToolkitError &&
+                        getErrorId(e) === 'Error' &&
+                        e.message === 'ctx: throwsError' &&
+                        e.cause === arbitraryError
+                    )
                 }
             )
         })

--- a/packages/core/src/test/shared/telemetry/spans.test.ts
+++ b/packages/core/src/test/shared/telemetry/spans.test.ts
@@ -11,7 +11,7 @@ import { assertTelemetry, getMetrics, installFakeClock } from '../../testUtil'
 import { selectFrom } from '../../../shared/utilities/tsUtils'
 import { getAwsServiceError } from '../errors.test'
 import { sleep } from '../../../shared'
-import { withTelemetryContext, withTelemetryContextFactory } from '../../../shared/telemetry/util'
+import { withTelemetryContext } from '../../../shared/telemetry/util'
 import { SinonSandbox } from 'sinon'
 import sinon from 'sinon'
 import * as crypto from '../../../shared/crypto'
@@ -681,44 +681,6 @@ describe('TelemetryTracer', function () {
                 () => inst.throwsErrorButNoCtx(),
                 (e) => e === arbitraryError
             )
-        })
-
-        const customWithTelemetryContext = withTelemetryContextFactory({ class: 'TestCustomContext', emit: true })
-
-        class TestCustomContext {
-            @customWithTelemetryContext({ name: 'testMethod' })
-            testMethod() {
-                return
-            }
-
-            @customWithTelemetryContext({ name: 'overridesTheClass', class: 'Overidden' })
-            overridesTheClass() {
-                return
-            }
-        }
-
-        it('Uses predefined context', function () {
-            const inst = new TestCustomContext()
-            inst.testMethod()
-            assertTelemetry('function_call', [
-                {
-                    functionName: 'testMethod',
-                    className: 'TestCustomContext',
-                    source: 'TestCustomContext#testMethod',
-                },
-            ])
-        })
-
-        it('can override the predefined context', function () {
-            const inst = new TestCustomContext()
-            inst.overridesTheClass()
-            assertTelemetry('function_call', [
-                {
-                    functionName: 'overridesTheClass',
-                    className: 'Overidden',
-                    source: 'Overidden#overridesTheClass',
-                },
-            ])
         })
     })
 


### PR DESCRIPTION
See each commit for the specific change. But this has multiple improvements to the `@withTelemetryContext` decorator.

The main change to note:
- Adding the `@withTelemetryContext` decorator to a method can wrap thrown errors with context about that function. This helps us to build some sort of stack trace in the `reasonDesc` of our telemetry when errors are thrown.
  - [This is the documentation updated to get a better idea of what this is](https://github.com/aws/aws-toolkit-vscode/blob/b3f2ad9c65b47cd61ca72652171e932ef2480d8c/docs/telemetry.md#adding-a-stack-trace-to-your-metric) 
- The decorator allows for minimal diffs to the code. It is replacing [this previous code](https://github.com/aws/aws-toolkit-vscode/blob/2a72e6df814e3cbabce1cfe2476f1ca98ea8de2b/packages/core/src/shared/crashMonitoring.ts#L651) which would cause a diff in the column indentation since all the method code needed to be in a callback

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
