### PR TITLE
fix(telemetry): session_end not caching events

### DIFF
--- a/packages/core/src/shared/telemetry/telemetryService.ts
+++ b/packages/core/src/shared/telemetry/telemetryService.ts
@@ -20,6 +20,7 @@ import { ClassToInterfaceType } from '../utilities/tsUtils'
 import { getClientId, validateMetricEvent } from './util'
 import { telemetry, MetricBase } from './telemetry'
 import fs from '../fs/fs'
+import fsNode from 'fs/promises'
 import * as collectionUtil from '../utilities/collectionUtils'
 
 export type TelemetryService = ClassToInterfaceType<DefaultTelemetryService>
@@ -116,7 +117,10 @@ export class DefaultTelemetryService {
             })
 
             try {
-                await fs.writeFile(this.persistFilePath, JSON.stringify(this._eventQueue))
+                /**
+                 * This function runs in deactivate() so we must use node fs. See the vscode behavior doc for more info.
+                 */
+                await fsNode.writeFile(this.persistFilePath, JSON.stringify(this._eventQueue))
             } catch {}
         }
     }


### PR DESCRIPTION
## Problem

When the user shutdown their extension gracefully our mechanism that would cache any pending metrics for the next startup would not save to disk.

This was due to the VS Code FS implementation being used, but it will not work since the function it is called in is called by `deactivate()` which does not have access to vscode apis on shutdown.

## Solution

Solution is to swap it with the node fs implementation
---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
