### PR TITLE
feat(feature dev): add .txt to code file extension allowlist

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-d08c2199-de16-44fe-92fa-df725293bbaf.json
+++ b/packages/amazonq/.changes/next-release/Feature-d08c2199-de16-44fe-92fa-df725293bbaf.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q feature dev: add txt extension to code extension allowlist"
+}

--- a/packages/core/src/shared/filetypes.ts
+++ b/packages/core/src/shared/filetypes.ts
@@ -328,6 +328,7 @@ export const codefileExtensions = new Set([
     '.ts',
     '.tsx',
     '.tu',
+    '.txt',
     '.v',
     '.vala',
     '.vapi',


### PR DESCRIPTION
## Problem

`.txt` files are filtered out previously, we want to add feature to utilize this specific file type

## Solution

Add `.txt` file into the code file extension allowlist

---

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
