### PR TITLE
ci(lint): run jscpd in CI, compare to static threshold. 

### DIFF
--- a/.github/workflows/jscpd.json
+++ b/.github/workflows/jscpd.json
@@ -1,0 +1,7 @@
+{
+    "pattern": "packages/**/*.ts",
+    "ignore": ["**node_modules**", "**dist**"],
+    "gitignore": true,
+    "threshold": 1.34,
+    "minLines": 15
+}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -56,8 +56,8 @@ jobs:
             - run: npm run lint
 
     jscpd:
-        # needs: lint-commits
-        runs-on: ubuntu-22.04
+        needs: lint-commits
+        runs-on: ubuntu-latest
         strategy:
             matrix:
                 node-version: [18.x]

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -64,14 +64,12 @@ jobs:
         env:
             NODE_OPTIONS: '--max-old-space-size=8192'
         steps:
-            - name: check out repo
-              uses: actions/checkout@v4
+            - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
-            - name: install jscpd
-              run: npm install jscpd
+            - run: npm install jscpd
             - name: Run jscpd
               run: npx jscpd --config "$GITHUB_WORKSPACE/.github/workflows/jscpd.json"
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -55,6 +55,26 @@ jobs:
             - run: npm run testCompile
             - run: npm run lint
 
+    jscpd:
+        # needs: lint-commits
+        runs-on: ubuntu-22.04
+        strategy:
+            matrix:
+                node-version: [18.x]
+        env:
+            NODE_OPTIONS: '--max-old-space-size=8192'
+        steps:
+            - name: check out repo
+              uses: actions/checkout@v4
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: install jscpd
+              run: npm install jscpd
+            - name: Run jscpd
+              run: npx jscpd --config "$GITHUB_WORKSPACE/.github/workflows/jscpd.json"
+
     macos:
         needs: lint-commits
         name: test macOS


### PR DESCRIPTION
## Problem
New contributors often copy-paste logic and test cases, which creates a maintenance cost for little gain.

Examples

- https://github.com/aws/aws-toolkit-vscode/pull/3837#discussion_r1367182525
- https://github.com/aws/aws-toolkit-vscode/pull/3805#discussion_r1317867006

We call these repeated segments of code "clones". 

## Solution
implement a static threshold. 
Run `jscpd` in CI and compare the % duplicated to a fixed threshold of 1.34%, which is the current duplication rate in the repo. 
The main issue with this solution is that it fails to provide easy debugging options when new duplicates are found. Currently exploring adding this functionality in a follow-up. 

#### Notes
- this is a summary of the problem/solution. For full information, see full doc (VSCode: Detecting and Reducing Duplicate Code) describing changes. 
---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
