### PR TITLE
fix(ssh): remove extra call to findSshPath in test. 

### DIFF
--- a/packages/core/src/test/shared/utilities/pathFind.test.ts
+++ b/packages/core/src/test/shared/utilities/pathFind.test.ts
@@ -62,13 +62,11 @@ describe('pathFind', function () {
             const fakeSshPath = path.join(workspace.uri.fsPath, `ssh`)
 
             process.env.PATH = workspace.uri.fsPath
-            const firstResult = await findSshPath(false)
 
             await testutil.createExecutableFile(fakeSshPath, '')
 
             const secondResult = await findSshPath(false)
 
-            assert.notStrictEqual(firstResult, secondResult)
             assert.strictEqual(secondResult, 'ssh')
         })
 


### PR DESCRIPTION
## Problem
Test is very sensitive to implementation changes. 
Specifically, if the environment PATH isn't completely overwritten, it fails. 

## Solution
avoid assumption that we completely overwrote PATH, and assume we only add to it. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
