### PR TITLE
feat(cwl): Add line trimming to LiveTail when limit is reached

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -108,7 +108,23 @@ async function updateTextDocumentWithNewLogEvents(
     formattedLogEvents.forEach((formattedLogEvent) =>
         edit.insert(document.uri, new vscode.Position(document.lineCount, 0), formattedLogEvent)
     )
+    if (document.lineCount + formattedLogEvents.length > maxLines) {
+        trimOldestLines(formattedLogEvents.length, maxLines, document, edit)
+    }
     await vscode.workspace.applyEdit(edit)
+}
+
+function trimOldestLines(
+    numNewLines: number,
+    maxLines: number,
+    document: vscode.TextDocument,
+    edit: vscode.WorkspaceEdit
+) {
+    const numLinesToTrim = document.lineCount + numNewLines - maxLines
+    const startPosition = new vscode.Position(0, 0)
+    const endPosition = new vscode.Position(numLinesToTrim, 0)
+    const range = new vscode.Range(startPosition, endPosition)
+    edit.delete(document.uri, range)
 }
 
 /**


### PR DESCRIPTION
## Problem
* LiveTail sessions can run for a long time, on LogGroups that have a high volume of LogEvents. We want to not infinitely add logs to a TextDocument, leading to memory issues within VSCode.

## Solution
Users can configure a `limit` preference (default: 10000 , max 10000 , min: 1000). 
When the number of lines in a Live Tail session (number of LogEvents) reaches the limit, the 'N' oldest logEvents will be removed, to fit in the 'N' newest events coming in from the response stream. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
