### PR TITLE
telemetry(amazonq): Create server request metrics that include conversation id creation

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -660,6 +660,7 @@ export class ChatController {
         session.createNewTokenSource()
         try {
             this.messenger.sendInitalStream(tabID, triggerID)
+            this.telemetryHelper.setConversationStreamStartTime(tabID)
             response = await session.chat(request)
             this.telemetryHelper.recordEnterFocusConversation(triggerEvent.tabID)
             this.telemetryHelper.recordStartConversation(triggerEvent, triggerPayload)

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -65,6 +65,8 @@ export class CWCTelemetryHelper {
     private triggerEventsStorage: TriggerEventsStorage
     private responseStreamStartTime: Map<string, number> = new Map()
     private responseStreamTotalTime: Map<string, number> = new Map()
+    private conversationStreamStartTime: Map<string, number> = new Map()
+    private conversationStreamTotalTime: Map<string, number> = new Map()
     private responseStreamTimeForChunks: Map<string, number[]> = new Map()
     private responseWithProjectContext: Map<string, boolean> = new Map()
 
@@ -447,7 +449,9 @@ export class CWCTelemetryHelper {
                 this.getTimeBetweenChunks(message.tabID, this.responseStreamTimeForChunks)
             ),
             cwsprChatFullResponseLatency: this.responseStreamTotalTime.get(message.tabID) ?? 0,
-            cwsprTimeToFirstDisplay: this.getFirstDisplayTime(tabID, startTime),
+            cwsprChatTimeToFirstDisplay: this.getFirstDisplayTime(tabID, startTime),
+            cwsprChatTimeFirstUsableChunk: this.getFirstUsableChunkTime(message.tabID) ?? 0,
+            cwsprChatFullServerResponseLatency: this.conversationStreamTotalTime.get(message.tabID) ?? 0,
             cwsprChatTimeBetweenDisplays: JSON.stringify(this.getTimeBetweenChunks(tabID, this.displayTimeForChunks)),
             cwsprChatFullDisplayLatency: fullDisplayLatency,
             cwsprChatRequestLength: triggerPayload.message?.length ?? 0,
@@ -549,6 +553,10 @@ export class CWCTelemetryHelper {
         this.responseWithProjectContext.set(messageId, true)
     }
 
+    public setConversationStreamStartTime(tabID: string) {
+        this.conversationStreamStartTime.set(tabID, performance.now())
+    }
+
     private getResponseStreamTimeToFirstChunk(tabID: string): number {
         const chunkTimes = this.responseStreamTimeForChunks.get(tabID) ?? [0, 0]
         if (chunkTimes.length === 1) {
@@ -568,6 +576,13 @@ export class CWCTelemetryHelper {
         return Math.round(chunkTimes[0] - startTime)
     }
 
+    private getFirstUsableChunkTime(tabID: string) {
+        const startTime = this.conversationStreamStartTime.get(tabID) ?? 0
+        const chunkTimes = this.responseStreamTimeForChunks.get(tabID) ?? [0, 0]
+        // first chunk is the start time, we use the second because thats the first actual usable chunk time
+        return Math.round(chunkTimes[1] - startTime)
+    }
+
     private getTimeBetweenChunks(tabID: string, chunks: Map<string, number[]>): number[] {
         try {
             const chunkDeltaTimes: number[] = []
@@ -584,8 +599,13 @@ export class CWCTelemetryHelper {
     }
 
     public setResponseStreamTotalTime(tabID: string) {
-        const totalTime = performance.now() - (this.responseStreamStartTime.get(tabID) ?? 0)
-        this.responseStreamTotalTime.set(tabID, Math.round(totalTime))
+        // time from when the requests started streaming until the end of the stream
+        const totalStreamingTime = performance.now() - (this.responseStreamStartTime.get(tabID) ?? 0)
+        this.responseStreamTotalTime.set(tabID, Math.round(totalStreamingTime))
+
+        // time from the initial server request, including creating the conversation id, until the end of the stream
+        const totalConversationTime = performance.now() - (this.conversationStreamStartTime.get(tabID) ?? 0)
+        this.conversationStreamTotalTime.set(tabID, Math.round(totalConversationTime))
     }
 
     public getConversationId(tabID: string): string | undefined {

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -157,7 +157,7 @@
         {
             "name": "cwsprChatTimeToFirstChunk",
             "type": "int",
-            "description": "The time between the initial server request and when we got back the first usable result"
+            "description": "The time between when the conversation id was created and when we got back the first usable result"
         },
         {
             "name": "cwsprChatTimeBetweenChunks",
@@ -167,10 +167,20 @@
         {
             "name": "cwsprChatFullResponseLatency",
             "type": "int",
-            "description": "The time between the initial server request and the final response from the server"
+            "description": "The time between when the conversation id was created and the final response from the server was received"
         },
         {
-            "name": "cwsprTimeToFirstDisplay",
+            "name": "cwsprChatTimeFirstUsableChunk",
+            "type": "int",
+            "description": "The time between the initial server request, including creating the conversation id, and the first usable result"
+        },
+        {
+            "name": "cwsprChatFullServerResponseLatency",
+            "type": "int",
+            "description": "The time between the initial server request, including creating the conversation id, and the final response from the server"
+        },
+        {
+            "name": "cwsprChatTimeToFirstDisplay",
             "type": "int",
             "description": "The time between the user pressing enter and when the first chunk of data is displayed to the user"
         },
@@ -753,7 +763,13 @@
                     "type": "cwsprChatFullResponseLatency"
                 },
                 {
-                    "type": "cwsprTimeToFirstDisplay"
+                    "type": "cwsprChatTimeFirstUsableChunk"
+                },
+                {
+                    "type": "cwsprChatFullServerResponseLatency"
+                },
+                {
+                    "type": "cwsprChatTimeToFirstDisplay"
                 },
                 {
                     "type": "cwsprChatFullDisplayLatency"


### PR DESCRIPTION
## Problem
- The full server response metrics don't include the ~2 seconds to create the conversation id, it just handles everything between after the conversation id was created

## Solution
- Create new metrics that include the conversation id creation data


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
