### PR TITLE
Pick SageMaker IAM credentials to use for code completion

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-0ee7be24-b0f8-460b-a852-a2d08b6d289e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-0ee7be24-b0f8-460b-a852-a2d08b6d289e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Use SM IAM Credentials for Code Completion"
+}

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -44,6 +44,7 @@ import {
     setContext,
     setupUninstallHandler,
     maybeShowMinVscodeWarning,
+    isSageMaker,
 } from 'aws-core-vscode/shared'
 import { ExtStartUpSources, telemetry } from 'aws-core-vscode/telemetry'
 import { VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
@@ -193,7 +194,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
                 }
             }
             const currConn = AuthUtil.instance.conn
-            if (currConn !== undefined && !isAnySsoConnection(currConn)) {
+            if (currConn !== undefined && !(isAnySsoConnection(currConn) || isSageMaker())) {
                 getLogger().error(`Current Amazon Q connection is not SSO, type is: %s`, currConn?.type)
             }
 


### PR DESCRIPTION
## Problem
SageMaker IAM are not automatically picked up from node environment for Amazon Q Code Completion. However, this feature is supported in AWS-Toolkit and was working fine for code completion before Amazon Q codebase split from aws-toolkit logic

## Solution
- Bring the IAM credential provider to Amazon Q extension activation
- The scope is narrowed down to Sagemaker environment for safety and since it's an existing feature, no extra tests need to be added

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
