### PR TITLE
deps(general): fix security vulnerability in http-proxy-middleware  < 2.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8470,17 +8470,20 @@
             "license": "MIT"
         },
         "node_modules/asn1.js": {
-            "version": "5.4.1",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.0.0",
                 "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "safer-buffer": "^2.1.0"
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "node_modules/asn1.js/node_modules/bn.js": {
             "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
             "license": "MIT"
         },
         "node_modules/assert": {
@@ -8970,22 +8973,74 @@
             }
         },
         "node_modules/browserify-sign": {
-            "version": "4.2.2",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
+            "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
             "license": "ISC",
             "dependencies": {
                 "bn.js": "^5.2.1",
                 "browserify-rsa": "^4.1.0",
                 "create-hash": "^1.2.0",
                 "create-hmac": "^1.1.7",
-                "elliptic": "^6.5.4",
+                "elliptic": "^6.5.5",
+                "hash-base": "~3.0",
                 "inherits": "^2.0.4",
-                "parse-asn1": "^5.1.6",
-                "readable-stream": "^3.6.2",
+                "parse-asn1": "^5.1.7",
+                "readable-stream": "^2.3.8",
                 "safe-buffer": "^5.2.1"
             },
             "engines": {
-                "node": ">= 4"
+                "node": ">= 0.12"
             }
+        },
+        "node_modules/browserify-sign/node_modules/hash-base": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+            "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "license": "MIT"
+        },
+        "node_modules/browserify-sign/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "license": "MIT"
         },
         "node_modules/browserify-zlib": {
             "version": "0.1.4",
@@ -10056,23 +10111,42 @@
             }
         },
         "node_modules/crypto-browserify": {
-            "version": "3.12.0",
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+            "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
             "license": "MIT",
             "dependencies": {
-                "browserify-cipher": "^1.0.0",
-                "browserify-sign": "^4.0.0",
-                "create-ecdh": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.0",
-                "diffie-hellman": "^5.0.0",
-                "inherits": "^2.0.1",
-                "pbkdf2": "^3.0.3",
-                "public-encrypt": "^4.0.0",
-                "randombytes": "^2.0.0",
-                "randomfill": "^1.0.3"
+                "browserify-cipher": "^1.0.1",
+                "browserify-sign": "^4.2.3",
+                "create-ecdh": "^4.0.4",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "diffie-hellman": "^5.0.3",
+                "hash-base": "~3.0.4",
+                "inherits": "^2.0.4",
+                "pbkdf2": "^3.1.2",
+                "public-encrypt": "^4.0.3",
+                "randombytes": "^2.1.0",
+                "randomfill": "^1.0.4"
             },
             "engines": {
-                "node": "*"
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/crypto-browserify/node_modules/hash-base": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+            "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/css-loader": {
@@ -12404,7 +12478,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.6",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+            "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14905,14 +14981,33 @@
             }
         },
         "node_modules/parse-asn1": {
-            "version": "5.1.6",
+            "version": "5.1.7",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
+            "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
             "license": "ISC",
             "dependencies": {
-                "asn1.js": "^5.2.0",
-                "browserify-aes": "^1.0.0",
-                "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3",
-                "safe-buffer": "^5.1.1"
+                "asn1.js": "^4.10.1",
+                "browserify-aes": "^1.2.0",
+                "evp_bytestokey": "^1.0.3",
+                "hash-base": "~3.0",
+                "pbkdf2": "^3.1.2",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/parse-asn1/node_modules/hash-base": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+            "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/parse-json": {
@@ -19776,17 +19871,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/abort-controller": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/config-resolver": {
             "version": "2.2.0",
             "license": "Apache-2.0",
@@ -19872,17 +19956,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/fetch-http-handler": {
-            "version": "2.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/querystring-builder": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-base64": "^2.3.0",
-                "tslib": "^2.6.2"
-            }
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/hash-node": {
             "version": "2.2.0",
             "license": "Apache-2.0",
@@ -19904,160 +19977,11 @@
                 "tslib": "^2.6.2"
             }
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/is-array-buffer": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/middleware-content-length": {
             "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/protocol-http": "^3.3.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/middleware-endpoint": {
-            "version": "2.5.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-serde": "^2.3.0",
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/shared-ini-file-loader": "^2.4.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/url-parser": "^2.2.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/middleware-retry": {
-            "version": "2.3.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/service-error-classification": "^2.1.5",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "@smithy/util-retry": "^2.2.0",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/middleware-retry/node_modules/uuid": {
-            "version": "9.0.1",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/middleware-serde": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/middleware-stack": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/node-config-provider": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/shared-ini-file-loader": "^2.4.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/node-http-handler": {
-            "version": "2.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^2.2.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/querystring-builder": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/property-provider": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/protocol-http": {
-            "version": "3.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/querystring-builder": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-uri-escape": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/querystring-parser": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
@@ -20073,73 +19997,6 @@
                 "tslib": "^2.6.2"
             }
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/service-error-classification": {
-            "version": "2.1.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/shared-ini-file-loader": {
-            "version": "2.4.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/smithy-client": {
-            "version": "2.5.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-endpoint": "^2.5.1",
-                "@smithy/middleware-stack": "^2.2.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-stream": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/types": {
-            "version": "2.12.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/url-parser": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/querystring-parser": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/util-base64": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/util-body-length-browser": {
             "version": "2.2.0",
             "license": "Apache-2.0",
@@ -20151,17 +20008,6 @@
             "version": "2.3.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/util-buffer-from": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -20208,82 +20054,6 @@
                 "node": ">= 10.0.0"
             }
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/util-hex-encoding": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/util-middleware": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/util-retry": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/service-error-classification": "^2.1.5",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/util-stream": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/fetch-http-handler": "^2.5.0",
-                "@smithy/node-http-handler": "^2.5.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-base64": "^2.3.0",
-                "@smithy/util-buffer-from": "^2.2.0",
-                "@smithy/util-hex-encoding": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/util-uri-escape": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/@tsconfig/node14": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT"
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/@types/node": {
             "version": "14.18.63",
             "dev": true,
@@ -20294,37 +20064,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/bowser": {
-            "version": "2.11.0",
-            "license": "MIT"
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/brace-expansion": {
             "version": "2.0.1",
             "dev": true,
@@ -20332,63 +20071,6 @@
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/chalk": {
-            "version": "4.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/cliui": {
-            "version": "7.0.4",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^7.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/color-convert": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/color-name": {
-            "version": "1.1.4",
-            "dev": true,
-            "license": "MIT"
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/concat-map": {
-            "version": "0.0.1",
-            "dev": true,
-            "license": "MIT"
         },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/concurrently": {
             "version": "7.0.0",
@@ -20451,38 +20133,12 @@
                 "node": ">=14.17"
             }
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/escalade": {
             "version": "3.2.0",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "ISC"
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/function-bind": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/get-caller-file": {
-            "version": "2.0.5",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
             }
         },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/glob": {
@@ -20524,39 +20180,6 @@
                 "node": "*"
             }
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/has-flag": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/hasown": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/inflight": {
-            "version": "1.0.6",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/inherits": {
-            "version": "2.0.4",
-            "dev": true,
-            "license": "ISC"
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/interpret": {
             "version": "1.4.0",
             "dev": true,
@@ -20579,21 +20202,8 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/jsonc-parser": {
             "version": "3.3.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/lodash": {
-            "version": "4.17.21",
             "dev": true,
             "license": "MIT"
         },
@@ -20624,27 +20234,6 @@
                 "node": ">=10"
             }
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/once": {
-            "version": "1.4.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/path-parse": {
-            "version": "1.0.7",
-            "dev": true,
-            "license": "MIT"
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/rechoir": {
             "version": "0.6.2",
             "dev": true,
@@ -20660,14 +20249,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/require-directory": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/resolve": {
             "version": "1.22.8",
             "dev": true,
@@ -20682,20 +20263,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/rimraf": {
-            "version": "3.0.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/rxjs": {
@@ -20755,30 +20322,6 @@
             "version": "0.0.2",
             "dev": true
         },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/supports-color": {
             "version": "8.1.1",
             "dev": true,
@@ -20791,17 +20334,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/tree-kill": {
@@ -20864,35 +20396,6 @@
             "version": "6.0.0",
             "dev": true,
             "license": "MIT"
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/wrappy": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "ISC"
-        },
-        "src.gen/@amzn/codewhisperer-streaming/node_modules/y18n": {
-            "version": "5.0.8",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
         },
         "src.gen/@amzn/codewhisperer-streaming/node_modules/yargs": {
             "version": "16.2.0",


### PR DESCRIPTION
## Problem
Security vulnerability in dependency: https://github.com/advisories/GHSA-c7qv-q95q-8v27

## Solution
Run `npm audit --fix` to update to non-breaking fixed versions. 


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
