### PR TITLE
feat(amazonq): Increase polling rate for Q agent code summary

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-4540d7be-edc2-42ce-b7e7-6f04b2bd9106.json
+++ b/packages/amazonq/.changes/next-release/Feature-4540d7be-edc2-42ce-b7e7-6f04b2bd9106.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Provide more frequent updates about code changes made by agent"
+}

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -131,8 +131,8 @@ function getDeletedFileInfos(deletedFiles: string[], workspaceFolders: CurrentWs
 }
 
 abstract class CodeGenBase {
-    private pollCount = 180
-    private requestDelay = 10000
+    private pollCount = 360
+    private requestDelay = 5000
     readonly tokenSource: vscode.CancellationTokenSource
     public phase: SessionStatePhase = DevPhase.CODEGEN
     public readonly conversationId: string


### PR DESCRIPTION
## Problem
Agent polling rate is too low, causing users to receive slow summary updates of changes agent has made to their code


## Solution
- Decrease requestDelay to 5000ms from 10000ms to ensure we poll for agent updates more frequently
- Increased pollCount to 360 from 180 as we are now polling twice as frequently


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
