### PR TITLE
fix(auth): Fix device code detection when running auth through tunneled vscode

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-771c645f-eeea-4da5-b2d2-4315dfad9506.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-771c645f-eeea-4da5-b2d2-4315dfad9506.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "fixed device code detection when running auth through tunneled vscode"
+}

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -38,7 +38,7 @@ import { getIdeProperties, isAmazonQ, isCloud9 } from '../../shared/extensionUti
 import { randomBytes, createHash } from 'crypto'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { randomUUID } from '../../shared/crypto'
-import { isRemoteWorkspace, isWebWorkspace } from '../../shared/vscode/env'
+import { getExtRuntimeContext } from '../../shared/vscode/env'
 import { showInputBox } from '../../shared/ui/inputPrompter'
 import { AmazonQPromptSettings, DevSettings, PromptSettings, ToolkitPromptSettings } from '../../shared/settings'
 import { onceChanged } from '../../shared/utilities/functionUtils'
@@ -304,10 +304,10 @@ export abstract class SsoAccessTokenProvider {
              *
              * Since we are unable to serve the final authorization page
              */
-            return isRemoteWorkspace() || isWebWorkspace()
+            return getExtRuntimeContext().extensionHost === 'remote'
         }
     ) {
-        if (DevSettings.instance.get('webAuth', false) && isWebWorkspace()) {
+        if (DevSettings.instance.get('webAuth', false) && getExtRuntimeContext().extensionHost === 'webworker') {
             return new WebAuthorization(profile, cache, oidc, reAuthState)
         }
         if (useDeviceFlow()) {

--- a/packages/core/src/shared/vscode/env.ts
+++ b/packages/core/src/shared/vscode/env.ts
@@ -145,13 +145,16 @@ const UIKind = {
 export type ExtensionHostUI = (typeof UIKind)[keyof typeof UIKind]
 export type ExtensionHostLocation = 'local' | 'remote' | 'webworker'
 
-// where extension is running
+/**
+ * Detects where the ui and the extension host are running
+ */
 export function getExtRuntimeContext(): {
     ui: ExtensionHostUI
     extensionHost: ExtensionHostLocation
 } {
     const extensionHost =
-        // i found it in vscode
+        // taken from https://github.com/microsoft/vscode/blob/7c9e4bb23992c63f20cd86bbe7a52a3aa4bed89d/extensions/github-authentication/src/githubServer.ts#L121 to help determine which auth flows
+        // should be used
         typeof navigator === 'undefined'
             ? globals.context.extension.extensionKind === vscode.ExtensionKind.UI
                 ? 'local'

--- a/packages/toolkit/.changes/next-release/Bug Fix-9c15d2c5-6b28-42ae-b068-f71821acf62a.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-9c15d2c5-6b28-42ae-b068-f71821acf62a.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "fixed device code detection when running auth through tunneled vscode"
+}


### PR DESCRIPTION
## Problem
- When running auth through tunneled vscode the auth server starts up even though its not accessible

## Solution
- Instead of detecting for ssh-remote we should detect where the extension host is running.
- If we are running in browser with compute backend -> use device code
- If we are running locally -> use authorization grant
- If we are connected to a remote instance through vscode -> use device code
- If we are running through tunneled vscode -> use device code

This keeps it inline with detecting the extension host from https://github.com/microsoft/vscode/blob/7c9e4bb23992c63f20cd86bbe7a52a3aa4bed89d/extensions/github-authentication/src/githubServer.ts#L121, which it uses to determine whether or not device code flow should be used

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
