### PR TITLE
feat(cwl): Support autoscrolling live tail session's visible editors

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -107,8 +107,7 @@ function formatLogEvent(logEvent: LiveTailSessionLogEvent): string {
 //This allows for newly added log events to stay in view.
 function getTextEditorsToScroll(document: vscode.TextDocument): vscode.TextEditor[] {
     return vscode.window.visibleTextEditors.filter((editor) => {
-        const isEditorForSession = editor.document === document
-        if (!isEditorForSession) {
+        if (editor.document !== document) {
             return false
         }
         return editor.visibleRanges[0].contains(new vscode.Position(document.lineCount - 1, 0))

--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -116,9 +116,8 @@ function getTextEditorsToScroll(document: vscode.TextDocument): vscode.TextEdito
 }
 
 function scrollTextEditorToBottom(editor: vscode.TextEditor) {
-    const topPosition = new vscode.Position(Math.max(editor.document.lineCount - 2, 0), 0)
-    const bottomPosition = new vscode.Position(Math.max(editor.document.lineCount - 2, 0), 0)
-    editor.revealRange(new vscode.Range(topPosition, bottomPosition), vscode.TextEditorRevealType.Default)
+    const position = new vscode.Position(Math.max(editor.document.lineCount - 2, 0), 0)
+    editor.revealRange(new vscode.Range(position, position), vscode.TextEditorRevealType.Default)
 }
 
 async function updateTextDocumentWithNewLogEvents(


### PR DESCRIPTION
## Problem
New log events in a LiveTail session are added to the end of a TextDocument. Session updates can contain multiple LogEvents, leading to the text document growing quickly past the user's view. requiring them to constantly be scrolling the document themselves. 

## Solution
To maintain parity with CWL console experience (and the classic `tail -f` experience), we want to auto scroll the customer's LiveTail session's visible editors to the bottom. 

This will only happen IF the end of file is already in view. Meaning, if a User scrolls UP (causing the end of file to not be in view), auto scrolling will not enable. However, if they scroll back down to EOF themselves, it will re-enable.

Simply, if the end of file is in view, when new logEvents are added to the document, the editor will be autoscrolled back to the end of the file.


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
