### PR TITLE
refactor(cw): avoid duplicating language list. 

### DIFF
--- a/packages/core/src/codewhispererChat/editor/context/file/languages.ts
+++ b/packages/core/src/codewhispererChat/editor/context/file/languages.ts
@@ -117,10 +117,7 @@ export function extractLanguageNameFromFile(file: TextDocument): string | undefi
 export function extractAdditionalLanguageMatchPoliciesFromFile(file: TextDocument): Set<string> {
     const languageId = file.languageId
 
-    if (languageId === undefined) {
-        return new Set<string>()
-    }
-    if (validLanguageIds.includes(languageId)) {
+    if (languageId === undefined || validLanguageIds.includes(languageId)) {
         return new Set<string>()
     }
     switch (languageId) {

--- a/packages/core/src/codewhispererChat/editor/context/file/languages.ts
+++ b/packages/core/src/codewhispererChat/editor/context/file/languages.ts
@@ -5,57 +5,57 @@
 
 import { TextDocument } from 'vscode'
 
+const validLanguageIds = [
+    'yaml',
+    'xsl',
+    'xml',
+    'vue',
+    'tex',
+    'typescript',
+    'swift',
+    'stylus',
+    'sql',
+    'slim',
+    'shaderlab',
+    'sass',
+    'rust',
+    'ruby',
+    'r',
+    'python',
+    'pug',
+    'powershell',
+    'php',
+    'perl',
+    'markdown',
+    'makefile',
+    'lua',
+    'less',
+    'latex',
+    'json',
+    'javascript',
+    'java',
+    'ini',
+    'html',
+    'haml',
+    'handlebars',
+    'groovy',
+    'go',
+    'diff',
+    'css',
+    'c',
+    'coffeescript',
+    'clojure',
+    'bibtex',
+    'abap',
+]
+
 export function extractLanguageNameFromFile(file: TextDocument): string | undefined {
     const languageId = file.languageId
 
     if (languageId === undefined) {
         return undefined
     }
-    if (
-        [
-            'yaml',
-            'xsl',
-            'xml',
-            'vue',
-            'tex',
-            'typescript',
-            'swift',
-            'stylus',
-            'sql',
-            'slim',
-            'shaderlab',
-            'sass',
-            'rust',
-            'ruby',
-            'r',
-            'python',
-            'pug',
-            'powershell',
-            'php',
-            'perl',
-            'markdown',
-            'makefile',
-            'lua',
-            'less',
-            'latex',
-            'json',
-            'javascript',
-            'java',
-            'ini',
-            'html',
-            'haml',
-            'handlebars',
-            'groovy',
-            'go',
-            'diff',
-            'css',
-            'c',
-            'coffeescript',
-            'clojure',
-            'bibtex',
-            'abap',
-        ].includes(languageId)
-    ) {
+    if (validLanguageIds.includes(languageId)) {
         return languageId
     }
     switch (languageId) {
@@ -120,51 +120,7 @@ export function extractAdditionalLanguageMatchPoliciesFromFile(file: TextDocumen
     if (languageId === undefined) {
         return new Set<string>()
     }
-    if (
-        [
-            'yaml',
-            'xsl',
-            'xml',
-            'vue',
-            'tex',
-            'typescript',
-            'swift',
-            'stylus',
-            'sql',
-            'slim',
-            'shaderlab',
-            'sass',
-            'rust',
-            'ruby',
-            'r',
-            'python',
-            'pug',
-            'powershell',
-            'php',
-            'perl',
-            'markdown',
-            'makefile',
-            'lua',
-            'less',
-            'latex',
-            'json',
-            'javascript',
-            'java',
-            'ini',
-            'html',
-            'haml',
-            'handlebars',
-            'groovy',
-            'go',
-            'diff',
-            'css',
-            'c',
-            'coffeescript',
-            'clojure',
-            'bibtex',
-            'abap',
-        ].includes(languageId)
-    ) {
+    if (validLanguageIds.includes(languageId)) {
         return new Set<string>()
     }
     switch (languageId) {

--- a/packages/core/src/codewhispererChat/editor/context/file/languages.ts
+++ b/packages/core/src/codewhispererChat/editor/context/file/languages.ts
@@ -5,7 +5,7 @@
 
 import { TextDocument } from 'vscode'
 
-const validLanguageIds = [
+const defaultLanguages = [
     'yaml',
     'xsl',
     'xml',
@@ -55,7 +55,7 @@ export function extractLanguageNameFromFile(file: TextDocument): string | undefi
     if (languageId === undefined) {
         return undefined
     }
-    if (validLanguageIds.includes(languageId)) {
+    if (defaultLanguages.includes(languageId)) {
         return languageId
     }
     switch (languageId) {
@@ -117,7 +117,7 @@ export function extractLanguageNameFromFile(file: TextDocument): string | undefi
 export function extractAdditionalLanguageMatchPoliciesFromFile(file: TextDocument): Set<string> {
     const languageId = file.languageId
 
-    if (languageId === undefined || validLanguageIds.includes(languageId)) {
+    if (languageId === undefined || defaultLanguages.includes(languageId)) {
         return new Set<string>()
     }
     switch (languageId) {


### PR DESCRIPTION
## Problem
This is the longest case of code duplication in the repo from `jscpd` (46 lines!). 

## Solution
Remove the duplication case, remove redundant if statement. 

The switch statements could also be refactored into something with significantly less code in the future. Want to keep this PR focused on reducing code duplication. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
