### PR TITLE
BugFix: fix perceivedLatency being calculated incorrectly

### DIFF
--- a/packages/core/src/codewhisperer/service/inlineCompletionItemProvider.ts
+++ b/packages/core/src/codewhisperer/service/inlineCompletionItemProvider.ts
@@ -12,6 +12,7 @@ import { ReferenceInlineProvider } from './referenceInlineProvider'
 import { ImportAdderProvider } from './importAdderProvider'
 import { application } from '../util/codeWhispererApplication'
 import path from 'path'
+import { vsCodeState } from '../indexNode'
 
 export class CWInlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
     private activeItemIndex: number | undefined
@@ -169,6 +170,7 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
             ImportAdderProvider.instance.onShowRecommendation(document, this.startPos.line, r)
             this.nextMove = 0
             TelemetryHelper.instance.setFirstSuggestionShowTime()
+            session.setPerceivedLatency()
             this._onDidShow.fire()
             if (matchedCount >= 2 || this.nextToken !== '') {
                 const result = [item]

--- a/packages/core/src/codewhisperer/util/codeWhispererSession.ts
+++ b/packages/core/src/codewhisperer/util/codeWhispererSession.ts
@@ -13,6 +13,7 @@ import {
 import { GenerateRecommendationsRequest, ListRecommendationsRequest, Recommendation } from '../client/codewhisperer'
 import { Position } from 'vscode'
 import { CodeWhispererSupplementalContext, vsCodeState } from '../models/model'
+import { resolveTransitionHooks } from 'vue'
 
 class CodeWhispererSession {
     static #instance: CodeWhispererSession
@@ -43,6 +44,7 @@ class CodeWhispererSession {
     invokeSuggestionStartTime = 0
     timeToFirstRecommendation = 0
     firstSuggestionShowTime = 0
+    perceivedLatency = 0
 
     public static get instance() {
         return (this.#instance ??= new CodeWhispererSession())
@@ -88,6 +90,17 @@ class CodeWhispererSession {
             return this.timeToFirstRecommendation
         } else {
             return session.firstSuggestionShowTime - vsCodeState.lastUserModificationTime
+        }
+    }
+
+    setPerceivedLatency() {
+        if (this.perceivedLatency !== 0) {
+            return
+        }
+        if (this.triggerType === 'OnDemand') {
+            this.perceivedLatency = this.timeToFirstRecommendation
+        } else {
+            this.perceivedLatency = this.firstSuggestionShowTime - vsCodeState.lastUserModificationTime
         }
     }
 

--- a/packages/core/src/codewhisperer/util/telemetryHelper.ts
+++ b/packages/core/src/codewhisperer/util/telemetryHelper.ts
@@ -325,9 +325,7 @@ export class TelemetryHelper {
                         suggestionState: this.getSendTelemetrySuggestionState(aggregatedSuggestionState),
                         recommendationLatencyMilliseconds: e2eLatency,
                         triggerToResponseLatencyMilliseconds: session.timeToFirstRecommendation,
-                        perceivedLatencyMilliseconds: session.getPerceivedLatency(
-                            this.sessionDecisions[0].codewhispererTriggerType
-                        ),
+                        perceivedLatencyMilliseconds: session.perceivedLatency,
                         timestamp: new Date(Date.now()),
                         suggestionReferenceCount: referenceCount,
                         generatedLine: generatedLines,
@@ -388,6 +386,7 @@ export class TelemetryHelper {
         this.typeAheadLength = 0
         this.timeSinceLastModification = 0
         session.timeToFirstRecommendation = 0
+        session.perceivedLatency = 0
         this.classifierResult = undefined
         this.classifierThreshold = undefined
     }


### PR DESCRIPTION
The perceivedLatency is currently calculateand and sent when we send STE, by then lastUserModificationTime is no longer accurate. Instead calculate perceivedLatency when we show the suggestions and use the lastUserModificationTime at that time to be accurate.

JB PR: https://github.com/aws/aws-toolkit-jetbrains/pull/5013
## Problem


## Solution


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
