### PR TITLE
fix(amazonq): utg findSourceFileByContent passes pass wrong context

### DIFF
--- a/packages/core/src/codewhisperer/util/supplementalContext/utgUtils.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/utgUtils.ts
@@ -129,7 +129,7 @@ async function findSourceFileByContent(
 
     throwIfCancelled(cancellationToken)
 
-    testElementList.push(...extractClasses(editor.document.fileName, languageConfig.classExtractionPattern))
+    testElementList.push(...extractClasses(testFileContent, languageConfig.classExtractionPattern))
 
     throwIfCancelled(cancellationToken)
 


### PR DESCRIPTION
## Problem
Using extractClasses with path as file content incorrectly, so always returns empty list.

## Solution
Fix the call.
fix #5864

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
