### PR TITLE
fix(amazonq): limit maximum size of supplementalContext being sent

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-279c3a22-246e-41ca-9a42-3e446cdb9565.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-279c3a22-246e-41ca-9a42-3e446cdb9565.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix potential validatiokn exception thrown from service if plugins send out supplementalContext with length greather than 10240 characters long"
+	"description": "Fix error thrown if plugins send out supplementalContext with the length greather than 10240 characters"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-279c3a22-246e-41ca-9a42-3e446cdb9565.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-279c3a22-246e-41ca-9a42-3e446cdb9565.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix potential validatiokn exception thrown from service if plugins send out supplementalContext with length greather than 10240 characters long"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-279c3a22-246e-41ca-9a42-3e446cdb9565.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-279c3a22-246e-41ca-9a42-3e446cdb9565.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix error thrown if plugins send out supplementalContext with the length greather than 10240 characters"
+	"description": "Inline Suggestions: Occasional `ValidationException` if user context has too many characters."
 }

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -712,7 +712,7 @@ export const crossFileContextConfig = {
     numberOfChunkToFetch: 60,
     topK: 3,
     numberOfLinesEachChunk: 50,
-    maximumTotalLength: 10240,
+    maximumTotalLength: 20480,
 }
 
 export const utgConfig = {

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -712,6 +712,7 @@ export const crossFileContextConfig = {
     numberOfChunkToFetch: 60,
     topK: 3,
     numberOfLinesEachChunk: 50,
+    maximumTotalLength: 10240,
 }
 
 export const utgConfig = {

--- a/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -136,16 +136,16 @@ export async function fetchSupplementalContextForSrcV1(
     for (const chunk of bestChunks) {
         throwIfCancelled(cancellationToken)
 
-        if (totalLength > crossFileContextConfig.maximumTotalLength) {
-            break
-        }
-
         supplementalContexts.push({
             filePath: chunk.fileName,
             content: chunk.nextContent,
             score: chunk.score,
         })
         totalLength += chunk.nextContent.length
+
+        if (totalLength > crossFileContextConfig.maximumTotalLength) {
+            break
+        }
     }
 
     // DO NOT send code chunk with empty content

--- a/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -136,16 +136,17 @@ export async function fetchSupplementalContextForSrcV1(
     for (const chunk of bestChunks) {
         throwIfCancelled(cancellationToken)
 
-        supplementalContexts.push({
-            filePath: chunk.fileName,
-            content: chunk.nextContent,
-            score: chunk.score,
-        })
         totalLength += chunk.nextContent.length
 
         if (totalLength > crossFileContextConfig.maximumTotalLength) {
             break
         }
+
+        supplementalContexts.push({
+            filePath: chunk.fileName,
+            content: chunk.nextContent,
+            score: chunk.score,
+        })
     }
 
     // DO NOT send code chunk with empty content

--- a/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -132,14 +132,20 @@ export async function fetchSupplementalContextForSrcV1(
 
     // Step 4: Transform best chunks to supplemental contexts
     const supplementalContexts: CodeWhispererSupplementalContextItem[] = []
+    let totalLength = 0
     for (const chunk of bestChunks) {
         throwIfCancelled(cancellationToken)
+
+        if (totalLength > crossFileContextConfig.maximumTotalLength) {
+            break
+        }
 
         supplementalContexts.push({
             filePath: chunk.fileName,
             content: chunk.nextContent,
             score: chunk.score,
         })
+        totalLength += chunk.nextContent.length
     }
 
     // DO NOT send code chunk with empty content


### PR DESCRIPTION
## Problem
We found there were lots of cases where open tabs context sent from the plugins with total length > 10240 chars long, which will result in `validationException` error while users trigger inline completion service. 

## Solution
Limit maximum length of supplemental context added in the result set and meanwhile Q team is conducting investigation to root cause it.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
