### PR TITLE
feat(amazonq): Add inline chat to context menu and reject empty inputs

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -366,6 +366,10 @@
                 {
                     "command": "aws.amazonq.sendToPrompt",
                     "group": "cw_chat@6"
+                },
+                {
+                    "command": "aws.amazonq.inline.invokeChat",
+                    "group": "cw_chat@7"
                 }
             ],
             "editor/context": [
@@ -594,6 +598,12 @@
                 "title": "%AWS.amazonq.toggleCodeScan%",
                 "category": "%AWS.amazonq.title%",
                 "enablement": "aws.codewhisperer.connected"
+            },
+            {
+                "command": "aws.amazonq.inline.invokeChat",
+                "title": "%AWS.amazonq.inline.invokeChat%",
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
             }
         ],
         "keybindings": [
@@ -669,7 +679,7 @@
                 "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected"
             },
             {
-                "command": "aws.amazonq.inline.waitForUserInput",
+                "command": "aws.amazonq.inline.invokeChat",
                 "win": "ctrl+i",
                 "mac": "cmd+i",
                 "linux": "ctrl+i",

--- a/packages/amazonq/src/inlineChat/command/registerInlineCommands.ts
+++ b/packages/amazonq/src/inlineChat/command/registerInlineCommands.ts
@@ -9,7 +9,7 @@ import { InlineTask } from '../controller/inlineTask'
 
 export function registerInlineCommands(context: vscode.ExtensionContext, inlineChatController: InlineChatController) {
     context.subscriptions.push(
-        vscode.commands.registerCommand('aws.amazonq.inline.waitForUserInput', async () => {
+        vscode.commands.registerCommand('aws.amazonq.inline.invokeChat', async () => {
             await inlineChatController.inlineQuickPick()
         }),
         vscode.commands.registerCommand('aws.amazonq.inline.waitForUserDecisionAcceptAll', async (task: InlineTask) => {

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -321,5 +321,6 @@
     "AWS.amazonq.featureDev.placeholder.additionalImprovements": "Describe your task or issue in detail",
     "AWS.amazonq.featureDev.placeholder.feedback": "Provide feedback or comments",
     "AWS.amazonq.featureDev.placeholder.describe": "Describe your task or issue in detail",
-    "AWS.amazonq.featureDev.placeholder.sessionClosed": "Open a new chat tab to continue"
+    "AWS.amazonq.featureDev.placeholder.sessionClosed": "Open a new chat tab to continue",
+    "AWS.amazonq.inline.invokeChat": "Inline chat"
 }


### PR DESCRIPTION
This PR adds the "Inline chat" menu option to the right click context menu and command palette. It also rejects empty inputs to inline chat to make it clearer to users they must input text into the dialog. 


License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
