### PR TITLE
fix(amazonq): Remove warning on empty inputs to inline chat

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-0be85264-f542-4383-a02e-0ae0e66dba90.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-0be85264-f542-4383-a02e-0ae0e66dba90.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Remove warning when no input is provided to inline chat input box"
+}

--- a/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
+++ b/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
@@ -191,7 +191,7 @@ export class InlineChatController {
             })
             .then(async (query) => {
                 if (!query || query.trim() === '') {
-                    void vscode.window.showWarningMessage('Amazon Q: Instructions for cannot be empty')
+                    getLogger().info('inlineQuickPick query is empty')
                     return
                 }
 


### PR DESCRIPTION
This PR removes the notification when a query is empty, this was not intended to be added and the menu should simply close when the input is empty.

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
