### PR TITLE
fix(amazonq): Align example help text with the prompt message that it sends in chat

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-63cca37f-cf3c-42ff-bc9d-b3f71c0e3202.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-63cca37f-cf3c-42ff-bc9d-b3f71c0e3202.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Align example help text with prompt message in chat"
+}

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -438,7 +438,7 @@ export class Messenger {
         let message = ''
         switch (quickAction) {
             case 'help':
-                message = 'What can Amazon Q help me with?'
+                message = 'How can Amazon Q help me?'
                 break
         }
 


### PR DESCRIPTION
## Problem
- The examples text shows "How can Amazon Q help me?" but when you click on it it shows "What can Amazon Q help me with?" in chat. This is confusing to users

## Solution
- Align both the example help text and the prompt message in chat as "How can Amazon Q help me?"
![Screenshot 2024-10-30 at 9 53 32 AM](https://github.com/user-attachments/assets/992f515d-7c22-4379-bafe-1ef50a9eb246)
![Screenshot 2024-10-30 at 9 55 37 AM](https://github.com/user-attachments/assets/3169c594-89e3-475a-b0c0-13adf80516a7)


## Alternative solution
- Align them with "What can Amazon Q help me with?" instead
---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
