### PR TITLE
build(vue): fix warnings from vue about unset flags. 

### DIFF
--- a/packages/webpack.base.config.js
+++ b/packages/webpack.base.config.js
@@ -101,6 +101,10 @@ module.exports = (env = {}, argv = {}) => {
             new webpack.DefinePlugin({
                 EXTENSION_VERSION: JSON.stringify(packageJson.version),
             }),
+            new webpack.DefinePlugin({
+                __VUE_OPTIONS_API__: 'true',
+                __VUE_PROD_DEVTOOLS__: 'false',
+            }),
             new CircularDependencyPlugin({
                 exclude: /node_modules|testFixtures/,
                 failOnError: true,


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/issues/4463

## Solution
The two required flags are set as follows:
- `__VUE_OPTIONS_API__`: `true` since we use the options API extensively. This is opposed to the newer composition API, which I don't believe we use. An example of us using the options API can be found here: https://github.com/aws/aws-toolkit-vscode/blob/f806ae04f5d56b872282e42d5f765b2b1a9e28dd/packages/core/src/login/webview/vue/login.vue#L321 and more info can be found here https://vuejs.org/guide/typescript/options-api
- `__VUE_PROD_DEVTOOLS__`: `false` since this is the default, and it otherwise increases the build size per https://vuejs.org/api/compile-time-flags.html#VUE_PROD_DEVTOOLS. 

## Notes
- Also relevant, composition API: https://vuejs.org/guide/extras/composition-api-faq.html
- More detail on the flags: https://vuejs.org/api/compile-time-flags.html#VUE_PROD_DEVTOOLS

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
