### PR TITLE
feat(amazonq): Allow users to View and Apply diff

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-4eed9d3c-8ada-44de-9621-fb34fbbc9e15.json
+++ b/packages/amazonq/.changes/next-release/Feature-4eed9d3c-8ada-44de-9621-fb34fbbc9e15.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Allow users to View and Apply diff when they explictily send code to Amazon Q using - Fix, Refactor, Optimize and Send To Prompt."
+}

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -90,10 +90,10 @@ export const createMynahUI = (
     // eslint-disable-next-line prefer-const
     let messageController: MessageController
 
+    // @ts-ignore
     let featureConfigs: Map<string, FeatureContext> = tryNewMap(featureConfigsSerialized)
 
     function shouldDisplayDiff(messageData: any) {
-        const isEnabled = featureConfigs.get('ViewDiffInChat')?.variation === 'TREATMENT'
         const tab = tabsStorage.getTab(messageData?.tabID || '')
         const allowedCommands = [
             'aws.amazonq.refactorCode',
@@ -101,7 +101,7 @@ export const createMynahUI = (
             'aws.amazonq.optimizeCode',
             'aws.amazonq.sendToPrompt',
         ]
-        if (isEnabled && tab?.type === 'cwc' && allowedCommands.includes(tab.lastCommand || '')) {
+        if (tab?.type === 'cwc' && allowedCommands.includes(tab.lastCommand || '')) {
             return true
         }
         return false

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -358,6 +358,10 @@ export class CWCTelemetryHelper {
                 return 'UPVOTE'
             case 'downvote':
                 return 'DOWNVOTE'
+            case 'acceptDiff':
+                return 'ACCEPT_DIFF'
+            case 'viewDiff':
+                return 'VIEW_DIFF'
             default:
                 return 'UNKNOWN'
         }


### PR DESCRIPTION
Allow users to View and Apply diff when they explictily send code to Amazon Q using - Fix, Refactor, Optimize and Send To Prompt.

Notes:
- Releasing it all customers
- The View and Apply diff is only retained for first response after Fix, Refactor, Optimize and Send To Prompt, and NOT for followup chats.
- `featureConfig`  is the setup for A/B experiments and`Ignored` by `tslint` because, 
  - currently View Diff and Apply Diff are the only feature that uses these.
  - If the changes are reverted the next time any team wants to use it, they will have to rewire the A/B experiments setup again.


https://github.com/user-attachments/assets/2f4c0e06-4185-435f-9969-8b8f92d32fd1



---

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
