### PR TITLE
fix(lambda): added walkthrough strings

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -333,5 +333,16 @@
     "AWS.amazonq.featureDev.placeholder.feedback": "Provide feedback or comments",
     "AWS.amazonq.featureDev.placeholder.describe": "Describe your task or issue in detail",
     "AWS.amazonq.featureDev.placeholder.sessionClosed": "Open a new chat tab to continue",
-    "AWS.amazonq.inline.invokeChat": "Inline chat"
+    "AWS.amazonq.inline.invokeChat": "Inline chat",
+    "AWS.toolkit.lambda.walkthrough.quickpickTitle": "Application Builder Walkthrough",
+    "AWS.toolkit.lambda.walkthrough.title": "Get started building your application",
+    "AWS.toolkit.lambda.walkthrough.description": "Your quick guide to build an application visually, iterate locally, and deploy to the cloud!",
+    "AWS.toolkit.lambda.walkthrough.toolInstall.title": "Complete installation",
+    "AWS.toolkit.lambda.walkthrough.toolInstall.description": "The AWS Command Line Interface (AWS CLI) is an open source tool that enables you to interact with AWS services using commands in your command-line shell. It is required to create and interact with AWS resources. \n\n[Install AWS CLI](command:aws.toolkit.installAWSCLI)\n\n Use the Serverless Application Model (SAM) CLI to locally build, invoke, and deploy your functions. Version 1.98+ is required. \n\n[Install SAM CLI](command:aws.toolkit.installSAMCLI)\n\n Use Docker to locally emulate a Lambda environment. Docker is optional. However, if you want to invoke locally, Docker is required so Lambda can locally emulate the execution environment. \n\n[Install Docker (optional)](command:aws.toolkit.installDocker)",
+    "AWS.toolkit.lambda.walkthrough.chooseTemplate.title": "Choose your application template",
+    "AWS.toolkit.lambda.walkthrough.chooseTemplate.description": "Select a starter application, visually compose an application from scratch, open an existing application, or browse more application examples. \n\nInfrastructure Composer allows you to visually compose modern applications in the cloud. It will define the necessary permissions between resources when you drag a connection between them. \n\n[Initialize your project](command:aws.toolkit.lambda.initializeWalkthroughProject)",
+    "AWS.toolkit.lambda.walkthrough.step1.title": "Iterate locally",
+    "AWS.toolkit.lambda.walkthrough.step1.description": "Locally test and debug your code.",
+    "AWS.toolkit.lambda.walkthrough.step2.title": "Deploy to the cloud",
+    "AWS.toolkit.lambda.walkthrough.step2.description": "Test your application in the cloud from within VS Code. \n\nNote: The AWS CLI and the SAM CLI require AWS Credentials to interact with the cloud. For information on setting up your credentials, see [Authentication and access credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html). \n\n[Configure credentials](command:aws.toolkit.lambda.walkthrough.credential)"
 }

--- a/packages/toolkit/.changes/next-release/Bug Fix-c45df2a7-e8f0-488a-815c-0883ab3919b9.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-c45df2a7-e8f0-488a-815c-0883ab3919b9.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "AWS Lambda: Added missing strings in guided walkthrough"
-}

--- a/packages/toolkit/.changes/next-release/Bug Fix-c45df2a7-e8f0-488a-815c-0883ab3919b9.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-c45df2a7-e8f0-488a-815c-0883ab3919b9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "AWS Lambda: Added missing strings in guided walkthrough"
+}


### PR DESCRIPTION
## Problem
Somehow missed merging some strings needed for guided walkthrough to package.nls.json 

## Solution
Added them back

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
