### PR TITLE
ci: condense messages, clarify "changelog" message

### DIFF
--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -37,7 +37,7 @@ jobs:
               if: github.event_name == 'pull_request_target'
               with:
                   node-version: '20'
-            - name: Check for tests
+            - name: Comment about contribution guidelines
               uses: actions/github-script@v7
               if: github.event_name == 'pull_request_target'
               with:

--- a/.github/workflows/notify.js
+++ b/.github/workflows/notify.js
@@ -6,9 +6,10 @@
 const { hasPath, dedupComment } = require('./utils')
 
 const testFilesMessage =
-    'This pull request modifies code in src/ but no tests were added/updated. Confirm whether tests should be added or ensure the PR description explains why tests are not required.'
+    '- This pull request modifies code in `src/*` but no tests were added/updated.\n    - Confirm whether tests should be added or ensure the PR description explains why tests are not required.\n'
 
-const changelogMessage = `This pull request implements a feature or fix, so it must include a changelog entry. See [CONTRIBUTING.md#changelog](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#changelog) for instructions.`
+const changelogMessage =
+    '- This pull request implements a `feat` or `fix`, so it must include a changelog entry (unless the fix is for an *unreleased* feature). Review the [changelog guidelines](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#changelog).\n    - Note: beta or "experiment" features that have active users *should* announce fixes in the changelog.\n    - If this is not a feature or fix, use an appropriate type from the [title guidelines](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#pull-request-title). For example, telemetry-only changes should use the `telemetry` type.\n'
 
 /**
  * Remind partner teams that tests are required. We don't need to remind them if:
@@ -44,12 +45,16 @@ module.exports = async ({ github, context }) => {
         issue_number: pullRequestId,
     })
 
+    let msg = ''
     if (shouldAddTestFileMessage) {
-        await dedupComment({ github, comments, owner, repo, pullRequestId, message: testFilesMessage })
+        msg += testFilesMessage
+    }
+    if (shouldAddChangelogMessage) {
+        msg += changelogMessage
     }
 
-    if (shouldAddChangelogMessage) {
-        await dedupComment({ github, comments, owner, repo, pullRequestId, message: changelogMessage })
+    if (shouldAddTestFileMessage || shouldAddChangelogMessage) {
+        await dedupComment({ github, comments, owner, repo, pullRequestId, message: msg })
     }
 }
 


### PR DESCRIPTION
Problem:
- Contributors get confused about when to add a changelog.
- Bot adds two comments which could be combined into one comment.

Solution:
- Clarify the changelog note.
- Combine messages into one comment.

Example: https://github.com/justinmk3/aws-toolkit-vscode/pull/21#issuecomment-2448660727


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
