### PR TITLE
fix(amazonq): Update keybinding for focus chat

### DIFF
--- a/packages/amazonq/.changes/next-release/Breaking Change-7a7320b8-e8a2-4d61-8f2d-7da04f1716da.json
+++ b/packages/amazonq/.changes/next-release/Breaking Change-7a7320b8-e8a2-4d61-8f2d-7da04f1716da.json
@@ -1,0 +1,4 @@
+{
+	"type": "Breaking Change",
+	"description": "Change focus chat keybind to win+alt+i on Windows, cmd+alt+i on macOS, and meta+alt+i on Linux"
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -609,9 +609,9 @@
         "keybindings": [
             {
                 "command": "_aws.amazonq.focusChat.keybinding",
-                "win": "ctrl+win+i",
-                "mac": "ctrl+cmd+i",
-                "linux": "ctrl+meta+i"
+                "win": "win+alt+i",
+                "mac": "cmd+alt+i",
+                "linux": "meta+alt+i"
             },
             {
                 "command": "aws.amazonq.explainCode",

--- a/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
+++ b/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
@@ -286,6 +286,7 @@ export class InlineChatController {
                     }
                 }
                 if (chatEvent.error) {
+                    getLogger().error('generateAssistantResponse stream error: %s', chatEvent.error)
                     await this.rejectAllChanges(this.task, false)
                     void vscode.window.showErrorMessage(`Amazon Q: ${chatEvent.error.message}`)
                     await this.updateTaskAndLenses(this.task, TaskState.Complete)


### PR DESCRIPTION
This PR updates the keybindings for Amazon Q's focus chat keybind to win+alt+i on Windows, cmd+alt+i on macOS, and meta+alt+i on Linux. This was requested by product to keep it consistent with the other keybinds:

![image](https://github.com/user-attachments/assets/b7bd8b93-adf5-4ecc-a89a-1a9bcf3758cb)

Additionally there is a small change to add a log line for when an in stream error occurs to help in debugging with customers.

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
