### PR TITLE
fix(lambda): remove template path from sam deploy command

### DIFF
--- a/packages/core/src/shared/sam/deploy.ts
+++ b/packages/core/src/shared/sam/deploy.ts
@@ -377,10 +377,6 @@ export async function runDeploy(arg: any, wizardParams?: DeployParams): Promise<
                 throw ToolkitError.chain(error, 'Failed to build SAM template', { details: { ...buildFlags } })
             }
 
-            // Pass built template to deployFlags
-            const templatePath = vscode.Uri.joinPath(params.projectRoot, '.aws-sam', 'build', 'template.yaml').fsPath
-            deployFlags.push('--template-file', `${templatePath}`)
-
             // Create a child process to run the SAM deploy command
             const deployProcess = new ChildProcess(samCliPath, ['deploy', ...deployFlags], {
                 spawnOptions: await addTelemetryEnvVar({

--- a/packages/core/src/test/shared/sam/deploy.test.ts
+++ b/packages/core/src/test/shared/sam/deploy.test.ts
@@ -709,8 +709,6 @@ describe('SAM Deploy', () => {
                     '--parameter-overrides',
                     `ParameterKey=SourceBucketName,ParameterValue=${mockDeployParams.SourceBucketName} ` +
                         `ParameterKey=DestinationBucketName,ParameterValue=${mockDeployParams.DestinationBucketName}`,
-                    '--template-file',
-                    vscode.Uri.joinPath(projectRoot, '.aws-sam', 'build', 'template.yaml').fsPath,
                 ],
                 {
                     spawnOptions: {
@@ -787,8 +785,6 @@ describe('SAM Deploy', () => {
                     '--parameter-overrides',
                     `ParameterKey=SourceBucketName,ParameterValue=${mockDeployParams.SourceBucketName} ` +
                         `ParameterKey=DestinationBucketName,ParameterValue=${mockDeployParams.DestinationBucketName}`,
-                    '--template-file',
-                    vscode.Uri.joinPath(projectRoot, '.aws-sam', 'build', 'template.yaml').fsPath,
                 ],
                 {
                     spawnOptions: {
@@ -867,8 +863,6 @@ describe('SAM Deploy', () => {
                     '--parameter-overrides',
                     `ParameterKey=SourceBucketName,ParameterValue=${mockDeployParams.SourceBucketName} ` +
                         `ParameterKey=DestinationBucketName,ParameterValue=${mockDeployParams.DestinationBucketName}`,
-                    '--template-file',
-                    vscode.Uri.joinPath(projectRoot, '.aws-sam', 'build', 'template.yaml').fsPath,
                 ],
                 {
                     spawnOptions: {

--- a/packages/core/src/testInteg/sam.test.ts
+++ b/packages/core/src/testInteg/sam.test.ts
@@ -883,8 +883,6 @@ describe('SAM Integration Tests', async function () {
                 '--capabilities',
                 'CAPABILITY_IAM',
                 'CAPABILITY_NAMED_IAM',
-                '--template-file',
-                vscode.Uri.joinPath(mockDeployParams.projectRoot, '.aws-sam', 'build', 'template.yaml').fsPath,
             ])
 
             // Check that runInTerminal is called with the correct arguments for deploy

--- a/packages/toolkit/.changes/next-release/Bug Fix-1ade44c5-bd1f-4b8f-a7f3-f2740ebb8097.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-1ade44c5-bd1f-4b8f-a7f3-f2740ebb8097.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM: Save SAM deploy parameters to correct samconfig.toml in project folder"
+}

--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.33.0 2024-11-06
+- **Bug Fix** SAM: Save SAM deploy parameters to correct samconfig.toml in project folder
+
 ## 3.31.0 2024-10-30
 
 - **Feature** SAM: Added support for Java 21 Lambda runtime

--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -1,6 +1,3 @@
-## 3.33.0 2024-11-06
-- **Bug Fix** SAM: Save SAM deploy parameters to correct samconfig.toml in project folder
-
 ## 3.31.0 2024-10-30
 
 - **Feature** SAM: Added support for Java 21 Lambda runtime


### PR DESCRIPTION
## Problem
Explicitly specifying template path in sam deploy command to point to the build artifact folder makes SAM CLI create/update `samconfig.toml` in the build artifact folder rather than updating the `samconfig.toml` file in project root folder. 

## Solution
Remove the `--template-path` from deploy flag. SAM will determine the template in the project folder and write to correct samconfig file

---

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
