### PR TITLE
fix(lambda): skip ecrRepoUri and syncFlags prompters when using flag from samconfig file 

### DIFF
--- a/packages/core/src/shared/sam/sync.ts
+++ b/packages/core/src/shared/sam/sync.ts
@@ -354,16 +354,24 @@ export class SyncWizard extends Wizard<SyncParams> {
         })
 
         this.form.ecrRepoUri.bindPrompter(({ region }) => createEcrPrompter(new DefaultEcrClient(region!)), {
-            showWhen: ({ template }) => !!template && hasImageBasedResources(template.data),
+            showWhen: ({ template, paramsSource }) =>
+                !!template &&
+                hasImageBasedResources(template.data) &&
+                (paramsSource === ParamsSource.Flags || paramsSource === ParamsSource.SpecifyAndSave),
         })
 
         // todo wrap with localize
-        this.form.syncFlags.bindPrompter(() =>
-            createMultiPick(syncFlagItems, {
-                title: 'Specify parameters for sync',
-                placeholder: 'Press enter to proceed with highlighted option',
-                buttons: createCommonButtons(samSyncParamUrl),
-            })
+        this.form.syncFlags.bindPrompter(
+            () =>
+                createMultiPick(syncFlagItems, {
+                    title: 'Specify parameters for sync',
+                    placeholder: 'Press enter to proceed with highlighted option',
+                    buttons: createCommonButtons(samSyncParamUrl),
+                }),
+            {
+                showWhen: ({ paramsSource }) =>
+                    paramsSource === ParamsSource.Flags || paramsSource === ParamsSource.SpecifyAndSave,
+            }
         )
     }
 }

--- a/packages/core/src/test/shared/sam/sync.test.ts
+++ b/packages/core/src/test/shared/sam/sync.test.ts
@@ -105,14 +105,26 @@ describe('SyncWizard', async function () {
     })
 
     it('prompts for ECR repo if template has image-based resource', async function () {
-        const template = { uri: vscode.Uri.file('/'), data: createBaseImageTemplate() }
-        const tester = await createTester({ template })
+        const workspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri || vscode.Uri.file('/')
+        const rootFolderUri = vscode.Uri.joinPath(workspaceUri, 'my')
+        const templateUri = vscode.Uri.joinPath(rootFolderUri, 'template.yaml')
+        const template = { uri: templateUri, data: createBaseImageTemplate() }
+        const tester = await createTester({
+            template,
+            paramsSource: ParamsSource.Flags,
+        })
         tester.ecrRepoUri.assertShow()
     })
 
     it('skips prompt for ECR repo if template has no image-based resources', async function () {
         const template = { uri: vscode.Uri.file('/'), data: createBaseTemplate() }
         const tester = await createTester({ template })
+        tester.ecrRepoUri.assertDoesNotShow()
+    })
+
+    it('skips prompt for ECR repo if param source is to use samconfig', async function () {
+        const template = { uri: vscode.Uri.file('/'), data: createBaseTemplate() }
+        const tester = await createTester({ template, paramsSource: ParamsSource.SamConfig })
         tester.ecrRepoUri.assertDoesNotShow()
     })
 

--- a/packages/toolkit/.changes/next-release/Bug Fix-2ad71338-1d0f-4bbf-a9e9-ac0f12be7a4d.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-2ad71338-1d0f-4bbf-a9e9-ac0f12be7a4d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM: Skip unnecessary prompters for sync operation when using flag from samconfig.toml file"
+}


### PR DESCRIPTION
## Problem
When customer choose use flag information from `samconfig.toml` for sync and deploy operations, we assume that all the needed parameters will be available in the `samconfig.toml`.  Only `--config-file <samconfig file path>` is passed to SAM CLI. 

We skip many prompters in such scenario reduce clicking. Yet, we also need to skip prompter for `ecrRepoUri` and `syncFlag` in sync wizard. 

## Solution
Add condition to skip these prompter when flag information from `samconfig.toml` is used. 

---

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
