### PR TITLE
fix(lambda): removed delete action for lambda and s3 in AppBuilder

### DIFF
--- a/packages/toolkit/.changes/next-release/Bug Fix-f6bb74e5-14cd-4e63-bc24-5e8e82dbaf46.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-f6bb74e5-14cd-4e63-bc24-5e8e82dbaf46.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "AWS Lambda: Removed action to delete a Lambda or S3 bucket in the AppBuilder section as resources created through IaC frameworks should not be directly modified since this creates drift"
+}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1652,7 +1652,7 @@
                 },
                 {
                     "command": "aws.deleteLambda",
-                    "when": "view =~ /^(aws.explorer|aws.appBuilder|aws.appBuilderForFileExplorer)$/ && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)$/ || viewItem == awsAppBuilderDeployedNode",
+                    "when": "view =~ /^(aws.explorer)$/ && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)$/",
                     "group": "4@1"
                 },
                 {
@@ -1877,7 +1877,7 @@
                 },
                 {
                     "command": "aws.s3.deleteBucket",
-                    "when": "view =~ /^(aws.explorer|aws.appBuilder|aws.appBuilderForFileExplorer)$/ && viewItem == awsS3BucketNode",
+                    "when": "view =~ /^(aws.explorer)$/ && viewItem == awsS3BucketNode",
                     "group": "3@1"
                 },
                 {


### PR DESCRIPTION
## Problem
When resources are provisioned and controlled through a SAM template, customers should never modify resources directly as this such action would create drift in the CFN template.

## Solution
Removed action to delete a Lambda or S3 bucket in the AppBuilder section

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
