### PR TITLE
deps: resolve http-proxy-middleware vulnerability by updating webpack-dev-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
                 "typescript": "^5.0.4",
                 "webpack": "^5.95.0",
                 "webpack-cli": "^5.1.4",
-                "webpack-dev-server": "^4.15.1",
+                "webpack-dev-server": "^4.15.2",
                 "webpack-merge": "^5.10.0"
             }
         },
@@ -13172,7 +13172,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.6",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+            "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19285,7 +19287,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.15.1",
+            "version": "4.15.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
+            "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19317,7 +19321,7 @@
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^5.3.1",
+                "webpack-dev-middleware": "^5.3.4",
                 "ws": "^8.13.0"
             },
             "bin": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "typescript": "^5.0.4",
         "webpack": "^5.95.0",
         "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^4.15.1",
+        "webpack-dev-server": "^4.15.2",
         "webpack-merge": "^5.10.0"
     },
     "dependencies": {


### PR DESCRIPTION


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
