### PR TITLE
fix(amazonq): default requestedConversions to undefined in manifest

### DIFF
--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -330,17 +330,19 @@ export class ZipManifest {
     hilCapabilities: string[] = ['HIL_1pDependency_VersionUpgrade']
     transformCapabilities: string[] = ['EXPLAINABILITY_V1'] // TO-DO: for SQL conversions, maybe make this = []
     customBuildCommand: string = 'clean test'
-    requestedConversions: {
-        sqlConversion:
-            | {
-                  source: string | undefined
-                  target: string | undefined
-                  schema: string | undefined
-                  host: string | undefined
-                  sctFileName: string | undefined
-              }
-            | undefined
-    } = { sqlConversion: undefined }
+    requestedConversions:
+        | {
+              sqlConversion:
+                  | {
+                        source: string | undefined
+                        target: string | undefined
+                        schema: string | undefined
+                        host: string | undefined
+                        sctFileName: string | undefined
+                    }
+                  | undefined
+          }
+        | undefined = undefined
 }
 
 export interface IHilZipManifestParams {

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -330,19 +330,15 @@ export class ZipManifest {
     hilCapabilities: string[] = ['HIL_1pDependency_VersionUpgrade']
     transformCapabilities: string[] = ['EXPLAINABILITY_V1'] // TO-DO: for SQL conversions, maybe make this = []
     customBuildCommand: string = 'clean test'
-    requestedConversions:
-        | {
-              sqlConversion:
-                  | {
-                        source: string | undefined
-                        target: string | undefined
-                        schema: string | undefined
-                        host: string | undefined
-                        sctFileName: string | undefined
-                    }
-                  | undefined
-          }
-        | undefined = undefined
+    requestedConversions?: {
+        sqlConversion?: {
+            source?: string
+            target?: string
+            schema?: string
+            host?: string
+            sctFileName?: string
+        }
+    }
 }
 
 export interface IHilZipManifestParams {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -327,12 +327,15 @@ export async function zipCode(
         ) {
             // note that zipManifest must be a ZipManifest since only other option is HilZipManifest which is not used for SQL conversions
             const metadataZip = new AdmZip(transformByQState.getMetadataPathSQL())
-            zipManifest.requestedConversions.sqlConversion = {
-                source: transformByQState.getSourceDB(),
-                target: transformByQState.getTargetDB(),
-                schema: transformByQState.getSchema(),
-                host: transformByQState.getSourceServerName(),
-                sctFileName: metadataZip.getEntries().filter((entry) => entry.entryName.endsWith('.sct'))[0].entryName,
+            zipManifest.requestedConversions = {
+                sqlConversion: {
+                    source: transformByQState.getSourceDB(),
+                    target: transformByQState.getTargetDB(),
+                    schema: transformByQState.getSchema(),
+                    host: transformByQState.getSourceServerName(),
+                    sctFileName: metadataZip.getEntries().filter((entry) => entry.entryName.endsWith('.sct'))[0]
+                        .entryName,
+                },
             }
             // TO-DO: later consider making this add to path.join(zipManifest.dependenciesRoot, 'qct-sct-metadata', entry.entryName) so that it's more organized
             metadataZip


### PR DESCRIPTION
## Problem

Recently noticed an issue where language upgrade transformations fail when our `manifest.json` includes this new key which was added for SQL conversions (unreleased feature).

## Solution

Use a default of `undefined` for `requestedConversions`, so that it does not appear in the `manifest.json`, and only add it to the `manifest.json` when the user is doing a SQL conversion, as this key is only used for SQL conversions.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
