### PR TITLE
feat(dev): File-level accepts of generated code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,13 +5171,15 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.15.11",
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.18.0.tgz",
+            "integrity": "sha512-oa26D9QtGxw9kZnDBq7OrVEPdBvmwK+MjlTIjW8L/TnlDTIYL3SBhU87iQCwkCRxWXckrjiSvW6Rexc2oasgvw==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
-                "marked": "^12.0.2",
+                "marked": "^14.1.0",
                 "prismjs": "1.29.0",
                 "sanitize-html": "^2.12.1",
                 "unescape-html": "^1.1.0"
@@ -5192,7 +5194,9 @@
             }
         },
         "node_modules/@aws/mynah-ui/node_modules/marked": {
-            "version": "12.0.2",
+            "version": "14.1.4",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+            "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
@@ -20030,7 +20034,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.15.11",
+                "@aws/mynah-ui": "^4.18.0",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Feature-d18cffcd-fd30-4936-9586-587b0ba88ec9.json
+++ b/packages/amazonq/.changes/next-release/Feature-d18cffcd-fd30-4936-9586-587b0ba88ec9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q /dev: Add an action to accept individual files"
+}

--- a/packages/amazonq/test/e2e/amazonq/featureDev.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/featureDev.test.ts
@@ -17,8 +17,8 @@ describe('Amazon Q Feature Dev', function () {
     let tab: Messenger
 
     const prompt = 'Add blank.txt file with empty content'
-    const codegenApproachPrompt = prompt + ' and add a readme that describes the changes'
-    const fileLevelAcceptPrompt = prompt + ' and add a license, and a contributing file'
+    const codegenApproachPrompt = `${prompt} and add a readme that describes the changes`
+    const fileLevelAcceptPrompt = `${prompt} and add a license, and a contributing file`
     const tooManyRequestsWaitTime = 100000
 
     function waitForButtons(buttons: FollowUpTypes[]) {

--- a/packages/amazonq/test/e2e/amazonq/featureDev.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/featureDev.test.ts
@@ -54,8 +54,8 @@ describe('Amazon Q Feature Dev', function () {
     async function clickActionButton(filePath: string, actionName: string) {
         tab.clickFileActionButton(filePath, actionName)
         await tab.waitForEvent(() => !tab.hasAction(filePath, actionName), {
-            waitIntervalInMs: 250,
-            waitTimeoutInMs: 2000,
+            waitIntervalInMs: 500,
+            waitTimeoutInMs: 600000,
         })
     }
 

--- a/packages/amazonq/test/e2e/amazonq/featureDev.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/featureDev.test.ts
@@ -53,7 +53,10 @@ describe('Amazon Q Feature Dev', function () {
 
     async function clickActionButton(filePath: string, actionName: string) {
         tab.clickFileActionButton(filePath, actionName)
-        await tab.waitForEvent(() => !tab.hasAction(filePath, actionName))
+        await tab.waitForEvent(() => !tab.hasAction(filePath, actionName), {
+            waitIntervalInMs: 250,
+            waitTimeoutInMs: 2000,
+        })
     }
 
     /**

--- a/packages/amazonq/test/e2e/amazonq/featureDev.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/featureDev.test.ts
@@ -314,6 +314,16 @@ describe('Amazon Q Feature Dev', function () {
                     insertCodeButton = tab.getFollowUpButton(FollowUpTypes.InsertCode)
                     assert.ok(insertCodeButton.pillText === 'Accept remaining changes')
                 })
+
+                it('shows "Continue" when all files are either accepted or rejected, with at least one of them rejected', async () => {
+                    const filePaths = tab.getFilePaths()
+                    for (const filePath of filePaths) {
+                        await clickActionButton(filePath, 'reject-change')
+                    }
+
+                    const insertCodeButton = tab.getFollowUpButton(FollowUpTypes.InsertCode)
+                    assert.ok(insertCodeButton.pillText === 'Continue')
+                })
             })
 
             it('disappears and automatically moves on to the next step when all changes are accepted', async () => {

--- a/packages/amazonq/test/e2e/amazonq/framework/messenger.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/messenger.ts
@@ -129,10 +129,7 @@ export class Messenger {
     getActionsByFilePath(filePath: string) {
         const fileList = this.getFileList()
         const actions = fileList?.fileList?.actions
-        if (!actions) {
-            assert.fail('Could not find file list actions')
-        }
-        return actions[filePath]
+        return actions?.[filePath] ?? []
     }
 
     hasButton(type: FollowUpTypes) {

--- a/packages/amazonq/test/e2e/amazonq/framework/messenger.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/messenger.ts
@@ -59,6 +59,14 @@ export class Messenger {
         this.mynahUIProps.onFollowUpClicked(this.tabID, lastChatItem?.messageId ?? '', option[0])
     }
 
+    clickFileActionButton(filePath: string, actionName: string) {
+        if (!this.mynahUIProps.onFileActionClick) {
+            assert.fail('onFileActionClick must be defined to use it in the tests')
+        }
+
+        this.mynahUIProps.onFileActionClick(this.tabID, this.getFileListMessageId(), filePath, actionName)
+    }
+
     findCommand(command: string) {
         return this.getCommands()
             .map((groups) => groups.commands)
@@ -78,6 +86,55 @@ export class Messenger {
         return this.getStore().promptInputPlaceholder
     }
 
+    getFollowUpButton(type: FollowUpTypes) {
+        const followUpButton = this.getChatItems()
+            .pop()
+            ?.followUp?.options?.find((action) => action.type === type)
+        if (!followUpButton) {
+            assert.fail(`Could not find follow up button with type ${type}`)
+        }
+        return followUpButton
+    }
+
+    getFileList() {
+        const chatItems = this.getChatItems()
+        const fileList = chatItems.find((item) => 'fileList' in item)
+        if (!fileList) {
+            assert.fail('Could not find file list')
+        }
+        return fileList
+    }
+
+    getFileListMessageId() {
+        const fileList = this.getFileList()
+        const messageId = fileList?.messageId
+        if (!messageId) {
+            assert.fail('Could not find file list message id')
+        }
+        return messageId
+    }
+
+    getFilePaths() {
+        const fileList = this.getFileList()
+        const filePaths = fileList?.fileList?.filePaths
+        if (!filePaths) {
+            assert.fail('Could not find file paths')
+        }
+        if (filePaths.length === 0) {
+            assert.fail('File paths list is empty')
+        }
+        return filePaths
+    }
+
+    getActionsByFilePath(filePath: string) {
+        const fileList = this.getFileList()
+        const actions = fileList?.fileList?.actions
+        if (!actions) {
+            assert.fail('Could not find file list actions')
+        }
+        return actions[filePath]
+    }
+
     hasButton(type: FollowUpTypes) {
         return (
             this.getChatItems()
@@ -85,6 +142,10 @@ export class Messenger {
                 ?.followUp?.options?.map((opt) => opt.type)
                 .includes(type) ?? false
         )
+    }
+
+    hasAction(filePath: string, actionName: string) {
+        return this.getActionsByFilePath(filePath).some((action) => action.name === actionName)
     }
 
     async waitForChatFinishesLoading() {

--- a/packages/amazonq/test/unit/amazonqFeatureDev/session/session.test.ts
+++ b/packages/amazonq/test/unit/amazonqFeatureDev/session/session.test.ts
@@ -83,6 +83,7 @@ describe('session', () => {
                         rejected: false,
                         virtualMemoryUri: uri,
                         workspaceFolder: controllerSetup.workspaceFolder,
+                        changeApplied: false,
                     },
                     {
                         zipFilePath: 'rejectedFile.js',
@@ -91,6 +92,7 @@ describe('session', () => {
                         rejected: true,
                         virtualMemoryUri: generateVirtualMemoryUri(uploadID, 'rejectedFile.js'),
                         workspaceFolder: controllerSetup.workspaceFolder,
+                        changeApplied: false,
                     },
                 ],
                 [],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -470,7 +470,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.15.11",
+        "@aws/mynah-ui": "^4.18.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -312,6 +312,7 @@
     "AWS.amazonq.featureDev.pillText.generatingCode": "Generating code...",
     "AWS.amazonq.featureDev.pillText.requestingChanges": "Requesting changes ...",
     "AWS.amazonq.featureDev.pillText.insertCode": "Accept code",
+    "AWS.amazonq.featureDev.pillText.continue": "Continue",
     "AWS.amazonq.featureDev.pillText.acceptAllChanges": "Accept all changes",
     "AWS.amazonq.featureDev.pillText.acceptRemainingChanges": "Accept remaining changes",
     "AWS.amazonq.featureDev.pillText.stoppingCodeGeneration": "Stopping code generation...",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -312,6 +312,8 @@
     "AWS.amazonq.featureDev.pillText.generatingCode": "Generating code...",
     "AWS.amazonq.featureDev.pillText.requestingChanges": "Requesting changes ...",
     "AWS.amazonq.featureDev.pillText.insertCode": "Accept code",
+    "AWS.amazonq.featureDev.pillText.acceptAllChanges": "Accept all changes",
+    "AWS.amazonq.featureDev.pillText.acceptRemainingChanges": "Accept remaining changes",
     "AWS.amazonq.featureDev.pillText.stoppingCodeGeneration": "Stopping code generation...",
     "AWS.amazonq.featureDev.pillText.sendFeedback": "Send feedback",
     "AWS.amazonq.featureDev.pillText.selectFiles": "Select files for context",

--- a/packages/core/src/amazonq/commons/diff.ts
+++ b/packages/core/src/amazonq/commons/diff.ts
@@ -32,3 +32,11 @@ export function createAmazonQUri(path: string, tabId: string) {
     // TODO change the featureDevScheme to a more general amazon q scheme
     return vscode.Uri.from({ scheme: featureDevScheme, path, query: `tabID=${tabId}` })
 }
+
+export async function openFile(path: string) {
+    if (!(await fs.exists(path))) {
+        return
+    }
+    const fileUri = vscode.Uri.file(path)
+    await vscode.commands.executeCommand('vscode.open', fileUri)
+}

--- a/packages/core/src/amazonq/commons/diff.ts
+++ b/packages/core/src/amazonq/commons/diff.ts
@@ -13,8 +13,9 @@ export async function openDiff(leftPath: string, rightPath: string, tabId: strin
 }
 
 export async function openDeletedDiff(filePath: string, name: string, tabId: string) {
-    const fileUri = await getOriginalFileUri(filePath, tabId)
-    await vscode.commands.executeCommand('vscode.open', fileUri, {}, `${name} (Deleted)`)
+    const left = await getOriginalFileUri(filePath, tabId)
+    const right = createAmazonQUri('empty', tabId)
+    await vscode.commands.executeCommand('vscode.diff', left, right, `${name} (Deleted)`)
 }
 
 export async function getOriginalFileUri(fullPath: string, tabId: string) {

--- a/packages/core/src/amazonq/commons/diff.ts
+++ b/packages/core/src/amazonq/commons/diff.ts
@@ -39,5 +39,5 @@ export async function openFile(path: string) {
         return
     }
     const fileUri = vscode.Uri.file(path)
-    await vscode.commands.executeCommand('vscode.open', fileUri)
+    await vscode.commands.executeCommand('vscode.diff', fileUri, fileUri)
 }

--- a/packages/core/src/amazonq/index.ts
+++ b/packages/core/src/amazonq/index.ts
@@ -27,7 +27,14 @@ export { amazonQHelpUrl } from '../shared/constants'
 export { listCodeWhispererCommandsWalkthrough } from '../codewhisperer/ui/statusBarMenu'
 export { focusAmazonQPanel, focusAmazonQPanelKeybinding } from '../codewhispererChat/commands/registerCommands'
 export { TryChatCodeLensProvider, tryChatCodeLensCommand } from '../codewhispererChat/editor/codelens'
-export { createAmazonQUri, openDiff, openDeletedDiff, getOriginalFileUri, getFileDiffUris } from './commons/diff'
+export {
+    createAmazonQUri,
+    openDiff,
+    openDeletedDiff,
+    getOriginalFileUri,
+    getFileDiffUris,
+    openFile,
+} from './commons/diff'
 export { CodeReference } from '../codewhispererChat/view/connector/connector'
 export { AuthMessageDataMap, AuthFollowUpType } from './auth/model'
 export { extractAuthFollowUp } from './util/authUtils'

--- a/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
@@ -17,6 +17,7 @@ export interface ConnectorProps extends BaseConnectorProps {
         messageId: string | undefined,
         enableStopAction: boolean
     ) => void
+    onChatAnswerUpdated?: (tabID: string, message: ChatItem) => void
     sendFeedback?: (tabId: string, feedbackPayload: FeedbackPayload) => void | undefined
     onFileComponentUpdate: (
         tabID: string,
@@ -34,6 +35,7 @@ export interface ConnectorProps extends BaseConnectorProps {
 
 export class Connector extends BaseConnector {
     private readonly onFileComponentUpdate
+    private readonly onChatAnswerUpdated
     private readonly onAsyncEventProgress
     private readonly updatePlaceholder
     private readonly chatInputEnabled
@@ -52,6 +54,7 @@ export class Connector extends BaseConnector {
         this.chatInputEnabled = props.onChatInputEnabled
         this.onUpdateAuthentication = props.onUpdateAuthentication
         this.onNewTab = props.onNewTab
+        this.onChatAnswerUpdated = props.onChatAnswerUpdated
     }
 
     onOpenDiff = (tabID: string, filePath: string, deleted: boolean, messageId?: string): void => {

--- a/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
@@ -22,7 +22,8 @@ export interface ConnectorProps extends BaseConnectorProps {
         tabID: string,
         filePaths: DiffTreeFileInfo[],
         deletedFiles: DiffTreeFileInfo[],
-        messageId: string
+        messageId: string,
+        disableFileActions: boolean
     ) => void
     onFileActionClick: (tabID: string, messageId: string, filePath: string, actionName: string) => void
     onUpdatePlaceholder: (tabID: string, newPlaceholder: string) => void
@@ -137,7 +138,8 @@ export class Connector extends BaseConnector {
                 messageData.tabID,
                 messageData.filePaths,
                 messageData.deletedFiles,
-                messageData.messageId
+                messageData.messageId,
+                messageData.disableFileActions
             )
             return
         }

--- a/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
@@ -100,6 +100,17 @@ export class Connector extends BaseConnector {
 
     private processCodeResultMessage = async (messageData: any): Promise<void> => {
         if (this.onChatAnswerReceived !== undefined) {
+            const messageId =
+                messageData.codeGenerationId ??
+                messageData.messageID ??
+                messageData.triggerID ??
+                messageData.conversationID
+            this.sendMessageToExtension({
+                tabID: messageData.tabID,
+                command: 'store-code-result-message-id',
+                messageId,
+                tabType: 'featuredev',
+            })
             const actions = getActions([...messageData.filePaths, ...messageData.deletedFiles])
             const answer: ChatItem = {
                 type: ChatItemType.ANSWER,
@@ -107,12 +118,7 @@ export class Connector extends BaseConnector {
                 followUp: undefined,
                 canBeVoted: true,
                 codeReference: messageData.references,
-                // TODO get the backend to store a message id in addition to conversationID
-                messageId:
-                    messageData.codeGenerationId ??
-                    messageData.messageID ??
-                    messageData.triggerID ??
-                    messageData.conversationID,
+                messageId,
                 fileList: {
                     rootFolderTitle: 'Changes',
                     filePaths: messageData.filePaths.map((f: DiffTreeFileInfo) => f.zipFilePath),

--- a/packages/core/src/amazonq/webview/ui/commands.ts
+++ b/packages/core/src/amazonq/webview/ui/commands.ts
@@ -35,5 +35,6 @@ type MessageCommand =
     | 'open-settings'
     | 'start-chat-message-telemetry'
     | 'stop-chat-message-telemetry'
+    | 'store-code-result-message-id'
 
 export type ExtensionMessage = Record<string, any> & { command: MessageCommand }

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -70,7 +70,8 @@ export interface ConnectorProps {
         tabID: string,
         filePaths: DiffTreeFileInfo[],
         deletedFiles: DiffTreeFileInfo[],
-        messageId: string
+        messageId: string,
+        disableFileActions: boolean
     ) => void
     onUpdatePlaceholder: (tabID: string, newPlaceholder: string) => void
     onChatInputEnabled: (tabID: string, enabled: boolean) => void

--- a/packages/core/src/amazonq/webview/ui/diffTree/actions.ts
+++ b/packages/core/src/amazonq/webview/ui/diffTree/actions.ts
@@ -33,29 +33,31 @@ export function getActions(filePaths: DiffTreeFileInfo[]): Record<string, FileNo
         if (filePath.changeApplied) {
             continue
         }
-        actions[filePath.relativePath] = [
-            {
-                icon: MynahIcons.OK,
-                status: 'success',
-                name: 'accept-change',
-                description: 'Accept file change',
-            },
-        ]
         switch (filePath.rejected) {
             case true:
-                actions[filePath.relativePath].push({
-                    icon: MynahIcons.REVERT,
-                    name: 'revert-rejection',
-                    description: 'Revert rejection',
-                })
+                actions[filePath.relativePath] = [
+                    {
+                        icon: MynahIcons.REVERT,
+                        name: 'revert-rejection',
+                        description: 'Revert rejection',
+                    },
+                ]
                 break
             case false:
-                actions[filePath.relativePath].push({
-                    icon: MynahIcons.CANCEL_CIRCLE,
-                    status: 'error',
-                    name: 'reject-change',
-                    description: 'Reject change',
-                })
+                actions[filePath.relativePath] = [
+                    {
+                        icon: MynahIcons.OK,
+                        status: 'success',
+                        name: 'accept-change',
+                        description: 'Accept file change',
+                    },
+                    {
+                        icon: MynahIcons.CANCEL_CIRCLE,
+                        status: 'error',
+                        name: 'reject-change',
+                        description: 'Reject change',
+                    },
+                ]
                 break
         }
     }

--- a/packages/core/src/amazonq/webview/ui/diffTree/actions.ts
+++ b/packages/core/src/amazonq/webview/ui/diffTree/actions.ts
@@ -6,6 +6,7 @@
 import { MynahIcons } from '@aws/mynah-ui'
 import { FileNodeAction, TreeNodeDetails } from '@aws/mynah-ui/dist/static'
 import { DiffTreeFileInfo } from './types'
+import { uiComponentsTexts } from '../texts/constants'
 
 export function getDetails(filePaths: DiffTreeFileInfo[]): Record<string, TreeNodeDetails> {
     const details: Record<string, TreeNodeDetails> = {}
@@ -13,13 +14,13 @@ export function getDetails(filePaths: DiffTreeFileInfo[]): Record<string, TreeNo
         if (filePath.changeApplied) {
             details[filePath.relativePath] = {
                 status: 'success',
-                label: 'Change accepted',
+                label: uiComponentsTexts.changeAccepted,
                 icon: MynahIcons.OK,
             }
         } else if (filePath.rejected) {
             details[filePath.relativePath] = {
                 status: 'error',
-                label: 'Change rejected',
+                label: uiComponentsTexts.changeRejected,
                 icon: MynahIcons.CANCEL_CIRCLE,
             }
         }
@@ -39,7 +40,7 @@ export function getActions(filePaths: DiffTreeFileInfo[]): Record<string, FileNo
                     {
                         icon: MynahIcons.REVERT,
                         name: 'revert-rejection',
-                        description: 'Revert rejection',
+                        description: uiComponentsTexts.revertRejection,
                     },
                 ]
                 break
@@ -49,13 +50,13 @@ export function getActions(filePaths: DiffTreeFileInfo[]): Record<string, FileNo
                         icon: MynahIcons.OK,
                         status: 'success',
                         name: 'accept-change',
-                        description: 'Accept change',
+                        description: uiComponentsTexts.acceptChange,
                     },
                     {
                         icon: MynahIcons.CANCEL_CIRCLE,
                         status: 'error',
                         name: 'reject-change',
-                        description: 'Reject change',
+                        description: uiComponentsTexts.rejectChange,
                     },
                 ]
                 break

--- a/packages/core/src/amazonq/webview/ui/diffTree/actions.ts
+++ b/packages/core/src/amazonq/webview/ui/diffTree/actions.ts
@@ -10,7 +10,13 @@ import { DiffTreeFileInfo } from './types'
 export function getDetails(filePaths: DiffTreeFileInfo[]): Record<string, TreeNodeDetails> {
     const details: Record<string, TreeNodeDetails> = {}
     for (const filePath of filePaths) {
-        if (filePath.rejected) {
+        if (filePath.changeApplied) {
+            details[filePath.relativePath] = {
+                status: 'success',
+                label: 'File accepted',
+                icon: MynahIcons.OK,
+            }
+        } else if (filePath.rejected) {
             details[filePath.relativePath] = {
                 status: 'error',
                 label: 'File rejected',
@@ -24,25 +30,32 @@ export function getDetails(filePaths: DiffTreeFileInfo[]): Record<string, TreeNo
 export function getActions(filePaths: DiffTreeFileInfo[]): Record<string, FileNodeAction[]> {
     const actions: Record<string, FileNodeAction[]> = {}
     for (const filePath of filePaths) {
+        if (filePath.changeApplied) {
+            continue
+        }
+        actions[filePath.relativePath] = [
+            {
+                icon: MynahIcons.OK,
+                status: 'success',
+                name: 'accept-change',
+                description: 'Accept file change',
+            },
+        ]
         switch (filePath.rejected) {
             case true:
-                actions[filePath.relativePath] = [
-                    {
-                        icon: MynahIcons.REVERT,
-                        name: 'revert-rejection',
-                        description: 'Revert rejection',
-                    },
-                ]
+                actions[filePath.relativePath].push({
+                    icon: MynahIcons.REVERT,
+                    name: 'revert-rejection',
+                    description: 'Revert rejection',
+                })
                 break
             case false:
-                actions[filePath.relativePath] = [
-                    {
-                        icon: MynahIcons.CANCEL_CIRCLE,
-                        status: 'error',
-                        name: 'reject-change',
-                        description: 'Reject change',
-                    },
-                ]
+                actions[filePath.relativePath].push({
+                    icon: MynahIcons.CANCEL_CIRCLE,
+                    status: 'error',
+                    name: 'reject-change',
+                    description: 'Reject change',
+                })
                 break
         }
     }

--- a/packages/core/src/amazonq/webview/ui/diffTree/actions.ts
+++ b/packages/core/src/amazonq/webview/ui/diffTree/actions.ts
@@ -13,13 +13,13 @@ export function getDetails(filePaths: DiffTreeFileInfo[]): Record<string, TreeNo
         if (filePath.changeApplied) {
             details[filePath.relativePath] = {
                 status: 'success',
-                label: 'File accepted',
+                label: 'Change accepted',
                 icon: MynahIcons.OK,
             }
         } else if (filePath.rejected) {
             details[filePath.relativePath] = {
                 status: 'error',
-                label: 'File rejected',
+                label: 'Change rejected',
                 icon: MynahIcons.CANCEL_CIRCLE,
             }
         }
@@ -49,7 +49,7 @@ export function getActions(filePaths: DiffTreeFileInfo[]): Record<string, FileNo
                         icon: MynahIcons.OK,
                         status: 'success',
                         name: 'accept-change',
-                        description: 'Accept file change',
+                        description: 'Accept change',
                     },
                     {
                         icon: MynahIcons.CANCEL_CIRCLE,

--- a/packages/core/src/amazonq/webview/ui/diffTree/types.ts
+++ b/packages/core/src/amazonq/webview/ui/diffTree/types.ts
@@ -7,4 +7,5 @@ export type DiffTreeFileInfo = {
     zipFilePath: string
     relativePath: string
     rejected: boolean
+    changeApplied: boolean
 }

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -348,7 +348,8 @@ export const createMynahUI = (
             tabID: string,
             filePaths: DiffTreeFileInfo[],
             deletedFiles: DiffTreeFileInfo[],
-            messageId: string
+            messageId: string,
+            disableFileActions: boolean
         ) => {
             const updateWith: Partial<ChatItem> = {
                 type: ChatItemType.ANSWER,
@@ -357,7 +358,7 @@ export const createMynahUI = (
                     filePaths: filePaths.map((i) => i.zipFilePath),
                     deletedFiles: deletedFiles.map((i) => i.zipFilePath),
                     details: getDetails(filePaths),
-                    actions: getActions([...filePaths, ...deletedFiles]),
+                    actions: disableFileActions ? undefined : getActions([...filePaths, ...deletedFiles]),
                 },
             }
             mynahUI.updateChatAnswerWithMessageId(tabID, messageId, updateWith)

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -357,7 +357,7 @@ export const createMynahUI = (
                     rootFolderTitle: 'Changes',
                     filePaths: filePaths.map((i) => i.zipFilePath),
                     deletedFiles: deletedFiles.map((i) => i.zipFilePath),
-                    details: getDetails(filePaths),
+                    details: getDetails([...filePaths, ...deletedFiles]),
                     actions: disableFileActions ? undefined : getActions([...filePaths, ...deletedFiles]),
                 },
             }

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -238,12 +238,14 @@ export const createMynahUI = (
                 mynahUI.updateChatAnswerWithMessageId(tabID, item.messageId, {
                     ...(item.body !== undefined ? { body: item.body } : {}),
                     ...(item.buttons !== undefined ? { buttons: item.buttons } : {}),
+                    ...(item.followUp !== undefined ? { followUp: item.followUp } : {}),
                 })
             } else {
                 mynahUI.updateLastChatAnswer(tabID, {
                     ...(item.body !== undefined ? { body: item.body } : {}),
                     ...(item.buttons !== undefined ? { buttons: item.buttons } : {}),
-                } as ChatItem)
+                    ...(item.followUp !== undefined ? { followUp: item.followUp } : {}),
+                })
             }
         },
         onChatAnswerReceived: (tabID: string, item: CWCChatItem, messageData: any) => {

--- a/packages/core/src/amazonq/webview/ui/texts/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/texts/constants.ts
@@ -24,6 +24,11 @@ export const uiComponentsTexts = {
     noMoreTabsTooltip: 'You can only open ten conversation tabs at a time.',
     codeSuggestionWithReferenceTitle: 'Some suggestions contain code with references.',
     spinnerText: 'Generating your answer...',
+    changeAccepted: 'Change accepted',
+    changeRejected: 'Change rejected',
+    acceptChange: 'Accept change',
+    rejectChange: 'Reject change',
+    revertRejection: 'Revert rejection',
 }
 
 export const userGuideURL = 'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/software-dev.html'

--- a/packages/core/src/amazonqFeatureDev/app.ts
+++ b/packages/core/src/amazonqFeatureDev/app.ts
@@ -34,6 +34,7 @@ export function init(appContext: AmazonQAppInitContext) {
         processResponseBodyLinkClick: new vscode.EventEmitter<any>(),
         insertCodeAtPositionClicked: new vscode.EventEmitter<any>(),
         fileClicked: new vscode.EventEmitter<any>(),
+        storeCodeResultMessageId: new vscode.EventEmitter<any>(),
     }
 
     const messenger = new Messenger(new AppToWebViewMessageDispatcher(appContext.getAppsToWebViewMessagePublisher()))

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -31,7 +31,7 @@ import { codeGenRetryLimit, defaultRetryLimit } from '../../limits'
 import { Session } from '../../session/session'
 import { featureName } from '../../constants'
 import { ChatSessionStorage } from '../../storages/chatSession'
-import { DevPhase, FollowUpTypes, SessionStatePhase } from '../../types'
+import { DevPhase, FollowUpTypes, type NewFileInfo, SessionStatePhase } from '../../types'
 import { Messenger } from './messenger/messenger'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { AuthController } from '../../../amazonq/auth/controller'
@@ -43,7 +43,7 @@ import { openUrl } from '../../../shared/utilities/vsCodeUtils'
 import { getPathsFromZipFilePath } from '../../util/files'
 import { examples, messageWithConversationId } from '../../userFacingText'
 import { getWorkspaceFoldersByPrefixes } from '../../../shared/utilities/workspaceUtils'
-import { openDeletedDiff, openDiff } from '../../../amazonq/commons/diff'
+import { openDeletedDiff, openDiff, openFile } from '../../../amazonq/commons/diff'
 import { i18n } from '../../../shared/i18n-helper'
 import globals from '../../../shared/extensionGlobals'
 
@@ -759,6 +759,7 @@ export class FeatureDevController {
             if (action === 'accept-change') {
                 await session.insertNewFiles([session.state.filePaths[filePathIndex]])
                 await session.insertCodeReferenceLogs(session.state.references ?? [])
+                await this.openFile(session.state.filePaths[filePathIndex])
             } else {
                 session.state.filePaths[filePathIndex].rejected = !session.state.filePaths[filePathIndex].rejected
             }
@@ -817,6 +818,11 @@ export class FeatureDevController {
             const rightPath = path.join(uploadId, zipFilePath)
             await openDiff(pathInfos.absolutePath, rightPath, tabId)
         }
+    }
+
+    private async openFile(filePath: NewFileInfo) {
+        const absolutePath = path.join(filePath.workspaceFolder.uri.fsPath, filePath.relativePath)
+        await openFile(absolutePath)
     }
 
     private async stopResponse(message: any) {

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -900,6 +900,7 @@ export class FeatureDevController {
     }
 
     private async newTask(message: any) {
+        await this.disablePreviousFileList(message.tabID)
         // Old session for the tab is ending, delete it so we can create a new one for the message id
         const session = await this.sessionStorage.getSession(message.tabID)
         telemetry.amazonq_endChat.emit({
@@ -917,6 +918,7 @@ export class FeatureDevController {
     }
 
     private async closeSession(message: any) {
+        await this.disablePreviousFileList(message.tabID)
         this.messenger.sendAnswer({
             type: 'answer',
             tabID: message.tabID,

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -289,7 +289,7 @@ export class FeatureDevController {
                     tabID: message.tabID,
                     followUps: [
                         {
-                            pillText: i18n('AWS.amazonq.featureDev.pillText.insertCode'),
+                            pillText: i18n('AWS.amazonq.featureDev.pillText.acceptAllChanges'),
                             type: FollowUpTypes.InsertCode,
                             icon: 'ok' as MynahIcons,
                             status: 'success',

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -349,6 +349,8 @@ export class FeatureDevController {
             return
         }
 
+        await this.disablePreviousFileList(message.tabID)
+
         /**
          * Don't attempt to process any chat messages when a workspace folder is not set.
          * When the tab is first opened we will throw an error and lock the chat if the workspace
@@ -586,6 +588,11 @@ export class FeatureDevController {
                 session?.conversationIdUnsafe
             )
         }
+    }
+
+    private async disablePreviousFileList(tabId: string) {
+        const session = await this.sessionStorage.getSession(tabId)
+        await session.disableFileList()
     }
 
     private async provideFeedbackAndRegenerateCode(message: any) {

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -289,7 +289,11 @@ export class FeatureDevController {
                     tabID: message.tabID,
                     followUps: [
                         {
-                            pillText: i18n('AWS.amazonq.featureDev.pillText.acceptAllChanges'),
+                            pillText:
+                                session?.getInsertCodePillText([
+                                    ...(session?.state.filePaths ?? []),
+                                    ...(session?.state.deletedFiles ?? []),
+                                ]) ?? i18n('AWS.amazonq.featureDev.pillText.acceptAllChanges'),
                             type: FollowUpTypes.InsertCode,
                             icon: 'ok' as MynahIcons,
                             status: 'success',

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -476,7 +476,7 @@ export class FeatureDevController {
                     tabID: tabID,
                     messageId,
                 })
-                await session.updateChatAnswer(tabID, 'Accept all changes')
+                await session.updateChatAnswer(tabID, i18n('AWS.amazonq.featureDev.pillText.acceptAllChanges'))
             }
             this.messenger.sendUpdatePlaceholder(tabID, i18n('AWS.amazonq.featureDev.pillText.selectOption'))
         } finally {
@@ -762,12 +762,12 @@ export class FeatureDevController {
             }
         }
 
-        await session.updateFilesPaths(
-            tabId,
-            session.state.filePaths ?? [],
-            session.state.deletedFiles ?? [],
-            messageId
-        )
+        await session.updateFilesPaths({
+            tabID: tabId,
+            filePaths: session.state.filePaths ?? [],
+            deletedFiles: session.state.deletedFiles ?? [],
+            messageId,
+        })
 
         if (session.acceptCodeMessageId) {
             const allFilePathsAccepted = session.state.filePaths?.every(

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -132,9 +132,12 @@ export class Messenger {
         tabID: string,
         filePaths: NewFileInfo[],
         deletedFiles: DeletedFileInfo[],
-        messageId: string
+        messageId: string,
+        disableFileActions: boolean
     ) {
-        this.dispatcher.updateFileComponent(new FileComponent(tabID, filePaths, deletedFiles, messageId))
+        this.dispatcher.updateFileComponent(
+            new FileComponent(tabID, filePaths, deletedFiles, messageId, disableFileActions)
+        )
     }
 
     public sendUpdatePlaceholder(tabID: string, newPlaceholder: string) {

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -15,6 +15,7 @@ import {
     AuthNeededException,
     OpenNewTabMessage,
     FileComponent,
+    UpdateAnswerMessage,
 } from '../../../views/connector/connector'
 import { AppToWebViewMessageDispatcher } from '../../../views/connector/connector'
 import { ChatItemAction } from '@aws/mynah-ui'
@@ -33,6 +34,7 @@ export class Messenger {
         tabID: string
         canBeVoted?: boolean
         snapToTop?: boolean
+        messageId?: string
     }) {
         this.dispatcher.sendChatMessage(
             new ChatMessage(
@@ -43,6 +45,7 @@ export class Messenger {
                     relatedSuggestions: undefined,
                     canBeVoted: params.canBeVoted ?? false,
                     snapToTop: params.snapToTop ?? false,
+                    messageId: params.messageId,
                 },
                 params.tabID
             )
@@ -138,6 +141,10 @@ export class Messenger {
         this.dispatcher.updateFileComponent(
             new FileComponent(tabID, filePaths, deletedFiles, messageId, disableFileActions)
         )
+    }
+
+    public updateChatAnswer(message: UpdateAnswerMessage) {
+        this.dispatcher.updateChatAnswer(message)
     }
 
     public sendUpdatePlaceholder(tabID: string, newPlaceholder: string) {

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -171,10 +171,8 @@ export class Session {
                 this.state.tabID,
                 this.state.filePaths ?? [],
                 this.state.deletedFiles ?? [],
-                this._codeResultMessageId,
-                true
+                this._codeResultMessageId
             )
-            this._codeResultMessageId = undefined
         }
     }
 
@@ -204,6 +202,21 @@ export class Session {
         for (const ref of codeReferences) {
             ReferenceLogViewProvider.instance.addReferenceLog(referenceLogText(ref))
         }
+    }
+
+    public async disableFileList() {
+        if (this._codeResultMessageId === undefined) {
+            return
+        }
+
+        await this.updateFilesPaths(
+            this.state.tabID,
+            this.state.filePaths ?? [],
+            this.state.deletedFiles ?? [],
+            this._codeResultMessageId,
+            true
+        )
+        this._codeResultMessageId = undefined
     }
 
     public updateCodeResultMessageId(messageId?: string) {

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -151,9 +151,10 @@ export class Session {
         tabID: string,
         filePaths: NewFileInfo[],
         deletedFiles: DeletedFileInfo[],
-        messageId: string
+        messageId: string,
+        disableFileActions: boolean = false
     ) {
-        this.messenger.updateFileComponent(tabID, filePaths, deletedFiles, messageId)
+        this.messenger.updateFileComponent(tabID, filePaths, deletedFiles, messageId, disableFileActions)
     }
 
     public async insertChanges() {
@@ -170,7 +171,8 @@ export class Session {
                 this.state.tabID,
                 this.state.filePaths ?? [],
                 this.state.deletedFiles ?? [],
-                this._codeResultMessageId
+                this._codeResultMessageId,
+                true
             )
             this._codeResultMessageId = undefined
         }

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -157,16 +157,7 @@ export class Session {
     public async updateFilesPaths(params: UpdateFilesPathsParams) {
         const { tabID, filePaths, deletedFiles, messageId, disableFileActions = false } = params
         this.messenger.updateFileComponent(tabID, filePaths, deletedFiles, messageId, disableFileActions)
-        const allFiles = [...filePaths, ...deletedFiles]
-        if (allFiles.some((file) => file.rejected || file.changeApplied)) {
-            if (allFiles.every((file) => file.rejected || file.changeApplied)) {
-                await this.updateChatAnswer(tabID, i18n('AWS.amazonq.featureDev.pillText.continue'))
-            } else {
-                await this.updateChatAnswer(tabID, i18n('AWS.amazonq.featureDev.pillText.acceptRemainingChanges'))
-            }
-        } else {
-            await this.updateChatAnswer(tabID, i18n('AWS.amazonq.featureDev.pillText.acceptAllChanges'))
-        }
+        await this.updateChatAnswer(tabID, this.getInsertCodePillText([...filePaths, ...deletedFiles]))
     }
 
     public async updateChatAnswer(tabID: string, insertCodePillText: string) {
@@ -270,6 +261,16 @@ export class Session {
 
     public updateAcceptCodeTelemetrySent(sent: boolean) {
         this._acceptCodeTelemetrySent = sent
+    }
+
+    public getInsertCodePillText(files: Array<NewFileInfo | DeletedFileInfo>) {
+        if (files.every((file) => file.rejected || file.changeApplied)) {
+            return i18n('AWS.amazonq.featureDev.pillText.continue')
+        }
+        if (files.some((file) => file.rejected || file.changeApplied)) {
+            return i18n('AWS.amazonq.featureDev.pillText.acceptRemainingChanges')
+        }
+        return i18n('AWS.amazonq.featureDev.pillText.acceptAllChanges')
     }
 
     get state() {

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -42,6 +42,7 @@ export class Session {
     private _telemetry: TelemetryHelper
     private _codeResultMessageId: string | undefined = undefined
     private _acceptCodeMessageId: string | undefined = undefined
+    private _acceptCodeTelemetrySent = false
 
     // Used to keep track of whether or not the current session is currently authenticating/needs authenticating
     public isAuthenticating: boolean
@@ -264,6 +265,10 @@ export class Session {
         this._acceptCodeMessageId = messageId
     }
 
+    public updateAcceptCodeTelemetrySent(sent: boolean) {
+        this._acceptCodeTelemetrySent = sent
+    }
+
     get state() {
         if (!this._state) {
             throw new Error("State should be initialized before it's read")
@@ -311,5 +316,9 @@ export class Session {
 
     get acceptCodeMessageId() {
         return this._acceptCodeMessageId
+    }
+
+    get acceptCodeTelemetrySent() {
+        return this._acceptCodeTelemetrySent
     }
 }

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -308,4 +308,8 @@ export class Session {
     get telemetry() {
         return this._telemetry
     }
+
+    get acceptCodeMessageId() {
+        return this._acceptCodeMessageId
+    }
 }

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -157,8 +157,13 @@ export class Session {
     public async updateFilesPaths(params: UpdateFilesPathsParams) {
         const { tabID, filePaths, deletedFiles, messageId, disableFileActions = false } = params
         this.messenger.updateFileComponent(tabID, filePaths, deletedFiles, messageId, disableFileActions)
-        if ([...filePaths, ...deletedFiles].some((file) => file.rejected || file.changeApplied)) {
-            await this.updateChatAnswer(tabID, i18n('AWS.amazonq.featureDev.pillText.acceptRemainingChanges'))
+        const allFiles = [...filePaths, ...deletedFiles]
+        if (allFiles.some((file) => file.rejected || file.changeApplied)) {
+            if (allFiles.every((file) => file.rejected || file.changeApplied)) {
+                await this.updateChatAnswer(tabID, i18n('AWS.amazonq.featureDev.pillText.continue'))
+            } else {
+                await this.updateChatAnswer(tabID, i18n('AWS.amazonq.featureDev.pillText.acceptRemainingChanges'))
+            }
         } else {
             await this.updateChatAnswer(tabID, i18n('AWS.amazonq.featureDev.pillText.acceptAllChanges'))
         }

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -445,6 +445,7 @@ export class MockCodeGenState implements SessionState {
                 this.uploadId,
                 this.codeGenerationId ?? ''
             )
+            // TODO: store id and update logic for testing
             action.messenger.sendAnswer({
                 message: undefined,
                 type: 'system-prompt',

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -450,7 +450,7 @@ export class MockCodeGenState implements SessionState {
                 type: 'system-prompt',
                 followUps: [
                     {
-                        pillText: i18n('AWS.amazonq.featureDev.pillText.insertCode'),
+                        pillText: i18n('AWS.amazonq.featureDev.pillText.acceptAllChanges'),
                         type: FollowUpTypes.InsertCode,
                         icon: 'ok' as MynahIcons,
                         status: 'success',

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -445,7 +445,6 @@ export class MockCodeGenState implements SessionState {
                 this.uploadId,
                 this.codeGenerationId ?? ''
             )
-            // TODO: store id and update logic for testing
             action.messenger.sendAnswer({
                 message: undefined,
                 type: 'system-prompt',

--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -102,6 +102,7 @@ export function registerNewFiles(
                 workspaceFolderPrefixes === undefined ? 0 : prefix.length > 0 ? prefix.length + 1 : 0
             ),
             rejected: false,
+            changeApplied: false,
         })
     }
 
@@ -127,6 +128,7 @@ function getDeletedFileInfos(deletedFiles: string[], workspaceFolders: CurrentWs
                 workspaceFolder: folder,
                 relativePath: deletedFilePath.substring(prefixLength),
                 rejected: false,
+                changeApplied: false,
             }
         })
         .filter(isPresent)
@@ -426,6 +428,7 @@ export class MockCodeGenState implements SessionState {
                     workspaceFolder: this.config.workspaceFolders[0],
                     relativePath: 'src/this-file-should-be-deleted.ts',
                     rejected: false,
+                    changeApplied: false,
                 },
             ]
             action.messenger.sendCodeResult(

--- a/packages/core/src/amazonqFeatureDev/types.ts
+++ b/packages/core/src/amazonqFeatureDev/types.ts
@@ -114,3 +114,11 @@ export interface SessionStorage {
 }
 
 export type LLMResponseType = 'EMPTY' | 'INVALID_STATE' | 'VALID'
+
+export interface UpdateFilesPathsParams {
+    tabID: string
+    filePaths: NewFileInfo[]
+    deletedFiles: DeletedFileInfo[]
+    messageId: string
+    disableFileActions?: boolean
+}

--- a/packages/core/src/amazonqFeatureDev/views/actions/uiMessageListener.ts
+++ b/packages/core/src/amazonqFeatureDev/views/actions/uiMessageListener.ts
@@ -64,6 +64,9 @@ export class UIMessageListener {
             case 'file-click':
                 this.fileClicked(msg)
                 break
+            case 'store-code-result-message-id':
+                this.storeCodeResultMessageId(msg)
+                break
         }
     }
 
@@ -154,6 +157,13 @@ export class UIMessageListener {
             code: msg.code,
             insertionTargetType: msg.insertionTargetType,
             codeReference: msg.codeReference,
+        })
+    }
+
+    private storeCodeResultMessageId(msg: any) {
+        this.featureDevControllerEventsEmitters?.storeCodeResultMessageId.fire({
+            messageId: msg.messageId,
+            tabID: msg.tabID,
         })
     }
 }

--- a/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
+++ b/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
@@ -87,12 +87,20 @@ export class FileComponent extends UiMessage {
     readonly deletedFiles: DeletedFileInfo[]
     override type = 'updateFileComponent'
     readonly messageId: string
+    readonly disableFileActions: boolean
 
-    constructor(tabID: string, filePaths: NewFileInfo[], deletedFiles: DeletedFileInfo[], messageId: string) {
+    constructor(
+        tabID: string,
+        filePaths: NewFileInfo[],
+        deletedFiles: DeletedFileInfo[],
+        messageId: string,
+        disableFileActions: boolean
+    ) {
         super(tabID)
         this.filePaths = filePaths
         this.deletedFiles = deletedFiles
         this.messageId = messageId
+        this.disableFileActions = disableFileActions
     }
 }
 

--- a/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
+++ b/packages/core/src/amazonqFeatureDev/views/connector/connector.ts
@@ -162,6 +162,7 @@ export interface ChatMessageProps {
     readonly relatedSuggestions: SourceLink[] | undefined
     readonly canBeVoted: boolean
     readonly snapToTop: boolean
+    readonly messageId?: string
 }
 
 export class ChatMessage extends UiMessage {
@@ -172,6 +173,7 @@ export class ChatMessage extends UiMessage {
     readonly canBeVoted: boolean
     readonly requestID!: string
     readonly snapToTop: boolean
+    readonly messageId: string | undefined
     override type = 'chatMessage'
 
     constructor(props: ChatMessageProps, tabID: string) {
@@ -182,6 +184,27 @@ export class ChatMessage extends UiMessage {
         this.relatedSuggestions = props.relatedSuggestions
         this.canBeVoted = props.canBeVoted
         this.snapToTop = props.snapToTop
+        this.messageId = props.messageId
+    }
+}
+
+export interface UpdateAnswerMessageProps {
+    readonly messageId: string
+    readonly messageType: ChatItemType
+    readonly followUps: ChatItemAction[] | undefined
+}
+
+export class UpdateAnswerMessage extends UiMessage {
+    readonly messageId: string
+    readonly messageType: ChatItemType
+    readonly followUps: ChatItemAction[] | undefined
+    override type = 'updateChatAnswer'
+
+    constructor(props: UpdateAnswerMessageProps, tabID: string) {
+        super(tabID)
+        this.messageId = props.messageId
+        this.messageType = props.messageType
+        this.followUps = props.followUps
     }
 }
 
@@ -224,7 +247,11 @@ export class AppToWebViewMessageDispatcher {
         this.appsToWebViewMessagePublisher.publish(message)
     }
 
-    public updateFileComponent(message: any) {
+    public updateFileComponent(message: FileComponent) {
+        this.appsToWebViewMessagePublisher.publish(message)
+    }
+
+    public updateChatAnswer(message: UpdateAnswerMessage) {
         this.appsToWebViewMessagePublisher.publish(message)
     }
 }

--- a/packages/core/src/test/amazonq/common/diff.test.ts
+++ b/packages/core/src/test/amazonq/common/diff.test.ts
@@ -61,7 +61,7 @@ describe('diff', () => {
             await openDeletedDiff(filePath, name, tabId)
 
             const expectedPath = vscode.Uri.file(filePath)
-            assert.ok(executeCommandSpy.calledWith('vscode.open', expectedPath, {}, `${name} (Deleted)`))
+            assert.ok(executeCommandSpy.calledWith('vscode.diff', expectedPath, expectedPath, `${name} (Deleted)`))
         })
 
         it('file does not exists locally', async () => {
@@ -69,7 +69,7 @@ describe('diff', () => {
             await openDeletedDiff(filePath, name, tabId)
 
             const expectedPath = createAmazonQUri('empty', tabId)
-            assert.ok(executeCommandSpy.calledWith('vscode.open', expectedPath, {}, `${name} (Deleted)`))
+            assert.ok(executeCommandSpy.calledWith('vscode.open', expectedPath, expectedPath, `${name} (Deleted)`))
         })
     })
 

--- a/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -402,6 +402,7 @@ describe('Controller', () => {
         }
 
         describe('processErrorChatMessage', function () {
+            // TODO: fix disablePreviousFileList error
             const runs = [
                 { name: 'ContentLengthError', error: new ContentLengthError() },
                 {

--- a/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -53,6 +53,7 @@ describe('Controller', () => {
             rejected: false,
             virtualMemoryUri: generateVirtualMemoryUri(uploadID, 'myfile1.js'),
             workspaceFolder: controllerSetup.workspaceFolder,
+            changeApplied: false,
         },
         {
             zipFilePath: 'myfile2.js',
@@ -61,6 +62,7 @@ describe('Controller', () => {
             rejected: true,
             virtualMemoryUri: generateVirtualMemoryUri(uploadID, 'myfile2.js'),
             workspaceFolder: controllerSetup.workspaceFolder,
+            changeApplied: false,
         },
     ]
 
@@ -70,12 +72,14 @@ describe('Controller', () => {
             relativePath: 'myfile3.js',
             rejected: false,
             workspaceFolder: controllerSetup.workspaceFolder,
+            changeApplied: false,
         },
         {
             zipFilePath: 'myfile4.js',
             relativePath: 'myfile4.js',
             rejected: true,
             workspaceFolder: controllerSetup.workspaceFolder,
+            changeApplied: false,
         },
     ]
 

--- a/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -258,14 +258,6 @@ describe('Controller', () => {
 
             assertTelemetry('amazonq_endChat', { amazonqConversationId: conversationID, result: 'Succeeded' })
         })
-
-        it('calls disableFileList', async () => {
-            const disableFileListSpy = sinon.stub(session, 'disableFileList').resolves()
-
-            await newTaskClicked()
-
-            assert.ok(disableFileListSpy.calledOnce)
-        })
     })
 
     describe('fileClicked', () => {
@@ -409,14 +401,6 @@ describe('Controller', () => {
             }, {})
         }
 
-        it('calls disableFileList', async () => {
-            const disableFileListSpy = sinon.stub(session, 'disableFileList').resolves()
-
-            await fireChatMessage()
-
-            assert.ok(disableFileListSpy.calledOnce)
-        })
-
         describe('processErrorChatMessage', function () {
             // TODO: fix disablePreviousFileList error
             const runs = [
@@ -453,13 +437,11 @@ describe('Controller', () => {
                 const sendAnswerSpy = sinon.stub(controllerSetup.messenger, 'sendAnswer')
                 const sendErrorMessageSpy = sinon.stub(controllerSetup.messenger, 'sendErrorMessage')
                 const sendMonthlyLimitErrorSpy = sinon.stub(controllerSetup.messenger, 'sendMonthlyLimitError')
-                const disableFileListSpy = sinon.stub(session, 'disableFileList').resolves()
 
                 await fireChatMessage()
 
                 switch (error.constructor.name) {
                     case ContentLengthError.name:
-                        assert.ok(disableFileListSpy.calledOnce)
                         assert.ok(
                             sendAnswerSpy.calledWith({
                                 type: 'answer',
@@ -470,7 +452,6 @@ describe('Controller', () => {
                         )
                         break
                     case MonthlyConversationLimitError.name:
-                        assert.ok(disableFileListSpy.calledOnce)
                         assert.ok(sendMonthlyLimitErrorSpy.calledWith(tabID))
                         break
                     case FeatureDevServiceError.name:
@@ -478,7 +459,6 @@ describe('Controller', () => {
                     case UserMessageNotFoundError.name:
                     case TabIdNotFoundError.name:
                     case PrepareRepoFailedError.name:
-                        assert.ok(disableFileListSpy.calledOnce)
                         assert.ok(
                             sendErrorMessageSpy.calledWith(
                                 createTestErrorMessage(error.message),
@@ -490,7 +470,6 @@ describe('Controller', () => {
                         break
                     case PromptRefusalException.name:
                     case ZipFileError.name:
-                        assert.ok(disableFileListSpy.calledOnce)
                         assert.ok(
                             sendErrorMessageSpy.calledWith(
                                 createTestErrorMessage(error.message),
@@ -502,19 +481,8 @@ describe('Controller', () => {
                         )
                         break
                     case NoChangeRequiredException.name:
-                        assert.ok(disableFileListSpy.calledTwice)
-                        assert.ok(
-                            sendAnswerSpy.calledWith({
-                                type: 'answer',
-                                tabID,
-                                message: error.message,
-                                canBeVoted: true,
-                            })
-                        )
-                        break
                     case CodeIterationLimitError.name:
                     case UploadURLExpired.name:
-                        assert.ok(disableFileListSpy.calledOnce)
                         assert.ok(
                             sendAnswerSpy.calledWith({
                                 type: 'answer',
@@ -525,7 +493,6 @@ describe('Controller', () => {
                         )
                         break
                     default:
-                        assert.ok(disableFileListSpy.calledOnce)
                         assert.ok(
                             sendErrorMessageSpy.calledWith(
                                 i18n('AWS.amazonq.featureDev.error.codeGen.default'),
@@ -579,14 +546,6 @@ describe('Controller', () => {
             await closeSessionClicked()
 
             assertTelemetry('amazonq_endChat', { amazonqConversationId: conversationID, result: 'Succeeded' })
-        })
-
-        it('calls disableFileList', async () => {
-            const disableFileListSpy = sinon.stub(session, 'disableFileList').resolves()
-
-            await closeSessionClicked()
-
-            assert.ok(disableFileListSpy.calledOnce)
         })
     })
 })

--- a/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -9,7 +9,7 @@ import * as path from 'path'
 import sinon from 'sinon'
 import { waitUntil } from '../../../../shared/utilities/timeoutUtils'
 import { ControllerSetup, createController, createSession, generateVirtualMemoryUri } from '../../utils'
-import { CurrentWsFolders, FollowUpTypes, NewFileInfo, DeletedFileInfo } from '../../../../amazonqFeatureDev/types'
+import { CurrentWsFolders, DeletedFileInfo, FollowUpTypes, NewFileInfo } from '../../../../amazonqFeatureDev/types'
 import { Session } from '../../../../amazonqFeatureDev/session/session'
 import { Prompter } from '../../../../shared/ui/prompter'
 import { assertTelemetry, toFile } from '../../../testUtil'
@@ -259,7 +259,7 @@ describe('Controller', () => {
             assertTelemetry('amazonq_endChat', { amazonqConversationId: conversationID, result: 'Succeeded' })
         })
 
-        it('disableFileList is called', async () => {
+        it('calls disableFileList', async () => {
             const disableFileListSpy = sinon.stub(session, 'disableFileList').resolves()
 
             await newTaskClicked()
@@ -408,6 +408,14 @@ describe('Controller', () => {
                 return Promise.resolve(getSessionStub.callCount > 0)
             }, {})
         }
+
+        it('calls disableFileList', async () => {
+            const disableFileListSpy = sinon.stub(session, 'disableFileList').resolves()
+
+            await fireChatMessage()
+
+            assert.ok(disableFileListSpy.calledOnce)
+        })
 
         describe('processErrorChatMessage', function () {
             // TODO: fix disablePreviousFileList error
@@ -573,7 +581,7 @@ describe('Controller', () => {
             assertTelemetry('amazonq_endChat', { amazonqConversationId: conversationID, result: 'Succeeded' })
         })
 
-        it('disableFileList is called', async () => {
+        it('calls disableFileList', async () => {
             const disableFileListSpy = sinon.stub(session, 'disableFileList').resolves()
 
             await closeSessionClicked()

--- a/packages/core/src/test/amazonqFeatureDev/utils.ts
+++ b/packages/core/src/test/amazonqFeatureDev/utils.ts
@@ -39,6 +39,7 @@ export function createMockChatEmitters(): ChatControllerEventEmitters {
         processResponseBodyLinkClick: new vscode.EventEmitter<any>(),
         insertCodeAtPositionClicked: new vscode.EventEmitter<any>(),
         fileClicked: new vscode.EventEmitter<any>(),
+        storeCodeResultMessageId: new vscode.EventEmitter<any>(),
     }
 }
 


### PR DESCRIPTION
## Problem
For the current /dev experience for code review, user needs to review the entire file list of generated code, reject the changes they do not want, and then accept the remaining changes in bulk at the end.

This PR introduces improvements in user experience around the code review experience in which user can now review the file changes and accept them one at a time. User can start editing the file right away after accepting the changes without having to go through the entire generated file list.

## Solution
<img width="276" alt="new-action-button" src="https://github.com/user-attachments/assets/1be94091-7435-4401-bd17-6627d4238af2">

<img width="270" alt="file-accepted" src="https://github.com/user-attachments/assets/d45690d9-2f82-4de6-99b8-af73dd4d6ddb">


- introduces a new action button for accepting file change for each change suggested on the file list
- accepted changes are now highlighted in green
- when accepting changes in bulk, the file list is updated to reflect the status if a change is rejected or accepted
- minor text changes / improvements

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
