### PR TITLE
fix(amazonq): Improve indexing auto start-stop strategy

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-8459b9ba-8260-411b-ad00-0ed1394263d0.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-8459b9ba-8260-411b-ad00-0ed1394263d0.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Improve `@workspace` index auto pause start strategy, avoid out-of-memory issue. "
+	"description": "Improve `@workspace` index auto pause start strategy. "
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-8459b9ba-8260-411b-ad00-0ed1394263d0.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-8459b9ba-8260-411b-ad00-0ed1394263d0.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Improve `@workspace` index auto pause start strategy, avoid out-of-memory issue. "
+}

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -66,7 +66,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.24']
+const supportedLspServerVersions = ['0.1.25']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 


### PR DESCRIPTION
## Problem
When multiple IDE instances are opened at the same time, the `@workspace ` indexing can increase CPU usage to a point that system fan needs to engage. IDE can be slow if it is older devices like intel i5 or i7 Mac OS.

## Solution

When multiple IDE instances are opened at the same time, the `@workspace`  indexing can increase CPU usage to a point that system fan needs to engage. IDE can be slow if it is older devices like intel i5 or i7 Mac OS. This PR is to improve indexing auto start-stop strategy, detect CPU usage more frequently and pause indexing more aggressively whenever system total CPU usage goes up. In the mean time, further reduce CPU usage for old Intel i5, i7 devices, make sure one IDE instance at most utilize one physical core and all instance combined cannot exceed 1 for any extended period of time more than a few seconds, unless user explicit allows more CPU usage in settings. Other mechanisms are implemented to stop indexing if system available memory is small.  

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
