### PR TITLE
fix(jscpd): change pattern to allow for nested script patterns. 

### DIFF
--- a/.github/workflows/jscpd.json
+++ b/.github/workflows/jscpd.json
@@ -1,6 +1,6 @@
 {
     "pattern": "packages/**/*.ts",
-    "ignore": ["**node_modules**", "**dist**", "*/scripts/*"],
+    "ignore": ["**node_modules**", "**dist**", "**/scripts/**"],
     "gitignore": true,
     "threshold": 3.0,
     "minLines": 3,


### PR DESCRIPTION
## Problem
The current pattern will not catch the script files because they are nested beyond one directory deep. 

## Solution
change it to `**/script/**`. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
