### PR TITLE
telemetry(amazonq): include trace id in amazonq_addMessage

### DIFF
--- a/packages/core/src/amazonq/messages/chatMessageDuration.ts
+++ b/packages/core/src/amazonq/messages/chatMessageDuration.ts
@@ -96,7 +96,12 @@ export class AmazonQChatMessageDuration {
                 })
             }
 
-            CWCTelemetryHelper.instance.emitAddMessage(tabID, totalDuration, metrics.events.chatMessageSent)
+            CWCTelemetryHelper.instance.emitAddMessage(
+                tabID,
+                totalDuration,
+                metrics.traceId,
+                metrics.events.chatMessageSent
+            )
 
             uiEventRecorder.delete(tabID)
         })

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -420,7 +420,7 @@ export class CWCTelemetryHelper {
         })
     }
 
-    public emitAddMessage(tabID: string, fullDisplayLatency: number, startTime?: number) {
+    public emitAddMessage(tabID: string, fullDisplayLatency: number, traceId: string, startTime?: number) {
         const payload = this.messageStorage.get(tabID)
         if (!payload) {
             return
@@ -464,6 +464,7 @@ export class CWCTelemetryHelper {
             credentialStartUrl: AuthUtil.instance.startUrl,
             codewhispererCustomizationArn: triggerPayload.customization.arn,
             cwsprChatHasProjectContext: hasProjectLevelContext,
+            traceId,
         }
 
         telemetry.amazonq_addMessage.emit(event)


### PR DESCRIPTION
## Problem
the trace id that gets emitted for amazonq_addMessage is different then the one that gets emitted for amazonq_chatRoundTrip

## Solution
Use the same trace id

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
