### PR TITLE
refactor(logging): cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,6 +216,16 @@ To run tests against a specific folder in VSCode, do any one of:
         $Env:TEST_DIR = "../core/src/test/foo"; npm run test
         ```
 
+#### Run jscpd ("Copy-Paste Detection")
+
+If the "Copy-Paste Detection" CI job fails, you will find it useful to check things locally. To
+check a specific file:
+
+    npx jscpd --config .github/workflows/jscpd.json --pattern packages/…/src/foo.ts
+
+See the [jscpd cli documentation](https://github.com/kucherenko/jscpd/tree/master/apps/jscpd) for
+more options.
+
 ### Coverage report
 
 You can find the coverage report at `./coverage/amazonq/lcov-report/index.html` and `./coverage/toolkit/lcov-report/index.html` after running the tests. Tests ran from the workspace launch config won't generate a coverage report automatically because it can break file watching.

--- a/packages/core/src/shared/logger/toolkitLogger.ts
+++ b/packages/core/src/shared/logger/toolkitLogger.ts
@@ -14,9 +14,6 @@ import { SharedFileTransport } from './sharedFileTransport'
 import { ConsoleLogTransport } from './consoleLogTransport'
 import { isWeb } from '../extensionGlobals'
 
-/* define log topics */
-export type LogTopic = 'unknown' | 'test' | 'crashReport' | 'notifications'
-
 class ErrorLog {
     constructor(
         public topic: string,
@@ -30,7 +27,6 @@ const logmapSize: number = 1000
 export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
     private readonly logger: winston.Logger
     /* topic is used for header in log messages, default is 'Unknown' */
-    private topic: LogTopic = 'unknown'
     private disposed: boolean = false
     private idCounter: number = 0
     private logMap: { [logID: number]: { [filePath: string]: string } } = {}
@@ -115,16 +111,10 @@ export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
               })
     }
 
-    public setTopic(topic: LogTopic = 'unknown') {
-        this.topic = topic
-    }
-
     /* Format the message with topic header */
     private addTopicToMessage(message: string | Error): string | ErrorLog {
         if (typeof message === 'string') {
-            /*We shouldn't print unknow before current logging calls are migrated
-             * TODO: remove this once migration of current calls is completed
-             */
+            // TODO: remove this after all calls are migrated and topic is a required param.
             if (this.topic === 'unknown') {
                 return message
             }

--- a/packages/core/src/test/shared/logger/toolkitLogger.test.ts
+++ b/packages/core/src/test/shared/logger/toolkitLogger.test.ts
@@ -239,32 +239,26 @@ describe('ToolkitLogger', function () {
             assert.ok(!(await waitForMessage).includes(nonLoggedVerboseEntry), 'unexpected message in log')
         })
 
-        it('logs append topic header in message', async function () {
-            const testMessage = 'This is a test message'
+        it('prepends topic to message', async function () {
+            testLogger = new ToolkitLogger('info')
+            testLogger.logToOutputChannel(outputChannel, false)
+            testLogger.setTopic('test')
+            testLogger.setLogLevel('verbose')
+
             const testMessageWithHeader = 'test: This is a test message'
+            testLogger.verbose('This is a test message')
+            assert.ok(
+                (await waitForLoggedTextByContents(testMessageWithHeader)).includes(testMessageWithHeader),
+                'Expected header added'
+            )
 
-            testLogger = new ToolkitLogger('info')
-            testLogger.logToOutputChannel(outputChannel, false)
-            testLogger.setTopic('test')
-            testLogger.setLogLevel('verbose')
-            testLogger.verbose(testMessage)
+            const msg = "topic: 'test'"
+            testLogger.verbose(new ToolkitError('root error', { code: 'something went wrong' }))
+            assert.ok((await waitForLoggedTextByContents(msg)).includes(msg), 'Expected header added')
 
-            const waitForMessage = waitForLoggedTextByContents(testMessageWithHeader)
-            assert.ok((await waitForMessage).includes(testMessageWithHeader), 'Expected header added')
-        })
-
-        it('logs append topic header in errors', async function () {
-            const testError = new ToolkitError('root error', { code: 'something went wrong' })
-            const testErrorWithHeader = "topic: 'test'"
-
-            testLogger = new ToolkitLogger('info')
-            testLogger.logToOutputChannel(outputChannel, false)
-            testLogger.setTopic('test')
-            testLogger.setLogLevel('verbose')
-            testLogger.verbose(testError)
-
-            const waitForMessage = waitForLoggedTextByContents(testErrorWithHeader)
-            assert.ok((await waitForMessage).includes(testErrorWithHeader), 'Expected header added')
+            const msg2 = "topic: 'test'"
+            testLogger.verbose(new ToolkitError('root error', { code: 'something went wrong' }))
+            assert.ok((await waitForLoggedTextByContents(msg2)).includes(msg2), 'Expected header added')
         })
 
         it('unknown topic header ignored in message', async function () {
@@ -282,7 +276,7 @@ describe('ToolkitLogger', function () {
             assert.ok(!(await waitForMessage).includes(unknowntestMessage), 'unexpected header in log')
         })
 
-        it('switch topic within same logger', async function () {
+        it('switch topic on same logger', async function () {
             const testMessage = 'This is a test message'
             const testMessageWithHeader = 'test: This is a test message'
 


### PR DESCRIPTION
- deduplicate tests
- define `setTopic` on `BaseLogger`, not `ToolkitLogger`
  - it's not specific to ToolkitLogger, so it should live in the base interface.
- define `LogTopic` in `logger.ts`, not `ToolkitLogger`
  - it's not specific to ToolkitLogger, so it should live in the base interface.



---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
