### PR TITLE
feat(cwl): LiveTail statusbar

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -8,8 +8,12 @@ import { TailLogGroupWizard } from '../wizard/tailLogGroupWizard'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import { LiveTailSession, LiveTailSessionConfiguration } from '../registry/liveTailSession'
 import { LiveTailSessionRegistry } from '../registry/liveTailSessionRegistry'
-import { LiveTailSessionLogEvent, StartLiveTailResponseStream } from '@aws-sdk/client-cloudwatch-logs'
-import { ToolkitError } from '../../../shared'
+import {
+    LiveTailSessionLogEvent,
+    LiveTailSessionUpdate,
+    StartLiveTailResponseStream,
+} from '@aws-sdk/client-cloudwatch-logs'
+import { globals, ToolkitError } from '../../../shared'
 
 export async function tailLogGroup(
     registry: LiveTailSessionRegistry,
@@ -35,13 +39,17 @@ export async function tailLogGroup(
     registry.set(session.uri, session)
 
     const document = await prepareDocument(session)
-    registerTabChangeCallback(session, registry, document)
+    const timer = startSessionTimer(session)
+    hideShowStatusBarItemsOnActiveEditor(session, document)
+    registerTabChangeCallback(session, registry, document, timer)
+
     const stream = await session.startLiveTailSession()
 
-    await handleSessionStream(stream, document, session)
+    await handleSessionStream(stream, document, session, timer)
 }
 
-export function closeSession(sessionUri: vscode.Uri, registry: LiveTailSessionRegistry) {
+export function closeSession(sessionUri: vscode.Uri, registry: LiveTailSessionRegistry, timer: NodeJS.Timer) {
+    globals.clock.clearInterval(timer)
     const session = registry.get(sessionUri)
     if (session === undefined) {
         throw new ToolkitError(`No LiveTail session found for URI: ${sessionUri.toString()}`)
@@ -63,27 +71,34 @@ async function prepareDocument(session: LiveTailSession): Promise<vscode.TextDoc
     await clearDocument(textDocument)
     await vscode.window.showTextDocument(textDocument, { preview: false })
     await vscode.languages.setTextDocumentLanguage(textDocument, 'log')
+    session.showStatusBarItem(true)
     return textDocument
 }
 
 async function handleSessionStream(
     stream: AsyncIterable<StartLiveTailResponseStream>,
     document: vscode.TextDocument,
-    session: LiveTailSession
+    session: LiveTailSession,
+    timer: NodeJS.Timer
 ) {
-    for await (const event of stream) {
-        if (event.sessionUpdate !== undefined && event.sessionUpdate.sessionResults !== undefined) {
-            const formattedLogEvents = event.sessionUpdate.sessionResults.map<string>((logEvent) =>
-                formatLogEvent(logEvent)
-            )
-            if (formattedLogEvents.length !== 0) {
-                //Determine should scroll before adding new lines to doc because adding large
-                //amount of new lines can push bottom of file out of view before scrolling.
-                const editorsToScroll = getTextEditorsToScroll(document)
-                await updateTextDocumentWithNewLogEvents(formattedLogEvents, document, session.maxLines)
-                editorsToScroll.forEach(scrollTextEditorToBottom)
+    try {
+        for await (const event of stream) {
+            if (event.sessionUpdate !== undefined && event.sessionUpdate.sessionResults !== undefined) {
+                const formattedLogEvents = event.sessionUpdate.sessionResults.map<string>((logEvent) =>
+                    formatLogEvent(logEvent)
+                )
+                if (formattedLogEvents.length !== 0) {
+                    //Determine should scroll before adding new lines to doc because adding large
+                    //amount of new lines can push bottom of file out of view before scrolling.
+                    const editorsToScroll = getTextEditorsToScroll(document)
+                    await updateTextDocumentWithNewLogEvents(formattedLogEvents, document, session.maxLines)
+                    editorsToScroll.forEach(scrollTextEditorToBottom)
+                }
+                updateStatusBarItemsOnStreamEvent(session, event.sessionUpdate)
             }
         }
+    } finally {
+        globals.clock.clearInterval(timer)
     }
 }
 
@@ -147,6 +162,38 @@ function trimOldestLines(
     edit.delete(document.uri, range)
 }
 
+function updateStatusBarItemsOnStreamEvent(session: LiveTailSession, event: LiveTailSessionUpdate) {
+    updateIsSampled(session, event)
+    updateEventRate(session, event)
+}
+
+function updateIsSampled(session: LiveTailSession, event: LiveTailSessionUpdate) {
+    session.isSampled =
+        event.sessionMetadata === undefined || event.sessionMetadata.sampled === undefined
+            ? false
+            : event.sessionMetadata.sampled
+}
+
+function updateEventRate(session: LiveTailSession, event: LiveTailSessionUpdate) {
+    session.eventRate = event.sessionResults === undefined ? 0 : event.sessionResults.length
+}
+
+function hideShowStatusBarItemsOnActiveEditor(session: LiveTailSession, document: vscode.TextDocument) {
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+        if (editor?.document === document) {
+            session.showStatusBarItem(true)
+        } else {
+            session.showStatusBarItem(false)
+        }
+    })
+}
+
+function startSessionTimer(session: LiveTailSession): NodeJS.Timer {
+    return globals.clock.setInterval(() => {
+        session.updateStatusBarItemText()
+    }, 500)
+}
+
 /**
  * The LiveTail session should be automatically closed if the user does not have the session's
  * document in any Tab in their editor.
@@ -162,12 +209,13 @@ function trimOldestLines(
 function registerTabChangeCallback(
     session: LiveTailSession,
     registry: LiveTailSessionRegistry,
-    document: vscode.TextDocument
+    document: vscode.TextDocument,
+    timer: NodeJS.Timer
 ) {
     vscode.window.tabGroups.onDidChangeTabs((tabEvent) => {
         const isOpen = isLiveTailSessionOpenInAnyTab(session)
         if (!isOpen) {
-            closeSession(session.uri, registry)
+            closeSession(session.uri, registry, timer)
             void clearDocument(document)
         }
     })

--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
@@ -143,6 +143,6 @@ export class LiveTailSession {
         const elapsedTime = this.getLiveTailSessionDuration()
         const timeString = convertToTimeString(elapsedTime)
         const sampledString = this._isSampled ? 'Yes' : 'No'
-        this.statusBarItem.text = `Tailing Session: ${timeString}, ${this._eventRate} events/sec, Sampled: ${sampledString}`
+        this.statusBarItem.text = `Tailing: ${timeString}, ${this._eventRate} events/sec, Sampled: ${sampledString}`
     }
 }

--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
@@ -10,7 +10,7 @@ import {
 } from '@aws-sdk/client-cloudwatch-logs'
 import { LogStreamFilterResponse } from '../wizard/liveTailLogStreamSubmenu'
 import { CloudWatchLogsSettings } from '../cloudWatchLogsUtils'
-import { Settings, ToolkitError } from '../../../shared'
+import { convertToTimeString, Settings, ToolkitError } from '../../../shared'
 import { createLiveTailURIFromArgs } from './liveTailSessionRegistry'
 import { getUserAgent } from '../../../shared/telemetry/util'
 
@@ -33,6 +33,11 @@ export class LiveTailSession {
     private logEventFilterPattern?: string
     private _maxLines: number
     private _uri: vscode.Uri
+    private statusBarItem: vscode.StatusBarItem
+    private startTime: number | undefined
+    private endTime: number | undefined
+    private _eventRate: number
+    private _isSampled: boolean
 
     static settings = new CloudWatchLogsSettings(Settings.instance)
 
@@ -48,6 +53,9 @@ export class LiveTailSession {
         }
         this._maxLines = LiveTailSession.settings.get('limit', 10000)
         this._uri = createLiveTailURIFromArgs(configuration)
+        this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 0)
+        this._eventRate = 0
+        this._isSampled = false
     }
 
     public get maxLines() {
@@ -62,6 +70,14 @@ export class LiveTailSession {
         return this._logGroupName
     }
 
+    public set eventRate(rate: number) {
+        this._eventRate = rate
+    }
+
+    public set isSampled(isSampled: boolean) {
+        this._isSampled = isSampled
+    }
+
     public async startLiveTailSession(): Promise<AsyncIterable<StartLiveTailResponseStream>> {
         const command = this.buildStartLiveTailCommand()
         try {
@@ -71,6 +87,8 @@ export class LiveTailSession {
             if (!commandOutput.responseStream) {
                 throw new ToolkitError('LiveTail session response stream is undefined.')
             }
+            this.startTime = Date.now()
+            this.endTime = undefined
             return commandOutput.responseStream
         } catch (e) {
             throw new ToolkitError('Encountered error while trying to start LiveTail session.')
@@ -78,8 +96,22 @@ export class LiveTailSession {
     }
 
     public stopLiveTailSession() {
+        this.endTime = Date.now()
+        this.statusBarItem.dispose()
         this.liveTailClient.abortController.abort()
         this.liveTailClient.cwlClient.destroy()
+    }
+
+    public getLiveTailSessionDuration(): number {
+        //Never started
+        if (this.startTime === undefined) {
+            return 0
+        }
+        //Currently running
+        if (this.endTime === undefined) {
+            return Date.now() - this.startTime
+        }
+        return this.endTime - this.startTime
     }
 
     private buildStartLiveTailCommand(): StartLiveTailCommand {
@@ -101,5 +133,16 @@ export class LiveTailSession {
             logStreamNames: logStreamName ? [logStreamName] : undefined,
             logEventFilterPattern: this.logEventFilterPattern ? this.logEventFilterPattern : undefined,
         })
+    }
+
+    public showStatusBarItem(shouldShow: boolean) {
+        shouldShow ? this.statusBarItem.show() : this.statusBarItem.hide()
+    }
+
+    public updateStatusBarItemText() {
+        const elapsedTime = this.getLiveTailSessionDuration()
+        const timeString = convertToTimeString(elapsedTime)
+        const sampledString = this._isSampled ? 'Yes' : 'No'
+        this.statusBarItem.text = `Tailing Session: ${timeString}, ${this._eventRate} events/sec, Sampled: ${sampledString}`
     }
 }


### PR DESCRIPTION
Problem
As LiveTail session is running, we want to display to the user metadata about their session.

**While updating my local feature branch after fixing the merge conflicts in https://github.com/aws/aws-toolkit-vscode/pull/5889, my original PR for this change was closed.**

**Please see original PR [here](https://github.com/aws/aws-toolkit-vscode/pull/5894) for addional comments and context**

Solution
While a livetail session is the active editor, in the bottom status bar, we will display the duration the session has been running for, how many events per/s, and if the log data is being sampled or not.

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.