### PR TITLE
feat(notification): Use virtual txt file and telemetry url wrapper

### DIFF
--- a/packages/core/src/shared/utilities/textDocumentUtilities.ts
+++ b/packages/core/src/shared/utilities/textDocumentUtilities.ts
@@ -223,3 +223,47 @@ export async function addEofNewline(editor: vscode.TextEditor) {
         })
     }
 }
+
+class ReadonlyTextDocumentProvider implements vscode.TextDocumentContentProvider {
+    private content = ''
+
+    setContent(content: string) {
+        this.content = content
+    }
+
+    provideTextDocumentContent(uri: vscode.Uri): string {
+        return this.content
+    }
+}
+
+/**
+ * Shows a read only virtual txt file on a side column
+ * It's read-only so that the "save" option doesn't appear when user closes the pop up window
+ * Usage: ReadonlyDocument.show(content, filename)
+ * @param content The content to be displayed in the virtual document
+ * @param filename The title on top of the pop up window
+ */
+class ReadonlyDocument {
+    private readonly scheme = 'AWStoolkit-readonly'
+    private readonly provider = new ReadonlyTextDocumentProvider()
+
+    constructor() {
+        vscode.workspace.registerTextDocumentContentProvider(this.scheme, this.provider)
+    }
+
+    public async show(content: string, filename: string) {
+        this.provider.setContent(content)
+        const uri = vscode.Uri.parse(`${this.scheme}:/${filename}.txt`)
+        const options: vscode.TextDocumentShowOptions = {
+            viewColumn: vscode.ViewColumn.Beside,
+            preserveFocus: true,
+            preview: true,
+        }
+
+        // Open the document with the updated content
+        const document = await vscode.workspace.openTextDocument(uri)
+        await vscode.window.showTextDocument(document, options)
+    }
+}
+
+export const readonlyDocument = new ReadonlyDocument()

--- a/packages/core/src/test/notifications/resources/emergency/1.x.json
+++ b/packages/core/src/test/notifications/resources/emergency/1.x.json
@@ -2,16 +2,36 @@
     "schemaVersion": "1.x",
     "notifications": [
         {
-            "id": "amazonq_emergency_local_1",
+            "id": "emergency1",
             "displayIf": {
                 "extensionId": "amazonwebservices.amazon-q-vscode"
             },
             "uiRenderInstructions": {
                 "content": {
                     "en-US": {
-                        "title": "[local] Emergency: url",
-                        "description": "Something crazy is happening! Please update your extension.",
-                        "toastPreview": "omg"
+                        "title": "Can't sign in to Amazon Q",
+                        "description": "There is currently a bug that is preventing users from signing into Amazon Q. If this impacts you, please try this workaround:\n\n 1. Reload your IDE\n 2. Run the command in the command palette:: `Amazon Q: Reset State`.\n 3. Set your default region to `us-east-3`.\n 4. Try to sign into Amazon Q with your desired region in the dropdown.\n\nWe are currently working on releasing a fix so that this workaround is not required.\nPlease reach out on our github issues with any questions.",
+                        "toastPreview": "Signing into Amazon Q is broken, please try this workaround while we work on releasing a fix."
+                    }
+                },
+                "onRecieve": "toast",
+                "onClick": {
+                    "type": "openTextDocument"
+                },
+                "actions": []
+            }
+        },
+        {
+            "id": "emergency2",
+            "displayIf": {
+                "extensionId": "amazonwebservices.amazon-q-vscode"
+            },
+            "uiRenderInstructions": {
+                "content": {
+                    "en-US": {
+                        "title": "Update Amazon Q to avoid breaking bugs",
+                        "description": "There is currently a bug that prevents Amazon Q from responding to chat requests. It is fixed in the latest version. Please update your Amazon Q now.",
+                        "toastPreview": "This version of Amazon Q is currently broken, please update to avoid issues."
                     }
                 },
                 "onRecieve": "toast",
@@ -23,66 +43,6 @@
                         "type": "updateAndReload",
                         "displayText": {
                             "en-US": "Update and Reload"
-                        }
-                    },
-                    {
-                        "type": "openUrl",
-                        "url": "https://aws.amazon.com/visualstudiocode/",
-                        "displayText": {
-                            "en-US": "Proceed to wiki"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "id": "amazonq_emergency_local_2",
-            "displayIf": {
-                "extensionId": "amazonwebservices.amazon-q-vscode"
-            },
-            "uiRenderInstructions": {
-                "content": {
-                    "en-US": {
-                        "title": "[local] Emergency: txt",
-                        "description": "Something crazy is happening! Please update your extension.",
-                        "toastPreview": "omg"
-                    }
-                },
-                "onRecieve": "toast",
-                "onClick": {
-                    "type": "openTextDocument"
-                }
-            }
-        },
-        {
-            "id": "amazonq_emergency_local_3",
-            "displayIf": {
-                "extensionId": "amazonwebservices.amazon-q-vscode"
-            },
-            "uiRenderInstructions": {
-                "content": {
-                    "en-US": {
-                        "title": "[local] Emergency: modal",
-                        "description": "Something crazy is happening! Please update your extension.",
-                        "toastPreview": "new notification: something crazy is happening! Please update your entension and look on our wiki."
-                    }
-                },
-                "onRecieve": "toast",
-                "onClick": {
-                    "type": "openTextDocument"
-                },
-                "actions": [
-                    {
-                        "type": "updateAndReload",
-                        "displayText": {
-                            "en-US": "Update and Reload"
-                        }
-                    },
-                    {
-                        "type": "openUrl",
-                        "url": "https://aws.amazon.com/visualstudiocode/",
-                        "displayText": {
-                            "en-US": "Proceed to wiki"
                         }
                     }
                 ]

--- a/packages/core/src/test/notifications/resources/startup/1.x.json
+++ b/packages/core/src/test/notifications/resources/startup/1.x.json
@@ -2,23 +2,51 @@
     "schemaVersion": "1.x",
     "notifications": [
         {
-            "id": "amazonq_startUp_local_1",
+            "id": "startup1",
             "displayIf": {
                 "extensionId": "amazonwebservices.amazon-q-vscode"
             },
             "uiRenderInstructions": {
                 "content": {
                     "en-US": {
-                        "title": "[local] What's New, url",
-                        "description": "Check out this new stuff!",
-                        "toastPreview": "omg"
+                        "title": "New Amazon Q Chat features",
+                        "description": "You can now use Amazon Q inline in your IDE, without ever touching the mouse or using copy and paste. \nPress ⌘+I (Ctrl+I on Windows) to trigger inline chat. \nDescribe a function or feature you'd like to develop and Amazon Q will generate and display a code diff that inserts new code at the cursor position. \nPress Enter to accept and apply the diff, or Escape to reject it. \nAlternatively you select a block of code (maybe even the entire file) then press ⌘+I (Ctrl+I on Windows) to provide instructions on how to refactor the selected code. \nYou will see a diff against the selected code and can press Enter to accept and apply the diff.",
+                        "toastPreview": "New Amazon Q features available: inline chat"
+                    }
+                },
+                "onRecieve": "toast",
+                "onClick": {
+                    "type": "openTextDocument"
+                },
+                "actions": [
+                    {
+                        "type": "openUrl",
+                        "url": "https://aws.amazon.com/developer/generative-ai/amazon-q/change-log/",
+                        "displayText": {
+                            "en-US": "Learn more"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "id": "startup2",
+            "displayIf": {
+                "extensionId": "amazonwebservices.amazon-q-vscode"
+            },
+            "uiRenderInstructions": {
+                "content": {
+                    "en-US": {
+                        "title": "What's New",
+                        "toastPreview": "New Amazon Q features are available!"
                     }
                 },
                 "onRecieve": "toast",
                 "onClick": {
                     "type": "openUrl",
-                    "url": "https://aws.amazon.com/visualstudiocode/"
-                }
+                    "url": "https://aws.amazon.com/developer/generative-ai/amazon-q/change-log/"
+                },
+                "actions": []
             }
         }
     ]


### PR DESCRIPTION
Created a `ReadonlyDocument` class in `textDocumentUtilities` to show a virtual read-only txt file. Converted existing txt notifications.

Use telemetry url wrapper instead of `openExternal` 

Also updated some local notification JSON for future testing