### PR TITLE
telemetry(amazonq): Add more information for outlier chat round trips

### DIFF
--- a/packages/core/src/amazonq/messages/chatMessageDuration.ts
+++ b/packages/core/src/amazonq/messages/chatMessageDuration.ts
@@ -83,16 +83,28 @@ export class AmazonQChatMessageDuration {
 
             // TODO: handle onContextCommand round trip time
             if (metrics.trigger !== 'onContextCommand') {
+                const editorReceivedMessage = durationFrom('chatMessageSent', 'editorReceivedMessage')
+                const featureReceivedMessage = durationFrom('editorReceivedMessage', 'featureReceivedMessage')
+                const messageDisplayed = durationFrom('featureReceivedMessage', 'messageDisplayed')
+                let reasonDesc = undefined
+
+                /**
+                 * Temporary include more information about outliers so that we can find out if the messages
+                 * aren't being sent or the user is actually doing a different chat flow
+                 */
+                if ([editorReceivedMessage, featureReceivedMessage].some((val) => val > 30000 || val < -30000)) {
+                    reasonDesc = JSON.stringify(metrics.events)
+                }
                 telemetry.amazonq_chatRoundTrip.emit({
                     amazonqChatMessageSentTime: metrics.events.chatMessageSent ?? -1,
-                    amazonqEditorReceivedMessageMs: durationFrom('chatMessageSent', 'editorReceivedMessage') ?? -1,
-                    amazonqFeatureReceivedMessageMs:
-                        durationFrom('editorReceivedMessage', 'featureReceivedMessage') ?? -1,
-                    amazonqMessageDisplayedMs: durationFrom('featureReceivedMessage', 'messageDisplayed') ?? -1,
+                    amazonqEditorReceivedMessageMs: editorReceivedMessage ?? -1,
+                    amazonqFeatureReceivedMessageMs: featureReceivedMessage ?? -1,
+                    amazonqMessageDisplayedMs: messageDisplayed ?? -1,
                     source: metrics.trigger,
                     duration: totalDuration,
                     result: 'Succeeded',
                     traceId: metrics.traceId,
+                    ...(reasonDesc !== undefined ? { reasonDesc } : {}),
                 })
             }
 


### PR DESCRIPTION
## Problem
It's hard to diagnose why we sometimes get some extreme values for a chat round trip. One idea is that some remote instances might be hosted in a different region and that's causing the increased values in some rare instances

## Solution
Add the stringified version to the reasonDesc field temporarily so that we can get more information. This would look like:
```
'{"chatMessageSent":1730994444010,"editorReceivedMessage":1730994444011,"featureReceivedMessage":1730994444013,"messageDisplayed":1730994459698}',
```

## Additional info
The numbers picked were pretty arbitrary `(x > 30000 || x < -30000)` but it should give us a sampling of 50+ examples in the next week. After that we can revert this code since we should have all the data we need to see if this is the issue
