### PR TITLE
fix(amazonq): tutorial always showing on start

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-46c5fb9b-1b36-4826-8520-ec03409bce79.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-46c5fb9b-1b36-4826-8520-ec03409bce79.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Resolve tutorial always showing on start"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-46c5fb9b-1b36-4826-8520-ec03409bce79.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-46c5fb9b-1b36-4826-8520-ec03409bce79.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Resolve tutorial always showing on start"
+	"description": "tutorial always showing on start"
 }

--- a/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
+++ b/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
@@ -122,6 +122,9 @@ export class InlineChatController {
     }
 
     public async updateTaskAndLenses(task: InlineTask, taskState?: TaskState) {
+        if (!task) {
+            return
+        }
         if (taskState) {
             task.state = taskState
         } else if (!task.diff || task.diff.length === 0) {
@@ -200,7 +203,7 @@ export class InlineChatController {
                 this.task = await this.createTask(query, editor.document, editor.selection)
                 await this.inlineLineAnnotationController.disable(editor)
                 await this.computeDiffAndRenderOnEditor(query, editor.document).catch(async (err) => {
-                    getLogger().error(err)
+                    getLogger().error('computeDiffAndRenderOnEditor error: %s', (err as Error)?.message)
                     if (err instanceof Error) {
                         void vscode.window.showErrorMessage(`Amazon Q: ${err.message}`)
                     } else {

--- a/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
+++ b/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
@@ -121,7 +121,7 @@ export class InlineChatController {
         await this.reset()
     }
 
-    public async updateTaskAndLenses(task: InlineTask, taskState?: TaskState) {
+    public async updateTaskAndLenses(task?: InlineTask, taskState?: TaskState) {
         if (!task) {
             return
         }


### PR DESCRIPTION
The LineAnnotationController could get stuck showing the tutorial for new users due to changes in the inline chat logic, this PR resolve that bug and prevents the `aws.codewhisperer.tutorial.workInProgress` from being set to `true` when using inline chat.

Additional a more descriptive error log for the `computeDiffAndRenderOnEditor` function call and check for not null in `updateTaskAndLenses`

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
