### PR TITLE
test(ssh): Add explicit timeout on child process to avoid hanging. 

### DIFF
--- a/packages/core/src/awsService/ec2/sshKeyPair.ts
+++ b/packages/core/src/awsService/ec2/sshKeyPair.ts
@@ -80,6 +80,7 @@ export class SshKeyPair {
         }
         return !(await tryRun('ssh-keygen', ['-t', keyType, '-N', '', '-q', '-f', keyPath], 'yes', 'unknown key type', {
             onStdout: overrideKeys,
+            timeout: new Timeout(3000),
         }))
     }
 

--- a/packages/core/src/awsService/ec2/sshKeyPair.ts
+++ b/packages/core/src/awsService/ec2/sshKeyPair.ts
@@ -80,7 +80,7 @@ export class SshKeyPair {
         }
         return !(await tryRun('ssh-keygen', ['-t', keyType, '-N', '', '-q', '-f', keyPath], 'yes', 'unknown key type', {
             onStdout: overrideKeys,
-            timeout: new Timeout(3000),
+            timeout: new Timeout(5000),
         }))
     }
 

--- a/packages/core/src/shared/utilities/pathFind.ts
+++ b/packages/core/src/shared/utilities/pathFind.ts
@@ -11,6 +11,7 @@ import { GitExtension } from '../extensions/git'
 import { Settings } from '../settings'
 import { getLogger } from '../logger/logger'
 import { mergeResolvedShellPath } from '../env/resolveEnv'
+import { Timeout } from './timeoutUtils'
 
 /** Full path to VSCode CLI. */
 let vscPath: string
@@ -32,9 +33,13 @@ export async function tryRun(
     p: string,
     args: string[],
     logging: 'yes' | 'no' | 'noresult' = 'yes',
+    timeout?: Timeout,
     expected?: string,
     opt?: ChildProcessOptions
 ): Promise<boolean> {
+    timeout?.onCompletion(() => {
+        throw new Error(`tryRun timed out: ${p} ${args.join(' ')}`)
+    })
     const proc = new ChildProcess(p, args, { logging: 'no' })
     const r = await proc.run({
         ...opt,

--- a/packages/core/src/shared/utilities/pathFind.ts
+++ b/packages/core/src/shared/utilities/pathFind.ts
@@ -11,7 +11,6 @@ import { GitExtension } from '../extensions/git'
 import { Settings } from '../settings'
 import { getLogger } from '../logger/logger'
 import { mergeResolvedShellPath } from '../env/resolveEnv'
-import { Timeout } from './timeoutUtils'
 
 /** Full path to VSCode CLI. */
 let vscPath: string
@@ -33,13 +32,9 @@ export async function tryRun(
     p: string,
     args: string[],
     logging: 'yes' | 'no' | 'noresult' = 'yes',
-    timeout?: Timeout,
     expected?: string,
     opt?: ChildProcessOptions
 ): Promise<boolean> {
-    timeout?.onCompletion(() => {
-        throw new Error(`tryRun timed out: ${p} ${args.join(' ')}`)
-    })
     const proc = new ChildProcess(p, args, { logging: 'no' })
     const r = await proc.run({
         ...opt,


### PR DESCRIPTION
## Problem
Starting in https://github.com/aws/aws-toolkit-vscode/pull/5936 some tests started expiring, since fixed in https://github.com/aws/aws-toolkit-vscode/pull/5954. However, than expire, the `SshKeyPair` tests hang because they are stuck in a child process. This leads to these tests failing to timeout, even when exceeding the test timeout threshold. 

## Solution
Add explicit timeout on the child process we use to spawn ssh keys. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
