### PR TITLE
feat(cwl): Add clear screen and stop session code lens

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -13,7 +13,7 @@ import {
     LiveTailSessionUpdate,
     StartLiveTailResponseStream,
 } from '@aws-sdk/client-cloudwatch-logs'
-import { globals, ToolkitError } from '../../../shared'
+import { getLogger, ToolkitError } from '../../../shared'
 
 export async function tailLogGroup(
     registry: LiveTailSessionRegistry,
@@ -32,32 +32,29 @@ export async function tailLogGroup(
         region: wizardResponse.regionLogGroupSubmenuResponse.region,
     }
     const session = new LiveTailSession(liveTailSessionConfig)
-    if (registry.has(session.uri)) {
+    if (registry.has(session.uri.toString())) {
         await prepareDocument(session)
         return
     }
-    registry.set(session.uri, session)
+    registry.set(session.uri.toString(), session)
 
     const document = await prepareDocument(session)
-    const timer = globals.clock.setInterval(() => {
-        session.updateStatusBarItemText()
-    }, 500)
+
     hideShowStatusBarItemsOnActiveEditor(session, document)
-    registerTabChangeCallback(session, registry, document, timer)
+    registerTabChangeCallback(session, registry, document)
 
     const stream = await session.startLiveTailSession()
 
-    await handleSessionStream(stream, document, session, timer)
+    await handleSessionStream(stream, document, session)
 }
 
-export function closeSession(sessionUri: vscode.Uri, registry: LiveTailSessionRegistry, timer: NodeJS.Timer) {
-    globals.clock.clearInterval(timer)
-    const session = registry.get(sessionUri)
+export function closeSession(sessionUri: vscode.Uri, registry: LiveTailSessionRegistry) {
+    const session = registry.get(sessionUri.toString())
     if (session === undefined) {
         throw new ToolkitError(`No LiveTail session found for URI: ${sessionUri.toString()}`)
     }
     session.stopLiveTailSession()
-    registry.delete(sessionUri)
+    registry.delete(sessionUri.toString())
 }
 
 export async function clearDocument(textDocument: vscode.TextDocument) {
@@ -80,8 +77,7 @@ async function prepareDocument(session: LiveTailSession): Promise<vscode.TextDoc
 async function handleSessionStream(
     stream: AsyncIterable<StartLiveTailResponseStream>,
     document: vscode.TextDocument,
-    session: LiveTailSession,
-    timer: NodeJS.Timer
+    session: LiveTailSession
 ) {
     try {
         for await (const event of stream) {
@@ -100,8 +96,21 @@ async function handleSessionStream(
                 session.isSampled = isSampled(event.sessionUpdate)
             }
         }
-    } finally {
-        globals.clock.clearInterval(timer)
+    } catch (e) {
+        if (session.isAborted) {
+            //Expected case. User action cancelled stream (CodeLens, Close Editor, etc.).
+            //AbortSignal interrupts the LiveTail stream, causing error to be thrown here.
+            //Can assume that stopLiveTailSession() has already been called - AbortSignal is only
+            //exposed through that method.
+            getLogger().info(`Session ${session.uri.toString()} stopped.`)
+        } else {
+            //Unexpected exception.
+            session.stopLiveTailSession()
+            throw ToolkitError.chain(
+                e,
+                `Unexpected on-stream execption while tailing session: ${session.uri.toString()}`
+            )
+        }
     }
 }
 
@@ -196,13 +205,12 @@ function hideShowStatusBarItemsOnActiveEditor(session: LiveTailSession, document
 function registerTabChangeCallback(
     session: LiveTailSession,
     registry: LiveTailSessionRegistry,
-    document: vscode.TextDocument,
-    timer: NodeJS.Timer
+    document: vscode.TextDocument
 ) {
     vscode.window.tabGroups.onDidChangeTabs((tabEvent) => {
         const isOpen = isLiveTailSessionOpenInAnyTab(session)
         if (!isOpen) {
-            closeSession(session.uri, registry, timer)
+            closeSession(session.uri, registry)
             void clearDocument(document)
         }
     })

--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -102,7 +102,7 @@ async function handleSessionStream(
             //AbortSignal interrupts the LiveTail stream, causing error to be thrown here.
             //Can assume that stopLiveTailSession() has already been called - AbortSignal is only
             //exposed through that method.
-            getLogger().info(`Session ${session.uri.toString()} stopped.`)
+            getLogger().info(`Session stopped: ${session.uri.toString()}`)
         } else {
             //Unexpected exception.
             session.stopLiveTailSession()

--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -108,7 +108,7 @@ async function handleSessionStream(
             session.stopLiveTailSession()
             throw ToolkitError.chain(
                 e,
-                `Unexpected on-stream execption while tailing session: ${session.uri.toString()}`
+                `Unexpected on-stream exception while tailing session: ${session.uri.toString()}`
             )
         }
     }

--- a/packages/core/src/awsService/cloudWatchLogs/document/liveTailCodeLensProvider.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/document/liveTailCodeLensProvider.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { cloudwatchLogsLiveTailScheme } from '../../../shared/constants'
+
+export class LiveTailCodeLensProvider implements vscode.CodeLensProvider {
+    onDidChangeCodeLenses?: vscode.Event<void> | undefined
+
+    provideCodeLenses(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.CodeLens[]> {
+        const uri = document.uri
+        if (uri.scheme !== cloudwatchLogsLiveTailScheme) {
+            return []
+        }
+        const codeLenses: vscode.CodeLens[] = []
+        codeLenses.push(this.buildClearDocumentCodeLens(document))
+        codeLenses.push(this.buildStopTailingCodeLens(document))
+        return codeLenses
+    }
+
+    private buildClearDocumentCodeLens(document: vscode.TextDocument): vscode.CodeLens {
+        const range = new vscode.Range(
+            new vscode.Position(document.lineCount - 1, 0),
+            new vscode.Position(document.lineCount - 1, 0)
+        )
+        const command: vscode.Command = {
+            title: 'Clear document',
+            command: 'aws.cwl.clearDocument',
+            arguments: [document],
+        }
+        return new vscode.CodeLens(range, command)
+    }
+
+    private buildStopTailingCodeLens(document: vscode.TextDocument): vscode.CodeLens {
+        const range = new vscode.Range(
+            new vscode.Position(document.lineCount - 1, 0),
+            new vscode.Position(document.lineCount - 1, 0)
+        )
+        const command: vscode.Command = {
+            title: 'Stop tailing',
+            command: 'aws.cwl.stopTailingLogGroup',
+            arguments: [document],
+        }
+        return new vscode.CodeLens(range, command)
+    }
+}

--- a/packages/core/src/awsService/cloudWatchLogs/document/liveTailCodeLensProvider.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/document/liveTailCodeLensProvider.ts
@@ -24,10 +24,7 @@ export class LiveTailCodeLensProvider implements vscode.CodeLensProvider {
     }
 
     private buildClearDocumentCodeLens(document: vscode.TextDocument): vscode.CodeLens {
-        const range = new vscode.Range(
-            new vscode.Position(document.lineCount - 1, 0),
-            new vscode.Position(document.lineCount - 1, 0)
-        )
+        const range = this.getBottomOfDocumentRange(document)
         const command: vscode.Command = {
             title: 'Clear document',
             command: 'aws.cwl.clearDocument',
@@ -37,15 +34,19 @@ export class LiveTailCodeLensProvider implements vscode.CodeLensProvider {
     }
 
     private buildStopTailingCodeLens(document: vscode.TextDocument): vscode.CodeLens {
-        const range = new vscode.Range(
-            new vscode.Position(document.lineCount - 1, 0),
-            new vscode.Position(document.lineCount - 1, 0)
-        )
+        const range = this.getBottomOfDocumentRange(document)
         const command: vscode.Command = {
             title: 'Stop tailing',
             command: 'aws.cwl.stopTailingLogGroup',
             arguments: [document],
         }
         return new vscode.CodeLens(range, command)
+    }
+
+    private getBottomOfDocumentRange(document: vscode.TextDocument): vscode.Range {
+        return new vscode.Range(
+            new vscode.Position(document.lineCount - 1, 0),
+            new vscode.Position(document.lineCount - 1, 0)
+        )
     }
 }

--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSessionRegistry.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSessionRegistry.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode'
 import { cloudwatchLogsLiveTailScheme } from '../../../shared/constants'
 import { LiveTailSession, LiveTailSessionConfiguration } from './liveTailSession'
 
-export class LiveTailSessionRegistry extends Map<vscode.Uri, LiveTailSession> {
+export class LiveTailSessionRegistry extends Map<string, LiveTailSession> {
     static #instance: LiveTailSessionRegistry
 
     public static get instance() {

--- a/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
@@ -125,15 +125,14 @@ describe('TailLogGroup', function () {
             .callsFake(async function () {
                 return
             })
-        // const fakeClock = installFakeClock()
-        const timer = setInterval(() => {}, 1000)
+
         const session = new LiveTailSession({
             logGroupName: testLogGroup,
             region: testRegion,
         })
-        registry.set(session.uri, session)
+        registry.set(session.uri.toString(), session)
 
-        closeSession(session.uri, registry, timer)
+        closeSession(session.uri, registry)
         assert.strictEqual(0, registry.size)
         assert.strictEqual(true, stopLiveTailSessionSpy.calledOnce)
         assert.strictEqual(0, clock.countTimers())

--- a/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
@@ -18,7 +18,7 @@ import {
     TailLogGroupWizardResponse,
 } from '../../../../awsService/cloudWatchLogs/wizard/tailLogGroupWizard'
 import { getTestWindow } from '../../../shared/vscode/window'
-import { CloudWatchLogsSettings } from '../../../../awsService/cloudWatchLogs/cloudWatchLogsUtils'
+import { CloudWatchLogsSettings, uriToKey } from '../../../../awsService/cloudWatchLogs/cloudWatchLogsUtils'
 import { installFakeClock } from '../../../testUtil'
 
 describe('TailLogGroup', function () {
@@ -130,7 +130,7 @@ describe('TailLogGroup', function () {
             logGroupName: testLogGroup,
             region: testRegion,
         })
-        registry.set(session.uri.toString(), session)
+        registry.set(uriToKey(session.uri), session)
 
         closeSession(session.uri, registry)
         assert.strictEqual(0, registry.size)


### PR DESCRIPTION
## Problem
Users may want to clear their screen during a tailing session. The liveTail document is read only.
Users may want to stop their session without closing the document. 

## Solution
Provide a codeLens to clear the screen (make document empty)
Provide a codeLens to stop the session without closing the document. 

Moves Interval Timer for updating the StatusBar to the LiveTailSession object so `stopLiveTailSession()` can interrupt it, and be guaranteed to be cleaned up.

The TextDocument's URI and Session URI seem to not be equal. Looking up in the LiveTailSessionRegistry with a document URI causes a session to not be found. Converting with `toString` allows these URIs to match and the registry to work as intended. 

Improves Exception handling on-stream. Previously, stopping the session in an expected fashion (codeLens, Closing editors) would cause an exception to bubble up and appear to the User. New change recognizes when the Abort Controller triggers, signifying an error has not occured, and logs the event as opposed to surfacing an error. Exposing only `isAborted` so that a caller has to use `stopLiveTailSession` to trigger the abortController and guarantee that other clean up actions have taken place. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
