### PR TITLE
refactor(webview): avoid race conditions in constructors. 

### DIFF
--- a/packages/core/src/applicationcomposer/activation.ts
+++ b/packages/core/src/applicationcomposer/activation.ts
@@ -10,7 +10,7 @@ import { openTemplateInComposerCommand } from './commands/openTemplateInComposer
 import { openInComposerDialogCommand } from './commands/openInComposerDialog'
 
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
-    const visualizationManager = new ApplicationComposerManager(extensionContext)
+    const visualizationManager = await ApplicationComposerManager.create(extensionContext)
 
     extensionContext.subscriptions.push(
         openTemplateInComposerCommand.register(visualizationManager),

--- a/packages/core/src/applicationcomposer/webviewManager.ts
+++ b/packages/core/src/applicationcomposer/webviewManager.ts
@@ -43,7 +43,7 @@ export class ApplicationComposerManager {
         }
     }
 
-    private getWebviewContent = () => {
+    private getWebviewContent = async () => {
         if (!this.webviewHtml) {
             void this.fetchWebviewHtml()
             return ''
@@ -78,7 +78,11 @@ export class ApplicationComposerManager {
 
         // Existing visualization does not exist, construct new visualization
         try {
-            const newVisualization = new ApplicationComposer(document, this.extensionContext, this.getWebviewContent)
+            const newVisualization = await ApplicationComposer.create(
+                document,
+                this.extensionContext,
+                this.getWebviewContent
+            )
             this.handleNewVisualization(document.uri.fsPath, newVisualization)
 
             if (vscode.version === '1.91.0') {
@@ -101,7 +105,11 @@ export class ApplicationComposerManager {
             const document = await vscode.workspace.openTextDocument({
                 language: 'yaml',
             })
-            const newVisualization = new ApplicationComposer(document, this.extensionContext, this.getWebviewContent)
+            const newVisualization = await ApplicationComposer.create(
+                document,
+                this.extensionContext,
+                this.getWebviewContent
+            )
             this.handleNewVisualization(document.uri.fsPath, newVisualization)
 
             return newVisualization.getPanel()

--- a/packages/core/src/applicationcomposer/webviewManager.ts
+++ b/packages/core/src/applicationcomposer/webviewManager.ts
@@ -23,13 +23,15 @@ export class ApplicationComposerManager {
     protected readonly name: string = 'ApplicationComposerManager'
 
     protected readonly managedVisualizations = new Map<string, ApplicationComposer>()
-    protected extensionContext: vscode.ExtensionContext
     protected webviewHtml?: string
     protected readonly logger = getLogger()
 
-    public constructor(extensionContext: vscode.ExtensionContext) {
-        this.extensionContext = extensionContext
-        void this.fetchWebviewHtml()
+    private constructor(protected extensionContext: vscode.ExtensionContext) {}
+
+    public static async create(extensionContext: vscode.ExtensionContext): Promise<ApplicationComposerManager> {
+        const obj = new ApplicationComposerManager(extensionContext)
+        await obj.fetchWebviewHtml()
+        return obj
     }
 
     private async fetchWebviewHtml() {

--- a/packages/core/src/test/applicationcomposer/utils.ts
+++ b/packages/core/src/test/applicationcomposer/utils.ts
@@ -10,7 +10,7 @@ import { WebviewContext } from '../../applicationcomposer/types'
 import { MockDocument } from '../fake/fakeDocument'
 
 export async function createTemplate() {
-    const manager = new ApplicationComposerManager(globals.context)
+    const manager = await ApplicationComposerManager.create(globals.context)
     const panel = await manager.createTemplate()
     assert.ok(panel)
     return panel


### PR DESCRIPTION
## Problem
In the constructor for `ApplicationComposerManager`, there is an async call (non-awaited). This call is modifying state within the object and therefore causes a race condition with any other function relying on this state. See https://github.com/aws/aws-toolkit-vscode/blob/81132884f4fb3319bda4be7d3d873265191f43ce/packages/core/src/applicationcomposer/webviewManager.ts#L30-L33

~This is potentially related to a flaky test.~ The test is still failing, but this refactor is still a win. 

## Solution
- Implement an async `create` method with a private constructor. Move this pattern upward to enable async calls. 


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
