### PR TITLE
fix(amazonq): wrongly formatted supplemental context for inline suggestion

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-15ddd682-232b-4bcd-a6e5-969f5c1c40c9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-15ddd682-232b-4bcd-a6e5-969f5c1c40c9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "fix wrongly formatted supplemental context for inline suggestion"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-15ddd682-232b-4bcd-a6e5-969f5c1c40c9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-15ddd682-232b-4bcd-a6e5-969f5c1c40c9.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix poor inline suggestions from Amazon Q caused by improperly formatted supplemental context"
+	"description": "Fix suboptimal inline suggestions from Amazon Q caused by improperly formatted supplemental context"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-15ddd682-232b-4bcd-a6e5-969f5c1c40c9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-15ddd682-232b-4bcd-a6e5-969f5c1c40c9.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "fix wrongly formatted supplemental context for inline suggestion"
+	"description": "Fix poor inline suggestions from Amazon Q caused by improperly formatted supplemental context"
 }

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -66,7 +66,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.25']
+const supportedLspServerVersions = ['0.1.27']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 


### PR DESCRIPTION
## Problem

List of fixes:
- `def func (a) :` -> `def func(a):`
- `class (A) :` -> `class(A):`
- for python, change `// Function definitions to # Function definitions` ,` // Class definitions`  to `# Class definitions`
- for js/ts: `function findMax (arr: number[]) : number | undefined{.`  ->  `function findMax(arr: number[]): number | undefined {.`
- for all language: `// File path: a.ts`  -> `//File path a.ts`  
- for js/ts: `String privateString ;`  -> `String privateString;` 




<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
