### PR TITLE
test(slowsam): samcli test speed up

### DIFF
--- a/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -6,7 +6,6 @@
 import * as proc from 'child_process'
 import { pushIf } from '../../utilities/collectionUtils'
 import * as nls from 'vscode-nls'
-import { fileExists } from '../../filesystemUtilities'
 import { getLogger, getDebugConsoleLogger, Logger } from '../../logger'
 import { ChildProcess } from '../../utilities/processUtils'
 import { Timeout } from '../../utilities/timeoutUtils'
@@ -15,6 +14,7 @@ import * as vscode from 'vscode'
 import globals from '../../extensionGlobals'
 import { SamCliSettings } from './samCliSettings'
 import { addTelemetryEnvVar, collectSamErrors, SamCliError } from './samCliInvokerUtils'
+import { fs } from '../..'
 
 const localize = nls.loadMessageBundle()
 
@@ -236,6 +236,8 @@ export class SamCliLocalInvokeInvocation {
         const sam = await this.config.getOrDetectSamCli()
         // eslint-disable-next-line aws-toolkits/no-console-log
         console.log('getOrDetect took %O seconds', (Date.now() - start) / 1000)
+        // eslint-disable-next-line aws-toolkits/no-console-log
+        console.log('autodetect is %O', sam.autoDetected)
         if (!sam.path) {
             getLogger().warn('SAM CLI not found and not configured')
         } else if (sam.autoDetected) {
@@ -290,11 +292,11 @@ export class SamCliLocalInvokeInvocation {
             throw new Error('template resource name is missing or empty')
         }
 
-        if (!(await fileExists(this.args.templatePath))) {
+        if (!(await fs.exists(this.args.templatePath))) {
             throw new Error(`template path does not exist: ${this.args.templatePath}`)
         }
 
-        if (this.args.eventPath !== undefined && !(await fileExists(this.args.eventPath))) {
+        if (this.args.eventPath !== undefined && !(await fs.exists(this.args.eventPath))) {
             throw new Error(`event path does not exist: ${this.args.eventPath}`)
         }
     }

--- a/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -232,12 +232,7 @@ export class SamCliLocalInvokeInvocation {
 
     public async execute(timeout?: Timeout): Promise<ChildProcess> {
         await this.validate()
-        const start = Date.now()
         const sam = await this.config.getOrDetectSamCli()
-        // eslint-disable-next-line aws-toolkits/no-console-log
-        console.log('getOrDetect took %O seconds', (Date.now() - start) / 1000)
-        // eslint-disable-next-line aws-toolkits/no-console-log
-        console.log('autodetect is %O', sam.autoDetected)
         if (!sam.path) {
             getLogger().warn('SAM CLI not found and not configured')
         } else if (sam.autoDetected) {

--- a/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -232,8 +232,10 @@ export class SamCliLocalInvokeInvocation {
 
     public async execute(timeout?: Timeout): Promise<ChildProcess> {
         await this.validate()
-
+        const start = Date.now()
         const sam = await this.config.getOrDetectSamCli()
+        // eslint-disable-next-line aws-toolkits/no-console-log
+        console.log('getOrDetect took %O seconds', (Date.now() - start) / 1000)
         if (!sam.path) {
             getLogger().warn('SAM CLI not found and not configured')
         } else if (sam.autoDetected) {

--- a/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -14,7 +14,7 @@ import * as vscode from 'vscode'
 import globals from '../../extensionGlobals'
 import { SamCliSettings } from './samCliSettings'
 import { addTelemetryEnvVar, collectSamErrors, SamCliError } from './samCliInvokerUtils'
-import { fs } from '../..'
+import { fs } from '../../fs/fs'
 
 const localize = nls.loadMessageBundle()
 

--- a/packages/core/src/shared/sam/cli/samCliLocator.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocator.ts
@@ -13,9 +13,14 @@ import { PerfLog } from '../../logger/perfLogger'
 import { tryRun } from '../../utilities/pathFind'
 import { mergeResolvedShellPath } from '../../env/resolveEnv'
 
+interface SamLocation {
+    path: string
+    version: string
+    verified?: boolean
+}
 export class SamCliLocationProvider {
     private static samCliLocator: BaseSamCliLocator | undefined
-    protected static cachedSamLocation: { path: string; version: string } | undefined
+    protected static cachedSamLocation: SamLocation | undefined
 
     /** Checks that the given `sam` actually works by invoking `sam --version`. */
     private static async isValidSamLocation(samPath: string) {
@@ -31,11 +36,11 @@ export class SamCliLocationProvider {
         const cachedLoc = forceSearch ? undefined : SamCliLocationProvider.cachedSamLocation
 
         // Avoid searching the system for `sam` (especially slow on Windows).
-        if (cachedLoc && (await SamCliLocationProvider.isValidSamLocation(cachedLoc.path))) {
+        if (cachedLoc && (cachedLoc.verified || (await SamCliLocationProvider.isValidSamLocation(cachedLoc.path)))) {
+            cachedLoc.verified = true
             perflog.done()
             return cachedLoc
         }
-
         SamCliLocationProvider.cachedSamLocation = await SamCliLocationProvider.getSamCliLocator().getLocation()
         perflog.done()
         return SamCliLocationProvider.cachedSamLocation

--- a/packages/core/src/shared/sam/cli/samCliLocator.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocator.ts
@@ -29,8 +29,6 @@ export class SamCliLocationProvider {
     public async getLocation(forceSearch?: boolean): Promise<{ path: string; version: string } | undefined> {
         const perflog = new PerfLog('samCliLocator: getLocation')
         const cachedLoc = forceSearch ? undefined : SamCliLocationProvider.cachedSamLocation
-        // eslint-disable-next-line aws-toolkits/no-console-log
-        console.log('cachedLoc is: %O', cachedLoc)
 
         // Avoid searching the system for `sam` (especially slow on Windows).
         if (cachedLoc && (await SamCliLocationProvider.isValidSamLocation(cachedLoc.path))) {

--- a/packages/core/src/shared/sam/cli/samCliLocator.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocator.ts
@@ -29,6 +29,8 @@ export class SamCliLocationProvider {
     public async getLocation(forceSearch?: boolean): Promise<{ path: string; version: string } | undefined> {
         const perflog = new PerfLog('samCliLocator: getLocation')
         const cachedLoc = forceSearch ? undefined : SamCliLocationProvider.cachedSamLocation
+        // eslint-disable-next-line aws-toolkits/no-console-log
+        console.log('cachedLoc is: %O', cachedLoc)
 
         // Avoid searching the system for `sam` (especially slow on Windows).
         if (cachedLoc && (await SamCliLocationProvider.isValidSamLocation(cachedLoc.path))) {

--- a/packages/core/src/shared/sam/cli/samCliSettings.ts
+++ b/packages/core/src/shared/sam/cli/samCliSettings.ts
@@ -84,7 +84,6 @@ export class SamCliSettings extends fromExtensionManifest('aws.samcli', descript
             return { path: fromConfig, autoDetected: false }
         }
         const fromSearch = await this.locationProvider.getLocation(forceSearch)
-
         SamCliSettings.logIfChanged(`SAM CLI location (version: ${fromSearch?.version}): ${fromSearch?.path}`)
         return { path: fromSearch?.path, autoDetected: true }
     }

--- a/packages/core/src/shared/sam/cli/samCliSettings.ts
+++ b/packages/core/src/shared/sam/cli/samCliSettings.ts
@@ -83,10 +83,7 @@ export class SamCliSettings extends fromExtensionManifest('aws.samcli', descript
             SamCliSettings.logIfChanged(`SAM CLI location (from settings): ${fromConfig}`)
             return { path: fromConfig, autoDetected: false }
         }
-        const start = Date.now()
         const fromSearch = await this.locationProvider.getLocation(forceSearch)
-        // eslint-disable-next-line aws-toolkits/no-console-log
-        console.log('getOrDetect took %O seconds', (Date.now() - start) / 1000)
 
         SamCliSettings.logIfChanged(`SAM CLI location (version: ${fromSearch?.version}): ${fromSearch?.path}`)
         return { path: fromSearch?.path, autoDetected: true }

--- a/packages/core/src/shared/sam/cli/samCliSettings.ts
+++ b/packages/core/src/shared/sam/cli/samCliSettings.ts
@@ -83,8 +83,11 @@ export class SamCliSettings extends fromExtensionManifest('aws.samcli', descript
             SamCliSettings.logIfChanged(`SAM CLI location (from settings): ${fromConfig}`)
             return { path: fromConfig, autoDetected: false }
         }
-
+        const start = Date.now()
         const fromSearch = await this.locationProvider.getLocation(forceSearch)
+        // eslint-disable-next-line aws-toolkits/no-console-log
+        console.log('getOrDetect took %O seconds', (Date.now() - start) / 1000)
+
         SamCliSettings.logIfChanged(`SAM CLI location (version: ${fromSearch?.version}): ${fromSearch?.path}`)
         return { path: fromSearch?.path, autoDetected: true }
     }

--- a/packages/core/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/packages/core/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -35,7 +35,7 @@ describe('SamCliLocalInvokeInvocation', async function () {
     before(async function () {
         // File system search on windows can take a while.
         if (isWin()) {
-            this.timeout(45000)
+            this.retries(3)
         }
         // This will place the result in the cache allowing all tests to run under same conditions.
         await SamCliSettings.instance.getOrDetectSamCli()

--- a/packages/core/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/packages/core/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -15,8 +15,6 @@ import { ChildProcess } from '../../../../shared/utilities/processUtils'
 import { assertArgIsPresent, assertArgNotPresent, assertArgsContainArgument } from './samCliTestUtils'
 import { fs } from '../../../../shared'
 import { isWin } from '../../../../shared/vscode/env'
-import Sinon from 'sinon'
-import { SamCliLocationProvider } from '../../../../shared/sam/cli/samCliLocator'
 // eslint-disable-next-line aws-toolkits/no-only-in-tests
 describe.only('SamCliLocalInvokeInvocation', async function () {
     class TestSamLocalInvokeCommand implements SamLocalInvokeCommand {


### PR DESCRIPTION
## Problem
- The test failure is due to timeout on Windows when first searching for the SAM cli path in `src/shared/sam/cli/samCliLocator.ts`. This is a known slow process. 
- The verification of SAM is also slow (100-200ms), even if result is cached and we do this each time we read from cache. 

## Solution
- Verify the cache once, rather than on each read. 
- Find sam cli in the before hook to allow all sam tests to run under same conditions. Otherwise, the first test is then responsible for actually finding the path causing it to take way longer than the rest of the tests. 
- Allow 3x retries on before hook on windows to avoid flakiness. 

## Notes
- An alternative solution could involve manually inserting into the cache, or mocking a piece of the component, but wanted to keep the test coverage as is. 
- This approach also allows us to isolate the finding code into its own test (rather than whatever the first test is) to see if there are performance regressions. 
- Additionally, retry mechanism was more effective than increasing the timeout in reducing flakiness. 

fix #2675

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
