### PR TITLE
config(amazonq): update supplementalContext timeout from 50 to 100ms

### DIFF
--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -67,7 +67,7 @@ export const lineBreak = '\n'
 
 export const lineBreakWin = '\r\n'
 
-export const supplementalContextTimeoutInMs = 50
+export const supplementalContextTimeoutInMs = 100
 
 /**
  * Ux of recommendations


### PR DESCRIPTION
## Problem
based on data, we found out that 50ms cap is not sufficient for larger repo and it tends to return empty supplementalContext due to timeout.

## Solution
Increase to 100ms for now and there will be action items for Q team to collect p50, p75, p90 latency according to different repo size to conduct a detailed investigation.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
