### PR TITLE
config(amazonq): patch #5965

### DIFF
--- a/packages/core/src/codewhisperer/client/user-service-2.json
+++ b/packages/core/src/codewhisperer/client/user-service-2.json
@@ -2,14 +2,11 @@
     "version": "2.0",
     "metadata": {
         "apiVersion": "2022-11-11",
-        "auth": ["smithy.api#httpBearerAuth"],
         "endpointPrefix": "amazoncodewhispererservice",
         "jsonVersion": "1.0",
         "protocol": "json",
-        "protocols": ["json"],
         "serviceFullName": "Amazon CodeWhisperer",
         "serviceId": "CodeWhispererRuntime",
-        "signatureVersion": "bearer",
         "signingName": "amazoncodewhispererservice",
         "targetPrefix": "AmazonCodeWhispererService",
         "uid": "codewhispererruntime-2022-11-11"


### PR DESCRIPTION
## Problem
not clear why is this but these lines will make client generated not able to call the service correctly and seems it always timeout.

https://github.com/aws/aws-toolkit-vscode/pull/5965/files#diff-1993309d74a00d453d972baa185cc65e227911391f8de06add4ee0998684e638R5-R12

## Solution


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
