### PR TITLE
fix(dev): dev menu wasnt loading items

### DIFF
--- a/packages/core/src/dev/activation.ts
+++ b/packages/core/src/dev/activation.ts
@@ -168,9 +168,10 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
             // eslint-disable-next-line aws-toolkits/no-banned-usages
             globalState = targetContext.globalState
             targetAuth = opts.auth
+            const options = menuOptions()
             void openMenu(
-                entries(menuOptions())
-                    .filter((e) => (opts.menuOptions ?? Object.keys(menuOptions)).includes(e[0]))
+                entries(options)
+                    .filter((e) => (opts.menuOptions ?? Object.keys(options)).includes(e[0]))
                     .map((e) => e[1])
             )
         }),


### PR DESCRIPTION
## Problem
When opening the AWS Developer Menu for toolkit, no items were showing.

This is due to a wrong value being used for menu options. The second use was expecting it to be an object with keys, when it was actually a function. This happened due to a recent change that didn't catch this

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
