### PR TITLE
test(vscode): fix failure to close editors on `beforeEach` hook.

### DIFF
--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -490,30 +490,30 @@ export async function closeAllEditors(): Promise<void> {
         /amazonwebservices\.[a-z\-]+-vscode\./,
         /nullExtensionDescription./, // Sometimes exists instead of the prior line, see https://github.com/aws/aws-toolkit-vscode/issues/4658
     ]
-    const editors: vscode.TextEditor[] = []
+    const visibleEditors: vscode.TextEditor[] = []
 
     const noVisibleEditor: boolean | undefined = await waitUntil(
         async () => {
             // Race: documents could appear after the call to closeAllEditors(), so retry.
             await vscode.commands.executeCommand(closeAllCmd)
-            editors.length = 0
-            editors.push(
+            visibleEditors.length = 0
+            visibleEditors.push(
                 ...vscode.window.visibleTextEditors.filter(
                     (editor) => !ignorePatterns.some((p) => p.test(editor.document.fileName))
                 )
             )
 
-            return editors.length === 0
+            return visibleEditors.length === 0
         },
         {
-            timeout: 1000, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
+            timeout: 5000, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
             interval: 250,
             truthy: true,
         }
     )
 
-    if (!noVisibleEditor) {
-        const editorNames = editors.map((editor) => `\t${editor.document.fileName}`)
+    if (!noVisibleEditor && visibleEditors.length > 0) {
+        const editorNames = visibleEditors.map((editor) => `\t${editor.document.fileName}`)
         throw new Error(`Editors were still open after closeAllEditors():\n${editorNames.join('\n')}`)
     }
 }

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -506,7 +506,7 @@ export async function closeAllEditors(): Promise<void> {
             return visibleEditors.length === 0
         },
         {
-            timeout: 5000, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
+            timeout: 1000, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
             interval: 250,
             truthy: true,
         }

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -490,20 +490,20 @@ export async function closeAllEditors(): Promise<void> {
         /amazonwebservices\.[a-z\-]+-vscode\./,
         /nullExtensionDescription./, // Sometimes exists instead of the prior line, see https://github.com/aws/aws-toolkit-vscode/issues/4658
     ]
-    const visibleEditors: vscode.TextEditor[] = []
+    const editorsToClose: vscode.TextEditor[] = []
 
     const noVisibleEditor: boolean | undefined = await waitUntil(
         async () => {
             // Race: documents could appear after the call to closeAllEditors(), so retry.
             await vscode.commands.executeCommand(closeAllCmd)
-            visibleEditors.length = 0
-            visibleEditors.push(
+            editorsToClose.length = 0
+            editorsToClose.push(
                 ...vscode.window.visibleTextEditors.filter(
                     (editor) => !ignorePatterns.some((p) => p.test(editor.document.fileName))
                 )
             )
 
-            return visibleEditors.length === 0
+            return editorsToClose.length === 0
         },
         {
             timeout: 1000, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
@@ -512,8 +512,8 @@ export async function closeAllEditors(): Promise<void> {
         }
     )
 
-    if (!noVisibleEditor && visibleEditors.length > 0) {
-        const editorNames = visibleEditors.map((editor) => `\t${editor.document.fileName}`)
+    if (!noVisibleEditor && editorsToClose.length > 0) {
+        const editorNames = editorsToClose.map((editor) => `\t${editor.document.fileName}`)
         throw new Error(`Editors were still open after closeAllEditors():\n${editorNames.join('\n')}`)
     }
 }

--- a/packages/core/src/test/testUtil.ts
+++ b/packages/core/src/test/testUtil.ts
@@ -506,7 +506,7 @@ export async function closeAllEditors(): Promise<void> {
             return editors.length === 0
         },
         {
-            timeout: 5000, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
+            timeout: 1000, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
             interval: 250,
             truthy: true,
         }


### PR DESCRIPTION
## Problem
- See https://github.com/aws/aws-toolkit-vscode/issues/5325
- the following `waitUntil` is timing out: https://github.com/aws/aws-toolkit-vscode/blob/43299f368308b6720ba22bbd910c6714bc47bdcb/packages/core/src/test/testUtil.ts#L495-L518
- All occurrences of error (AFAIK) fail to list any editors open. This implies `waitUntil` is timing out even though all editors (that aren't ignored by pattern) are closed. 

## Solution
A potential explanation is that the `executeCommand` is taking a long time to close the editors ignored by the patterns, and causing a timeout in `waitUntil`. In this case, we don't want to error. 
- refactor to also check if activeEditors is cleared. If there aren't any, we shouldn't be throwing an error. 
- Also, decrease timeout to avoid wasting time here during tests (if we can't close ignored editors, don't waste time trying). This code is run between every test so 5 second timeout per test is huge. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
