### PR TITLE
fix(cwl): Remove wrapping pre-stream exceptions and just letting them throw

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
@@ -82,24 +82,18 @@ export class LiveTailSession {
     }
 
     public async startLiveTailSession(): Promise<AsyncIterable<StartLiveTailResponseStream>> {
-        const command = this.buildStartLiveTailCommand()
-        try {
-            const commandOutput = await this.liveTailClient.cwlClient.send(command, {
-                abortSignal: this.liveTailClient.abortController.signal,
-            })
-            if (!commandOutput.responseStream) {
-                throw new ToolkitError('LiveTail session response stream is undefined.')
-            }
-            this.startTime = Date.now()
-            this.endTime = undefined
-            this.statusBarUpdateTimer = globals.clock.setInterval(() => {
-                this.updateStatusBarItemText()
-            }, 500)
-
-            return commandOutput.responseStream
-        } catch (e) {
-            throw new ToolkitError('Encountered error while trying to start LiveTail session.')
+        const commandOutput = await this.liveTailClient.cwlClient.send(this.buildStartLiveTailCommand(), {
+            abortSignal: this.liveTailClient.abortController.signal,
+        })
+        if (!commandOutput.responseStream) {
+            throw new ToolkitError('LiveTail session response stream is undefined.')
         }
+        this.startTime = Date.now()
+        this.endTime = undefined
+        this.statusBarUpdateTimer = globals.clock.setInterval(() => {
+            this.updateStatusBarItemText()
+        }, 500)
+        return commandOutput.responseStream
     }
 
     public stopLiveTailSession() {


### PR DESCRIPTION
## Problem
Exceptions can occur pre-stream (the synchronous portion of a StartLiveTail call that establishes the streaming connection). Currently, we are calling StartLiveTail in a try-catch, catching errrors, and throwing them as a ToolkitException. These are not chaining the root exception. This means when an error occurs, its root cause is being swallowed - causing user's to not know *why* their LiveTall command is failing.

## Solution
Given that we are just rethrowing `err`. There's probably no point to this catch. Removing it, and letting the root exception throw. 

Forced pre-stream exception to throw with an IAM permission violation and this change applied. More clear as to what the actual problem is:
Pop-up: `Failed to run command: aws.cwl.tailLogGroup: User: arn:aws:sts::203607498903:assumed-role/NoLiveTail/keegani-Isengard is not authorized to perform: logs:StartLiveTail on resource: arn:aws:logs:us-east-1:203607498903:log-group:/aws/codebuild/BATSSandboxCodeBuildPr-bf0a23097fbc3948a2c5b26f1616f7d32b622cba because no identity-based policy allows the logs:StartLiveTail action`

Full log:
```
2024-11-11 13:00:04.310 [error] aws.cwl.tailLogGroup: [AccessDeniedException: User: arn:aws:sts::203607498903:assumed-role/NoLiveTail/keegani-Isengard is not authorized to perform: logs:StartLiveTail on resource: arn:aws:logs:us-east-1:203607498903:log-group:/aws/codebuild/BATSSandboxCodeBuildPr-bf0a23097fbc3948a2c5b26f1616f7d32b622cba because no identity-based policy allows the logs:StartLiveTail action
	at de_AccessDeniedExceptionRes (/Users/keegani/workplace/aws-toolkit-vscode-release/aws-toolkit-vscode/node_modules/@aws-sdk/client-cloudwatch-logs/dist-cjs/index.js:2249:21)
	at de_CommandError (/Users/keegani/workplace/aws-toolkit-vscode-release/aws-toolkit-vscode/node_modules/@aws-sdk/client-cloudwatch-logs/dist-cjs/index.js:2203:19)
	at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
	at async /Users/keegani/workplace/aws-toolkit-vscode-release/aws-toolkit-vscode/node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@smithy/middleware-serde/dist-cjs/index.js:35:20
	at async /Users/keegani/workplace/aws-toolkit-vscode-release/aws-toolkit-vscode/node_modules/@smithy/core/dist-cjs/index.js:168:18
	at async /Users/keegani/workplace/aws-toolkit-vscode-release/aws-toolkit-vscode/node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@smithy/middleware-retry/dist-cjs/index.js:320:38
	at async /Users/keegani/workplace/aws-toolkit-vscode-release/aws-toolkit-vscode/node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-logger/dist-cjs/index.js:34:22
	at async LiveTailSession.startLiveTailSession (/Users/keegani/workplace/aws-toolkit-vscode-release/aws-toolkit-vscode/packages/core/dist/src/awsService/cloudWatchLogs/registry/liveTailSession.js:70:31)
	at async tailLogGroup (/Users/keegani/workplace/aws-toolkit-vscode-release/aws-toolkit-vscode/packages/core/dist/src/awsService/cloudWatchLogs/commands/tailLogGroup.js:58:20)
	at async /Users/keegani/workplace/aws-toolkit-vscode-release/aws-toolkit-vscode/packages/core/dist/src/awsService/cloudWatchLogs/activation.js:91:9
	at async runCommand (/Users/keegani/workplace/aws-toolkit-vscode-release/aws-toolkit-vscode/packages/core/dist/src/shared/vscode/commands2.js:445:16)
	at async Y0.h (file:///Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:114:32825)] {
  '$fault': 'client',
  '$metadata': [Object],
  __type: 'AccessDeniedException'
}
```
---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
