### PR TITLE
config(amazonq): adjust timeout for supplemental context

### DIFF
--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -130,9 +130,11 @@ export async function buildGenerateRecommendationRequest(editor: vscode.TextEdit
     const fileContext = extractContextForCodeWhisperer(editor)
 
     const tokenSource = new vscode.CancellationTokenSource()
+    // the supplement context fetch mechanisms each has a timeout of supplementalContextTimeoutInMs
+    // adding 10 ms for overall timeout as buffer
     setTimeout(() => {
         tokenSource.cancel()
-    }, supplementalContextTimeoutInMs)
+    }, supplementalContextTimeoutInMs + 10)
     const supplementalContexts = await fetchSupplementalContext(editor, tokenSource.token)
 
     logSupplementalContext(supplementalContexts)

--- a/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -71,13 +71,13 @@ export async function fetchSupplementalContextForSrc(
         async function () {
             return await fetchSupplementalContextForSrcV1(editor, cancellationToken)
         },
-        { timeout: supplementalContextTimeoutInMs, interval: 10, truthy: false }
+        { timeout: supplementalContextTimeoutInMs, interval: 5, truthy: false }
     )
     const promiseV2 = waitUntil(
         async function () {
             return await fetchSupplementalContextForSrcV2(editor)
         },
-        { timeout: supplementalContextTimeoutInMs, interval: 10, truthy: false }
+        { timeout: supplementalContextTimeoutInMs, interval: 5, truthy: false }
     )
     const [resultV1, resultV2] = await Promise.all([promiseV1, promiseV2])
     return resultV2 ?? resultV1


### PR DESCRIPTION
## Problem

The overall supplemental context has a timeout of 50ms, each sub promise has a timeout of 50ms. Problem is these 2 timeout are very tight, leaving no buffer time for node js runtime to do context switch. The poll interval of each sub promise is 10ms, which does not precisely timeout at 50ms. 

## Solution

Add a 10ms buffer time for supplemental context.
Reduce poll duration


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
