### PR TITLE
build(lint): increase `minLines` in jscpd. 

### DIFF
--- a/.github/workflows/jscpd.json
+++ b/.github/workflows/jscpd.json
@@ -3,7 +3,7 @@
     "ignore": ["**node_modules**", "**dist**", "**/scripts/**"],
     "gitignore": true,
     "threshold": 3.0,
-    "minLines": 3,
+    "minLines": 10,
     "output": "./",
     "reporters": ["json"]
 }


### PR DESCRIPTION
## Problem
Copy paste detection is very sensitive as the minLines is currently set to 3. 

## Solution
increase it to 10. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
