### PR TITLE
fix(cwl): Convert LogGroupName to ARN from CWLGroupInfo

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -27,7 +27,7 @@ export async function tailLogGroup(
     }
 
     const liveTailSessionConfig: LiveTailSessionConfiguration = {
-        logGroupName: wizardResponse.regionLogGroupSubmenuResponse.data,
+        logGroupArn: wizardResponse.regionLogGroupSubmenuResponse.data,
         logStreamFilter: wizardResponse.logStreamFilter,
         logEventFilterPattern: wizardResponse.filterPattern,
         region: wizardResponse.regionLogGroupSubmenuResponse.region,

--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSessionRegistry.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSessionRegistry.ts
@@ -19,7 +19,7 @@ export class LiveTailSessionRegistry extends Map<string, LiveTailSession> {
 }
 
 export function createLiveTailURIFromArgs(sessionData: LiveTailSessionConfiguration): vscode.Uri {
-    let uriStr = `${cloudwatchLogsLiveTailScheme}:${sessionData.region}:${sessionData.logGroupName}`
+    let uriStr = `${cloudwatchLogsLiveTailScheme}:${sessionData.region}:${sessionData.logGroupArn}`
 
     if (sessionData.logStreamFilter) {
         if (sessionData.logStreamFilter.type !== 'all') {

--- a/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
@@ -20,11 +20,13 @@ import {
 import { getTestWindow } from '../../../shared/vscode/window'
 import { CloudWatchLogsSettings, uriToKey } from '../../../../awsService/cloudWatchLogs/cloudWatchLogsUtils'
 import { installFakeClock } from '../../../testUtil'
+import { DefaultAwsContext } from '../../../../shared'
 
 describe('TailLogGroup', function () {
     const testLogGroup = 'test-log-group'
     const testRegion = 'test-region'
     const testMessage = 'test-message'
+    const testAwsAccountId = '1234'
 
     let sandbox: sinon.SinonSandbox
     let registry: LiveTailSessionRegistry
@@ -54,6 +56,7 @@ describe('TailLogGroup', function () {
     })
 
     it('starts LiveTailSession and writes to document. Closes tab and asserts session gets closed.', async function () {
+        sandbox.stub(DefaultAwsContext.prototype, 'getCredentialAccountId').returns(testAwsAccountId)
         wizardSpy = sandbox.stub(TailLogGroupWizard.prototype, 'run').callsFake(async function () {
             return getTestWizardResponse()
         })
@@ -127,7 +130,7 @@ describe('TailLogGroup', function () {
             })
 
         const session = new LiveTailSession({
-            logGroupName: testLogGroup,
+            logGroupArn: testLogGroup,
             region: testRegion,
         })
         registry.set(uriToKey(session.uri), session)
@@ -140,7 +143,7 @@ describe('TailLogGroup', function () {
 
     it('clearDocument clears all text from document', async function () {
         const session = new LiveTailSession({
-            logGroupName: testLogGroup,
+            logGroupArn: testLogGroup,
             region: testRegion,
         })
         const testData = 'blah blah blah'

--- a/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailRegistry.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailRegistry.test.ts
@@ -15,7 +15,7 @@ describe('LiveTailSession URI', async function () {
 
     it('is correct with no logStream filter, no filter pattern', function () {
         const config: LiveTailSessionConfiguration = {
-            logGroupName: testLogGroupName,
+            logGroupArn: testLogGroupName,
             region: testRegion,
         }
         const expectedUri = vscode.Uri.parse(expectedUriBase)
@@ -25,7 +25,7 @@ describe('LiveTailSession URI', async function () {
 
     it('is correct with no logStream filter, with filter pattern', function () {
         const config: LiveTailSessionConfiguration = {
-            logGroupName: testLogGroupName,
+            logGroupArn: testLogGroupName,
             region: testRegion,
             logEventFilterPattern: 'test-filter',
         }
@@ -36,7 +36,7 @@ describe('LiveTailSession URI', async function () {
 
     it('is correct with ALL logStream filter', function () {
         const config: LiveTailSessionConfiguration = {
-            logGroupName: testLogGroupName,
+            logGroupArn: testLogGroupName,
             region: testRegion,
             logStreamFilter: {
                 type: 'all',
@@ -49,7 +49,7 @@ describe('LiveTailSession URI', async function () {
 
     it('is correct with prefix logStream filter', function () {
         const config: LiveTailSessionConfiguration = {
-            logGroupName: testLogGroupName,
+            logGroupArn: testLogGroupName,
             region: testRegion,
             logStreamFilter: {
                 type: 'prefix',
@@ -63,7 +63,7 @@ describe('LiveTailSession URI', async function () {
 
     it('is correct with specific logStream filter', function () {
         const config: LiveTailSessionConfiguration = {
-            logGroupName: testLogGroupName,
+            logGroupArn: testLogGroupName,
             region: testRegion,
             logStreamFilter: {
                 type: 'specific',
@@ -77,7 +77,7 @@ describe('LiveTailSession URI', async function () {
 
     it('is correct with specific logStream filter and filter pattern', function () {
         const config: LiveTailSessionConfiguration = {
-            logGroupName: testLogGroupName,
+            logGroupArn: testLogGroupName,
             region: testRegion,
             logStreamFilter: {
                 type: 'specific',

--- a/packages/core/src/test/awsService/cloudWatchLogs/wizard/tailLogGroupWizard.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/wizard/tailLogGroupWizard.test.ts
@@ -2,11 +2,28 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as sinon from 'sinon'
 
-import { TailLogGroupWizard } from '../../../../awsService/cloudWatchLogs/wizard/tailLogGroupWizard'
+import assert from 'assert'
+import { buildLogGroupArn, TailLogGroupWizard } from '../../../../awsService/cloudWatchLogs/wizard/tailLogGroupWizard'
 import { createWizardTester } from '../../../shared/wizards/wizardTestUtils'
+import { DefaultAwsContext, globals } from '../../../../shared'
 
 describe('TailLogGroupWizard', async function () {
+    let sandbox: sinon.SinonSandbox
+
+    const testLogGroupName = 'testLogGroup'
+    const testRegion = 'testRegion'
+    const testAwsAccountId = '1234'
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+    })
+
     it('prompts regionLogGroup submenu first if context not provided', async function () {
         const wizard = new TailLogGroupWizard()
         const tester = await createWizardTester(wizard)
@@ -16,13 +33,20 @@ describe('TailLogGroupWizard', async function () {
     })
 
     it('skips regionLogGroup submenu if context provided', async function () {
+        sandbox.stub(DefaultAwsContext.prototype, 'getCredentialAccountId').returns(testAwsAccountId)
         const wizard = new TailLogGroupWizard({
-            groupName: 'test-groupName',
-            regionName: 'test-regionName',
+            groupName: testLogGroupName,
+            regionName: testRegion,
         })
         const tester = await createWizardTester(wizard)
         tester.regionLogGroupSubmenuResponse.assertDoesNotShow()
         tester.logStreamFilter.assertShowFirst()
         tester.filterPattern.assertShowSecond()
+    })
+
+    it('builds LogGroup Arn properly', async function () {
+        sandbox.stub(DefaultAwsContext.prototype, 'getCredentialAccountId').returns(testAwsAccountId)
+        const arn = buildLogGroupArn(testLogGroupName, testRegion)
+        assert.strictEqual(arn, `arn:aws:logs:${testRegion}:${testAwsAccountId}:log-group:${testLogGroupName}`)
     })
 })


### PR DESCRIPTION
## Problem
User can select a LogGroup to tail by pressing a `Play` button next to a listed LogGroup in the explorer menu. The context of the selected LogGroup is used to initialize the state of the TailLogGroup wizard, and skip the need to select a LogGroup via the Wizard's prompters.

The LogGroup context contains the LogGroup's *name* not arn.

StartLiveTail's request, requires LogGroup Arns. 

## Solution
Detect if the context when initializing the TailLogGroup wizard is a LogGroup Name or Arn. If it is just a name, construct the Arn and set that in the Wizard response. 

Renames `LogGroupName` in `LiveTailSession` to `LogGroupArn` to make it more clear what is expected. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
