### PR TITLE
fix(amazonq): users not able to auto trigger Q inline suggestion on systemVerilog files

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-30c6bfc4-9411-4bc4-bfd1-41305859109d.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-30c6bfc4-9411-4bc4-bfd1-41305859109d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix broken inline suggestion auto-trigger on Systemverfilog files if users dont have systemverilog extension installed and enabled"
+}

--- a/packages/amazonq/test/unit/codewhisperer/util/runtimeLanguageContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/runtimeLanguageContext.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { resetCodeWhispererGlobalVariables } from 'aws-core-vscode/test'
+import { resetCodeWhispererGlobalVariables, toTextDocument } from 'aws-core-vscode/test'
 import { runtimeLanguageContext, RuntimeLanguageContext, PlatformLanguageId } from 'aws-core-vscode/codewhisperer'
 import * as codewhispererClient from 'aws-core-vscode/codewhisperer'
 import { CodewhispererLanguage } from 'aws-core-vscode/shared'
@@ -12,7 +12,7 @@ import { CodewhispererLanguage } from 'aws-core-vscode/shared'
 describe('runtimeLanguageContext', function () {
     const languageContext = new RuntimeLanguageContext()
 
-    describe('test isLanguageSupported', function () {
+    describe('test isLanguageSupported with languageId as the argument', function () {
         const cases: [string, boolean][] = [
             ['java', true],
             ['javascript', true],
@@ -59,6 +59,61 @@ describe('runtimeLanguageContext', function () {
             it(`should ${expected ? '' : 'not'} support ${languageId}`, function () {
                 const actual = languageContext.isLanguageSupported(languageId)
                 assert.strictEqual(actual, expected)
+            })
+        })
+
+        describe('test isLanguageSupported with document as the argument', function () {
+            const cases: [string, boolean][] = [
+                ['helloJava.java', true],
+                ['helloPython.py', true],
+                ['helloJavascript.js', true],
+                ['helloJsx.jsx', true],
+                ['helloTypescript.ts', true],
+                ['helloTsx.tsx', true],
+                ['helloCsharp.cs', true],
+                ['helloC.c', true],
+                ['helloC.h', true],
+                ['helloCpp.cpp', true],
+                ['helloCpp.cc', true],
+                ['helloGo.go', true],
+                ['helloKotlin.kt', true],
+                ['helloPhp.php', true],
+                ['helloRuby.rb', true],
+                ['helloRust.rs', true],
+                ['helloScala.scala', true],
+                ['helloShellscript.sh', true],
+                ['helloSql.sql', true],
+                ['helloSystemVerilog.svh', true],
+                ['helloSystemVerilog.sv', true],
+                ['helloSystemVerilog.vh', true],
+                ['helloDart.dart', true],
+                ['helloLua.lua', true],
+                ['helloLua.wlua', true],
+                ['helloSwift.swift', true],
+                ['helloVue.vue', true],
+                ['helloPowerShell.ps1', true],
+                ['helloPowerShell.psm1', true],
+                ['helloR.r', true],
+                ['helloJson.json', true],
+                ['helloYaml.yaml', true],
+                ['helloYaml.yml', true],
+                ['helloTf.tf', true],
+                ['helloPlaintext.txt', false],
+                ['helloHtml.html', false],
+                ['helloCss.css', false],
+                ['helloUnknown', false],
+                ['helloFoo.foo', false],
+            ]
+
+            cases.forEach((tuple) => {
+                const fileName = tuple[0]
+                const expected = tuple[1]
+
+                it(`pass document ${fileName} as argument should first try determine by languageId then file extensions`, async function () {
+                    const doc = await toTextDocument('', fileName)
+                    const actual = languageContext.isLanguageSupported(doc)
+                    assert.strictEqual(actual, expected)
+                })
             })
         })
     })

--- a/packages/amazonq/test/unit/codewhisperer/util/runtimeLanguageContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/runtimeLanguageContext.test.ts
@@ -12,7 +12,7 @@ import { CodewhispererLanguage } from 'aws-core-vscode/shared'
 describe('runtimeLanguageContext', function () {
     const languageContext = new RuntimeLanguageContext()
 
-    describe('test isLanguageSupported with languageId as the argument', function () {
+    describe('test isLanguageSupported', function () {
         const cases: [string, boolean][] = [
             ['java', true],
             ['javascript', true],

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -478,7 +478,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 if (e.document !== editor.document) {
                     return
                 }
-                if (!runtimeLanguageContext.isLanguageSupported(e.document.languageId)) {
+                if (!runtimeLanguageContext.isLanguageSupported(e.document)) {
                     return
                 }
 
@@ -549,7 +549,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 if (e.document !== editor.document) {
                     return
                 }
-                if (!runtimeLanguageContext.isLanguageSupported(e.document.languageId)) {
+                if (!runtimeLanguageContext.isLanguageSupported(e.document)) {
                     return
                 }
                 /**

--- a/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -108,7 +108,10 @@ export class RuntimeLanguageContext {
         })
         this.supportedLanguageExtensionMap = createConstantMap<string, CodewhispererLanguage>({
             c: 'c',
+            h: 'c',
             cpp: 'cpp',
+            cc: 'cpp',
+            'c++': 'cpp',
             cs: 'csharp',
             go: 'go',
             hcl: 'tf',

--- a/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode'
 import { getLogger } from '../../shared/logger/logger'
 import { CodewhispererLanguage } from '../../shared/telemetry/telemetry.gen'
 import { createConstantMap, ConstantMap } from '../../shared/utilities/tsUtils'
 import * as codewhispererClient from '../client/codewhisperer'
 import * as CodeWhispererConstants from '../models/constants'
+import * as path from 'path'
 
 type RuntimeLanguage = Exclude<CodewhispererLanguage, 'jsx' | 'tsx' | 'systemVerilog'> | 'systemverilog'
 
@@ -251,24 +253,24 @@ export class RuntimeLanguageContext {
         }
     }
 
-    /**
-     *
-     * @param languageId: either vscodeLanguageId or CodewhispererLanguage
-     * @returns true if the language is supported by CodeWhisperer otherwise false
-     */
-    public isLanguageSupported(languageId: string): boolean {
-        const lang = this.normalizeLanguage(languageId)
-        switch (lang) {
-            case undefined:
-                return false
+    public isLanguageSupported(languageId: string): boolean
+    public isLanguageSupported(doc: vscode.TextDocument): boolean
+    public isLanguageSupported(arg: string | vscode.TextDocument): boolean {
+        if (typeof arg === 'string') {
+            const normalizedLanguageId = this.normalizeLanguage(arg)
+            const byLanguageId = !normalizedLanguageId || normalizedLanguageId === 'plaintext' ? false : true
 
-            case 'plaintext':
-                return false
+            return byLanguageId
+        } else {
+            const normalizedLanguageId = this.normalizeLanguage(arg.languageId)
+            const byLanguageId = !normalizedLanguageId || normalizedLanguageId === 'plaintext' ? false : true
+            const extension = path.extname(arg.uri.fsPath)
+            const byFileExtension = this.isFileFormatSupported(extension.substring(1))
 
-            default:
-                return true
+            return byLanguageId || byFileExtension
         }
     }
+
     /**
      *
      * @param fileFormat : vscode editor filecontext filename extension

--- a/packages/core/src/codewhisperer/views/lineAnnotationController.ts
+++ b/packages/core/src/codewhisperer/views/lineAnnotationController.ts
@@ -425,7 +425,7 @@ export class LineAnnotationController implements vscode.Disposable {
         }
 
         // Disable Tips when language is not supported by Amazon Q.
-        if (!runtimeLanguageContext.isLanguageSupported(editor.document.languageId)) {
+        if (!runtimeLanguageContext.isLanguageSupported(editor.document)) {
             return
         }
 


### PR DESCRIPTION
## Problem
within inline suggestion code path, `isLanguageSupported()` relies on `vscode.editor.document.langaugeId` to determine whether the given language is supported Q inline suggestion functionality. However, it's possible that some languages are not recognized by VSCode IDE itself without 3rd party extensions, for example: VSCode doesn't recognize `.sv`, `svh`, `vh` files which is bound to SystemVerilog language if users do not have the 3rd party extension installed and enabled, in this case, `vscode.editor.document.languageId` will simply return `plaintext`. 

This is the root cause why autotrigger doesn't work for systemverilog files, because at the beginning, we don't even register keyStrokeHandler for files with `.sv`, `svh`, `vh` files.

## Solution
if language check return false, we should also check file extension

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
