### PR TITLE
fix(cwl): Pass in active credentials when creating CWL client for LiveTail

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode'
+import * as AWS from '@aws-sdk/types'
 import {
     CloudWatchLogsClient,
     StartLiveTailCommand,
@@ -19,6 +20,7 @@ export type LiveTailSessionConfiguration = {
     logStreamFilter?: LogStreamFilterResponse
     logEventFilterPattern?: string
     region: string
+    awsCredentials: AWS.Credentials
 }
 
 export type LiveTailSessionClient = {
@@ -49,6 +51,7 @@ export class LiveTailSession {
         this.logStreamFilter = configuration.logStreamFilter
         this.liveTailClient = {
             cwlClient: new CloudWatchLogsClient({
+                credentials: configuration.awsCredentials,
                 region: configuration.region,
                 customUserAgent: getUserAgent(),
             }),

--- a/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailRegistry.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailRegistry.test.ts
@@ -11,12 +11,14 @@ import { cloudwatchLogsLiveTailScheme } from '../../../../shared/constants'
 describe('LiveTailSession URI', async function () {
     const testLogGroupName = 'test-log-group'
     const testRegion = 'test-region'
+    const testAwsCredentials = {} as any as AWS.Credentials
     const expectedUriBase = `${cloudwatchLogsLiveTailScheme}:${testRegion}:${testLogGroupName}`
 
     it('is correct with no logStream filter, no filter pattern', function () {
         const config: LiveTailSessionConfiguration = {
             logGroupArn: testLogGroupName,
             region: testRegion,
+            awsCredentials: testAwsCredentials,
         }
         const expectedUri = vscode.Uri.parse(expectedUriBase)
         const uri = createLiveTailURIFromArgs(config)
@@ -28,6 +30,7 @@ describe('LiveTailSession URI', async function () {
             logGroupArn: testLogGroupName,
             region: testRegion,
             logEventFilterPattern: 'test-filter',
+            awsCredentials: testAwsCredentials,
         }
         const expectedUri = vscode.Uri.parse(`${expectedUriBase}:test-filter`)
         const uri = createLiveTailURIFromArgs(config)
@@ -41,6 +44,7 @@ describe('LiveTailSession URI', async function () {
             logStreamFilter: {
                 type: 'all',
             },
+            awsCredentials: testAwsCredentials,
         }
         const expectedUri = vscode.Uri.parse(`${expectedUriBase}:all`)
         const uri = createLiveTailURIFromArgs(config)
@@ -55,6 +59,7 @@ describe('LiveTailSession URI', async function () {
                 type: 'prefix',
                 filter: 'test-prefix',
             },
+            awsCredentials: testAwsCredentials,
         }
         const expectedUri = vscode.Uri.parse(`${expectedUriBase}:prefix:test-prefix`)
         const uri = createLiveTailURIFromArgs(config)
@@ -69,6 +74,7 @@ describe('LiveTailSession URI', async function () {
                 type: 'specific',
                 filter: 'test-stream',
             },
+            awsCredentials: testAwsCredentials,
         }
         const expectedUri = vscode.Uri.parse(`${expectedUriBase}:specific:test-stream`)
         const uri = createLiveTailURIFromArgs(config)
@@ -84,6 +90,7 @@ describe('LiveTailSession URI', async function () {
                 filter: 'test-stream',
             },
             logEventFilterPattern: 'test-filter',
+            awsCredentials: testAwsCredentials,
         }
         const expectedUri = vscode.Uri.parse(`${expectedUriBase}:specific:test-stream:test-filter`)
         const uri = createLiveTailURIFromArgs(config)


### PR DESCRIPTION
## Problem
When creating the CloudWatchClient for a LiveTail session, we are not specifying which credentials to use. This is causing the client to always use the `Default` credential profile, even if a different AWS Credential profile is selected within AWSToolkit.

## Solution
Resolve the active AWS credential from `globals.awsContext`, and supply that to the LiveTailSession constructor. These credentials are then use to construct the CWL client. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
