### PR TITLE
fix(feature dev): retry message without problem statement

### DIFF
--- a/packages/amazonq/test/unit/amazonqFeatureDev/session/session.test.ts
+++ b/packages/amazonq/test/unit/amazonqFeatureDev/session/session.test.ts
@@ -37,8 +37,9 @@ describe('session', () => {
     describe('preloader', () => {
         it('emits start chat telemetry', async () => {
             const session = await createSession({ messenger, conversationID })
+            session.latestMessage = 'implement twosum in typescript'
 
-            await session.preloader('implement twosum in typescript')
+            await session.preloader()
 
             assertTelemetry('amazonq_startConversationInvoke', {
                 amazonqConversationId: conversationID,

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -366,6 +366,9 @@ export class FeatureDevController {
             getLogger().debug(`${featureName}: Processing message: ${message.message}`)
 
             session = await this.sessionStorage.getSession(message.tabID)
+            // set latestMessage in session as retry would lose context if function returns early
+            session.latestMessage = message.message
+
             const authState = await AuthUtil.instance.getChatAuthState()
             if (authState.amazonQ !== 'connected') {
                 await this.messenger.sendAuthNeededExceptionMessage(authState, message.tabID)
@@ -383,7 +386,7 @@ export class FeatureDevController {
                 return
             }
 
-            await session.preloader(message.message)
+            await session.preloader()
 
             if (session.state.phase === DevPhase.CODEGEN) {
                 await this.onCodeGeneration(session, message.message, message.tabID)

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -58,9 +58,9 @@ export class Session {
     /**
      * Preload any events that have to run before a chat message can be sent
      */
-    async preloader(msg: string) {
+    async preloader() {
         if (!this.preloaderFinished) {
-            await this.setupConversation(msg)
+            await this.setupConversation()
             this.preloaderFinished = true
             this.messenger.sendAsyncEventProgress(this.tabID, true, undefined)
             await this.proxyClient.sendFeatureDevTelemetryEvent(this.conversationId) // send the event only once per conversation.
@@ -72,10 +72,7 @@ export class Session {
      *
      * Starts a conversation with the backend and uploads the repo for the LLMs to be able to use it.
      */
-    private async setupConversation(msg: string) {
-        // Store the initial message when setting up the conversation so that if it fails we can retry with this message
-        this._latestMessage = msg
-
+    private async setupConversation() {
         await telemetry.amazonq_startConversationInvoke.run(async (span) => {
             this._conversationId = await this.proxyClient.createConversation()
             getLogger().info(logWithConversationId(this.conversationId))
@@ -219,6 +216,10 @@ export class Session {
 
     get latestMessage() {
         return this._latestMessage
+    }
+
+    set latestMessage(msg: string) {
+        this._latestMessage = msg
     }
 
     get telemetry() {


### PR DESCRIPTION
## Problem

retry message without problem statement

## Solution

Move latestMessage setter call outside of session in controller as it interrupts with retryMessage functionality

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
