### PR TITLE
fix(cwl): Set LogEventFilter when constructing LiveTailSession

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
@@ -49,6 +49,7 @@ export class LiveTailSession {
     public constructor(configuration: LiveTailSessionConfiguration) {
         this._logGroupArn = configuration.logGroupArn
         this.logStreamFilter = configuration.logStreamFilter
+        this.logEventFilterPattern = configuration.logEventFilterPattern
         this.liveTailClient = {
             cwlClient: new CloudWatchLogsClient({
                 credentials: configuration.awsCredentials,
@@ -120,7 +121,7 @@ export class LiveTailSession {
         return this.endTime - this.startTime
     }
 
-    private buildStartLiveTailCommand(): StartLiveTailCommand {
+    public buildStartLiveTailCommand(): StartLiveTailCommand {
         let logStreamNamePrefix = undefined
         let logStreamName = undefined
         if (this.logStreamFilter) {

--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
@@ -11,9 +11,10 @@ import {
 } from '@aws-sdk/client-cloudwatch-logs'
 import { LogStreamFilterResponse } from '../wizard/liveTailLogStreamSubmenu'
 import { CloudWatchLogsSettings, uriToKey } from '../cloudWatchLogsUtils'
-import { convertToTimeString, getLogger, globals, Settings, ToolkitError } from '../../../shared'
+import { getLogger, globals, Settings, ToolkitError } from '../../../shared'
 import { createLiveTailURIFromArgs } from './liveTailSessionRegistry'
 import { getUserAgent } from '../../../shared/telemetry/util'
+import { convertToTimeString } from '../../../shared/datetime'
 
 export type LiveTailSessionConfiguration = {
     logGroupArn: string

--- a/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
@@ -10,7 +10,7 @@ describe('LiveTailSession', async function () {
     const testRegion = 'test-region'
     const testFilter = 'test-filter'
     const testAwsCredentials = {} as any as AWS.Credentials
-    it('correctly builds StartLiveTailCommand: no stream Filter, no event filter.', function () {
+    it('builds StartLiveTailCommand: no stream Filter, no event filter.', function () {
         const session = new LiveTailSession({
             logGroupArn: testLogGroupArn,
             region: testRegion,
@@ -28,7 +28,7 @@ describe('LiveTailSession', async function () {
             )
         )
     })
-    it('correctly builds StartLiveTailCommand: with prefix stream Filter', function () {
+    it('builds StartLiveTailCommand: with prefix stream Filter', function () {
         const session = new LiveTailSession({
             logGroupArn: testLogGroupArn,
             logStreamFilter: {
@@ -50,7 +50,7 @@ describe('LiveTailSession', async function () {
             )
         )
     })
-    it('correctly builds StartLiveTailCommand: with specific stream Filter', function () {
+    it('builds StartLiveTailCommand: with specific stream Filter', function () {
         const session = new LiveTailSession({
             logGroupArn: testLogGroupArn,
             logStreamFilter: {
@@ -72,7 +72,7 @@ describe('LiveTailSession', async function () {
             )
         )
     })
-    it('correctly builds StartLiveTailCommand: with log event Filter', function () {
+    it('builds StartLiveTailCommand: with log event Filter', function () {
         const session = new LiveTailSession({
             logGroupArn: testLogGroupArn,
             logStreamFilter: {

--- a/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
@@ -15,53 +15,53 @@ describe('LiveTailSession', async function () {
 
     it('builds StartLiveTailCommand: no stream Filter, no event filter.', function () {
         const session = buildLiveTailSession({ type: 'all' }, undefined)
-        validateStartLiveTailCommand(
-            session.buildStartLiveTailCommand(),
+        assert.deepStrictEqual(
+            session.buildStartLiveTailCommand().input,
             new StartLiveTailCommand({
                 logGroupIdentifiers: [testLogGroupArn],
                 logEventFilterPattern: undefined,
                 logStreamNamePrefixes: undefined,
                 logStreamNames: undefined,
-            })
+            }).input
         )
     })
 
     it('builds StartLiveTailCommand: with prefix stream Filter', function () {
         const session = buildLiveTailSession({ type: 'prefix', filter: testFilter }, undefined)
-        validateStartLiveTailCommand(
-            session.buildStartLiveTailCommand(),
+        assert.deepStrictEqual(
+            session.buildStartLiveTailCommand().input,
             new StartLiveTailCommand({
                 logGroupIdentifiers: [testLogGroupArn],
                 logEventFilterPattern: undefined,
                 logStreamNamePrefixes: [testFilter],
                 logStreamNames: undefined,
-            })
+            }).input
         )
     })
 
     it('builds StartLiveTailCommand: with specific stream Filter', function () {
         const session = buildLiveTailSession({ type: 'specific', filter: testFilter }, undefined)
-        validateStartLiveTailCommand(
-            session.buildStartLiveTailCommand(),
+        assert.deepStrictEqual(
+            session.buildStartLiveTailCommand().input,
             new StartLiveTailCommand({
                 logGroupIdentifiers: [testLogGroupArn],
                 logEventFilterPattern: undefined,
                 logStreamNamePrefixes: undefined,
                 logStreamNames: [testFilter],
-            })
+            }).input
         )
     })
 
     it('builds StartLiveTailCommand: with log event Filter', function () {
         const session = buildLiveTailSession({ type: 'all' }, testFilter)
-        validateStartLiveTailCommand(
-            session.buildStartLiveTailCommand(),
+        assert.deepStrictEqual(
+            session.buildStartLiveTailCommand().input,
             new StartLiveTailCommand({
                 logGroupIdentifiers: [testLogGroupArn],
                 logEventFilterPattern: testFilter,
                 logStreamNamePrefixes: undefined,
                 logStreamNames: undefined,
-            })
+            }).input
         )
     })
 
@@ -76,9 +76,5 @@ describe('LiveTailSession', async function () {
             region: testRegion,
             awsCredentials: testAwsCredentials,
         })
-    }
-
-    function validateStartLiveTailCommand(actual: StartLiveTailCommand, expected: StartLiveTailCommand) {
-        assert.strictEqual(JSON.stringify(actual), JSON.stringify(expected))
     }
 })

--- a/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
@@ -1,0 +1,97 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import assert from 'assert'
+import { LiveTailSession } from '../../../../awsService/cloudWatchLogs/registry/liveTailSession'
+import { StartLiveTailCommand } from '@aws-sdk/client-cloudwatch-logs'
+describe('LiveTailSession', async function () {
+    const testLogGroupArn = 'arn:aws:test-log-group'
+    const testRegion = 'test-region'
+    const testFilter = 'test-filter'
+    const testAwsCredentials = {} as any as AWS.Credentials
+    it('correctly builds StartLiveTailCommand: no stream Filter, no event filter.', function () {
+        const session = new LiveTailSession({
+            logGroupArn: testLogGroupArn,
+            region: testRegion,
+            awsCredentials: testAwsCredentials,
+        })
+        assert.strictEqual(
+            JSON.stringify(session.buildStartLiveTailCommand()),
+            JSON.stringify(
+                new StartLiveTailCommand({
+                    logGroupIdentifiers: [testLogGroupArn],
+                    logEventFilterPattern: undefined,
+                    logStreamNamePrefixes: undefined,
+                    logStreamNames: undefined,
+                })
+            )
+        )
+    })
+    it('correctly builds StartLiveTailCommand: with prefix stream Filter', function () {
+        const session = new LiveTailSession({
+            logGroupArn: testLogGroupArn,
+            logStreamFilter: {
+                type: 'prefix',
+                filter: 'test-filter',
+            },
+            region: testRegion,
+            awsCredentials: testAwsCredentials,
+        })
+        assert.strictEqual(
+            JSON.stringify(session.buildStartLiveTailCommand()),
+            JSON.stringify(
+                new StartLiveTailCommand({
+                    logGroupIdentifiers: [testLogGroupArn],
+                    logEventFilterPattern: undefined,
+                    logStreamNamePrefixes: [testFilter],
+                    logStreamNames: undefined,
+                })
+            )
+        )
+    })
+    it('correctly builds StartLiveTailCommand: with specific stream Filter', function () {
+        const session = new LiveTailSession({
+            logGroupArn: testLogGroupArn,
+            logStreamFilter: {
+                type: 'specific',
+                filter: 'test-filter',
+            },
+            region: testRegion,
+            awsCredentials: testAwsCredentials,
+        })
+        assert.strictEqual(
+            JSON.stringify(session.buildStartLiveTailCommand()),
+            JSON.stringify(
+                new StartLiveTailCommand({
+                    logGroupIdentifiers: [testLogGroupArn],
+                    logEventFilterPattern: undefined,
+                    logStreamNamePrefixes: undefined,
+                    logStreamNames: [testFilter],
+                })
+            )
+        )
+    })
+    it('correctly builds StartLiveTailCommand: with log event Filter', function () {
+        const session = new LiveTailSession({
+            logGroupArn: testLogGroupArn,
+            logStreamFilter: {
+                type: 'all',
+            },
+            logEventFilterPattern: 'test-filter',
+            region: testRegion,
+            awsCredentials: testAwsCredentials,
+        })
+        assert.strictEqual(
+            JSON.stringify(session.buildStartLiveTailCommand()),
+            JSON.stringify(
+                new StartLiveTailCommand({
+                    logGroupIdentifiers: [testLogGroupArn],
+                    logEventFilterPattern: testFilter,
+                    logStreamNamePrefixes: undefined,
+                    logStreamNames: undefined,
+                })
+            )
+        )
+    })
+})

--- a/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
@@ -5,93 +5,80 @@
 import assert from 'assert'
 import { LiveTailSession } from '../../../../awsService/cloudWatchLogs/registry/liveTailSession'
 import { StartLiveTailCommand } from '@aws-sdk/client-cloudwatch-logs'
+import { LogStreamFilterResponse } from '../../../../awsService/cloudWatchLogs/wizard/liveTailLogStreamSubmenu'
+
 describe('LiveTailSession', async function () {
     const testLogGroupArn = 'arn:aws:test-log-group'
     const testRegion = 'test-region'
     const testFilter = 'test-filter'
     const testAwsCredentials = {} as any as AWS.Credentials
+
     it('builds StartLiveTailCommand: no stream Filter, no event filter.', function () {
-        const session = new LiveTailSession({
-            logGroupArn: testLogGroupArn,
-            region: testRegion,
-            awsCredentials: testAwsCredentials,
-        })
-        assert.strictEqual(
-            JSON.stringify(session.buildStartLiveTailCommand()),
-            JSON.stringify(
-                new StartLiveTailCommand({
-                    logGroupIdentifiers: [testLogGroupArn],
-                    logEventFilterPattern: undefined,
-                    logStreamNamePrefixes: undefined,
-                    logStreamNames: undefined,
-                })
-            )
+        const session = buildLiveTailSession({ type: 'all' }, undefined)
+        validateStartLiveTailCommand(
+            session.buildStartLiveTailCommand(),
+            new StartLiveTailCommand({
+                logGroupIdentifiers: [testLogGroupArn],
+                logEventFilterPattern: undefined,
+                logStreamNamePrefixes: undefined,
+                logStreamNames: undefined,
+            })
         )
     })
+
     it('builds StartLiveTailCommand: with prefix stream Filter', function () {
-        const session = new LiveTailSession({
-            logGroupArn: testLogGroupArn,
-            logStreamFilter: {
-                type: 'prefix',
-                filter: 'test-filter',
-            },
-            region: testRegion,
-            awsCredentials: testAwsCredentials,
-        })
-        assert.strictEqual(
-            JSON.stringify(session.buildStartLiveTailCommand()),
-            JSON.stringify(
-                new StartLiveTailCommand({
-                    logGroupIdentifiers: [testLogGroupArn],
-                    logEventFilterPattern: undefined,
-                    logStreamNamePrefixes: [testFilter],
-                    logStreamNames: undefined,
-                })
-            )
+        const session = buildLiveTailSession({ type: 'prefix', filter: testFilter }, undefined)
+        validateStartLiveTailCommand(
+            session.buildStartLiveTailCommand(),
+            new StartLiveTailCommand({
+                logGroupIdentifiers: [testLogGroupArn],
+                logEventFilterPattern: undefined,
+                logStreamNamePrefixes: [testFilter],
+                logStreamNames: undefined,
+            })
         )
     })
+
     it('builds StartLiveTailCommand: with specific stream Filter', function () {
-        const session = new LiveTailSession({
-            logGroupArn: testLogGroupArn,
-            logStreamFilter: {
-                type: 'specific',
-                filter: 'test-filter',
-            },
-            region: testRegion,
-            awsCredentials: testAwsCredentials,
-        })
-        assert.strictEqual(
-            JSON.stringify(session.buildStartLiveTailCommand()),
-            JSON.stringify(
-                new StartLiveTailCommand({
-                    logGroupIdentifiers: [testLogGroupArn],
-                    logEventFilterPattern: undefined,
-                    logStreamNamePrefixes: undefined,
-                    logStreamNames: [testFilter],
-                })
-            )
+        const session = buildLiveTailSession({ type: 'specific', filter: testFilter }, undefined)
+        validateStartLiveTailCommand(
+            session.buildStartLiveTailCommand(),
+            new StartLiveTailCommand({
+                logGroupIdentifiers: [testLogGroupArn],
+                logEventFilterPattern: undefined,
+                logStreamNamePrefixes: undefined,
+                logStreamNames: [testFilter],
+            })
         )
     })
+
     it('builds StartLiveTailCommand: with log event Filter', function () {
-        const session = new LiveTailSession({
+        const session = buildLiveTailSession({ type: 'all' }, testFilter)
+        validateStartLiveTailCommand(
+            session.buildStartLiveTailCommand(),
+            new StartLiveTailCommand({
+                logGroupIdentifiers: [testLogGroupArn],
+                logEventFilterPattern: testFilter,
+                logStreamNamePrefixes: undefined,
+                logStreamNames: undefined,
+            })
+        )
+    })
+
+    function buildLiveTailSession(
+        logStreamFilter: LogStreamFilterResponse,
+        logEventFilterPattern: string | undefined
+    ): LiveTailSession {
+        return new LiveTailSession({
             logGroupArn: testLogGroupArn,
-            logStreamFilter: {
-                type: 'all',
-            },
-            logEventFilterPattern: 'test-filter',
+            logStreamFilter: logStreamFilter,
+            logEventFilterPattern: logEventFilterPattern,
             region: testRegion,
             awsCredentials: testAwsCredentials,
         })
-        assert.strictEqual(
-            JSON.stringify(session.buildStartLiveTailCommand()),
-            JSON.stringify(
-                new StartLiveTailCommand({
-                    logGroupIdentifiers: [testLogGroupArn],
-                    logEventFilterPattern: testFilter,
-                    logStreamNamePrefixes: undefined,
-                    logStreamNames: undefined,
-                })
-            )
-        )
-    })
+    }
+
+    function validateStartLiveTailCommand(actual: StartLiveTailCommand, expected: StartLiveTailCommand) {
+        assert.strictEqual(JSON.stringify(actual), JSON.stringify(expected))
+    }
 })


### PR DESCRIPTION
## Problem
LogEventFilter is an optional configuration parameter when building a LiveTailSession. Currently, the Constructor is not actually setting this property so it is always undefined. This means that if a user sets a Filter pattern, it will not be applied. 

## Solution
Set the property in LiveTailSession Constructor.
Add missing unit tests to validate that LiveTailSession config values are set properly. Testing via `buildStartLiveTailCommand` because this is what actually gets sent to the CWL backend to start a LiveTailSession.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
