### PR TITLE
test(policychecks): remove flaky check with executeCommand

### DIFF
--- a/packages/core/src/test/awsService/accessanalyzer/iamPolicyChecks.test.ts
+++ b/packages/core/src/test/awsService/accessanalyzer/iamPolicyChecks.test.ts
@@ -369,7 +369,6 @@ describe('customChecks', function () {
         assert.deepStrictEqual(actualCommand.referencePolicyType, policyType)
 
         assert(onCustomPolicyCheckResponseFireSpy.notCalled)
-        assert(executeCommandStub.notCalled)
     })
 
     it('checkNoNewAccess should handle CloudFormation document type correctly', async function () {
@@ -400,7 +399,6 @@ describe('customChecks', function () {
         assert.deepStrictEqual(actualCommand.referencePolicyType, policyType)
 
         assert(onCustomPolicyCheckResponseFireSpy.notCalled)
-        assert(executeCommandStub.notCalled)
     })
 
     it('checkNoNewAccess should handle missing reference document', async function () {


### PR DESCRIPTION
## Problem
Flaky tests: https://github.com/aws/aws-toolkit-vscode/issues/5996

## Solution
The check for executeCommand is not important to these tests, and can be removed. 

fix #5996