### PR TITLE
fix(appbuilder): Issue related to App-builder placeholder wrong message

### DIFF
--- a/packages/core/src/awsService/appBuilder/explorer/nodes/appNode.ts
+++ b/packages/core/src/awsService/appBuilder/explorer/nodes/appNode.ts
@@ -17,7 +17,6 @@ import { getSamCliContext } from '../../../../shared/sam/cli/samCliContext'
 import { SamCliListResourcesParameters } from '../../../../shared/sam/cli/samCliListResources'
 import { getDeployedResources, StackResource } from '../../../../lambda/commands/listSamResources'
 import * as path from 'path'
-import fs from '../../../../shared/fs/fs'
 import { generateStackNode } from './deployedStack'
 
 export class AppNode implements TreeNode {
@@ -61,19 +60,9 @@ export class AppNode implements TreeNode {
 
             // indicate that App exists, but it is empty
             if (resources.length === 0) {
-                if (await fs.exists(this.location.samTemplateUri)) {
-                    return [
-                        createPlaceholderItem(
-                            localize(
-                                'AWS.appBuilder.explorerNode.app.noResource',
-                                '[No resource found in IaC template]'
-                            )
-                        ),
-                    ]
-                }
                 return [
                     createPlaceholderItem(
-                        localize('AWS.appBuilder.explorerNode.app.noTemplate', '[No IaC templates found in Workspaces]')
+                        localize('AWS.appBuilder.explorerNode.app.noResource', '[No resource found in SAM template]')
                     ),
                 ]
             }
@@ -84,7 +73,7 @@ export class AppNode implements TreeNode {
                 createPlaceholderItem(
                     localize(
                         'AWS.appBuilder.explorerNode.app.noResourceTree',
-                        '[Unable to load Resource tree for this App. Update IaC template]'
+                        '[Unable to load Resource tree for this App. Update SAM template]'
                     )
                 ),
             ]

--- a/packages/core/src/awsService/appBuilder/explorer/nodes/rootNode.ts
+++ b/packages/core/src/awsService/appBuilder/explorer/nodes/rootNode.ts
@@ -26,7 +26,7 @@ export async function getAppNodes(): Promise<TreeNode[]> {
     if (appsFound.length === 0) {
         return [
             createPlaceholderItem(
-                localize('AWS.appBuilder.explorerNode.noApps', '[No IaC templates found in Workspaces]')
+                localize('AWS.appBuilder.explorerNode.noApps', '[No SAM templates found in Workspaces]')
             ),
         ]
     }

--- a/packages/core/src/test/shared/applicationBuilder/explorer/nodes/appNode.test.ts
+++ b/packages/core/src/test/shared/applicationBuilder/explorer/nodes/appNode.test.ts
@@ -90,7 +90,7 @@ describe('AppNode', () => {
 
             const resourceNode = resources[0] as TreeNode
             assert.strictEqual(resourceNode.id, 'placeholder')
-            assert.strictEqual(resourceNode.resource, '[No IaC templates found in Workspaces]')
+            assert.strictEqual(resourceNode.resource, '[No resource found in SAM template]')
             assert(getAppStub.calledOnce)
             assert(getStackNameStub.calledOnce)
             assert(generateStackNodeStub.notCalled)
@@ -157,7 +157,7 @@ describe('AppNode', () => {
             assert.strictEqual(resourceNode.id, 'placeholder')
             assert.strictEqual(
                 resourceNode.resource,
-                '[Unable to load Resource tree for this App. Update IaC template]'
+                '[Unable to load Resource tree for this App. Update SAM template]'
             )
             assert(getAppStub.calledOnce)
             assert(getStackNameStub.notCalled)

--- a/packages/core/src/test/shared/applicationBuilder/explorer/nodes/rootNode.test.ts
+++ b/packages/core/src/test/shared/applicationBuilder/explorer/nodes/rootNode.test.ts
@@ -34,7 +34,7 @@ describe('getAppNodes', async () => {
         const appNodes = await getAppNodes()
         assert.strictEqual(appNodes.length, 1)
         assert.strictEqual(appNodes[0].id, 'placeholder')
-        assert.strictEqual(appNodes[0].resource, '[No IaC templates found in Workspaces]')
+        assert.strictEqual(appNodes[0].resource, '[No SAM templates found in Workspaces]')
     })
 
     it('should return all SAM projects as AppNode', async () => {

--- a/packages/toolkit/.changes/next-release/Bug Fix-3f75e95c-f940-42e3-b0e2-b6a3b9143a58.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-3f75e95c-f940-42e3-b0e2-b6a3b9143a58.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Update incorrect messgae in placeholder"
+	"description": "SAM debugging: misleading 'IaC' message/placeholder"
 }

--- a/packages/toolkit/.changes/next-release/Bug Fix-3f75e95c-f940-42e3-b0e2-b6a3b9143a58.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-3f75e95c-f940-42e3-b0e2-b6a3b9143a58.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Update incorrect messgae in placeholder"
+}


### PR DESCRIPTION
## Problem
I was working on a CDK project, and after synthesizing my CDK template, I noticed that the app-builder is showing a misleading notification to customers: No IaC templates found in the workspace. This seems incorrect, as I do have IaC templates in the workspace, including both raw and synthesized CDK templates.

![Screenshot 2024-11-05 at 9 30 15 AM](https://github.com/user-attachments/assets/88af2b28-2e9b-49ac-8f02-178c45fe06a9)

While I understand the intention behind the message, it needs to be more precise to avoid confusion. I suggest we roll it back to something more accurate, like No SAM templates found in the workspace, to clearly indicate the specific missing template type. I'm considering this a P0 issue and will raise a PR to address it.

## Solution
Solution is to change all instance where IAC is mentioned to the customer to SAM, we would roll back to IaC once we start support CDK.

Remove redundant Logic.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
