### PR TITLE
fix(appbuilder): SAM local debugging: region and credential in launch config should override toolkit default

### DIFF
--- a/packages/core/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/packages/core/src/shared/sam/debugger/awsSamDebugger.ts
@@ -537,7 +537,8 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         }
 
         const runtimeFamily = getFamily(runtime)
-        const region = this.ctx.awsContext.getCredentialDefaultRegion()
+        // use region in debug config first, if not found, fall back to toolkit default region.
+        const region = config.aws?.region ?? this.ctx.awsContext.getCredentialDefaultRegion()
         const documentUri =
             vscode.window.activeTextEditor?.document.uri ??
             // XXX: don't know what URI to choose...

--- a/packages/core/src/shared/sam/localLambdaRunner.ts
+++ b/packages/core/src/shared/sam/localLambdaRunner.ts
@@ -31,6 +31,7 @@ import { ToolkitError, UnknownError } from '../errors'
 import { SamCliError } from './cli/samCliInvokerUtils'
 import fs from '../fs/fs'
 import { getSpawnEnv } from '../env/resolveEnv'
+import { asEnvironmentVariables } from '../../auth/credentials/utils'
 
 const localize = nls.loadMessageBundle()
 
@@ -287,10 +288,17 @@ export async function runLambdaFunction(
         getLogger().info(localize('AWS.output.sam.local.startRun', 'Preparing to run locally: {0}', config.handlerName))
     }
 
-    const envVars = await getSpawnEnv({
-        ...process.env,
-        ...(config.aws?.region ? { AWS_DEFAULT_REGION: config.aws.region } : {}),
-    })
+    const envVars = await getSpawnEnv(
+        {
+            ...process.env,
+            ...(config.awsCredentials ? asEnvironmentVariables(config.awsCredentials) : {}),
+            ...(config.aws?.region ? { AWS_DEFAULT_REGION: config.aws.region } : {}),
+        },
+        {
+            // only inject toolkit credential if config credential is not set
+            injectCredential: config.awsCredentials ? false : true,
+        }
+    )
 
     const settings = SamCliSettings.instance
     const timer = new Timeout(settings.getLocalInvokeTimeout())

--- a/packages/core/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/packages/core/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -2950,7 +2950,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 templatePath: pathutil.normalize(path.join(actual.baseBuildDir!, 'app___vsctk___template.yaml')),
                 parameterOverrides: undefined,
                 architecture: 'x86_64',
-                // the region in debug config should override default toolkit region
+                // The `aws.region` field in debug config, overrides default toolkit region.
                 region: 'us-weast-9',
 
                 //

--- a/packages/core/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/packages/core/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -2914,6 +2914,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const tempDir = path.dirname(actual.codeRoot)
 
             const expected: SamLaunchRequestArgs = {
+                // the credential in debug config will override default toolkit credential
                 awsCredentials: configCredentials,
                 ...awsSection,
                 type: AWS_SAM_DEBUG_TYPE,
@@ -2949,7 +2950,8 @@ describe('SamDebugConfigurationProvider', async function () {
                 templatePath: pathutil.normalize(path.join(actual.baseBuildDir!, 'app___vsctk___template.yaml')),
                 parameterOverrides: undefined,
                 architecture: 'x86_64',
-                region: 'us-west-2',
+                // the region in debug config should override default toolkit region
+                region: 'us-weast-9',
 
                 //
                 // Node-related fields

--- a/packages/core/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/packages/core/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -2914,7 +2914,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const tempDir = path.dirname(actual.codeRoot)
 
             const expected: SamLaunchRequestArgs = {
-                // the credential in debug config will override default toolkit credential
+                // The `aws.credentials` field in debug config, overrides default toolkit credentials.
                 awsCredentials: configCredentials,
                 ...awsSection,
                 type: AWS_SAM_DEBUG_TYPE,

--- a/packages/toolkit/.changes/next-release/Bug Fix-e5a76bd7-06a7-4a59-aead-8ea3e3924ee9.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-e5a76bd7-06a7-4a59-aead-8ea3e3924ee9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "region in debug config should override default toolkit region"
+}

--- a/packages/toolkit/.changes/next-release/Bug Fix-e5a76bd7-06a7-4a59-aead-8ea3e3924ee9.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-e5a76bd7-06a7-4a59-aead-8ea3e3924ee9.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "region in debug config should override default toolkit region"
+	"description": "SAM local debugging: `aws.region` and `aws.credentials` specified in launch config should override default Toolkit region and credentials"
 }


### PR DESCRIPTION
## Problem
fix #5957 
Appbuilder added `--region` parameter to `sam local invoke`, however this region is always reading region prop from default toolkit connection. Ignoring region set in sam debug config.

## Solution
region and credential set in sam debug config should override region and credential in current active toolkit connection.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
