### PR TITLE
fix(amazonq): file opening behavior on accepted changes

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-fd4826b9-25e6-428e-ba73-c774e79dd2ca.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-fd4826b9-25e6-428e-ba73-c774e79dd2ca.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /dev: update diff window behavior after a change is accepted"
+}

--- a/packages/core/src/amazonq/commons/diff.ts
+++ b/packages/core/src/amazonq/commons/diff.ts
@@ -33,11 +33,3 @@ export function createAmazonQUri(path: string, tabId: string) {
     // TODO change the featureDevScheme to a more general amazon q scheme
     return vscode.Uri.from({ scheme: featureDevScheme, path, query: `tabID=${tabId}` })
 }
-
-export async function openFile(path: string) {
-    if (!(await fs.exists(path))) {
-        return
-    }
-    const fileUri = vscode.Uri.file(path)
-    await vscode.commands.executeCommand('vscode.diff', fileUri, fileUri)
-}

--- a/packages/core/src/amazonq/index.ts
+++ b/packages/core/src/amazonq/index.ts
@@ -27,14 +27,7 @@ export { amazonQHelpUrl } from '../shared/constants'
 export { listCodeWhispererCommandsWalkthrough } from '../codewhisperer/ui/statusBarMenu'
 export { focusAmazonQPanel, focusAmazonQPanelKeybinding } from '../codewhispererChat/commands/registerCommands'
 export { TryChatCodeLensProvider, tryChatCodeLensCommand } from '../codewhispererChat/editor/codelens'
-export {
-    createAmazonQUri,
-    openDiff,
-    openDeletedDiff,
-    getOriginalFileUri,
-    getFileDiffUris,
-    openFile,
-} from './commons/diff'
+export { createAmazonQUri, openDiff, openDeletedDiff, getOriginalFileUri, getFileDiffUris } from './commons/diff'
 export { CodeReference } from '../codewhispererChat/view/connector/connector'
 export { AuthMessageDataMap, AuthFollowUpType } from './auth/model'
 export { extractAuthFollowUp } from './util/authUtils'

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -43,7 +43,7 @@ import { openUrl } from '../../../shared/utilities/vsCodeUtils'
 import { getPathsFromZipFilePath } from '../../util/files'
 import { examples, messageWithConversationId } from '../../userFacingText'
 import { getWorkspaceFoldersByPrefixes } from '../../../shared/utilities/workspaceUtils'
-import { openDeletedDiff, openDiff, openFile } from '../../../amazonq/commons/diff'
+import { openDeletedDiff, openDiff } from '../../../amazonq/commons/diff'
 import { i18n } from '../../../shared/i18n-helper'
 import globals from '../../../shared/extensionGlobals'
 import { randomUUID } from '../../../shared'
@@ -750,7 +750,7 @@ export class FeatureDevController {
                 this.sendAcceptCodeTelemetry(session, 1)
                 await session.insertNewFiles([session.state.filePaths[filePathIndex]])
                 await session.insertCodeReferenceLogs(session.state.references ?? [])
-                await this.openFile(session.state.filePaths[filePathIndex])
+                await this.openFile(session.state.filePaths[filePathIndex], tabId)
             } else {
                 session.state.filePaths[filePathIndex].rejected = !session.state.filePaths[filePathIndex].rejected
             }
@@ -828,9 +828,10 @@ export class FeatureDevController {
         }
     }
 
-    private async openFile(filePath: NewFileInfo) {
-        const absolutePath = path.join(filePath.workspaceFolder.uri.fsPath, filePath.relativePath)
-        await openFile(absolutePath)
+    private async openFile(filePath: NewFileInfo, tabId: string) {
+        const leftPath = path.join(filePath.workspaceFolder.uri.fsPath, filePath.relativePath)
+        const rightPath = filePath.virtualMemoryUri.path
+        await openDiff(leftPath, rightPath, tabId)
     }
 
     private async stopResponse(message: any) {

--- a/packages/core/src/test/amazonq/common/diff.test.ts
+++ b/packages/core/src/test/amazonq/common/diff.test.ts
@@ -12,14 +12,7 @@ import assert from 'assert'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import sinon from 'sinon'
-import {
-    createAmazonQUri,
-    getFileDiffUris,
-    getOriginalFileUri,
-    openDeletedDiff,
-    openDiff,
-    openFile,
-} from '../../../amazonq'
+import { createAmazonQUri, getFileDiffUris, getOriginalFileUri, openDeletedDiff, openDiff } from '../../../amazonq'
 import { FileSystem } from '../../../shared/fs/fs'
 
 describe('diff', () => {
@@ -117,23 +110,6 @@ describe('diff', () => {
 
             const rightExpected = createAmazonQUri(rightPath, tabId)
             assert.deepStrictEqual(right, rightExpected)
-        })
-    })
-
-    describe('openFile', () => {
-        it('file exists locally', async () => {
-            sandbox.stub(FileSystem.prototype, 'exists').resolves(true)
-            await openFile(filePath)
-
-            const expected = vscode.Uri.file(filePath)
-            assert.ok(executeCommandSpy.calledWith('vscode.diff', expected, expected))
-        })
-
-        it('file does not exists locally', async () => {
-            sandbox.stub(FileSystem.prototype, 'exists').resolves(false)
-            await openFile(filePath)
-
-            assert.ok(executeCommandSpy.notCalled)
         })
     })
 })


### PR DESCRIPTION
## Problem
- when you accept an individual code change, it will bring up the file window
- when you update the accepted file, both left and right of the window reflects the changes you made immediately
- it should only show the changes made on the left, while the right stays the same as the original suggested code change

## Solution
- updated the way vscode.diff is called when opening up the file such that it is the actual file on the left, and the suggested code change stays on the right

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
