### PR TITLE
telemetry(auth): report sessionDuration on reauth `aws_loginWithBrowser`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,12 @@
                 "plugins/*"
             ],
             "dependencies": {
-                "@aws-toolkits/telemetry": "^1.0.242",
                 "@types/node": "^22.7.5",
                 "vscode-nls": "^5.2.0",
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.274",
+                "@aws-toolkits/telemetry": "^1.0.282",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@types/he": "^1.2.3",
                 "@types/vscode": "^1.68.0",
@@ -5136,10 +5135,11 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.275",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.275.tgz",
-            "integrity": "sha512-wy8L1xerMwBq+p/fcMkmR5pmPbZ17hG1dPgmThAaKEj6qYJ42pxEWjsCa+VqftA4FtXj4yEtSdja+M0d6Qd4bQ==",
+            "version": "1.0.282",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.282.tgz",
+            "integrity": "sha512-MHktYmucYHvEm4Sscr93UmKr83D9pKJIvETo1bZiNtCsE0jxcNglxZwqZruy13Fks5uk523ZhaIALW22TF0Zpg==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^6.12.6",
                 "fs-extra": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "generateNonCodeFiles": "npm run generateNonCodeFiles -w packages/ --if-present"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.274",
+        "@aws-toolkits/telemetry": "^1.0.282",
         "@playwright/browser-chromium": "^1.43.1",
         "@types/he": "^1.2.3",
         "@types/vscode": "^1.68.0",
@@ -71,7 +71,6 @@
     },
     "dependencies": {
         "@types/node": "^22.7.5",
-        "@aws-toolkits/telemetry": "^1.0.242",
         "vscode-nls": "^5.2.0",
         "vscode-nls-dev": "^4.0.4"
     }

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -397,7 +397,7 @@ async function pollForTokenWithProgress<T extends { requestId?: string }>(
  */
 function getSessionDuration(id: string) {
     const creationDate = globals.globalState.getSsoSessionCreationDate(id)
-    return creationDate !== undefined ? Date.now() - creationDate : undefined
+    return creationDate !== undefined ? globals.clock.Date.now() - creationDate : undefined
 }
 
 /**

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -256,6 +256,7 @@ export abstract class SsoAccessTokenProvider {
                 awsRegion: this.profile.region,
                 ssoRegistrationExpiresAt: args?.registrationExpiresAt,
                 ssoRegistrationClientId: args?.registrationClientId,
+                sessionDuration: getSessionDuration(this.tokenCacheKey),
             })
 
             // Reset source in case there is a case where browser login was called but we forgot to set the source.


### PR DESCRIPTION
Depends on https://github.com/aws/aws-toolkit-common/pull/914

## Problem

On the condition of:

- SSO session is BuilderID or Internal Amazon IdC
- Subsequent login for same SSO session happened earlier than 90 days (the expected session expiration)

We need to know on the client side to be able to report this information so that CloudWatch alarms can consume this. 

## Solution

By adding the existing sessionDuration field, which is `currentTime - whenThePreviousSessionWasCreated`, to `aws_loginWithBrowser` we will have all the information we need to alarm on.


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
