### PR TITLE
test(amazonq): patch #5994 causing CI test failing

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -37,7 +37,6 @@ describe('crossFileContextUtil', function () {
 
     describe('fetchSupplementalContextForSrc', function () {
         beforeEach(async function () {
-            sinon.restore()
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
         })
 
@@ -312,7 +311,6 @@ describe('crossFileContextUtil', function () {
         })
 
         beforeEach(async function () {
-            sinon.restore()
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
         })
 

--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -323,7 +323,7 @@ describe('crossFileContextUtil', function () {
 
         fileExtLists.forEach((fileExt) => {
             it('should be non empty', async function () {
-                sinon.stub(FeatureConfigProvider.instance, 'getProjectContextGroup').alwaysReturned('control')
+                sinon.stub(FeatureConfigProvider.instance, 'getProjectContextGroup').returns('control')
                 const editor = await toTextEditor('content-1', `file-1.${fileExt}`, tempFolder)
                 await toTextEditor('content-2', `file-2.${fileExt}`, tempFolder, { preview: false })
                 await toTextEditor('content-3', `file-3.${fileExt}`, tempFolder, { preview: false })

--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -37,6 +37,7 @@ describe('crossFileContextUtil', function () {
 
     describe('fetchSupplementalContextForSrc', function () {
         beforeEach(async function () {
+            sinon.restore()
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
         })
 

--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -41,8 +41,12 @@ describe('crossFileContextUtil', function () {
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
         })
 
+        afterEach(async function () {
+            sinon.restore()
+        })
+
         it('for control group, should return opentabs context where there will be 3 chunks and each chunk should contains 50 lines', async function () {
-            sinon.stub(FeatureConfigProvider.instance, 'getProjectContextGroup').alwaysReturned('control')
+            sinon.stub(FeatureConfigProvider.instance, 'getProjectContextGroup').returns('control')
             await toTextEditor(aStringWithLineCount(200), 'CrossFile.java', tempFolder, { preview: false })
             const myCurrentEditor = await toTextEditor('', 'TargetFile.java', tempFolder, {
                 preview: false,

--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -308,6 +308,7 @@ describe('crossFileContextUtil', function () {
         })
 
         beforeEach(async function () {
+            sinon.restore()
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
         })
 


### PR DESCRIPTION
## Problem
#5994 is causing CI test failure
misuse of `sinon.alwaysReturned()`

## Solution
should use `sinon.returns()`

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
