### PR TITLE
fix(logger): logs show "%s" instead of replaced value

### DIFF
--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -248,7 +248,7 @@ export class TopicLogger extends BaseLogger implements vscode.Disposable {
         if (typeof message === 'string') {
             message = prependTopic(this.topic, message) as string
         }
-        return this.logger.sendToLog(level, message, meta)
+        return this.logger.sendToLog(level, message, ...meta)
     }
 
     public async dispose(): Promise<void> {}

--- a/packages/core/src/test/testLogger.ts
+++ b/packages/core/src/test/testLogger.ts
@@ -51,7 +51,7 @@ export class TestLogger implements Logger {
             .map((loggedEntry) => loggedEntry.entry)
     }
 
-    public sendToLog(logLevel: LogLevel, msg: string, entries: Loggable[]): number {
+    public sendToLog(logLevel: LogLevel, msg: string, ...entries: Loggable[]): number {
         return this.addLoggedEntries(logLevel, [msg, ...entries])
     }
 


### PR DESCRIPTION
Problem:
Log messages have literal format strings such as "%s", even though values were passed to the log function:

    2024-11-14 11:00:33.778 [info] CloudFormationTemplateRegistry: processed … %s
    2024-11-14 11:00:34.634 [debug] schema service: handle … -> %s

Solution:
Regression introduced by `TopicLogger`. Fix the call.




---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
