### PR TITLE
test(amazonq): fix test failure supplementalContext.test.ts

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/supplemetalContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/supplemetalContextUtil.test.ts
@@ -21,7 +21,7 @@ describe('supplementalContextUtil', function () {
 
     beforeEach(async function () {
         testFolder = await TestFolder.create()
-        sinon.stub(FeatureConfigProvider.instance, 'getProjectContextGroup').alwaysReturned('control')
+        sinon.stub(FeatureConfigProvider.instance, 'getProjectContextGroup').returns('control')
     })
 
     afterEach(function () {
@@ -31,8 +31,6 @@ describe('supplementalContextUtil', function () {
     describe('fetchSupplementalContext', function () {
         describe('openTabsContext', function () {
             it('opentabContext should include chunks if non empty', async function () {
-                sinon.stub(FeatureConfigProvider.instance, 'getProjectContextGroup').alwaysReturned('control')
-
                 await toTextEditor('class Foo', 'Foo.java', testFolder.path, { preview: false })
                 await toTextEditor('class Bar', 'Bar.java', testFolder.path, { preview: false })
                 await toTextEditor('class Baz', 'Baz.java', testFolder.path, { preview: false })
@@ -46,8 +44,6 @@ describe('supplementalContextUtil', function () {
             })
 
             it('opentabsContext should filter out empty chunks', async function () {
-                sinon.stub(FeatureConfigProvider.instance, 'getProjectContextGroup').alwaysReturned('control')
-
                 // open 3 files as supplemental context candidate files but none of them have contents
                 await toTextEditor('', 'Foo.java', testFolder.path, { preview: false })
                 await toTextEditor('', 'Bar.java', testFolder.path, { preview: false })


### PR DESCRIPTION
## Problem
same issue #6019 is trying to fix
misuse of `sinon.alwaysReturned()`

failure
https://github.com/aws/aws-toolkit-vscode/actions/runs/11844970504/job/33009408730
https://github.com/aws/aws-toolkit-vscode/actions/runs/11844970504/job/33009410300

## Solution
`sinon.returns()`

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
