### PR TITLE
fix(amazonq): `@workspace` command shown in all tab types

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-17fd1915-ab2a-4fe8-aa1e-6fc15524b46a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-17fd1915-ab2a-4fe8-aa1e-6fc15524b46a.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q chat: @workspace command shown in all tab types"
+	"description": "Amazon Q chat: `@workspace` command shown in all tab types"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-17fd1915-ab2a-4fe8-aa1e-6fc15524b46a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-17fd1915-ab2a-4fe8-aa1e-6fc15524b46a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "@workspace command shown in all tab types"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-17fd1915-ab2a-4fe8-aa1e-6fc15524b46a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-17fd1915-ab2a-4fe8-aa1e-6fc15524b46a.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "@workspace command shown in all tab types"
+	"description": "Amazon Q chat: @workspace command shown in all tab types"
 }

--- a/packages/core/src/amazonq/webview/ui/tabs/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/constants.ts
@@ -4,11 +4,23 @@
  */
 import { isSQLTransformReady } from '../../../../dev/config'
 import { TabType } from '../storages/tabsStorage'
+import { QuickActionCommandGroup } from '@aws/mynah-ui'
 
 export type TabTypeData = {
     title: string
     placeholder: string
     welcome: string
+    contextCommands?: QuickActionCommandGroup[]
+}
+
+const workspaceCommand: QuickActionCommandGroup = {
+    groupName: 'Mention code',
+    commands: [
+        {
+            command: '@workspace',
+            description: '(BETA) Reference all code in workspace.',
+        },
+    ],
 }
 
 const commonTabData: TabTypeData = {
@@ -17,6 +29,7 @@ const commonTabData: TabTypeData = {
     welcome: `Hi, I'm Amazon Q. I can answer your software development questions.
   Ask me to explain, debug, or optimize your code.
   You can enter \`/\` to see a list of quick actions. Add @workspace to beginning of your message to include your entire workspace as context.`,
+    contextCommands: [workspaceCommand],
 }
 
 export const TabTypeDataMap: Record<TabType, TabTypeData> = {

--- a/packages/core/src/amazonq/webview/ui/tabs/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/generator.ts
@@ -35,17 +35,7 @@ export class TabDataGenerator {
                 'Amazon Q Developer uses generative AI. You may need to verify responses. See the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
             quickActionCommands: this.quickActionsGenerator.generateForTab(tabType),
             promptInputPlaceholder: TabTypeDataMap[tabType].placeholder,
-            contextCommands: [
-                {
-                    groupName: 'Mention code',
-                    commands: [
-                        {
-                            command: '@workspace',
-                            description: '(BETA) Reference all code in workspace.',
-                        },
-                    ],
-                },
-            ],
+            contextCommands: TabTypeDataMap[tabType].contextCommands,
             chatItems: needWelcomeMessages
                 ? [
                       {


### PR DESCRIPTION
## Problem
The `@workspace` [context command](https://github.com/aws/mynah-ui/blob/main/docs/DATAMODEL.md#contextcommands-default-) is being shown in all tab types, even though it is only relevant to Amazon Q chat ('cwc' tabType).

## Solution
Move the context command to the tab specific config file. This change also allows other tab types to specify their own context commands if applicable.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
