### PR TITLE
fix(logger): support module-scope getLogger()

### DIFF
--- a/packages/core/src/shared/fs/watchedFiles.ts
+++ b/packages/core/src/shared/fs/watchedFiles.ts
@@ -220,7 +220,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
                     item: item,
                 }
             } else {
-                getLogger().info(`${this.name}: failed to process: ${uri}`)
+                getLogger().debug(`${this.name}: failed to process: ${uri}`)
                 // if value isn't valid for type, remove from registry
                 this.registryData.delete(pathAsString)
             }
@@ -228,7 +228,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
             if (!quiet) {
                 throw e
             }
-            getLogger().info(`${this.name}: failed to process: ${uri}: ${(e as Error).message}`)
+            getLogger().error(`${this.name}: failed to process: ${uri}: ${(e as Error).message}`)
         }
         return undefined
     }


### PR DESCRIPTION
## Problem
Assigning a `const logger = getLogger()` in module scope, may default to `ConsoleLogger`, because modules may be loaded before logging is initialized.

## Solution
Move the decision into `TopicLogger`, so that the time of the `getLogger()` assignment is irrelevant (just-in-time).




---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
