### PR TITLE
test(amazonq): fix flaky crossfileContextUtil.test

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -38,6 +38,7 @@ describe('crossFileContextUtil', function () {
     describe('fetchSupplementalContextForSrc', function () {
         beforeEach(async function () {
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
+            sinon.restore()
         })
 
         afterEach(async function () {
@@ -50,10 +51,12 @@ describe('crossFileContextUtil', function () {
             const myCurrentEditor = await toTextEditor('', 'TargetFile.java', tempFolder, {
                 preview: false,
             })
+
+            await assertTabCount(2)
+
             const actual = await crossFile.fetchSupplementalContextForSrc(myCurrentEditor, fakeCancellationToken)
             assert.ok(actual)
-            assert.ok(actual.supplementalContextItems.length === 3)
-
+            assert.strictEqual(actual.supplementalContextItems.length, 3)
             assert.strictEqual(actual.supplementalContextItems[0].content.split('\n').length, 50)
             assert.strictEqual(actual.supplementalContextItems[1].content.split('\n').length, 50)
             assert.strictEqual(actual.supplementalContextItems[2].content.split('\n').length, 50)
@@ -64,6 +67,9 @@ describe('crossFileContextUtil', function () {
             const myCurrentEditor = await toTextEditor('', 'TargetFile.java', tempFolder, {
                 preview: false,
             })
+
+            await assertTabCount(2)
+
             sinon.stub(FeatureConfigProvider.instance, 'getProjectContextGroup').returns('t1')
             sinon
                 .stub(LspController.instance, 'queryInlineProjectContext')
@@ -78,7 +84,7 @@ describe('crossFileContextUtil', function () {
 
             const actual = await crossFile.fetchSupplementalContextForSrc(myCurrentEditor, fakeCancellationToken)
             assert.ok(actual)
-            assert.ok(actual.supplementalContextItems.length === 4)
+            assert.strictEqual(actual.supplementalContextItems.length, 4)
             assert.strictEqual(actual?.strategy, 'codemap')
             assert.deepEqual(actual?.supplementalContextItems[0], {
                 content: 'foo',
@@ -96,6 +102,9 @@ describe('crossFileContextUtil', function () {
             const myCurrentEditor = await toTextEditor('', 'TargetFile.java', tempFolder, {
                 preview: false,
             })
+
+            await assertTabCount(2)
+
             sinon.stub(FeatureConfigProvider.instance, 'getProjectContextGroup').returns('t2')
             sinon
                 .stub(LspController.instance, 'queryInlineProjectContext')
@@ -130,7 +139,7 @@ describe('crossFileContextUtil', function () {
 
             const actual = await crossFile.fetchSupplementalContextForSrc(myCurrentEditor, fakeCancellationToken)
             assert.ok(actual)
-            assert.ok(actual.supplementalContextItems.length === 5)
+            assert.strictEqual(actual.supplementalContextItems.length, 5)
             assert.strictEqual(actual?.strategy, 'bm25')
 
             assert.deepEqual(actual?.supplementalContextItems[0], {

--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -38,7 +38,6 @@ describe('crossFileContextUtil', function () {
     describe('fetchSupplementalContextForSrc', function () {
         beforeEach(async function () {
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
-            sinon.restore()
         })
 
         afterEach(async function () {

--- a/packages/amazonq/test/unit/codewhisperer/util/supplemetalContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/supplemetalContextUtil.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import * as crossFile from 'aws-core-vscode/codewhisperer'
-import { TestFolder } from 'aws-core-vscode/test'
+import { TestFolder, assertTabCount } from 'aws-core-vscode/test'
 import { FeatureConfigProvider } from 'aws-core-vscode/codewhisperer'
 import { toTextEditor } from 'aws-core-vscode/test'
 
@@ -39,6 +39,8 @@ describe('supplementalContextUtil', function () {
                     preview: false,
                 })
 
+                await assertTabCount(4)
+
                 const actual = await crossFile.fetchSupplementalContext(editor, fakeCancellationToken)
                 assert.ok(actual?.supplementalContextItems.length === 3)
             })
@@ -52,6 +54,8 @@ describe('supplementalContextUtil', function () {
                 const editor = await toTextEditor('public class Foo {}', 'Query.java', testFolder.path, {
                     preview: false,
                 })
+
+                await assertTabCount(4)
 
                 const actual = await crossFile.fetchSupplementalContext(editor, fakeCancellationToken)
                 assert.ok(actual?.supplementalContextItems.length === 0)


### PR DESCRIPTION
## Problem


## Solution
call `assertTabCount()` to wait until text editors are opened correctly

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
