### PR TITLE
feat(beta): force debug/verbose logging for Beta users

### DIFF
--- a/packages/core/src/dev/beta.ts
+++ b/packages/core/src/dev/beta.ts
@@ -26,7 +26,7 @@ import { getRelativeDate } from '../shared/datetime'
 const localize = nls.loadMessageBundle()
 const logger = getLogger('dev/beta')
 
-const downloadIntervalMs = 1000 * 60 * 60 * 24 // A day in milliseconds
+const downloadIntervalMs = 1000 * 60 * 60 * 3 // 3 hours (8 times/day).
 
 interface BetaToolkit {
     readonly needUpdate: boolean

--- a/packages/core/src/dev/beta.ts
+++ b/packages/core/src/dev/beta.ts
@@ -19,7 +19,7 @@ import { telemetry } from '../shared/telemetry/telemetry'
 import { cast } from '../shared/utilities/typeConstructors'
 import { CancellationError } from '../shared/utilities/timeoutUtils'
 import { isAmazonQ, isCloud9, productName } from '../shared/extensionUtilities'
-import * as config from './config'
+import * as devConfig from './config'
 import { isReleaseVersion } from '../shared/vscode/env'
 import { getRelativeDate } from '../shared/datetime'
 
@@ -48,7 +48,7 @@ async function updateBetaToolkitData(vsixUrl: string, data: BetaToolkit) {
  * Set up "beta" update monitoring.
  */
 export async function activate(ctx: vscode.ExtensionContext) {
-    const betaUrl = isAmazonQ() ? config.betaUrl.amazonq : config.betaUrl.toolkit
+    const betaUrl = isAmazonQ() ? devConfig.betaUrl.amazonq : devConfig.betaUrl.toolkit
     if (!isCloud9() && !isReleaseVersion() && betaUrl) {
         ctx.subscriptions.push(watchBetaVSIX(betaUrl))
     }

--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -13,6 +13,7 @@ import { resolvePath } from '../utilities/pathUtils'
 import fs from '../../shared/fs/fs'
 import { isWeb } from '../extensionGlobals'
 import { getUserAgent } from '../telemetry/util'
+import { isBeta } from '../vscode/env'
 
 /**
  * Activate Logger functionality for the extension.
@@ -80,7 +81,7 @@ export function makeLogger(opts: {
     outputChannels?: vscode.OutputChannel[]
     useConsoleLog?: boolean
 }): Logger {
-    const logger = new ToolkitLogger(opts.logLevel)
+    const logger = new ToolkitLogger(opts.logLevel, isBeta())
     if (opts.logFile) {
         logger.logToFile(opts.logFile)
         logger.logFile = opts.logFile

--- a/packages/core/src/shared/logger/toolkitLogger.ts
+++ b/packages/core/src/shared/logger/toolkitLogger.ts
@@ -24,7 +24,10 @@ export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
     private idCounter: number = 0
     private logMap: { [logID: number]: { [filePath: string]: string } } = {}
 
-    public constructor(logLevel: LogLevel) {
+    public constructor(
+        logLevel: LogLevel,
+        private readonly isBeta: boolean = false
+    ) {
         super()
         this.logger = winston.createLogger({
             format: winston.format.combine(
@@ -120,6 +123,9 @@ export class ToolkitLogger extends BaseLogger implements vscode.Disposable {
     }
 
     override sendToLog(level: LogLevel, message: string | Error, ...meta: any[]): number {
+        // XXX: force debug/verbose logs for Beta users.
+        level = this.isBeta && compareLogLevel(level, 'info') > 0 ? 'info' : level
+
         if (this.disposed) {
             throw new Error('Cannot write to disposed logger')
         }

--- a/packages/core/src/shared/vscode/env.ts
+++ b/packages/core/src/shared/vscode/env.ts
@@ -11,6 +11,7 @@ import { getLogger } from '../logger'
 import { onceChanged } from '../utilities/functionUtils'
 import { ChildProcess } from '../utilities/processUtils'
 import globals, { isWeb } from '../extensionGlobals'
+import * as devConfig from '../../dev/config'
 
 /**
  * Returns true if the current build is running on CI (build server).
@@ -31,10 +32,29 @@ try {
 
 /**
  * Returns true if the current build is a production build (as opposed to a
- * prerelease/test/nightly build)
+ * prerelease/test/nightly build).
+ *
+ * Note: `isBeta()` is treated separately.
  */
 export function isReleaseVersion(prereleaseOk: boolean = false): boolean {
     return (prereleaseOk || !semver.prerelease(extensionVersion)) && extensionVersion !== testVersion
+}
+
+/**
+ * Returns true if the current build is a "beta" build.
+ */
+export function isBeta(): boolean {
+    const testing = extensionVersion === testVersion
+    for (const url of Object.values(devConfig.betaUrl)) {
+        if (url && url.length > 0) {
+            if (!testing && semver.lt(extensionVersion, '99.0.0')) {
+                throw Error('beta build must set version=99.0.0 in package.json')
+            }
+
+            return true
+        }
+    }
+    return false
 }
 
 /**


### PR DESCRIPTION
## Problem
Beta and bug-bash users often need logs.

## Solution
Log debug/verbose messages at "info" log-level. They will appear as "info" logs in the Output channel, even though they were logged at "debug" or "verbose" level.

## Related

https://github.com/aws/aws-toolkit-vscode-staging/pull/1961 confirms CI behavior in a beta branch.





---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
