### PR TITLE
feat(amazonq): Using AB variation value as customization name when overridden

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-7ffbdb5d-40c5-4c3e-bc20-63d731bc51d2.json
+++ b/packages/amazonq/.changes/next-release/Feature-7ffbdb5d-40c5-4c3e-bc20-63d731bc51d2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Retrieve and display a customization name when a customization is overridden in an AB test"
+}

--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -18,7 +18,7 @@ import { showMessageWithUrl } from '../../shared/utilities/messages'
 import { parse } from '@aws-sdk/util-arn-parser'
 import { Commands } from '../../shared/vscode/commands2'
 import { vsCodeState } from '../models/model'
-import { FeatureConfigProvider } from '../../shared/featureConfig'
+import { FeatureConfigProvider, Features } from '../../shared/featureConfig'
 
 /**
  *
@@ -108,7 +108,9 @@ export const getSelectedCustomization = (): Customization => {
     const result = selectedCustomizationArr[AuthUtil.instance.conn.label] || baseCustomization
 
     // A/B case
-    const arnOverride = FeatureConfigProvider.instance.getCustomizationArnOverride()
+    const customizationFeature = FeatureConfigProvider.getFeature(Features.customizationArnOverride)
+    const arnOverride = customizationFeature?.value.stringValue
+    const customizationOverrideName = customizationFeature?.variation
     if (arnOverride === undefined || arnOverride === '') {
         return result
     } else {
@@ -116,7 +118,7 @@ export const getSelectedCustomization = (): Customization => {
         // but still shows customization info of user's currently selected.
         return {
             arn: arnOverride,
-            name: result.name,
+            name: customizationOverrideName,
             description: result.description,
         }
     }

--- a/packages/core/src/shared/featureConfig.ts
+++ b/packages/core/src/shared/featureConfig.ts
@@ -9,6 +9,7 @@ import {
     ListFeatureEvaluationsRequest,
     ListFeatureEvaluationsResponse,
 } from '../codewhisperer/client/codewhispereruserclient'
+import * as vscode from 'vscode'
 import { codeWhispererClient as client } from '../codewhisperer/client/codewhisperer'
 import { AuthUtil } from '../codewhisperer/util/authUtil'
 import { getLogger } from './logger'
@@ -152,6 +153,8 @@ export class FeatureConfigProvider {
                         )
                         this.featureConfigs.delete(Features.customizationArnOverride)
                     }
+
+                    await vscode.commands.executeCommand('aws.amazonq.refreshStatusBar')
                 }
             }
             if (Auth.instance.isInternalAmazonUser()) {

--- a/packages/core/src/test/fake/mockFeatureConfigData.ts
+++ b/packages/core/src/test/fake/mockFeatureConfigData.ts
@@ -21,4 +21,9 @@ export const mockFeatureConfigsData: FeatureEvaluation[] = [
         variation: 'TREATMENT',
         value: { stringValue: 'testValue' },
     },
+    {
+        feature: 'customizationArnOverride',
+        variation: 'customizationName',
+        value: { stringValue: 'customizationARN' },
+    },
 ]

--- a/packages/core/src/test/shared/featureConfig.test.ts
+++ b/packages/core/src/test/shared/featureConfig.test.ts
@@ -48,7 +48,7 @@ describe('FeatureConfigProvider', () => {
     it('test getFeatureConfigsTelemetry will return expected string', async () => {
         assert.strictEqual(
             FeatureConfigProvider.instance.getFeatureConfigsTelemetry(),
-            `{testFeature: TREATMENT, featureA: CONTROL, featureB: TREATMENT}`
+            `{testFeature: TREATMENT, featureA: CONTROL, featureB: TREATMENT, customizationArnOverride: customizationName}`
         )
     })
 
@@ -77,6 +77,13 @@ describe('FeatureConfigProvider', () => {
                     },
                     variation: 'TREATMENT',
                 },
+                customizationArnOverride: {
+                    name: 'customizationArnOverride',
+                    value: {
+                        stringValue: 'customizationARN',
+                    },
+                    variation: 'customizationName',
+                },
             }
 
             assert.deepStrictEqual(Object.fromEntries(featureConfigs), expectedFeatureConfigs)
@@ -93,6 +100,17 @@ describe('FeatureConfigProvider', () => {
 
     it('should test feature-does-not-exist as disabled', async () => {
         assert.strictEqual(FeatureConfigProvider.isEnabled('feature-does-not-exist' as FeatureName), false)
+    })
+
+    it('should retrieve customization override values', async () => {
+        assert.strictEqual(
+            FeatureConfigProvider.getFeature(Features.customizationArnOverride)?.value.stringValue,
+            'customizationARN'
+        )
+        assert.strictEqual(
+            FeatureConfigProvider.getFeature(Features.customizationArnOverride)?.variation,
+            'customizationName'
+        )
     })
 
     describe('getProjectContextGroup', function () {


### PR DESCRIPTION
## Problem

When a customization is overridden via AB, the name of the customization is not shown to users

## Solution

Uses the variation field from the customizationArnOverride feature as the name for the customization. This allows the UX to show a customization name when the customizationArn is overriden

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
