### PR TITLE
fix(amazonq): fixed bug with high CPU use event loop for security scan findings

### DIFF
--- a/packages/core/src/codewhisperer/views/securityIssue/securityIssueWebview.ts
+++ b/packages/core/src/codewhisperer/views/securityIssue/securityIssueWebview.ts
@@ -74,7 +74,8 @@ const Panel = VueWebview.compilePanel(SecurityIssueWebview)
 let activePanel: InstanceType<typeof Panel> | undefined
 
 export async function showSecurityIssueWebview(ctx: vscode.ExtensionContext, issue: CodeScanIssue, filePath: string) {
-    activePanel ??= new Panel(ctx)
+    // always create a new panel per finding
+    activePanel = new Panel(ctx)
     activePanel.server.setIssue(issue)
     activePanel.server.setFilePath(filePath)
 

--- a/packages/core/src/codewhisperer/views/securityIssue/vue/root.vue
+++ b/packages/core/src/codewhisperer/views/securityIssue/vue/root.vue
@@ -129,9 +129,6 @@ export default defineComponent({
     created() {
         this.getData()
     },
-    updated() {
-        this.getData()
-    },
     methods: {
         async getData() {
             const issue = await client.getIssue()


### PR DESCRIPTION

## Problem

Opening the security scan issues webview led to an infinite loop on the `update` call, consuming significant amounts of customer CPU.

## Solution

Updated the webview to not auto-update, and made it so that each "view" command opened a new window, even if already present.

This isn't fully ideal, but it at least immediately fixes the CPU consumption issue.  Any setup to watch/poll for updates from the server would be either expensive or latent.  This will be the most clean, but may lead to a different UX than expected.

---

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
