### PR TITLE
build(test): undo automatic retries.

### DIFF
--- a/packages/core/src/test/testRunner.ts
+++ b/packages/core/src/test/testRunner.ts
@@ -22,7 +22,7 @@ export async function runTests(
     testFolder: string | string[],
     extensionId: string,
     initTests: string[] = [],
-    options?: { retries?: number; testFiles?: string[] }
+    options?: { testFiles?: string[] }
 ): Promise<void> {
     if (!process.env['AWS_TOOLKIT_AUTOMATION']) {
         throw new Error('Expected the "AWS_TOOLKIT_AUTOMATION" environment variable to be set for tests.')
@@ -79,7 +79,6 @@ export async function runTests(
                 mochaFile: outputFile,
             },
         },
-        retries: options?.retries ?? 0,
         timeout: 0,
     })
 

--- a/packages/toolkit/test/unit/index.ts
+++ b/packages/toolkit/test/unit/index.ts
@@ -7,10 +7,7 @@ import { runTests } from 'aws-core-vscode/test'
 import { VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
 
 export function run(): Promise<void> {
-    return runTests(
-        process.env.TEST_DIR ?? ['test/unit', '../../core/dist/src/test'],
-        VSCODE_EXTENSION_ID.awstoolkit,
-        ['../../core/dist/src/test/globalSetup.test.ts'],
-        { retries: 3 }
-    )
+    return runTests(process.env.TEST_DIR ?? ['test/unit', '../../core/dist/src/test'], VSCODE_EXTENSION_ID.awstoolkit, [
+        '../../core/dist/src/test/globalSetup.test.ts',
+    ])
 }


### PR DESCRIPTION
## Problem
Some tests appear to be hanging indefinitely with the new retry system. Example: https://github.com/aws/aws-toolkit-vscode/actions/runs/11899590502/job/33158551534?pr=6037

## Solution
Rollback changes until proper solution is found. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
