### PR TITLE
feat(cwl): Emit telemetry when starting and stopping liveTail sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.282",
+                "@aws-toolkits/telemetry": "^1.0.284",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@types/he": "^1.2.3",
                 "@types/vscode": "^1.68.0",
@@ -6046,9 +6046,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.282",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.282.tgz",
-            "integrity": "sha512-MHktYmucYHvEm4Sscr93UmKr83D9pKJIvETo1bZiNtCsE0jxcNglxZwqZruy13Fks5uk523ZhaIALW22TF0Zpg==",
+            "version": "1.0.284",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.284.tgz",
+            "integrity": "sha512-+3uHmr4St2cw8yuvVZOUY4Recv0wmzendGODCeUPIIUjsjCANF3H7G/qzIKRN3BHCoedcvzA/eSI+l4ENRXtiA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "generateNonCodeFiles": "npm run generateNonCodeFiles -w packages/ --if-present"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.282",
+        "@aws-toolkits/telemetry": "^1.0.284",
         "@playwright/browser-chromium": "^1.43.1",
         "@types/he": "^1.2.3",
         "@types/vscode": "^1.68.0",

--- a/packages/core/src/awsService/cloudWatchLogs/activation.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/activation.ts
@@ -120,11 +120,12 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
                 node instanceof LogGroupNode
                     ? { regionName: node.regionCode, groupName: node.logGroup.logGroupName! }
                     : undefined
-            await tailLogGroup(liveTailRegistry, logGroupInfo)
+            const source = node ? (logGroupInfo ? 'ExplorerLogGroupNode' : 'ExplorerServiceNode') : 'Command'
+            await tailLogGroup(liveTailRegistry, source, logGroupInfo)
         }),
 
-        Commands.register('aws.cwl.stopTailingLogGroup', async (document: vscode.TextDocument) => {
-            closeSession(document.uri, liveTailRegistry)
+        Commands.register('aws.cwl.stopTailingLogGroup', async (document: vscode.TextDocument, source: string) => {
+            closeSession(document.uri, liveTailRegistry, source)
         }),
 
         Commands.register('aws.cwl.clearDocument', async (document: vscode.TextDocument) => {

--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -43,17 +43,12 @@ export async function tailLogGroup(
         if (registry.has(uriToKey(session.uri))) {
             await prepareDocument(session)
             span.record({
+                result: 'Succeeded',
                 sessionAlreadyStarted: true,
                 source: source,
             })
             return
         }
-        span.record({
-            source: source,
-            sessionAlreadyStarted: false,
-            hasLogEventFilterPattern: Boolean(wizardResponse.filterPattern),
-            logStreamFilterType: wizardResponse.logStreamFilter.type,
-        })
 
         registry.set(uriToKey(session.uri), session)
 
@@ -63,7 +58,13 @@ export async function tailLogGroup(
         registerTabChangeCallback(session, registry, document)
 
         const stream = await session.startLiveTailSession()
-
+        span.record({
+            source: source,
+            result: 'Succeeded',
+            sessionAlreadyStarted: false,
+            hasLogEventFilterPattern: Boolean(wizardResponse.filterPattern),
+            logStreamFilterType: wizardResponse.logStreamFilter.type,
+        })
         await handleSessionStream(stream, document, session)
     })
 }
@@ -77,6 +78,7 @@ export function closeSession(sessionUri: vscode.Uri, registry: LiveTailSessionRe
         session.stopLiveTailSession()
         registry.delete(uriToKey(sessionUri))
         span.record({
+            result: 'Succeeded',
             source: source,
             duration: session.getLiveTailSessionDuration(),
         })

--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -43,16 +43,16 @@ export async function tailLogGroup(
         if (registry.has(uriToKey(session.uri))) {
             await prepareDocument(session)
             span.record({
-                livetailSessionAlreadyStarted: true,
+                sessionAlreadyStarted: true,
                 source: source,
             })
             return
         }
         span.record({
             source: source,
-            livetailSessionAlreadyStarted: false,
-            livetailHasLogEventFilterPattern: Boolean(wizardResponse.filterPattern),
-            livetailLogStreamFilterType: wizardResponse.logStreamFilter.type,
+            sessionAlreadyStarted: false,
+            hasLogEventFilterPattern: Boolean(wizardResponse.filterPattern),
+            logStreamFilterType: wizardResponse.logStreamFilter.type,
         })
 
         registry.set(uriToKey(session.uri), session)

--- a/packages/core/src/awsService/cloudWatchLogs/document/liveTailCodeLensProvider.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/document/liveTailCodeLensProvider.ts
@@ -38,7 +38,7 @@ export class LiveTailCodeLensProvider implements vscode.CodeLensProvider {
         const command: vscode.Command = {
             title: 'Stop tailing',
             command: 'aws.cwl.stopTailingLogGroup',
-            arguments: [document],
+            arguments: [document, 'codeLens'],
         }
         return new vscode.CodeLens(range, command)
     }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -350,6 +350,21 @@
             "name": "amazonqMessageDisplayedMs",
             "type": "int",
             "description": "Duration between the partner teams code receiving the message and when the message was finally displayed in ms"
+        },
+        {
+            "name": "livetailSessionAlreadyStarted",
+            "type": "boolean",
+            "description": "Session already open"
+        },
+        {
+            "name": "livetailHasLogEventFilterPattern",
+            "type": "boolean",
+            "description": "If LogEvent filter pattern is applied"
+        },
+        {
+            "name": "livetailLogStreamFilterType",
+            "type": "string",
+            "description": "Type of LogStream filter applied to session"
         }
     ],
     "metrics": [
@@ -1230,6 +1245,42 @@
                 }
             ],
             "passive": true
+        },
+        {
+            "name": "cwlLiveTail_Start",
+            "description": "When user starts a new LiveTail command",
+            "metadata": [
+                {
+                    "type": "source",
+                    "required": true
+                },
+                {
+                    "type": "livetailSessionAlreadyStarted",
+                    "required": true
+                },
+                {
+                    "type": "livetailHasLogEventFilterPattern",
+                    "required": false
+                },
+                {
+                    "type": "livetailLogStreamFilterType",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "cwlLiveTail_Stop",
+            "description": "When user stops a liveTailSession",
+            "metadata": [
+                {
+                    "type": "source",
+                    "required": true
+                },
+                {
+                    "type": "duration",
+                    "required": true
+                }
+            ]
         }
     ]
 }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -350,21 +350,6 @@
             "name": "amazonqMessageDisplayedMs",
             "type": "int",
             "description": "Duration between the partner teams code receiving the message and when the message was finally displayed in ms"
-        },
-        {
-            "name": "sessionAlreadyStarted",
-            "type": "boolean",
-            "description": "Session already open"
-        },
-        {
-            "name": "hasLogEventFilterPattern",
-            "type": "boolean",
-            "description": "If LogEvent filter pattern is applied"
-        },
-        {
-            "name": "logStreamFilterType",
-            "type": "string",
-            "description": "Type of LogStream filter applied to session"
         }
     ],
     "metrics": [
@@ -1245,42 +1230,6 @@
                 }
             ],
             "passive": true
-        },
-        {
-            "name": "cwlLiveTail_Start",
-            "description": "When user starts a new LiveTail command",
-            "metadata": [
-                {
-                    "type": "source",
-                    "required": true
-                },
-                {
-                    "type": "sessionAlreadyStarted",
-                    "required": true
-                },
-                {
-                    "type": "hasLogEventFilterPattern",
-                    "required": false
-                },
-                {
-                    "type": "logStreamFilterType",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "cwlLiveTail_Stop",
-            "description": "When user stops a liveTailSession",
-            "metadata": [
-                {
-                    "type": "source",
-                    "required": true
-                },
-                {
-                    "type": "duration",
-                    "required": true
-                }
-            ]
         }
     ]
 }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -352,17 +352,17 @@
             "description": "Duration between the partner teams code receiving the message and when the message was finally displayed in ms"
         },
         {
-            "name": "livetailSessionAlreadyStarted",
+            "name": "sessionAlreadyStarted",
             "type": "boolean",
             "description": "Session already open"
         },
         {
-            "name": "livetailHasLogEventFilterPattern",
+            "name": "hasLogEventFilterPattern",
             "type": "boolean",
             "description": "If LogEvent filter pattern is applied"
         },
         {
-            "name": "livetailLogStreamFilterType",
+            "name": "logStreamFilterType",
             "type": "string",
             "description": "Type of LogStream filter applied to session"
         }
@@ -1255,15 +1255,15 @@
                     "required": true
                 },
                 {
-                    "type": "livetailSessionAlreadyStarted",
+                    "type": "sessionAlreadyStarted",
                     "required": true
                 },
                 {
-                    "type": "livetailHasLogEventFilterPattern",
+                    "type": "hasLogEventFilterPattern",
                     "required": false
                 },
                 {
-                    "type": "livetailLogStreamFilterType",
+                    "type": "logStreamFilterType",
                     "required": false
                 }
             ]

--- a/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
@@ -27,6 +27,7 @@ describe('TailLogGroup', function () {
     const testRegion = 'test-region'
     const testMessage = 'test-message'
     const testAwsAccountId = '1234'
+    const testSource = 'test-source'
     const testAwsCredentials = {} as any as AWS.Credentials
 
     let sandbox: sinon.SinonSandbox
@@ -93,7 +94,7 @@ describe('TailLogGroup', function () {
         cloudwatchSettingsSpy = sandbox.stub(CloudWatchLogsSettings.prototype, 'get').callsFake(() => {
             return 1
         })
-        await tailLogGroup(registry, {
+        await tailLogGroup(registry, testSource, {
             groupName: testLogGroup,
             regionName: testRegion,
         })
@@ -131,7 +132,7 @@ describe('TailLogGroup', function () {
             return getTestWizardResponse()
         })
         await assert.rejects(async () => {
-            await tailLogGroup(registry, {
+            await tailLogGroup(registry, testSource, {
                 groupName: testLogGroup,
                 regionName: testRegion,
             })
@@ -152,7 +153,7 @@ describe('TailLogGroup', function () {
         })
         registry.set(uriToKey(session.uri), session)
 
-        closeSession(session.uri, registry)
+        closeSession(session.uri, registry, testSource)
         assert.strictEqual(0, registry.size)
         assert.strictEqual(true, stopLiveTailSessionSpy.calledOnce)
         assert.strictEqual(0, clock.countTimers())


### PR DESCRIPTION
## Problem
Cloudwatch wants to monitor usage metrics of the LiveTail integration

## Solution
When starting a session emit telemetry for: 
* Session already started (this case happens when session is already running, and customer sends a new command that matches the already running session)
* Has LogEventFilter
* LogStream filter type
* Source of the command (command palette, explorer)

When closing a session: 
* Session duration
* source of cancellation (ex: CodeLens, ClosingEditors)

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
