### PR TITLE
fix(notifications): extension activation hangs if fetch fails

### DIFF
--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -75,7 +75,7 @@ async function activateAmazonQNode(context: vscode.ExtensionContext) {
         ...authState,
     })
 
-    await activateNotifications(context, authState, getAuthState)
+    void activateNotifications(context, authState, getAuthState)
 }
 
 async function getAuthState(): Promise<Omit<AuthUserState, 'source'>> {

--- a/packages/core/src/extensionNode.ts
+++ b/packages/core/src/extensionNode.ts
@@ -246,7 +246,7 @@ export async function activate(context: vscode.ExtensionContext) {
             ...authState,
         })
 
-        await activateNotifications(context, authState, getAuthState)
+        void activateNotifications(context, authState, getAuthState)
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')
         // truncate if the stacktrace is unusually long

--- a/packages/core/src/test/notifications/controller.test.ts
+++ b/packages/core/src/test/notifications/controller.test.ts
@@ -160,7 +160,7 @@ describe('Notifications Controller', function () {
                 payload: content,
                 eTag,
             },
-            dismissed: [content.notifications[0].id],
+            dismissed: [],
             newlyReceived: ['id:emergency2'],
         })
         assert.equal(panelNode.startUpNotifications.length, 0)
@@ -218,7 +218,7 @@ describe('Notifications Controller', function () {
                 payload: emergencyContent,
                 eTag: eTag2,
             },
-            dismissed: [emergencyContent.notifications[0].id],
+            dismissed: [],
             newlyReceived: ['id:startup2', 'id:emergency2'],
         })
         assert.equal(panelNode.startUpNotifications.length, 1)
@@ -415,7 +415,7 @@ describe('Notifications Controller', function () {
                 payload: emergencyContent,
                 eTag: '1',
             },
-            dismissed: [emergencyContent.notifications[0].id, startUpContent.notifications[0].id],
+            dismissed: [startUpContent.notifications[0].id],
             newlyReceived: [],
         })
 
@@ -438,7 +438,7 @@ describe('Notifications Controller', function () {
                 payload: emergencyContent,
                 eTag: '1',
             },
-            dismissed: [emergencyContent.notifications[0].id],
+            dismissed: [],
             newlyReceived: [],
         })
         assert.equal(panelNode.getChildren().length, 1)


### PR DESCRIPTION
## Problem
 If notifications fail to fetch, it will retry multiple times with 30 second waits. Activation is awaiting on this though, so it may take forever to finish.

## Solution
don't await on notification activation


Also, update logging statements.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
