### PR TITLE
fix(amazonq): do not overwrite failure reason, use lowercase lang name

### DIFF
--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -718,8 +718,12 @@ export async function finalizeTransformationJob(status: string) {
     if (!(status === 'COMPLETED' || status === 'PARTIALLY_COMPLETED')) {
         getLogger().error(`CodeTransformation: ${CodeWhispererConstants.failedToCompleteJobNotification}`)
         jobPlanProgress['transformCode'] = StepProgress.Failed
-        transformByQState.setJobFailureErrorNotification(CodeWhispererConstants.failedToCompleteJobNotification)
-        transformByQState.setJobFailureErrorChatMessage(CodeWhispererConstants.failedToCompleteJobChatMessage)
+        if (!transformByQState.getJobFailureErrorNotification()) {
+            transformByQState.setJobFailureErrorNotification(CodeWhispererConstants.failedToCompleteJobNotification)
+        }
+        if (!transformByQState.getJobFailureErrorChatMessage()) {
+            transformByQState.setJobFailureErrorChatMessage(CodeWhispererConstants.failedToCompleteJobChatMessage)
+        }
         throw new Error('Job was not successful nor partially successful')
     }
     transformByQState.setToSucceeded()

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -423,8 +423,8 @@ export class ProposedTransformationExplorer {
                             programmingLanguage: {
                                 languageName:
                                     transformByQState.getTransformationType() === TransformationType.LANGUAGE_UPGRADE
-                                        ? 'JAVA'
-                                        : 'SQL',
+                                        ? 'java'
+                                        : 'sql',
                             },
                             linesOfCodeChanged: metricsData.linesOfCodeChanged,
                             charsOfCodeChanged: metricsData.charactersOfCodeChanged,


### PR DESCRIPTION
## Problem

Our backend is expecting the language name (`java` or `sql`) to be lowercase, not uppercase. Also, the failure reason returned by one of our APIs was being overwritten and not shown to users.


## Solution

User lowercase, and prevent overwriting.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
