### PR TITLE
fix(amazonq): skip indexing when no workspace folders are found

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-54e46358-d60f-492b-af5c-b23f4aa2b1b8.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-54e46358-d60f-492b-af5c-b23f4aa2b1b8.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "amazon q inline: skip indexing when no workspace folders are found"
+}

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -23,14 +23,6 @@ import { isWeb } from '../../shared/extensionGlobals'
 import { getUserAgent } from '../../shared/telemetry/util'
 import { isAmazonInternalOs } from '../../shared/vscode/env'
 
-function getProjectPaths() {
-    const workspaceFolders = vscode.workspace.workspaceFolders
-    if (!workspaceFolders || workspaceFolders.length === 0) {
-        throw new ToolkitError('No workspace folders found')
-    }
-    return workspaceFolders.map((folder) => folder.uri.fsPath)
-}
-
 export interface Chunk {
     readonly filePath: string
     readonly content: string
@@ -322,12 +314,13 @@ export class LspController {
     async buildIndex(buildIndexConfig: BuildIndexConfig) {
         getLogger().info(`LspController: Starting to build index of project`)
         const start = performance.now()
-        const projPaths = getProjectPaths()
+        const projPaths = (vscode.workspace.workspaceFolders ?? []).map((folder) => folder.uri.fsPath)
+        if (projPaths.length === 0) {
+            getLogger().info(`LspController: Skipping building index. No projects found in workspace`)
+            return
+        }
         projPaths.sort()
         try {
-            if (projPaths.length === 0) {
-                throw Error('No project')
-            }
             this._isIndexingInProgress = true
             const projRoot = projPaths[0]
             const files = await collectFilesForIndex(
@@ -340,7 +333,7 @@ export class LspController {
                 (accumulator, currentFile) => accumulator + currentFile.fileSizeBytes,
                 0
             )
-            getLogger().info(`LspController: Found ${files.length} files in current project ${getProjectPaths()}`)
+            getLogger().info(`LspController: Found ${files.length} files in current project ${projPaths}`)
             const config = buildIndexConfig.isVectorIndexEnabled ? 'all' : 'default'
             const r = files.map((f) => f.fileUri.fsPath)
             const resp = await LspClient.instance.buildIndex(r, projRoot, config)


### PR DESCRIPTION
## Problem
If customers open a workspace without a workspace folder they get:
```
2024-11-19 10:49:16.189 [error] Error: No workspace folders found
	at k (/Users/myuser/.vscode/extensions/amazonwebservices.amazon-q-vscode-99.0.0-g3afd54d/dist/src/extensionNode.js:5464:5562)
	at L.buildIndex (/Users/myuser/.vscode/extensions/amazonwebservices.amazon-q-vscode-99.0.0-g3afd54d/dist/src/extensionNode.js:5464:9890)
	at Immediate.<anonymous> (/Users/myuser/.vscode/extensions/amazonwebservices.amazon-q-vscode-99.0.0-g3afd54d/dist/src/extensionNode.js:5464:11854)
```

because workspace indexing is throwing an error

## Solution
Log that no workspace folders were found so indexing is skipped

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
