### PR TITLE
deps(amazonq): Update mynah-ui to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,11 +5171,10 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.18.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.18.0.tgz",
-            "integrity": "sha512-oa26D9QtGxw9kZnDBq7OrVEPdBvmwK+MjlTIjW8L/TnlDTIYL3SBhU87iQCwkCRxWXckrjiSvW6Rexc2oasgvw==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.18.1.tgz",
+            "integrity": "sha512-531FL5509O081eWIk0P0reQhGTm/ZaXhRu6FLNqMvAKySPtJyyxee0ieeGAR8h5CVI75learQbXJEGJC6XibAA==",
             "hasInstallScript": true,
-            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
@@ -20033,7 +20032,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.18.0",
+                "@aws/mynah-ui": "^4.18.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-289bb195-ba14-4725-9e29-70b514f42df3.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-289bb195-ba14-4725-9e29-70b514f42df3.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Chat container exceeds width of container"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-5883c245-fb4d-4441-8361-38dc21146be5.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-5883c245-fb4d-4441-8361-38dc21146be5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "file details and name unneccessary cropping"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -469,7 +469,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.18.0",
+        "@aws/mynah-ui": "^4.18.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
- Partner teams need the newer version of mynah UI that solves a couple ux problems:
```
- File details and name unnecessary crop
- Chat container exceeds width of panel
```

## Solution
- Update mynah ui

Release notes: https://github.com/aws/mynah-ui/releases/tag/v4.18.1

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
