### PR TITLE
fix(cwl): Hide LiveTail CodeLenses and display info message when closing session

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/activation.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/activation.ts
@@ -34,7 +34,7 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
 
     const documentProvider = new LogDataDocumentProvider(registry)
     const liveTailDocumentProvider = new LiveTailDocumentProvider()
-
+    const liveTailCodeLensProvider = new LiveTailCodeLensProvider(liveTailRegistry)
     context.subscriptions.push(
         vscode.languages.registerCodeLensProvider(
             {
@@ -55,7 +55,7 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
                 language: 'log',
                 scheme: cloudwatchLogsLiveTailScheme,
             },
-            new LiveTailCodeLensProvider()
+            liveTailCodeLensProvider
         )
     )
 
@@ -121,11 +121,11 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
                     ? { regionName: node.regionCode, groupName: node.logGroup.logGroupName! }
                     : undefined
             const source = node ? (logGroupInfo ? 'ExplorerLogGroupNode' : 'ExplorerServiceNode') : 'Command'
-            await tailLogGroup(liveTailRegistry, source, logGroupInfo)
+            await tailLogGroup(liveTailRegistry, source, liveTailCodeLensProvider, logGroupInfo)
         }),
 
         Commands.register('aws.cwl.stopTailingLogGroup', async (document: vscode.TextDocument, source: string) => {
-            closeSession(document.uri, liveTailRegistry, source)
+            closeSession(document.uri, liveTailRegistry, source, liveTailCodeLensProvider)
         }),
 
         Commands.register('aws.cwl.clearDocument', async (document: vscode.TextDocument) => {

--- a/packages/core/src/awsService/cloudWatchLogs/document/liveTailCodeLensProvider.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/document/liveTailCodeLensProvider.ts
@@ -19,7 +19,7 @@ export class LiveTailCodeLensProvider implements vscode.CodeLensProvider {
         token: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.CodeLens[]> {
         const uri = document.uri
-        //if registry does not contain session, it is assumed to have already been stopped -> hide lenses.
+        //if registry does not contain session, it is assumed to have been stopped, thus, hide lenses.
         if (uri.scheme !== cloudwatchLogsLiveTailScheme || !this.registry.has(uriToKey(uri))) {
             return []
         }

--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
@@ -10,8 +10,8 @@ import {
     StartLiveTailResponseStream,
 } from '@aws-sdk/client-cloudwatch-logs'
 import { LogStreamFilterResponse } from '../wizard/liveTailLogStreamSubmenu'
-import { CloudWatchLogsSettings, uriToKey } from '../cloudWatchLogsUtils'
-import { getLogger, globals, Settings, ToolkitError } from '../../../shared'
+import { CloudWatchLogsSettings } from '../cloudWatchLogsUtils'
+import { globals, Settings, ToolkitError } from '../../../shared'
 import { createLiveTailURIFromArgs } from './liveTailSessionRegistry'
 import { getUserAgent } from '../../../shared/telemetry/util'
 import { convertToTimeString } from '../../../shared/datetime'
@@ -98,7 +98,6 @@ export class LiveTailSession {
         this.statusBarUpdateTimer = globals.clock.setInterval(() => {
             this.updateStatusBarItemText()
         }, 500)
-        getLogger().info(`LiveTail session started: ${uriToKey(this.uri)}`)
         return commandOutput.responseStream
     }
 


### PR DESCRIPTION
## Problem
Currently after closing a session in a way that leaves the TextDocument open (`Stop tailing` CodeLens), the codeLenses remain visible. This means a user could click `Stop tailing` again, and receive an error for not being able to find the running LiveTail session for the given document. 

Additionally, there is no feedback when a session is closed. Clicking `Stop tailing` doesn't signal to the user that the session was actually stopped. 

## Solution
* Provide a `refresh` method in the LiveTail CodeLens provider. This fires an event to force recomputing the CodeLenses on a document. 
* Modify LiveTail Lens provider to return no Lenses if the session is not running (in the registry)
* Display an information window when a Session is stopped
* Changes wording/placement on some log statements for consistency. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
