### PR TITLE
include pl1 as a code file extension

### DIFF
--- a/packages/core/src/shared/filetypes.ts
+++ b/packages/core/src/shared/filetypes.ts
@@ -265,6 +265,7 @@ export const codefileExtensions = new Set([
     '.pike',
     '.pir',
     '.pl',
+    '.pl1',
     '.pm',
     '.pmod',
     '.pp',


### PR DESCRIPTION
## Problem
The codefileExtensions does not contain an extension type for `.pl1` which is the common extension for PL/1. Because of this, PL/1 files and code are not seen in the workspace context for Amazon Q, and chat interactions with Q and `.pl1` file types are not possible.

## Solution
This adds the PL/1 code extension `.pl1` as a known extension

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
