### PR TITLE
fix(lambda): add artificat bucket source prompter in SAM sync wizards

### DIFF
--- a/packages/core/src/shared/sam/sync.ts
+++ b/packages/core/src/shared/sam/sync.ts
@@ -50,7 +50,7 @@ import { TemplateItem, createTemplatePrompter } from '../ui/sam/templatePrompter
 import { createStackPrompter } from '../ui/sam/stackPrompter'
 import { ParamsSource, createSyncParamsSourcePrompter } from '../ui/sam/paramsSourcePrompter'
 import { createEcrPrompter } from '../ui/sam/ecrPrompter'
-import { BucketSource, createBucketNamePrompter } from '../ui/sam/bucketPrompter'
+import { BucketSource, createBucketNamePrompter, createBucketSourcePrompter } from '../ui/sam/bucketPrompter'
 import { runInTerminal } from './processTerminal'
 
 export interface SyncParams {
@@ -175,12 +175,15 @@ export class SyncWizard extends Wizard<SyncParams> {
                     paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
             }
         )
+        this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(), {
+            showWhen: ({ paramsSource }) =>
+                paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
+        })
 
         this.form.bucketName.bindPrompter(
             ({ region }) => createBucketNamePrompter(new DefaultS3Client(region!), syncMementoRootKey),
             {
-                showWhen: ({ paramsSource }) =>
-                    paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
+                showWhen: ({ bucketSource }) => bucketSource === BucketSource.UserProvided,
             }
         )
 

--- a/packages/toolkit/.changes/next-release/Breaking Change-782109cf-be90-4472-8600-8e90ed0ce398.json
+++ b/packages/toolkit/.changes/next-release/Breaking Change-782109cf-be90-4472-8600-8e90ed0ce398.json
@@ -1,0 +1,4 @@
+{
+	"type": "Breaking Change",
+	"description": "SAM: Add artifact bucket source prompter for SAM sync command"
+}


### PR DESCRIPTION
## Problem
Unlike in SAM deploy wizard, SAM sync wizard skip a question about bucket source for sync artifact and go directly to question for bucket name.

## Solution
Add prompter asking for bucket source option: 
1) Create a SAM CLI managed S3 bucket
2) Specify an S3 bucket
---

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
