### PR TITLE
fix(amazon q): add pl/1 and bms extensions as a recognized code file type

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-80f16b7a-440d-4e06-89ad-1454c58ff28f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-80f16b7a-440d-4e06-89ad-1454c58ff28f.json
@@ -1,4 +1,4 @@
 {
-	"type": "Bug Fix",
+	"type": "Feature",
 	"description": "Q feature dev: recognize .bms, .pli code files"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-80f16b7a-440d-4e06-89ad-1454c58ff28f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-80f16b7a-440d-4e06-89ad-1454c58ff28f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Q feature dev: update file extension list"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-80f16b7a-440d-4e06-89ad-1454c58ff28f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-80f16b7a-440d-4e06-89ad-1454c58ff28f.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Q feature dev: update file extension list"
+	"description": "Q feature dev: recognize .bms, .pli code files"
 }

--- a/packages/core/src/shared/filetypes.ts
+++ b/packages/core/src/shared/filetypes.ts
@@ -265,6 +265,7 @@ export const codefileExtensions = new Set([
     '.pike',
     '.pir',
     '.pl',
+    '.pl1',
     '.pm',
     '.pmod',
     '.pp',

--- a/packages/core/src/shared/filetypes.ts
+++ b/packages/core/src/shared/filetypes.ts
@@ -161,6 +161,7 @@ export const codefileExtensions = new Set([
     '.bash',
     '.bat',
     '.boo',
+    '.bms',
     '.c',
     '.cbl',
     '.cc',

--- a/packages/core/src/shared/filetypes.ts
+++ b/packages/core/src/shared/filetypes.ts
@@ -266,7 +266,7 @@ export const codefileExtensions = new Set([
     '.pike',
     '.pir',
     '.pl',
-    '.pl1',
+    '.pli',
     '.pm',
     '.pmod',
     '.pp',


### PR DESCRIPTION
## Problem
The codefileExtensions does not contain an extension type for `.pli` which is the common extension for PL/1, or for `.bms` which is Basic Mapping Support and common for screen definition files in IBM mainframe. Because of this, the files and code in them are not accessible in the workspace context for Amazon Q using the `/dev` quick action.

When using the Q quick action '\dev' for `.pli` or `.bms` files, Q responds with the following message
> This appears to be an empty program or workspace with no source files present. There is nothing to explain at this time since no code or files are available for analysis.


## Solution
- Add the PL/1 language extension `.pli` as a known code file extension type
- Add the Basic Mapping Support extension `.bms` as a known code file extension type

No tests were updated as there are none exclusively for filetype extensions

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
