### PR TITLE
feat(amazonq): support `.gradle` files in /dev

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-13564075-487c-424c-a48e-43ee446d1dad.json
+++ b/packages/amazonq/.changes/next-release/Feature-13564075-487c-424c-a48e-43ee446d1dad.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q /dev: support `.gradle` files"
+}

--- a/packages/core/src/shared/filetypes.ts
+++ b/packages/core/src/shared/filetypes.ts
@@ -206,6 +206,7 @@ export const codefileExtensions = new Set([
     '.gd',
     '.go',
     '.gql',
+    '.gradle',
     '.graphql',
     '.groovy',
     '.gs',


### PR DESCRIPTION
## Problem
`.gradle` files are not currently supported by /dev

## Solution
Add `.gradle` to list of supported file extensions

I manually tested some prompts in /dev with requests to modify the build.gradle and it worked

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
