### PR TITLE
fix(amazon q): updating string for final patch of selective transformation

### DIFF
--- a/packages/core/resources/css/amazonqTransformationHub.css
+++ b/packages/core/resources/css/amazonqTransformationHub.css
@@ -73,7 +73,7 @@ body {
 }
 
 .status-FAILED {
-    color: red;
+    color: grey;
 }
 
 .substep {

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -33,8 +33,8 @@ const patchDescriptions: { [key: string]: string } = {
         'This diff patch covers the set of upgrades for ArchUnit, Mockito, TestContainers, Cucumber, and additionally, Jenkins plugins and the Maven Wrapper.',
     'Miscellaneous Processing Documentation upgrade':
         'This diff patch covers a diverse set of upgrades spanning ORMs, XML processing, API documentation, and more.',
-    'Deprecated API replacement and dependency upgrades':
-        'This diff patch replaces deprecated APIs and makes additional dependency version upgrades.',
+    'Deprecated API replacement, dependency upgrades, and formatting':
+        'This diff patch replaces deprecated APIs, makes additional dependency version upgrades, and formats code changes.',
 }
 
 export const JsonConfigFileNamingConvention = new Set([
@@ -482,7 +482,7 @@ I can now divide the transformation results into diff patches (if applicable to 
 
 • Miscellaneous Processing Documentation: Upgrades ORMs, XML processing, and Swagger to SpringDoc/OpenAPI.
 
-• Deprecated API replacement and dependency upgrades: Replaces deprecated APIs and makes additional dependency version upgrades.
+• Deprecated API replacement, dependency upgrades, and formatting: Replaces deprecated APIs, makes additional dependency version upgrades, and formats code changes.
 `
 
 export const uploadingCodeStepMessage = 'Upload your code'


### PR DESCRIPTION
## Problem
After meeting with customer team, we wanted to be more specific about the last patch we were presenting the user

## Solution
The new strings in the constants replaced have been confirmed and provide better understandability.  

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
