### PR TITLE
fix(cwl): Change wording in menus, add info message when opening running session

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -44,9 +44,7 @@ export async function tailLogGroup(
         const session = new LiveTailSession(liveTailSessionConfig)
         if (registry.has(uriToKey(session.uri))) {
             await vscode.window.showTextDocument(session.uri, { preview: false })
-            void vscode.window.showInformationMessage(
-                `Switching editor to an existing session. Found running session that matches request.`
-            )
+            void vscode.window.showInformationMessage(`Switching editor to an existing session that matches request.`)
             span.record({
                 result: 'Succeeded',
                 sessionAlreadyStarted: true,

--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -45,7 +45,7 @@ export async function tailLogGroup(
         if (registry.has(uriToKey(session.uri))) {
             await vscode.window.showTextDocument(session.uri, { preview: false })
             void vscode.window.showInformationMessage(
-                `Opening already running session's document. Found running session that matches new request.`
+                `Switching editor to an existing session. Found running session that matches request.`
             )
             span.record({
                 result: 'Succeeded',

--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -43,7 +43,10 @@ export async function tailLogGroup(
         }
         const session = new LiveTailSession(liveTailSessionConfig)
         if (registry.has(uriToKey(session.uri))) {
-            await prepareDocument(session)
+            await vscode.window.showTextDocument(session.uri, { preview: false })
+            void vscode.window.showInformationMessage(
+                `Opening already running session's document. Found running session that matches new request.`
+            )
             span.record({
                 result: 'Succeeded',
                 sessionAlreadyStarted: true,

--- a/packages/core/src/awsService/cloudWatchLogs/wizard/liveTailLogStreamSubmenu.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/wizard/liveTailLogStreamSubmenu.ts
@@ -41,7 +41,7 @@ export class LogStreamFilterSubmenu extends Prompter<LogStreamFilterResponse> {
     public createMenuPrompter() {
         const helpUri = startLiveTailHelpUrl
         const prompter = createQuickPick(this.menuOptions, {
-            title: 'Select LogStream filter type',
+            title: 'Include log events from...',
             buttons: createCommonButtons(helpUri),
         })
         return prompter
@@ -50,18 +50,15 @@ export class LogStreamFilterSubmenu extends Prompter<LogStreamFilterResponse> {
     private get menuOptions(): DataQuickPickItem<LogStreamFilterType>[] {
         const options: DataQuickPickItem<LogStreamFilterType>[] = []
         options.push({
-            label: 'All',
-            detail: 'Include log events from all LogStreams in the selected LogGroup',
+            label: 'All Log Streams',
             data: 'all',
         })
         options.push({
-            label: 'Specific',
-            detail: 'Include log events from only a specific LogStream',
+            label: 'Specific Log Stream',
             data: 'specific',
         })
         options.push({
-            label: 'Prefix',
-            detail: 'Include log events from LogStreams that begin with a provided prefix',
+            label: 'Log Streams matching prefix',
             data: 'prefix',
         })
         return options
@@ -70,9 +67,9 @@ export class LogStreamFilterSubmenu extends Prompter<LogStreamFilterResponse> {
     public createLogStreamPrefixBox(): InputBoxPrompter {
         const helpUri = startLiveTailLogStreamPrefixHelpUrl
         return createInputBox({
-            title: 'Enter LogStream prefix',
-            placeholder: 'logStream prefix (case sensitive; empty matches all)',
-            prompt: 'Only log events in the LogStreams that have names that start with the prefix that you specify here are included in the Live Tail session',
+            title: 'Enter Log Stream prefix',
+            placeholder: 'log stream prefix (case sensitive; empty matches all)',
+            prompt: 'Only log events in Log Streams whose name starts with the supplied prefix will be included.',
             validateInput: (input) => this.validateLogStreamPrefix(input),
             buttons: createCommonButtons(helpUri),
         })
@@ -80,11 +77,11 @@ export class LogStreamFilterSubmenu extends Prompter<LogStreamFilterResponse> {
 
     public validateLogStreamPrefix(prefix: string) {
         if (prefix.length > 512) {
-            return 'LogStream prefix cannot be longer than 512 characters'
+            return 'Log Stream prefix cannot be longer than 512 characters'
         }
 
         if (!this.logStreamPrefixRegEx.test(prefix)) {
-            return 'LogStream prefix must match pattern: [^:*]*'
+            return 'Log Stream prefix must match pattern: [^:*]*'
         }
     }
 
@@ -104,7 +101,7 @@ export class LogStreamFilterSubmenu extends Prompter<LogStreamFilterResponse> {
             .map((streams) => streams!.map((stream) => ({ data: stream.logStreamName!, label: stream.logStreamName! })))
 
         return createQuickPick(items, {
-            title: 'Select LogStream',
+            title: 'Select Log Stream',
             buttons: createCommonButtons(helpUri),
         })
     }

--- a/packages/core/src/awsService/cloudWatchLogs/wizard/tailLogGroupWizard.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/wizard/tailLogGroupWizard.ts
@@ -38,7 +38,7 @@ export class TailLogGroupWizard extends Wizard<TailLogGroupWizardResponse> {
         this.form.regionLogGroupSubmenuResponse.bindPrompter(createRegionLogGroupSubmenu)
         this.form.logStreamFilter.bindPrompter((state) => {
             if (!state.regionLogGroupSubmenuResponse?.data) {
-                throw new ToolkitError('LogGroupName is null')
+                throw new ToolkitError('Log Group name is null')
             }
             return new LogStreamFilterSubmenu(
                 state.regionLogGroupSubmenuResponse.data,
@@ -57,7 +57,7 @@ export function createRegionLogGroupSubmenu(): RegionSubmenu<string> {
             buttons: [createExitButton()],
         },
         { title: localize('AWS.cwl.tailLogGroup.regionPromptTitle', 'Select Region for Log Group') },
-        'LogGroups'
+        'Log Groups'
     )
 }
 
@@ -69,7 +69,7 @@ async function getLogGroupQuickPickOptions(regionCode: string): Promise<DataQuic
 
     for await (const logGroupObject of logGroups) {
         if (!logGroupObject.arn || !logGroupObject.logGroupName) {
-            throw new ToolkitError('LogGroupObject name or arn undefined')
+            throw new ToolkitError('Log Group name or arn is undefined')
         }
 
         logGroupsOptions.push({
@@ -88,7 +88,7 @@ export function buildLogGroupArn(logGroupName: string, region: string): string {
     const awsAccountId = globals.awsContext.getCredentialAccountId()
     if (awsAccountId === undefined) {
         throw new ToolkitError(
-            `Failed to construct Arn for LogGroup because awsAccountId is undefined. LogGroup: ${logGroupName}`
+            `Failed to construct Arn for Log Group because awsAccountId is undefined. Log Group: ${logGroupName}`
         )
     }
     return `arn:aws:logs:${region}:${awsAccountId}:log-group:${logGroupName}`
@@ -103,7 +103,7 @@ export function createFilterPatternPrompter() {
     return createInputBox({
         title: 'Provide log event filter pattern',
         placeholder: 'filter pattern (case sensitive; empty matches all)',
-        prompt: 'Optional pattern to use to filter the results to include only log events that match the pattern.',
+        prompt: 'Optional filter to include only log events that match the supplied pattern.',
         buttons: [createHelpButton(helpUri), createBackButton(), createExitButton()],
     })
 }

--- a/packages/core/src/test/awsService/cloudWatchLogs/wizard/liveTailLogStreamSubmenu.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/wizard/liveTailLogStreamSubmenu.test.ts
@@ -21,8 +21,12 @@ describe('liveTailLogStreamSubmenu', async function () {
 
     describe('Menu prompter', async function () {
         it('gives option for each filter type', async function () {
-            logStreamMenuPrompter.assertContainsItems('All', 'Specific', 'Prefix')
-            logStreamMenuPrompter.acceptItem('All')
+            logStreamMenuPrompter.assertContainsItems(
+                'All Log Streams',
+                'Specific Log Stream',
+                'Log Streams matching prefix'
+            )
+            logStreamMenuPrompter.acceptItem('All Log Streams')
             await logStreamMenuPrompter.result()
         })
     })
@@ -42,7 +46,7 @@ describe('liveTailLogStreamSubmenu', async function () {
             const invalidInput = 'my-log-stream:'
             getTestWindow().onDidShowInputBox((input) => {
                 input.acceptValue(invalidInput)
-                assert.deepEqual(input.validationMessage, 'LogStream prefix must match pattern: [^:*]*')
+                assert.deepEqual(input.validationMessage, 'Log Stream prefix must match pattern: [^:*]*')
                 input.hide()
             })
             const inputBox = logStreamFilterSubmenu.createLogStreamPrefixBox()
@@ -53,7 +57,7 @@ describe('liveTailLogStreamSubmenu', async function () {
             const invalidInput = 'my-log-stream*'
             getTestWindow().onDidShowInputBox((input) => {
                 input.acceptValue(invalidInput)
-                assert.deepEqual(input.validationMessage, 'LogStream prefix must match pattern: [^:*]*')
+                assert.deepEqual(input.validationMessage, 'Log Stream prefix must match pattern: [^:*]*')
                 input.hide()
             })
             const inputBox = logStreamFilterSubmenu.createLogStreamPrefixBox()
@@ -64,7 +68,7 @@ describe('liveTailLogStreamSubmenu', async function () {
             const invalidInput = 'a'.repeat(520)
             getTestWindow().onDidShowInputBox((input) => {
                 input.acceptValue(invalidInput)
-                assert.deepEqual(input.validationMessage, 'LogStream prefix cannot be longer than 512 characters')
+                assert.deepEqual(input.validationMessage, 'Log Stream prefix cannot be longer than 512 characters')
                 input.hide()
             })
             const inputBox = logStreamFilterSubmenu.createLogStreamPrefixBox()


### PR DESCRIPTION
## Problem
Addresses feedback after working with Toolkit UXD. There are inconsistencies with formatting/capitalization of certain nouns in the LiveTail menu. Some of the verbiage is unclear/too lengthy.

In the case there is an already running session and the user tries to start a new session with the same parameters, it is unclear that we are opening an already existing session and not starting a new one. 

## Solution
* Consistent spacing and capitalization of "Log Group" and "Log Stream"
* Introduce new Info window when opening and existing session stream
* Re-words LogStream filter type sub menu.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
