### PR TITLE
fix(lambda): correct prompter url button for sam deploy sync build commands

### DIFF
--- a/packages/core/src/awsService/appBuilder/explorer/openTemplate.ts
+++ b/packages/core/src/awsService/appBuilder/explorer/openTemplate.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { samSyncUrl } from '../../../shared/constants'
 import { CloudFormationTemplateRegistry } from '../../../shared/fs/templateRegistry'
 import { syncMementoRootKey } from '../../../shared/sam/sync'
 
@@ -17,6 +18,6 @@ export interface OpenTemplateParams {
 export class OpenTemplateWizard extends Wizard<OpenTemplateParams> {
     public constructor(state: Partial<OpenTemplateParams>, registry: CloudFormationTemplateRegistry) {
         super({ initState: state, exitPrompterProvider: createExitPrompter })
-        this.form.template.bindPrompter(() => createTemplatePrompter(registry, syncMementoRootKey))
+        this.form.template.bindPrompter(() => createTemplatePrompter(registry, syncMementoRootKey, samSyncUrl))
     }
 }

--- a/packages/core/src/shared/sam/build.ts
+++ b/packages/core/src/shared/sam/build.ts
@@ -129,7 +129,9 @@ export class BuildWizard extends Wizard<BuildParams> {
         this.arg = arg
         if (this.arg === undefined) {
             // "Build" command was invoked on the command palette.
-            this.form.template.bindPrompter(() => createTemplatePrompter(this.registry, buildMementoRootKey))
+            this.form.template.bindPrompter(() =>
+                createTemplatePrompter(this.registry, buildMementoRootKey, samBuildUrl)
+            )
             this.form.projectRoot.setDefault(({ template }) => getProjectRoot(template))
             this.form.paramsSource.bindPrompter(async ({ projectRoot }) => {
                 const existValidSamConfig: boolean | undefined = await validateSamBuildConfig(projectRoot)

--- a/packages/core/src/shared/sam/deploy.ts
+++ b/packages/core/src/shared/sam/deploy.ts
@@ -112,19 +112,22 @@ export class DeployWizard extends Wizard<DeployParams> {
                         paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
                 }
             )
-            this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(), {
+            this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(samDeployUrl), {
                 showWhen: ({ paramsSource }) =>
                     paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
             })
             this.form.bucketName.bindPrompter(
-                ({ region }) => createBucketNamePrompter(new DefaultS3Client(region!), deployMementoRootKey),
+                ({ region }) =>
+                    createBucketNamePrompter(new DefaultS3Client(region!), deployMementoRootKey, samDeployUrl),
                 {
                     showWhen: ({ bucketSource }) => bucketSource === BucketSource.UserProvided,
                 }
             )
         } else if (this.arg && this.arg.regionCode) {
             // "Deploy" command was invoked on a regionNode.
-            this.form.template.bindPrompter(() => createTemplatePrompter(this.registry, deployMementoRootKey))
+            this.form.template.bindPrompter(() =>
+                createTemplatePrompter(this.registry, deployMementoRootKey, samDeployUrl)
+            )
             this.form.projectRoot.setDefault(({ template }) => getProjectRoot(template))
             this.form.paramsSource.bindPrompter(async ({ projectRoot }) => {
                 const existValidSamConfig: boolean | undefined = await validateSamDeployConfig(projectRoot)
@@ -139,12 +142,13 @@ export class DeployWizard extends Wizard<DeployParams> {
                         paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
                 }
             )
-            this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(), {
+            this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(samDeployUrl), {
                 showWhen: ({ paramsSource }) =>
                     paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
             })
             this.form.bucketName.bindPrompter(
-                ({ region }) => createBucketNamePrompter(new DefaultS3Client(region!), deployMementoRootKey),
+                ({ region }) =>
+                    createBucketNamePrompter(new DefaultS3Client(region!), deployMementoRootKey, samDeployUrl),
                 {
                     showWhen: ({ bucketSource }) => bucketSource === BucketSource.UserProvided,
                 }
@@ -173,12 +177,13 @@ export class DeployWizard extends Wizard<DeployParams> {
                         paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
                 }
             )
-            this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(), {
+            this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(samDeployUrl), {
                 showWhen: ({ paramsSource }) =>
                     paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
             })
             this.form.bucketName.bindPrompter(
-                ({ region }) => createBucketNamePrompter(new DefaultS3Client(region!), deployMementoRootKey),
+                ({ region }) =>
+                    createBucketNamePrompter(new DefaultS3Client(region!), deployMementoRootKey, samDeployUrl),
                 {
                     showWhen: ({ bucketSource }) => bucketSource === BucketSource.UserProvided,
                 }
@@ -186,7 +191,9 @@ export class DeployWizard extends Wizard<DeployParams> {
             this.form.projectRoot.setDefault(() => getProjectRoot(templateItem))
         } else {
             // "Deploy" command was invoked on the command palette.
-            this.form.template.bindPrompter(() => createTemplatePrompter(this.registry, deployMementoRootKey))
+            this.form.template.bindPrompter(() =>
+                createTemplatePrompter(this.registry, deployMementoRootKey, samDeployUrl)
+            )
             this.form.projectRoot.setDefault(({ template }) => getProjectRoot(template))
             this.form.paramsSource.bindPrompter(async ({ projectRoot }) => {
                 const existValidSamConfig: boolean | undefined = await validateSamDeployConfig(projectRoot)
@@ -204,12 +211,13 @@ export class DeployWizard extends Wizard<DeployParams> {
                         paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
                 }
             )
-            this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(), {
+            this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(samDeployUrl), {
                 showWhen: ({ paramsSource }) =>
                     paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
             })
             this.form.bucketName.bindPrompter(
-                ({ region }) => createBucketNamePrompter(new DefaultS3Client(region!), deployMementoRootKey),
+                ({ region }) =>
+                    createBucketNamePrompter(new DefaultS3Client(region!), deployMementoRootKey, samDeployUrl),
                 {
                     showWhen: ({ bucketSource }) => bucketSource === BucketSource.UserProvided,
                 }

--- a/packages/core/src/shared/sam/sync.ts
+++ b/packages/core/src/shared/sam/sync.ts
@@ -156,7 +156,7 @@ export class SyncWizard extends Wizard<SyncParams> {
     ) {
         super({ initState: state, exitPrompterProvider: shouldPromptExit ? createExitPrompter : undefined })
         this.registry = registry
-        this.form.template.bindPrompter(() => createTemplatePrompter(this.registry, syncMementoRootKey))
+        this.form.template.bindPrompter(() => createTemplatePrompter(this.registry, syncMementoRootKey, samSyncUrl))
         this.form.projectRoot.setDefault(({ template }) => getProjectRoot(template))
 
         this.form.paramsSource.bindPrompter(async ({ projectRoot }) => {
@@ -175,13 +175,13 @@ export class SyncWizard extends Wizard<SyncParams> {
                     paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
             }
         )
-        this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(), {
+        this.form.bucketSource.bindPrompter(() => createBucketSourcePrompter(samSyncUrl), {
             showWhen: ({ paramsSource }) =>
                 paramsSource === ParamsSource.Specify || paramsSource === ParamsSource.SpecifyAndSave,
         })
 
         this.form.bucketName.bindPrompter(
-            ({ region }) => createBucketNamePrompter(new DefaultS3Client(region!), syncMementoRootKey),
+            ({ region }) => createBucketNamePrompter(new DefaultS3Client(region!), syncMementoRootKey, samSyncUrl),
             {
                 showWhen: ({ bucketSource }) => bucketSource === BucketSource.UserProvided,
             }

--- a/packages/core/src/shared/ui/sam/bucketPrompter.ts
+++ b/packages/core/src/shared/ui/sam/bucketPrompter.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { DefaultS3Client } from '../../clients/s3Client'
-import { samDeployUrl, samSyncUrl } from '../../constants'
 import { createCommonButtons } from '../buttons'
 import { createQuickPick, DataQuickPickItem } from '../pickerPrompter'
 import type { SyncParams } from '../../sam/sync'
 import * as nls from 'vscode-nls'
+import * as vscode from 'vscode'
 import { getRecentResponse } from '../../sam/utils'
 
 const localize = nls.loadMessageBundle()
@@ -23,9 +23,10 @@ export enum BucketSource {
  * Provides two options:
  * 1. Create a SAM CLI managed bucket
  * 2. Specify an existing bucket
+ * @param samCommandUrl URL to the SAM CLI command documentation
  * @returns A QuickPick prompter configured with bucket source options
  */
-export function createBucketSourcePrompter() {
+export function createBucketSourcePrompter(samCommandUrl: vscode.Uri) {
     const items: DataQuickPickItem<BucketSource>[] = [
         {
             label: 'Create a SAM CLI managed S3 bucket',
@@ -40,7 +41,7 @@ export function createBucketSourcePrompter() {
     return createQuickPick(items, {
         title: 'Specify S3 bucket for deployment artifacts',
         placeholder: 'Press enter to proceed with highlighted option',
-        buttons: createCommonButtons(samDeployUrl),
+        buttons: createCommonButtons(samCommandUrl),
     })
 }
 
@@ -49,9 +50,10 @@ export function createBucketSourcePrompter() {
  * The prompter supports choosing from existing s3 bucket name or creating a new one
  * @param client S3 client
  * @param mementoRootKey Memento key to store recent bucket name (e.g 'samcli.deploy.params')
+ * @param samCommandUrl URL to the SAM CLI command documentation
  * @returns A quick pick prompter configured with bucket name options
  */
-export function createBucketNamePrompter(client: DefaultS3Client, mementoRootKey: string) {
+export function createBucketNamePrompter(client: DefaultS3Client, mementoRootKey: string, samCommandUrl: vscode.Uri) {
     const recentBucket = getRecentResponse(mementoRootKey, client.regionCode, 'bucketName')
     const items = client.listBucketsIterable().map((b) => [
         {
@@ -64,7 +66,7 @@ export function createBucketNamePrompter(client: DefaultS3Client, mementoRootKey
     return createQuickPick(items, {
         title: 'Select an S3 Bucket',
         placeholder: 'Select a bucket (or enter a name to create one)',
-        buttons: createCommonButtons(samSyncUrl),
+        buttons: createCommonButtons(samCommandUrl),
         filterBoxInputSettings: {
             label: 'Create a New Bucket',
             // This is basically a hack. I need to refactor `createQuickPick` a bit.

--- a/packages/core/src/shared/ui/sam/templatePrompter.ts
+++ b/packages/core/src/shared/ui/sam/templatePrompter.ts
@@ -7,7 +7,6 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import { getSamInitDocUrl } from '../..'
 import * as CloudFormation from '../../cloudformation/cloudformation'
-import { samSyncUrl } from '../../constants'
 import { CloudFormationTemplateRegistry } from '../../fs/templateRegistry'
 import { createCommonButtons } from '../buttons'
 import { createQuickPick } from '../pickerPrompter'
@@ -27,6 +26,7 @@ export interface TemplateItem {
  *
  * @param registry - Registry containing CloudFormation templates
  * @param mementoRootKey - Root key for storing recent template selections (e.g 'samcli.deploy.params')
+ * @param samCommandUrl URL to the SAM CLI command documentation
  * @param projectRoot - Optional URI of the project root to filter templates
  * @returns A QuickPick prompter configured for template selection
  *
@@ -37,6 +37,7 @@ export interface TemplateItem {
 export function createTemplatePrompter(
     registry: CloudFormationTemplateRegistry,
     mementoRootKey: string,
+    samCommandUrl: vscode.Uri,
     projectRoot?: vscode.Uri
 ) {
     const folders = new Set<string>()
@@ -63,7 +64,7 @@ export function createTemplatePrompter(
     return createQuickPick(trimmedItems, {
         title: 'Select a SAM/CloudFormation Template',
         placeholder: 'Select a SAM/CloudFormation Template',
-        buttons: createCommonButtons(samSyncUrl),
+        buttons: createCommonButtons(samCommandUrl),
         noItemsFoundItem: {
             label: localize('aws.sam.noWorkspace', 'No SAM template.yaml file(s) found. Select for help'),
             data: undefined,

--- a/packages/core/src/test/shared/ui/sam/bucketPrompter.test.ts
+++ b/packages/core/src/test/shared/ui/sam/bucketPrompter.test.ts
@@ -11,6 +11,7 @@ import * as SamUtilsModule from '../../../../shared/sam/utils'
 import { createBucketNamePrompter } from '../../../../shared/ui/sam/bucketPrompter'
 import { AsyncCollection } from '../../../../shared/utilities/asyncCollection'
 import { RequiredProps } from '../../../../shared/utilities/tsUtils'
+import { samDeployUrl } from '../../../../shared/constants'
 
 describe('createBucketNamePrompter', () => {
     let sandbox: sinon.SinonSandbox
@@ -39,7 +40,7 @@ describe('createBucketNamePrompter', () => {
         sandbox.stub(SamUtilsModule, 'getRecentResponse').returns(undefined) // Mock recent bucket
 
         // Act
-        const prompter = createBucketNamePrompter(s3Client, mementoRootKey)
+        const prompter = createBucketNamePrompter(s3Client, mementoRootKey, samDeployUrl)
 
         // Assert
         assert.ok(stub.calledOnce)
@@ -63,7 +64,7 @@ describe('createBucketNamePrompter', () => {
         sandbox.stub(SamUtilsModule, 'getRecentResponse').returns(undefined) // Mock recent bucket
 
         // Act
-        const prompter = createBucketNamePrompter(s3Client, mementoRootKey)
+        const prompter = createBucketNamePrompter(s3Client, mementoRootKey, samDeployUrl)
 
         // Assert
         assert.ok(stub.calledOnce)

--- a/packages/core/src/test/shared/ui/sam/templatePrompter.test.ts
+++ b/packages/core/src/test/shared/ui/sam/templatePrompter.test.ts
@@ -13,6 +13,7 @@ import { WatchedItem } from '../../../../shared/fs/watchedFiles'
 import * as SamUtilsModule from '../../../../shared/sam/utils'
 import { createTemplatePrompter } from '../../../../shared/ui/sam/templatePrompter'
 import { assertEqualPaths } from '../../../testUtil'
+import { samDeployUrl } from '../../../../shared/constants'
 
 describe('createTemplatePrompter', () => {
     let registry: CloudFormationTemplateRegistry
@@ -41,7 +42,7 @@ describe('createTemplatePrompter', () => {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
         assert.ok(workspaceFolder)
 
-        const prompter = createTemplatePrompter(registry, mementoRootKey)
+        const prompter = createTemplatePrompter(registry, mementoRootKey, samDeployUrl)
 
         assert.strictEqual(prompter.quickPick.items.length, 2)
         assertEqualPaths(prompter.quickPick.items[0].label, '/path/to/template1.yaml')

--- a/packages/toolkit/.changes/next-release/Bug Fix-c45b6435-6724-4cbf-bfac-eac4184985b5.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-c45b6435-6724-4cbf-bfac-eac4184985b5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM: Fix prompter button URLs for build, deploy and sync commands"
+}


### PR DESCRIPTION
## Problem
We have been using components from sync.ts, where all prompters created for other command still use samSyncUrl.

## Solution
Use correct url link for respective command in all prompter button. 
---


License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
