### PR TITLE
feat(amazon q): removing feature flag for selective transformation and confirmed string changes

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-75f96117-d8c5-4bd4-88d9-0d3919060f99.json
+++ b/packages/amazonq/.changes/next-release/Feature-75f96117-d8c5-4bd4-88d9-0d3919060f99.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Feature(Amazon Q Code Transformation): allow users to view results in 5 smaller diffs"
+}

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -430,6 +430,8 @@ export class GumbyController {
         const oneOrMultipleDiffsSelection = message.formSelectedValues['GumbyTransformOneOrMultipleDiffsForm']
         if (oneOrMultipleDiffsSelection === CodeWhispererConstants.multipleDiffsMessage) {
             transformByQState.setMultipleDiffs(true)
+        } else {
+            transformByQState.setMultipleDiffs(false)
         }
         this.messenger.sendOneOrMultipleDiffsMessage(oneOrMultipleDiffsSelection, message.tabID)
         // perform local build

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -62,7 +62,6 @@ import { getStringHash } from '../../../shared/utilities/textUtilities'
 import { getVersionData } from '../../../codewhisperer/service/transformByQ/transformMavenHandler'
 import AdmZip from 'adm-zip'
 import { AuthError } from '../../../auth/sso/server'
-import { isSelectiveTransformationReady } from '../../../dev/config'
 
 // These events can be interactions within the chat,
 // or elsewhere in the IDE
@@ -424,12 +423,7 @@ export class GumbyController {
             result: MetadataResult.Pass,
         })
         this.messenger.sendSkipTestsSelectionMessage(skipTestsSelection, message.tabID)
-        if (!isSelectiveTransformationReady) {
-            // perform local build
-            await this.validateBuildWithPromptOnError(message)
-        } else {
-            await this.messenger.sendOneOrMultipleDiffsPrompt(message.tabID)
-        }
+        await this.messenger.sendOneOrMultipleDiffsPrompt(message.tabID)
     }
 
     private async handleOneOrMultipleDiffs(message: any) {

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -603,7 +603,7 @@ export class Messenger {
     }
 
     public sendOneOrMultipleDiffsMessage(selectiveTransformationSelection: string, tabID: string) {
-        const message = `Okay, I will create ${selectiveTransformationSelection.toLowerCase()} when providing the proposed changes.`
+        const message = `Okay, I will create ${selectiveTransformationSelection.toLowerCase()} with my proposed changes.`
         this.dispatcher.sendChatMessage(new ChatMessage({ message, messageType: 'ai-prompt' }, tabID))
     }
 

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -28,9 +28,9 @@ const patchDescriptions: { [key: string]: string } = {
     'Popular Enterprise Specifications and Application Frameworks upgrade':
         'This diff patch covers the set of upgrades for Jakarta EE 10, Hibernate 6.2, and Micronaut 3.',
     'HTTP Client Utilities, Apache Commons Utilities, and Web Frameworks':
-        'This diff patch covers the set of upgrades for Apache HTTP Client 5, Apache Commons utilities (Collections, IO, Lang, Math), Struts 6.0.',
+        'This diff patch covers the set of upgrades for Apache HTTP Client 5, Apache Commons utilities (Collections, IO, Lang, Math), and Struts 6.0.',
     'Testing Tools and Frameworks upgrade':
-        'This diff patch covers the set of upgrades for ArchUnit, Mockito, TestContainers, Cucumber, and additionally, Jenkins plugins and the Maven Wrapper.',
+        'This diff patch covers the set of upgrades for ArchUnit, Mockito, TestContainers, and Cucumber, in addition to the Jenkins plugins and the Maven Wrapper.',
     'Miscellaneous Processing Documentation upgrade':
         'This diff patch covers a diverse set of upgrades spanning ORMs, XML processing, API documentation, and more.',
     'Deprecated API replacement, dependency upgrades, and formatting':
@@ -470,7 +470,7 @@ export const chooseTransformationObjective = `I can help you with the following 
 export const chooseTransformationObjectivePlaceholder = 'Enter "language upgrade" or "sql conversion"'
 
 export const userPatchDescriptionChatMessage = `
-I can now divide the transformation results into diff patches (if applicable to the app) if you would like to review and accept each diff with fewer changes:
+If you'd like to update and test your code with fewer changes at a time, I can divide the transformation results into separate diff patches. If applicable to your application, I can split up the diffs up into the following groups of upgrades. Here are the upgrades included in each diff:
 
 • Minimal Compatible Library Upgrade to Java 17: Dependencies to the minimum compatible versions in Java 17, including Springboot, JUnit, and PowerMockito.
 
@@ -616,16 +616,16 @@ export const jobCancelledNotification = 'You cancelled the transformation.'
 
 export const diffMessage = (multipleDiffs: boolean) => {
     return multipleDiffs
-        ? 'You can review the diff to see my proposed changes and accept or reject them. If you reject the diff, you will not be able to see the diffs later.'
+        ? 'You can review the diffs to see my proposed changes and accept or reject them. You will be able to accept changes from one diff at a time. If you reject changes in one diff, you will not be able to view or accept changes in the other diffs.'
         : 'You can review the diff to see my proposed changes and accept or reject them.'
 }
 
 export const jobCompletedChatMessage = (multipleDiffsString: string) => {
-    return `I transformed your code. ${multipleDiffsString} The transformation summary has details about the files I updated.`
+    return `I completed your transformation. ${multipleDiffsString} The transformation summary has details about the changes I'm proposing.`
 }
 
 export const jobCompletedNotification = (multipleDiffsString: string) => {
-    return `Amazon Q transformed your code. ${multipleDiffsString} The transformation summary has details about the files I updated.`
+    return `Amazon Q transformed your code. ${multipleDiffsString} The transformation summary has details about the changes.`
 }
 
 export const jobPartiallyCompletedChatMessage = (multipleDiffsString: string) => {

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -808,6 +808,7 @@ export class TransformByQState {
         this.errorLog = ''
         this.customBuildCommand = ''
         this.intervalId = undefined
+        this.produceMultipleDiffs = false
     }
 }
 

--- a/packages/core/src/dev/config.ts
+++ b/packages/core/src/dev/config.ts
@@ -10,6 +10,3 @@ export const betaUrl = {
     amazonq: '',
     toolkit: '',
 }
-
-//feature flag for Selective Transformation
-export const isSelectiveTransformationReady = false


### PR DESCRIPTION
## Problem
Selective transformation changes were released under an IDE feature flag due to backend changes that needed to be fixed.

## Solution
In this PR, we are removing the feature flag on the IDE side so the users will now be able to see the form to select if they want to view their changes in one or multiple diffs. If they select multiple diffs in this form, then selective transformation will be invoked. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
