### PR TITLE
test(amazonq): skip flaky crossfileContextUtil.test

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -35,7 +35,7 @@ describe('crossFileContextUtil', function () {
         sinon.restore()
     })
 
-    describe.skip('fetchSupplementalContextForSrc', function () {
+    describe('fetchSupplementalContextForSrc', function () {
         beforeEach(async function () {
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
         })
@@ -61,7 +61,7 @@ describe('crossFileContextUtil', function () {
             assert.strictEqual(actual.supplementalContextItems[2].content.split('\n').length, 50)
         })
 
-        it('for t1 group, should return repomap + opentabs context', async function () {
+        it.skip('for t1 group, should return repomap + opentabs context', async function () {
             await toTextEditor(aStringWithLineCount(200), 'CrossFile.java', tempFolder, { preview: false })
             const myCurrentEditor = await toTextEditor('', 'TargetFile.java', tempFolder, {
                 preview: false,

--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -35,7 +35,7 @@ describe('crossFileContextUtil', function () {
         sinon.restore()
     })
 
-    describe('fetchSupplementalContextForSrc', function () {
+    describe.skip('fetchSupplementalContextForSrc', function () {
         beforeEach(async function () {
             tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
         })


### PR DESCRIPTION
## Problem
#6079

## Solution
Ignore the flaky test cases for now until we root caused why it failed occasionally in some CI machines


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
