### PR TITLE
fix(ec2): show terminated icon on terminated instances. 

### DIFF
--- a/packages/core/src/awsService/ec2/utils.ts
+++ b/packages/core/src/awsService/ec2/utils.ts
@@ -18,6 +18,10 @@ export function getIconCode(instance: SafeEc2Instance) {
         return 'circle-slash'
     }
 
+    if (instance.LastSeenStatus === 'terminated') {
+        return 'stop'
+    }
+
     return 'loading~spin'
 }
 

--- a/packages/core/src/test/awsService/ec2/utils.test.ts
+++ b/packages/core/src/test/awsService/ec2/utils.test.ts
@@ -28,9 +28,14 @@ describe('utils', async function () {
                 InstanceId: 'XX',
                 LastSeenStatus: 'stopped',
             }
+            const terminatedInstance: SafeEc2Instance = {
+                InstanceId: 'XXX',
+                LastSeenStatus: 'terminated',
+            }
 
             assert.strictEqual(getIconCode(runningInstance), 'pass')
             assert.strictEqual(getIconCode(stoppedInstance), 'circle-slash')
+            assert.strictEqual(getIconCode(terminatedInstance), 'stop')
         })
 
         it('defaults to loading~spin', function () {


### PR DESCRIPTION
## Problem
The AWS SDK returns terminated instances for a short period and we display a `pending` icon in this case. 
![image](https://github.com/user-attachments/assets/75f918c5-ee91-4d39-ba2f-f621489e239a)

## Solution
Display a specific icon that indicates the instance is terminated. 
<img width="606" alt="image" src="https://github.com/user-attachments/assets/9bcaf466-6043-400e-bea2-394c3f7ec2fc">

## Alternative Solution 
We could have avoided showing terminated instances at all. However, by showing them terminated it provides consistency with the console(since it also shows terminated instances for a short period), and greater visibility. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
