### PR TITLE
refactor(logs): Use CrashMonitoring topic in logger

### DIFF
--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 
-export type LogTopic = 'crashReport' | 'dev/beta' | 'notifications' | 'test' | 'unknown'
+export type LogTopic = 'crashMonitoring' | 'dev/beta' | 'notifications' | 'test' | 'unknown'
 
 class ErrorLog {
     constructor(


### PR DESCRIPTION
Use the topic logger, removing the old prefixes since the topic is automatically prepended


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
