### PR TITLE
config(amazonq): enable implicit project context ab test for broader users

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -51,7 +51,6 @@ import { getHttpStatusCode, AwsClientResponseError } from '../../../shared/error
 import { uiEventRecorder } from '../../../amazonq/util/eventRecorder'
 import { globals, waitUntil } from '../../../shared'
 import { telemetry } from '../../../shared/telemetry'
-import { Auth } from '../../../auth'
 import { isSsoConnection } from '../../../auth/connection'
 import { inspect } from '../../../shared/utilities/collectionUtils'
 
@@ -637,7 +636,6 @@ export class ChatController {
             // if user does not have @workspace in the prompt, but user is Amazon internal
             // add project context by default
             else if (
-                Auth.instance.isInternalAmazonUser() &&
                 !LspController.instance.isIndexingInProgress() &&
                 CodeWhispererSettings.instance.isLocalIndexEnabled()
             ) {

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -632,10 +632,7 @@ export class ChatController {
                     this.messenger.sendOpenSettingsMessage(triggerID, tabID)
                     return
                 }
-            }
-            // if user does not have @workspace in the prompt, but user is Amazon internal
-            // add project context by default
-            else if (
+            } else if (
                 !LspController.instance.isIndexingInProgress() &&
                 CodeWhispererSettings.instance.isLocalIndexEnabled()
             ) {


### PR DESCRIPTION
## Problem
enable implicit workspace ab test for broader groups of users but not only internal users

## Solution
remove isInternalUser predicate

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
