### PR TITLE
test: add notification and reset state dev options

### DIFF
--- a/packages/core/src/extensionNode.ts
+++ b/packages/core/src/extensionNode.ts
@@ -238,15 +238,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
         // TODO: Should probably emit for web as well.
         // Will the web metric look the same?
-        const authState = await getAuthState()
         telemetry.auth_userState.emit({
             passive: true,
             result: 'Succeeded',
             source: ExtensionUse.instance.sourceForTelemetry(),
-            ...authState,
+            ...(await getAuthState()),
         })
 
-        void activateNotifications(context, authState, getAuthState)
+        void activateNotifications(context, getAuthState)
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')
         // truncate if the stacktrace is unusually long

--- a/packages/core/src/notifications/index.ts
+++ b/packages/core/src/notifications/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { activate } from './activation'
+export * from './controller'

--- a/packages/core/src/notifications/rules.ts
+++ b/packages/core/src/notifications/rules.ts
@@ -29,23 +29,24 @@ const logger = getLogger('notifications')
  * @returns true if the version satisfies the condition
  */
 function isValidVersion(version: string, condition: ConditionalClause): boolean {
+    const cleanVersion = version.split('-')[0] // remove any pre-release tags
     switch (condition.type) {
         case 'range': {
             const lowerConstraint =
                 !condition.lowerInclusive ||
                 condition.lowerInclusive === '-inf' ||
-                semver.gte(version, condition.lowerInclusive)
+                semver.gte(cleanVersion, condition.lowerInclusive)
             const upperConstraint =
                 !condition.upperExclusive ||
                 condition.upperExclusive === '+inf' ||
-                semver.lt(version, condition.upperExclusive)
+                semver.lt(cleanVersion, condition.upperExclusive)
             return lowerConstraint && upperConstraint
         }
         case 'exactMatch':
-            return condition.values.some((v) => semver.eq(v, version))
+            return condition.values.some((v) => semver.eq(v, cleanVersion))
         case 'or':
             /** Check case where any of the subconditions are true, i.e. one of multiple range or exactMatch conditions */
-            return condition.clauses.some((clause) => isValidVersion(version, clause))
+            return condition.clauses.some((clause) => isValidVersion(cleanVersion, clause))
         default:
             throw new Error(`Unknown clause type: ${(condition as any).type}`)
     }

--- a/packages/core/src/notifications/types.ts
+++ b/packages/core/src/notifications/types.ts
@@ -135,6 +135,15 @@ export type NotificationsState = {
     newlyReceived: string[]
 }
 
+export const defaultNotificationsState: () => NotificationsState = () => {
+    return {
+        startUp: {},
+        emergency: {},
+        dismissed: [],
+        newlyReceived: [],
+    }
+}
+
 export const NotificationsStateConstructor: TypeConstructor<NotificationsState> = (v: unknown): NotificationsState => {
     const isNotificationsState = (v: Partial<NotificationsState>): v is NotificationsState => {
         const requiredKeys: (keyof NotificationsState)[] = ['startUp', 'emergency', 'dismissed', 'newlyReceived']
@@ -173,3 +182,5 @@ export type AuthState = Omit<AuthUserState, 'source'>
 export function getNotificationTelemetryId(n: ToolkitNotification): string {
     return `TARGETED_NOTIFICATION:${n.id}`
 }
+
+export type DevNotificationsState = { startUp: ToolkitNotification[]; emergency: ToolkitNotification[] }

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -33,6 +33,7 @@ export type globalKey =
     | 'aws.amazonq.showTryChatCodeLens'
     | 'aws.amazonq.notifications'
     | 'aws.notifications'
+    | 'aws.notifications.dev' // keys to store notifications for testing
     | 'aws.downloadPath'
     | 'aws.lastTouchedS3Folder'
     | 'aws.lastUploadedToS3Folder'

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -761,7 +761,7 @@ const devSettings = {
     ssoCacheDirectory: String,
     autofillStartUrl: String,
     webAuth: Boolean,
-    notifications: Boolean,
+    notificationsPollInterval: Number,
 }
 type ResolvedDevSettings = FromDescriptor<typeof devSettings>
 type AwsDevSetting = keyof ResolvedDevSettings


### PR DESCRIPTION
- Add a generic dev menu item to reset the state of a feature. Simply extend with a function handler to add an item to the menu. The initial item resets in-ide notification state.
![image](https://github.com/user-attachments/assets/042bdad2-2bac-4694-a7ff-801a857bddd3)
![image](https://github.com/user-attachments/assets/43fa90aa-af58-4b6f-af0d-ca38fb01f5b7)

- Add a way to test notifications locally without modifying code. Using a dev menu item you can add a notification to global state and receive it in your IDE for visualization.
![image](https://github.com/user-attachments/assets/2a0f267c-e792-4535-a1a4-170f8f6f32ca)
![image](https://github.com/user-attachments/assets/dd08402c-c4db-422c-9b60-20cd4f9340a2)

- Refactor notifications controller to not require a RuleEngine when polling is requested.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
