### PR TITLE
feat(amazonq): support Dockerfile files in /dev

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-06d3549d-411e-43e3-a731-d1e435a86577.json
+++ b/packages/amazonq/.changes/next-release/Feature-06d3549d-411e-43e3-a731-d1e435a86577.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q /dev: support `Dockerfile` files"
+}

--- a/packages/core/src/shared/filetypes.ts
+++ b/packages/core/src/shared/filetypes.ts
@@ -185,6 +185,7 @@ export const codefileExtensions = new Set([
     '.d',
     '.dart',
     '.dfm',
+    '.dockerfile',
     '.dpr',
     '.e',
     '.el',
@@ -347,8 +348,16 @@ export const codefileExtensions = new Set([
     '.zig',
 ])
 
+// Some well-known code files without an extension
+export const wellKnownCodeFiles = new Set(['Dockerfile', 'Dockerfile.build'])
+
 /** Returns true if `filename` is a code file. */
 export function isCodeFile(filename: string): boolean {
-    const ext = path.extname(filename).toLowerCase()
-    return codefileExtensions.has(ext)
+    if (codefileExtensions.has(path.extname(filename).toLowerCase())) {
+        return true
+    } else if (wellKnownCodeFiles.has(filename)) {
+        return true
+    } else {
+        return false
+    }
 }


### PR DESCRIPTION
## Problem
`Dockerfile` files are not currently supported by /dev

## Solution
Add a list of file prefixes that are considered code files for /dev.  This approach supports not only `Dockerfile` but also popular variants of this such as `Dockerfile.build`, `Dockerfile-prod`, etc.

I manually tested some prompts in /dev with requests.  I set breakpoints to see that the file was being zipped up in workspace upload.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
