### PR TITLE
ci(automation): added openGate build spec

### DIFF
--- a/buildspec/release/35opengate.yml
+++ b/buildspec/release/35opengate.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            nodejs: 16
+
+    pre_build:
+        commands:
+            - STAGE_NAME=SourceWithGit
+            - PIPELINE=$(echo $CODEBUILD_INITIATOR | sed -e 's/codepipeline\///')
+    build:
+        commands:
+            - |
+                aws codepipeline enable-stage-transition \
+                  --pipeline-name "$PIPELINE" \
+                  --stage-name "$STAGE_NAME" \
+                  --transition-type "Inbound"


### PR DESCRIPTION
## Problem
We close source gate during the start of a release to prevent unwanted commits coming in, but we have to remember to manually open it again. 

We want to automatically re-open the source gate after a release is triggered. 

This PR creates the buildSpec file to be used by codeBuild project in our release pipeline to open the source transition.

Related infra CR: https://code.amazon.com/reviews/CR-162245234/revisions/1#/diff

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
