### PR TITLE
test(cwl): Add unit test for starting and stopping LiveTailSession object. 

### DIFF
--- a/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/registry/liveTailSession.ts
@@ -93,7 +93,7 @@ export class LiveTailSession {
         if (!commandOutput.responseStream) {
             throw new ToolkitError('LiveTail session response stream is undefined.')
         }
-        this.startTime = Date.now()
+        this.startTime = globals.clock.Date.now()
         this.endTime = undefined
         this.statusBarUpdateTimer = globals.clock.setInterval(() => {
             this.updateStatusBarItemText()
@@ -102,7 +102,7 @@ export class LiveTailSession {
     }
 
     public stopLiveTailSession() {
-        this.endTime = Date.now()
+        this.endTime = globals.clock.Date.now()
         this.statusBarItem.dispose()
         globals.clock.clearInterval(this.statusBarUpdateTimer)
         this.liveTailClient.abortController.abort()
@@ -116,7 +116,7 @@ export class LiveTailSession {
         }
         //Currently running
         if (this.endTime === undefined) {
-            return Date.now() - this.startTime
+            return globals.clock.Date.now() - this.startTime
         }
         return this.endTime - this.startTime
     }

--- a/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
@@ -94,7 +94,7 @@ describe('LiveTailSession', async function () {
     })
 
     it('closes a started session', async function () {
-        sinon.stub(CloudWatchLogsClient.prototype, 'send').callsFake(function () {
+        const startLiveTailStub = sinon.stub(CloudWatchLogsClient.prototype, 'send').callsFake(function () {
             return {
                 responseStream: mockResponseStream(),
             }
@@ -103,6 +103,10 @@ describe('LiveTailSession', async function () {
         assert.strictEqual(session.getLiveTailSessionDuration(), 0)
 
         const returnedResponseStream = await session.startLiveTailSession()
+        assert.strictEqual(startLiveTailStub.calledOnce, true)
+        const requestArgs = startLiveTailStub.getCall(0).args
+        assert.deepEqual(requestArgs[0].input, session.buildStartLiveTailCommand().input)
+        assert.strictEqual(requestArgs[1].abortSignal !== undefined && !requestArgs[1].abortSignal.aborted, true)
         assert.strictEqual(session.isAborted, false)
         assert.strictEqual(clock.countTimers(), 1)
         assert.deepStrictEqual(returnedResponseStream, mockResponseStream())

--- a/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/registry/liveTailSession.test.ts
@@ -9,7 +9,6 @@ import { LiveTailSession } from '../../../../awsService/cloudWatchLogs/registry/
 import {
     CloudWatchLogsClient,
     StartLiveTailCommand,
-    StartLiveTailCommandOutput,
     StartLiveTailResponseStream,
 } from '@aws-sdk/client-cloudwatch-logs'
 import { LogStreamFilterResponse } from '../../../../awsService/cloudWatchLogs/wizard/liveTailLogStreamSubmenu'


### PR DESCRIPTION
## Problem
The `LiveTailSession` object's start/stop methods aren't directly under test. TailLogGroup tests are mocking their behavior. TailLogGroup command tests are more focused on managing the session registry, opening/writing to the document, and the close tab behaviors. 

## Solution
Write a test that's scoped to creating a `session` and calling start and stop on it. Assert that timers are handled/disposed of properly, and that the session response stream is returned. 

Addresses [this comment](https://github.com/aws/aws-toolkit-vscode/pull/6095#discussion_r1857571286).

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
