### PR TITLE
refactor(logs): drop "Amazon Q Logs" channel and just have "Amazon Q"

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-fd23658e-ecc3-4d17-8944-240cbe24a7cc.json
+++ b/packages/amazonq/.changes/next-release/Feature-fd23658e-ecc3-4d17-8944-240cbe24a7cc.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q: Simplify log channel"
+}

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -97,10 +97,8 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     globals.manifestPaths.endpoints = context.asAbsolutePath(join('resources', 'endpoints.json'))
     globals.regionProvider = RegionProvider.fromEndpointsProvider(makeEndpointsProvider())
 
-    const qOutputChannel = vscode.window.createOutputChannel('Amazon Q', { log: true })
     const qLogChannel = vscode.window.createOutputChannel('Amazon Q Logs', { log: true })
-    await activateLogger(context, amazonQContextPrefix, qOutputChannel, qLogChannel)
-    globals.outputChannel = qOutputChannel
+    await activateLogger(context, amazonQContextPrefix, qLogChannel)
     globals.logOutputChannel = qLogChannel
     globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
 

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -30,7 +30,7 @@ import {
 } from './types'
 import { Writable } from 'stream'
 import { CodeWhispererSettings } from '../../codewhisperer/util/codewhispererSettings'
-import { fs, getLogger } from '../../shared'
+import { fs, getLogger, globals } from '../../shared'
 
 const localize = nls.loadMessageBundle()
 
@@ -201,6 +201,9 @@ export async function activate(extensionContext: ExtensionContext) {
             // this is used by LSP to determine index cache path, move to this folder so that when extension updates index is not deleted.
             extensionPath: path.join(fs.getUserHomeDir(), '.aws', 'amazonq', 'cache'),
         },
+        // Log to the Amazon Q Logs so everything is in a single channel
+        // TODO: Add prefix to the language server logs so it is easier to search
+        outputChannel: globals.logOutputChannel,
     }
 
     // Create the language client and start the client.

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -89,7 +89,7 @@ export async function activateCommon(
     // Setup the logger
     const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit', { log: true })
     const toolkitLogChannel = vscode.window.createOutputChannel('AWS Toolkit Logs', { log: true })
-    await activateLogger(context, contextPrefix, toolkitOutputChannel, toolkitLogChannel)
+    await activateLogger(context, contextPrefix, toolkitLogChannel, toolkitOutputChannel)
     globals.outputChannel = toolkitOutputChannel
     globals.logOutputChannel = toolkitLogChannel
 

--- a/packages/core/src/shared/logger/activation.ts
+++ b/packages/core/src/shared/logger/activation.ts
@@ -17,12 +17,14 @@ import { isBeta } from '../vscode/env'
 
 /**
  * Activate Logger functionality for the extension.
+ *
+ * @param outputChannel optional output channel for less granular logs
  */
 export async function activate(
     extensionContext: vscode.ExtensionContext,
     contextPrefix: string,
-    outputChannel: vscode.LogOutputChannel,
-    logChannel: vscode.LogOutputChannel
+    logChannel: vscode.LogOutputChannel,
+    outputChannel?: vscode.LogOutputChannel
 ): Promise<void> {
     const settings = Settings.instance.getSection('aws')
     const devLogfile = settings.get('dev.logfile', '')
@@ -52,7 +54,7 @@ export async function activate(
     setLogger(
         makeLogger({
             logLevel: chanLogLevel,
-            outputChannels: [outputChannel, logChannel],
+            outputChannels: outputChannel ? [outputChannel, logChannel] : [logChannel],
             useConsoleLog: true,
         }),
         'debugConsole'


### PR DESCRIPTION
## Problem

We didn't have much use for the old "Amazon Q" channel in addition to "Amazon Q Logs". All the logs we used were in "Amazon Q Logs".

## Solution

- Now, just have the useful "Amazon Q Logs" channel.
- Move the Amazon Q Language Server logs in to Amazon Q Logs to unify all logs


---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
