### PR TITLE
fix(amazonq): /dev to support upload of nested dockerfiles

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-5f545950-eae0-4ee9-bb41-3c0ac9b7dcb1.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-5f545950-eae0-4ee9-bb41-3c0ac9b7dcb1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /dev not adding Dockerfiles in nested folders"
+}

--- a/packages/core/src/shared/filetypes.ts
+++ b/packages/core/src/shared/filetypes.ts
@@ -348,16 +348,11 @@ export const codefileExtensions = new Set([
     '.zig',
 ])
 
-// Some well-known code files without an extension
-export const wellKnownCodeFiles = new Set(['Dockerfile', 'Dockerfile.build'])
+// Code file names without an extension
+export const codefileNames = new Set(['Dockerfile', 'Dockerfile.build'])
 
 /** Returns true if `filename` is a code file. */
 export function isCodeFile(filename: string): boolean {
-    if (codefileExtensions.has(path.extname(filename).toLowerCase())) {
-        return true
-    } else if (wellKnownCodeFiles.has(filename)) {
-        return true
-    } else {
-        return false
-    }
+    const ext = path.extname(filename).toLowerCase()
+    return codefileExtensions.has(ext) || codefileNames.has(path.basename(filename))
 }


### PR DESCRIPTION
[POST RE:INVENT]

## Problem

Nested `Dockerfile` files were not supported with https://github.com/aws/aws-toolkit-vscode/pull/6107

## Solution

Look at path basename when comparing file to list of well known files.

I manually tested adding nested `Dockerfile`s to various folders and ensured that pattern matched.

---

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
