### PR TITLE
build(pattern): remove ignore pattern related to 1.68 vscode version. 

### DIFF
--- a/buildspec/shared/common.sh
+++ b/buildspec/shared/common.sh
@@ -6,13 +6,9 @@
 
 # Ignore these patterns when deciding if the build should fail.
 #   - "waiting for browser": from `ssoAccessTokenProvider.test.ts`, unclear how to fix it.
-#   - "Webview is disposed": only happens on vscode "minimum" (1.68.0)
 #   - "HTTPError: Response code …": caused by github rate-limiting.
 #   - "npm WARN deprecated querystring": transitive dep of aws sdk v2 (check `npm ls querystring`), so that's blocked until we migrate to v3.
 _ignore_pat='Timed-out waiting for browser login flow\|HTTPError: Response code 403\|HTTPError: Response code 404\|npm WARN deprecated querystring\|npm WARN deprecated'
-if [ "$VSCODE_TEST_VERSION" = 'minimum' ]; then
-    _ignore_pat="$_ignore_pat"'\|Webview is disposed'
-fi
 
 # Do not print (noisy) lines matching these patterns.
 #   - "ERROR:bus… Failed to connect to the bus": noise related to "xvfb". https://github.com/cypress-io/cypress/issues/19299


### PR DESCRIPTION
## Problem
According to the comment in this file, there is an ignore pattern that is only needed on the vscode minimum version of 1.68, but we have bumped to 1.83.0. 

## Solution
Remove pattern for this case. 

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
