### PR TITLE
test(codewhisperer): Turn off CodeWhisperer Auto Scan after test case

### DIFF
--- a/packages/core/src/test/awsService/appBuilder/walkthrough.test.ts
+++ b/packages/core/src/test/awsService/appBuilder/walkthrough.test.ts
@@ -25,6 +25,7 @@ import { ChildProcess } from '../../../shared/utilities/processUtils'
 import { assertTelemetryCurried } from '../../testUtil'
 import { HttpResourceFetcher } from '../../../shared/resourcefetcher/httpResourceFetcher'
 import { SamCliInfoInvocation } from '../../../shared/sam/cli/samCliInfo'
+import { CodeScansState } from '../../../codewhisperer'
 
 interface TestScenario {
     toolID: AwsClis
@@ -81,6 +82,12 @@ const scenarios: TestScenario[] = [
 ]
 
 describe('AppBuilder Walkthrough', function () {
+    before(async function () {
+        // ensure auto scan is disabled before testrun
+        await CodeScansState.instance.setScansEnabled(false)
+        assert.strictEqual(CodeScansState.instance.isScansEnabled(), false)
+    })
+
     describe('Reopen template after reload', function () {
         let sandbox: sinon.SinonSandbox
         let spyExecuteCommand: sinon.SinonSpy

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -88,6 +88,12 @@ describe('CodeWhisperer-basicCommands', function () {
             codeSuggestionsState = new TestCodeSuggestionsState()
         })
 
+        after(async function () {
+            // disable auto scan after testrun
+            await CodeScansState.instance.setScansEnabled(false)
+            assert.strictEqual(CodeScansState.instance.isScansEnabled(), false)
+        })
+
         it('has suggestions enabled by default', async function () {
             targetCommand = testCommand(toggleCodeSuggestions, codeSuggestionsState)
             assert.strictEqual(codeSuggestionsState.isSuggestionsEnabled(), true)
@@ -493,12 +499,6 @@ describe('CodeWhisperer-basicCommands', function () {
 
         afterEach(function () {
             sandbox.restore()
-        })
-
-        after(async function () {
-            // disable auto scan after testrun
-            await CodeScansState.instance.setScansEnabled(false)
-            assert.strictEqual(CodeScansState.instance.isScansEnabled(), false)
         })
 
         it('should call applySecurityFix command successfully', async function () {

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -495,6 +495,12 @@ describe('CodeWhisperer-basicCommands', function () {
             sandbox.restore()
         })
 
+        after(async function () {
+            // disable auto scan after testrun
+            await CodeScansState.instance.setScansEnabled(false)
+            assert.strictEqual(CodeScansState.instance.isScansEnabled(), false)
+        })
+
         it('should call applySecurityFix command successfully', async function () {
             const fileName = 'sample.py'
             const textDocumentMock = createMockDocument('first line\n second line\n fourth line', fileName)

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -74,6 +74,12 @@ describe('CodeWhisperer-basicCommands', function () {
         sinon.restore()
     })
 
+    after(async function () {
+        // disable auto scan after testrun
+        await CodeScansState.instance.setScansEnabled(false)
+        assert.strictEqual(CodeScansState.instance.isScansEnabled(), false)
+    })
+
     describe('toggleCodeSuggestion', function () {
         class TestCodeSuggestionsState extends CodeSuggestionsState {
             public constructor(initialState?: boolean) {
@@ -86,12 +92,6 @@ describe('CodeWhisperer-basicCommands', function () {
         beforeEach(async function () {
             await resetCodeWhispererGlobalVariables()
             codeSuggestionsState = new TestCodeSuggestionsState()
-        })
-
-        after(async function () {
-            // disable auto scan after testrun
-            await CodeScansState.instance.setScansEnabled(false)
-            assert.strictEqual(CodeScansState.instance.isScansEnabled(), false)
         })
 
         it('has suggestions enabled by default', async function () {


### PR DESCRIPTION
## Problem
fix #6078 

## Solution
Turn off CodeWhisper scanning after test suite completes.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
