### PR TITLE
deps(amazonq): update mynah ui to 4.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5172,9 +5172,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.18.1.tgz",
-            "integrity": "sha512-531FL5509O081eWIk0P0reQhGTm/ZaXhRu6FLNqMvAKySPtJyyxee0ieeGAR8h5CVI75learQbXJEGJC6XibAA==",
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.0.tgz",
+            "integrity": "sha512-hEo9T1FeDoh79xA2nXaz3Le0SJES8YTuAOlleR8UKfbmzyfWzvvgO/yDIQ6dK39NO0cuQw+6XYGlIVDFpKfEkA==",
             "hasInstallScript": true,
             "dependencies": {
                 "escape-html": "^1.0.3",
@@ -20035,7 +20035,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.18.1",
+                "@aws/mynah-ui": "^4.21.0",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-17772b9d-7f10-4e16-8b53-0561d6b08f4a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-17772b9d-7f10-4e16-8b53-0561d6b08f4a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix chat syntax highlighting when using several different themes"
+}

--- a/packages/amazonq/.changes/next-release/Feature-3e91ab38-b708-4fcc-888e-7a532c210a69.json
+++ b/packages/amazonq/.changes/next-release/Feature-3e91ab38-b708-4fcc-888e-7a532c210a69.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "UI improvements to Amazon Q Chat: New splash loader animation, initial streaming card animation, improved button colours"
+}

--- a/packages/amazonq/.changes/next-release/Feature-c0fdc8fe-e0e5-422c-a76a-1d7461460e81.json
+++ b/packages/amazonq/.changes/next-release/Feature-c0fdc8fe-e0e5-422c-a76a-1d7461460e81.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Navigate through prompt history by using the up/down arrows"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -506,7 +506,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.18.1",
+        "@aws/mynah-ui": "^4.21.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
mynah ui has several improvements since we've last updated:
- Fix chat syntax highlighting when using several different themes
- UI improvements to Amazon Q Chat: New splash loader animation, initial streaming card animation, improved button colours
- Navigate through prompt history by using the up/down arrows

## Solution
Update mynah ui

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
