### PR TITLE
telemetry(amazonq): differentiate Internal vs External users

### DIFF
--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -255,6 +255,7 @@ export class TestController {
             result: isCancel ? 'Cancelled' : 'Failed',
             reasonDesc: getTelemetryReasonDesc(data.error),
             isSupportedLanguage: true,
+            credentialStartUrl: AuthUtil.instance.startUrl,
         })
         if (session.stopIteration) {
             // Error from Science
@@ -733,6 +734,7 @@ export class TestController {
             isCodeBlockSelected: session.isCodeBlockSelected,
             perfClientLatency: session.latencyOfTestGeneration,
             isSupportedLanguage: true,
+            credentialStartUrl: AuthUtil.instance.startUrl,
             result: 'Succeeded',
         })
 
@@ -855,6 +857,7 @@ export class TestController {
                 isCodeBlockSelected: session.isCodeBlockSelected,
                 perfClientLatency: session.latencyOfTestGeneration,
                 isSupportedLanguage: true,
+                credentialStartUrl: AuthUtil.instance.startUrl,
                 result: 'Succeeded',
             })
             telemetry.ui_click.emit({ elementId: 'unitTestGeneration_rejectDiff' })

--- a/packages/core/src/amazonqTest/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqTest/chat/controller/messenger/messenger.ts
@@ -36,7 +36,7 @@ import { CodeReference } from '../../../../amazonq/webview/ui/apps/amazonqCommon
 import { getHttpStatusCode, getRequestId, getTelemetryReasonDesc, ToolkitError } from '../../../../shared/errors'
 import { sleep, waitUntil } from '../../../../shared/utilities/timeoutUtils'
 import { keys } from '../../../../shared/utilities/tsUtils'
-import { testGenState } from '../../../../codewhisperer'
+import { AuthUtil, testGenState } from '../../../../codewhisperer'
 import { cancellingProgressField, testGenCompletedField } from '../../../models/constants'
 import { telemetry } from '../../../../shared/telemetry/telemetry'
 
@@ -281,6 +281,7 @@ export class Messenger {
                         result: 'Cancelled',
                         reasonDesc: getTelemetryReasonDesc(CodeWhispererConstants.unitTestGenerationCancelMessage),
                         isSupportedLanguage: false,
+                        credentialStartUrl: AuthUtil.instance.startUrl,
                     })
 
                     this.dispatcher.sendUpdatePromptProgress(
@@ -294,6 +295,7 @@ export class Messenger {
                         perfClientLatency: performance.now() - session.testGenerationStartTime,
                         result: 'Succeeded',
                         isSupportedLanguage: false,
+                        credentialStartUrl: AuthUtil.instance.startUrl,
                     })
                     this.dispatcher.sendUpdatePromptProgress(
                         new UpdatePromptProgressMessage(tabID, testGenCompletedField)


### PR DESCRIPTION
## Problem
- UTG toolkit telemetry can not differentiate the users from builderID users vs internal IAM IDC users vs external enterprise users.

## Solution
- Adding `credentialUrl = AuthUtil.instance.startUrl` field to differentiate the builderID users vs internal IAM IDC users vs external enterprise users.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
