### PR TITLE
telemetry(amazon q): adding telemetry after one or multiple diffs form selection

### DIFF
--- a/packages/core/src/amazonq/webview/ui/quickActions/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/generator.ts
@@ -86,7 +86,7 @@ export class QuickActionGenerator {
                         ? [
                               {
                                   command: '/transform',
-                                  description: 'Transform your Java 8 or 11 Maven project to Java 17',
+                                  description: 'Transform your Java 8, 11, or 17 Maven projects',
                                   icon: MynahIcons.TRANSFORM,
                               },
                           ]

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -433,10 +433,12 @@ export class GumbyController {
         } else {
             transformByQState.setMultipleDiffs(false)
         }
-        telemetry.codeTransform_submitSelection.emit({
-            codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-            userChoice: oneOrMultipleDiffsSelection,
-            result: MetadataResult.Pass,
+        await telemetry.codeTransform_submitSelection.run(async () => {
+            telemetry.codeTransform_submitSelection.emit({
+                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                userChoice: oneOrMultipleDiffsSelection,
+                result: MetadataResult.Pass,
+            })
         })
         this.messenger.sendOneOrMultipleDiffsMessage(oneOrMultipleDiffsSelection, message.tabID)
         // perform local build

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -411,19 +411,20 @@ export class GumbyController {
     }
 
     private async handleSkipTestsSelection(message: any) {
-        const skipTestsSelection = message.formSelectedValues['GumbyTransformSkipTestsForm']
-        if (skipTestsSelection === CodeWhispererConstants.skipUnitTestsMessage) {
-            transformByQState.setCustomBuildCommand(CodeWhispererConstants.skipUnitTestsBuildCommand)
-        } else {
-            transformByQState.setCustomBuildCommand(CodeWhispererConstants.doNotSkipUnitTestsBuildCommand)
-        }
-        telemetry.codeTransform_submitSelection.emit({
-            codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-            userChoice: skipTestsSelection,
-            result: MetadataResult.Pass,
+        await telemetry.codeTransform_submitSelection.run(async () => {
+            const skipTestsSelection = message.formSelectedValues['GumbyTransformSkipTestsForm']
+            if (skipTestsSelection === CodeWhispererConstants.skipUnitTestsMessage) {
+                transformByQState.setCustomBuildCommand(CodeWhispererConstants.skipUnitTestsBuildCommand)
+            } else {
+                transformByQState.setCustomBuildCommand(CodeWhispererConstants.doNotSkipUnitTestsBuildCommand)
+            }
+            telemetry.record({
+                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                userChoice: skipTestsSelection,
+            })
+            this.messenger.sendSkipTestsSelectionMessage(skipTestsSelection, message.tabID)
+            await this.messenger.sendOneOrMultipleDiffsPrompt(message.tabID)
         })
-        this.messenger.sendSkipTestsSelectionMessage(skipTestsSelection, message.tabID)
-        await this.messenger.sendOneOrMultipleDiffsPrompt(message.tabID)
     }
 
     private async handleOneOrMultipleDiffs(message: any) {
@@ -438,7 +439,6 @@ export class GumbyController {
             telemetry.record({
                 codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
                 userChoice: oneOrMultipleDiffsSelection,
-                result: MetadataResult.Pass,
             })
 
             this.messenger.sendOneOrMultipleDiffsMessage(oneOrMultipleDiffsSelection, message.tabID)

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -427,22 +427,24 @@ export class GumbyController {
     }
 
     private async handleOneOrMultipleDiffs(message: any) {
-        const oneOrMultipleDiffsSelection = message.formSelectedValues['GumbyTransformOneOrMultipleDiffsForm']
-        if (oneOrMultipleDiffsSelection === CodeWhispererConstants.multipleDiffsMessage) {
-            transformByQState.setMultipleDiffs(true)
-        } else {
-            transformByQState.setMultipleDiffs(false)
-        }
         await telemetry.codeTransform_submitSelection.run(async () => {
-            telemetry.codeTransform_submitSelection.emit({
+            const oneOrMultipleDiffsSelection = message.formSelectedValues['GumbyTransformOneOrMultipleDiffsForm']
+            if (oneOrMultipleDiffsSelection === CodeWhispererConstants.multipleDiffsMessage) {
+                transformByQState.setMultipleDiffs(true)
+            } else {
+                transformByQState.setMultipleDiffs(false)
+            }
+
+            telemetry.record({
                 codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
                 userChoice: oneOrMultipleDiffsSelection,
                 result: MetadataResult.Pass,
             })
+
+            this.messenger.sendOneOrMultipleDiffsMessage(oneOrMultipleDiffsSelection, message.tabID)
+            // perform local build
+            await this.validateBuildWithPromptOnError(message)
         })
-        this.messenger.sendOneOrMultipleDiffsMessage(oneOrMultipleDiffsSelection, message.tabID)
-        // perform local build
-        await this.validateBuildWithPromptOnError(message)
     }
 
     private async handleUserLanguageUpgradeProjectChoice(message: any) {

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -433,6 +433,11 @@ export class GumbyController {
         } else {
             transformByQState.setMultipleDiffs(false)
         }
+        telemetry.codeTransform_submitSelection.emit({
+            codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+            userChoice: oneOrMultipleDiffsSelection,
+            result: MetadataResult.Pass,
+        })
         this.messenger.sendOneOrMultipleDiffsMessage(oneOrMultipleDiffsSelection, message.tabID)
         // perform local build
         await this.validateBuildWithPromptOnError(message)


### PR DESCRIPTION
## Problem
We were only recording the metrics when the user accepts changes so we can track which patches were applied based on their description. We wanted to also keep track of the form in which the user is prompted to pick whether they want their changes in one or multiple diffs.

## Solution
Adding a telemetry call when we handle the form selection for selective transformation one or multiple diffs.

---
License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
