### PR TITLE
config(repository): renamed @aws/dexp to @aws/flare in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @aws/aws-ides-team
 packages/core/src/codewhisperer/ @aws/codewhisperer-team
 packages/core/src/amazonqFeatureDev/ @aws/earlybird
-packages/core/src/codewhispererChat/ @aws/dexp
-packages/core/src/amazonq/ @aws/dexp
+packages/core/src/codewhispererChat/ @aws/flare
+packages/core/src/amazonq/ @aws/flare
 packages/core/src/awsService/accessanalyzer/ @aws/access-analyzer


### PR DESCRIPTION
## Problem
As part of the renaming of "DEXP" to "Flare", the team name on GitHub has changed, and so the `.github/CODEOWNERS` file in this repository should be updated accordingly.

## Solution
Updated the `.github/CODEOWNERS` file accordingly.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
