### PR TITLE
fix(amazonq): progress bar persists after cancelling README creation

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-357cef5f-a2e7-43c4-b4ca-0e89bc8fccd7.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-357cef5f-a2e7-43c4-b4ca-0e89bc8fccd7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /doc: progress bar persists after cancelling README creation"
+}

--- a/packages/core/src/amazonqDoc/session/sessionState.ts
+++ b/packages/core/src/amazonqDoc/session/sessionState.ts
@@ -244,9 +244,9 @@ export class CodeGenState extends CodeGenBase implements SessionState {
                 action.telemetry.setGenerateCodeIteration(this.currentIteration)
                 action.telemetry.setGenerateCodeLastInvocationTime()
                 const codeGenerationId = randomUUID()
-
-                action.messenger.sendDocProgress(this.tabID, DocGenerationStep.SUMMARIZING_FILES, 0, action.mode)
-
+                if (!action.tokenSource?.token.isCancellationRequested) {
+                    action.messenger.sendDocProgress(this.tabID, DocGenerationStep.SUMMARIZING_FILES, 0, action.mode)
+                }
                 await this.config.proxyClient.startCodeGeneration(
                     this.config.conversationId,
                     this.config.uploadId,


### PR DESCRIPTION
## Problem
If a user creates or updates a README using /doc and hits "Cancel" during the "Scanning source files" step, the prompt input progress bar persists.

## Solution
Do not display the prompt progress bar if a user has cancelled the current task.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
