### PR TITLE
fix(amazonq): missing @workspace command on welcome tab

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-0e68107f-cd6c-488d-a457-d765b37a49c3.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-0e68107f-cd6c-488d-a457-d765b37a49c3.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "@workspace is missing from the welcome to q chat tab"
+}

--- a/packages/core/src/amazonq/webview/ui/walkthrough/welcome.ts
+++ b/packages/core/src/amazonq/webview/ui/walkthrough/welcome.ts
@@ -10,6 +10,7 @@ export const welcomeScreenTabData = (tabs: TabDataGenerator): MynahUITabStoreTab
     isSelected: true,
     store: {
         quickActionCommands: tabs.quickActionsGenerator.generateForTab('welcome'),
+        contextCommands: tabs.getTabData('cwc', false).contextCommands,
         tabTitle: 'Welcome to Q',
         tabBackground: true,
         chatItems: [


### PR DESCRIPTION
## Problem
- On the welcome to q chat tab `@workspace` is missing

## Solution
- Pull in all context commands that should be available for the regular cwc tab into the welcome to q tab

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
