### PR TITLE
ci: codecov always fails

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,37 +12,65 @@ coverage:
 
     status:
         project:
-            default:
-                target: 70%
+            # https://docs.codecov.com/docs/commit-status
+            all:
+                target: 80%
                 threshold: 5%
                 informational: true
+                only_pulls: true
             codewhisperer:
                 paths:
                     - packages/core/src/codewhisperer/*
                 flags:
                     - 'codewhisperer'
+                target: 80%
+                threshold: 5%
+                informational: true
+                only_pulls: true
             amazonqFeatureDev:
                 paths:
                     - packages/core/src/amazonqFeatureDev/*
                 flags:
                     - 'amazonqFeatureDev'
+                target: 80%
+                threshold: 5%
+                informational: true
+                only_pulls: true
             amazonqGumby:
                 paths:
                     - packages/core/src/amazonqGumby/*
+                target: 80%
+                threshold: 5%
+                informational: true
+                only_pulls: true
             codewhispererChat:
                 paths:
                     - packages/core/src/codewhispererChat/*
+                target: 80%
+                threshold: 5%
+                informational: true
+                only_pulls: true
             applicationcomposer:
                 paths:
                     - packages/core/src/applicationcomposer/*
+                target: 80%
+                threshold: 5%
+                informational: true
+                only_pulls: true
             stepFunctions:
-                target: 50%
-                threshold: 10%
                 paths:
                     - packages/core/src/stepFunctions/*
+                target: 50%
+                threshold: 10%
+                informational: true
+                only_pulls: true
             threatComposer:
                 paths:
                     - packages/core/src/threatComposer/*
+                target: 80%
+                threshold: 5%
+                informational: true
+                only_pulls: true
         patch: false
         changes: false
 


### PR DESCRIPTION
## Problem
codecov always fails for gumby/appcomposer:

    codecov/project/amazonqGumby — 75.29% (-3.93%)
    codecov/project/applicationcomposer — 82.69% (-0.…)

Based on https://docs.codecov.com/docs/commit-status , the "default" item is just a name, it doesn't set defaults that are "inherited".

## Solution
- rename the "default" project item to avoid confusion
- duplicate the configuration for all project items.





---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
