### PR TITLE
refactor(ec2): avoid logging somewhat sensitive data

### DIFF
--- a/packages/core/resources/ec2_connect
+++ b/packages/core/resources/ec2_connect
@@ -28,7 +28,6 @@ _require_nolog() {
 
 _require() {
     _require_nolog "$@"
-    _log "$1=$2"
 }
 
 _ec2() {
@@ -51,6 +50,12 @@ _main() {
     _require TOKEN "${TOKEN:-}"
     _require SESSION_ID "${SESSION_ID:-}"
     _require LOG_FILE_LOCATION "${LOG_FILE_LOCATION:-}"
+
+    # Avoid logging sensitive data
+    _log "AWS_SSM_CLI=$AWS_SSM_CLI"
+    _log "AWS_REGION=$AWS_REGION"
+    _log SESSION_ID "${SESSION_ID:-}"
+    _log "LOG_FILE_LOCATION=$LOG_FILE_LOCATION"
 
     _ec2 "$AWS_SSM_CLI" "$AWS_REGION" "$STREAM_URL" "$TOKEN" "$SESSION_ID"
 }

--- a/packages/core/src/awsService/ec2/model.ts
+++ b/packages/core/src/awsService/ec2/model.ts
@@ -226,6 +226,7 @@ export class Ec2Connecter implements vscode.Disposable {
         await this.addActiveSession(selection.instanceId, ssmSession.SessionId!)
 
         const vars = getEc2SsmEnv(selection, ssm, ssmSession)
+        getLogger().info(`ec2: connect script logs at ${vars.LOG_FILE_LOCATION}`)
         const envProvider = async () => {
             return { [sshAgentSocketVariable]: await startSshAgent(), ...vars }
         }


### PR DESCRIPTION
## Problem
We currently log `STREAM_URL` and `TOKEN` which are used to establish the SSM session. However, these could be used to establish a connection outside the toolkit. 

## Solution
- Omit these from the logs. 
- Also add a logging statement to make it easier to find these `connect_script` logs. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
