### PR TITLE
ci: codecov "patch" check

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -84,7 +84,7 @@ jobs:
               env:
                   # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
                   NODE_OPTIONS: ''
-              if: ${{ github.repository == 'aws/aws-toolkit-vscode' && github.ref == 'master' }}
+              if: ${{ github.repository == 'aws/aws-toolkit-vscode' && github.event_name == 'pull_request' && github.base_ref == 'master' }}
               uses: codecov/codecov-action@v5
               with:
                   flags: macos-toolkit-unittests
@@ -95,7 +95,7 @@ jobs:
               env:
                   # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
                   NODE_OPTIONS: ''
-              if: ${{ github.repository == 'aws/aws-toolkit-vscode' && github.ref == 'master' }}
+              if: ${{ github.repository == 'aws/aws-toolkit-vscode' && github.event_name == 'pull_request' && github.base_ref == 'master' }}
               uses: codecov/codecov-action@v5
               with:
                   flags: macos-amazonq-unittests
@@ -154,7 +154,7 @@ jobs:
               env:
                   # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
                   NODE_OPTIONS: ''
-              if: ${{ github.repository == 'aws/aws-toolkit-vscode' && github.ref == 'master' }}
+              if: ${{ github.repository == 'aws/aws-toolkit-vscode' && github.event_name == 'pull_request' && github.base_ref == 'master' }}
               uses: codecov/codecov-action@v5
               with:
                   flags: windows-unittests

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,12 @@ codecov:
     notify:
         require_ci_to_pass: no
 
+ignore:
+    - 'node_modules/'
+    - 'plugins/'
+    - 'scripts/'
+    - 'src.gen/'
+
 coverage:
     precision: 2
     round: down
@@ -12,66 +18,85 @@ coverage:
 
     status:
         project:
+            # Note: `default` measures the entire project.
+            # It does NOT define defaults "inherited" by other `project` items.
             # https://docs.codecov.com/docs/commit-status
-            all:
-                target: 80%
-                threshold: 5%
-                informational: true
+            default:
+                informational: true # Always pass. Ignore `target`, `threshold`, etc.
+                target: 80
+                threshold: 5
                 only_pulls: true
             codewhisperer:
+                informational: true # Always pass. Ignore `target`, `threshold`, etc.
                 paths:
-                    - packages/core/src/codewhisperer/*
+                    - 'packages/core/src/codewhisperer/'
+                    - 'packages/core/src/amazonq*/*'
+                    - 'packages/amazonq/src/'
                 flags:
                     - 'codewhisperer'
-                target: 80%
-                threshold: 5%
-                informational: true
+                target: 80
+                threshold: 5
                 only_pulls: true
             amazonqFeatureDev:
+                informational: true # Always pass. Ignore `target`, `threshold`, etc.
                 paths:
-                    - packages/core/src/amazonqFeatureDev/*
+                    - 'packages/core/src/amazonqFeatureDev/*'
                 flags:
                     - 'amazonqFeatureDev'
-                target: 80%
-                threshold: 5%
-                informational: true
+                target: 80
+                threshold: 5
                 only_pulls: true
             amazonqGumby:
+                informational: true # Always pass. Ignore `target`, `threshold`, etc.
                 paths:
-                    - packages/core/src/amazonqGumby/*
-                target: 80%
-                threshold: 5%
-                informational: true
+                    - 'packages/core/src/amazonqGumby/*'
+                target: 80
+                threshold: 5
                 only_pulls: true
             codewhispererChat:
+                informational: true # Always pass. Ignore `target`, `threshold`, etc.
                 paths:
-                    - packages/core/src/codewhispererChat/*
-                target: 80%
-                threshold: 5%
-                informational: true
+                    - 'packages/core/src/codewhispererChat/*'
+                target: 80
+                threshold: 5
                 only_pulls: true
             applicationcomposer:
+                informational: true # Always pass. Ignore `target`, `threshold`, etc.
                 paths:
-                    - packages/core/src/applicationcomposer/*
-                target: 80%
-                threshold: 5%
-                informational: true
+                    - 'packages/core/src/applicationcomposer/*'
+                target: 80
+                threshold: 5
                 only_pulls: true
             stepFunctions:
+                informational: true # Always pass. Ignore `target`, `threshold`, etc.
                 paths:
-                    - packages/core/src/stepFunctions/*
-                target: 50%
-                threshold: 10%
-                informational: true
+                    - 'packages/core/src/stepFunctions/*'
+                target: 50
+                threshold: 10
                 only_pulls: true
             threatComposer:
+                informational: true # Always pass. Ignore `target`, `threshold`, etc.
                 paths:
-                    - packages/core/src/threatComposer/*
-                target: 80%
-                threshold: 5%
-                informational: true
+                    - 'packages/core/src/threatComposer/*'
+                target: 80
+                threshold: 5
                 only_pulls: true
-        patch: false
+            tests:
+                # Most code in test/ should always be "covered"!
+                target: 95
+                paths:
+                    - '**/test/**'
+        patch:
+            default:
+                # Note: `default` measures the entire project.
+                # It does NOT define defaults "inherited" by other `project` items.
+                # https://docs.codecov.com/docs/commit-status
+                target: 90
+                threshold: 5
+                only_pulls: true
+                informational: false # Fail if PR changes are not covered.
+                # branches:
+                #     - master
         changes: false
 
 comment: false
@@ -82,7 +107,9 @@ github_checks:
 flags:
     codewhisperer:
         paths:
-            - packages/core/src/codewhisperer/
+            - 'packages/core/src/codewhisperer/'
+            - 'packages/core/src/amazonq*/*'
+            - 'packages/amazonq/src/'
     amazonqFeatureDev:
         paths:
-            - packages/core/src/amazonqFeatureDev/
+            - 'packages/core/src/amazonqFeatureDev/'


### PR DESCRIPTION
# Problem 

- codecov is always skipped in github actions:
    - <img width="430" alt="image" src="https://github.com/user-attachments/assets/669b25b7-1720-47e1-b8f9-a6eb9881dce5">
- We have a bot that attempts to remind contributors about adding tests, but it gets ignored.

# Solution 

- Fix the condition: https://github.com/aws/aws-toolkit-vscode/pull/6150/commits/cec8218a0bc7bfc8d0dfcc92a2764de18030e720
- Reintroduce the codecov "patch" check.





---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
