### PR TITLE
refactor(logs): avoid logging EC2 ARN on commands. 

### DIFF
--- a/packages/core/src/shared/vscode/commands2.ts
+++ b/packages/core/src/shared/vscode/commands2.ts
@@ -656,7 +656,7 @@ async function runCommand<T extends Callback>(fn: T, info: CommandInfo<T>): Prom
 
     logger.debug(
         `command: running ${label} with arguments: %O`,
-        partialClone(args, 3, ['clientSecret', 'accessToken', 'refreshToken'], '[omitted]')
+        partialClone(args, 3, ['clientSecret', 'accessToken', 'refreshToken', 'tooltip'], '[omitted]')
     )
 
     try {


### PR DESCRIPTION
## Problem
The EC2 ARN sneaks its away into the logs via the `Ec2InstanceNode` tooltip property from `packages/core/src/awsService/ec2/explorer/ec2InstanceNode.ts`. When we run any command on this instance, we get the following logs with the middle section omitted for brevity. 
``` 
2024-12-04 17:25:10.859 [debug] command: running "aws.ec2.openTerminal" with arguments: [
  {
    collapsibleState: 0,
    label: 'testInstance ({INSTANCE_ID}) RUNNING',
   ...
    contextValue: 'awsEc2RunningNode',
    iconPath: { id: 'pass', color: undefined },
    tooltip: 'testInstance\n' +
      '{INSTANCE_ID}\n' +
      'running\n' +
      'arn:aws:ec2:us-east-1:{ACCOUNT_ID}:instance/{INSTANCE_ID}',
    id: '{INSTANCE_ID}'
  },
  undefined
]
```
The actual AWS account ID in use is included in the logs. 

What makes this difficult is that this node is passed directly from VSCode here:
https://github.com/aws/aws-toolkit-vscode/blob/d74f96c61f79716edf8a9a706a86c587887d3b9b/packages/core/src/awsService/ec2/activation.ts#L32-L37
and is processed by our commands wrapper here: 
https://github.com/aws/aws-toolkit-vscode/blob/d74f96c61f79716edf8a9a706a86c587887d3b9b/packages/core/src/shared/vscode/commands2.ts#L649-L660
The wrapper is logging the node directly from vscode, not giving us a chance to use `partialClone` on it first. 
## Solution
- omit all tooltips from the logs, since this is usually redundant information anyway. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
