### PR TITLE
docs(ec2): add details about `authorized_keys`override

### DIFF
--- a/docs/arch_features.md
+++ b/docs/arch_features.md
@@ -43,6 +43,7 @@ For EC2 specifically, there are a few additional steps:
 
 1. If connecting to EC2 instance via remote window, the toolkit generates temporary SSH keys (30 second lifetime), with the public key sent to the remote instance.
     - Key type is ed25519 if supported, or RSA otherwise.
+    - This connection will overwrite the `.ssh/authorized_keys` file on the remote machine with each connection.
 1. If insufficient permissions are detected on the attached IAM role, toolkit will prompt to add an inline policy with the necessary actions.
 1. If SSM sessions remain open after closing the window/terminal, the toolkit will terminate them on-shutdown, or when starting another session to the same instance.
 


### PR DESCRIPTION
## Problem
Missing documentation about current behavior of ec2 remote window connect. 

## Solution
Add some detail to the docs. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
