### PR TITLE
refactor(ec2): pass log level to connect script

### DIFF
--- a/packages/core/resources/ec2_connect
+++ b/packages/core/resources/ec2_connect
@@ -2,7 +2,7 @@
 
 # Usage:
 #   When connecting to a dev environment
-#       AWS_REGION=… AWS_SSM_CLI=… STREAM_URL=… TOKEN=… LOG_FILE_LOCATION==… ./ec2_connect
+#       AWS_REGION=… AWS_SSM_CLI=… STREAM_URL=… TOKEN=… LOG_FILE_LOCATION==… LOG_LEVEL=… ./ec2_connect 
 
 set -e
 set -u
@@ -44,13 +44,20 @@ _ec2() {
 
 _main() {
     _log "=============================================================================="
-
-    _require AWS_SSM_CLI "${AWS_SSM_CLI:-}"
+    _require LOG_LEVEL "${LOG_LEVEL:-}"
     _require AWS_REGION "${AWS_REGION:-}"
+    _require SESSION_ID "${SESSION_ID:-}"
     _require_nolog STREAM_URL "${STREAM_URL:-}"
     _require_nolog TOKEN "${TOKEN:-}"
-    _require SESSION_ID "${SESSION_ID:-}"
-    _require LOG_FILE_LOCATION "${LOG_FILE_LOCATION:-}"
+
+    # Only log file paths when debug level is set in toolkit. 
+    if [ "${LOG_LEVEL:-}" -le 2 ]; then
+        _require AWS_SSM_CLI "${AWS_SSM_CLI:-}"
+        _require LOG_FILE_LOCATION "${LOG_FILE_LOCATION:-}"
+    else
+        _require_nolog AWS_SSM_CLI "${AWS_SSM_CLI:-}"
+        _require_nolog LOG_FILE_LOCATION "${LOG_FILE_LOCATION:-}"
+    fi
 
     _ec2 "$AWS_SSM_CLI" "$AWS_REGION" "$STREAM_URL" "$TOKEN" "$SESSION_ID"
 }

--- a/packages/core/resources/ec2_connect
+++ b/packages/core/resources/ec2_connect
@@ -28,7 +28,6 @@ _require_nolog() {
 
 _require() {
     _require_nolog "$@"
-    _log "$1=$2"
 }
 
 _ec2() {
@@ -51,6 +50,12 @@ _main() {
     _require TOKEN "${TOKEN:-}"
     _require SESSION_ID "${SESSION_ID:-}"
     _require LOG_FILE_LOCATION "${LOG_FILE_LOCATION:-}"
+
+    # Avoid logging sensitive data
+    _log "AWS_SSM_CLI=$AWS_SSM_CLI"
+    _log "AWS_REGION=$AWS_REGION"
+    _log SESSION_ID "${SESSION_ID:-}"
+    _log "LOG_FILE_LOCATION=$LOG_FILE_LOCATION"
 
     _ec2 "$AWS_SSM_CLI" "$AWS_REGION" "$STREAM_URL" "$TOKEN" "$SESSION_ID"
 }

--- a/packages/core/resources/ec2_connect
+++ b/packages/core/resources/ec2_connect
@@ -28,6 +28,7 @@ _require_nolog() {
 
 _require() {
     _require_nolog "$@"
+    _log "$1=$2"
 }
 
 _ec2() {
@@ -46,16 +47,10 @@ _main() {
 
     _require AWS_SSM_CLI "${AWS_SSM_CLI:-}"
     _require AWS_REGION "${AWS_REGION:-}"
-    _require STREAM_URL "${STREAM_URL:-}"
-    _require TOKEN "${TOKEN:-}"
+    _require_nolog STREAM_URL "${STREAM_URL:-}"
+    _require_nolog TOKEN "${TOKEN:-}"
     _require SESSION_ID "${SESSION_ID:-}"
     _require LOG_FILE_LOCATION "${LOG_FILE_LOCATION:-}"
-
-    # Avoid logging sensitive data
-    _log "AWS_SSM_CLI=$AWS_SSM_CLI"
-    _log "AWS_REGION=$AWS_REGION"
-    _log SESSION_ID "${SESSION_ID:-}"
-    _log "LOG_FILE_LOCATION=$LOG_FILE_LOCATION"
 
     _ec2 "$AWS_SSM_CLI" "$AWS_REGION" "$STREAM_URL" "$TOKEN" "$SESSION_ID"
 }

--- a/packages/core/src/awsService/ec2/model.ts
+++ b/packages/core/src/awsService/ec2/model.ts
@@ -226,6 +226,7 @@ export class Ec2Connecter implements vscode.Disposable {
         await this.addActiveSession(selection.instanceId, ssmSession.SessionId!)
 
         const vars = getEc2SsmEnv(selection, ssm, ssmSession)
+        getLogger().info(`ec2: connect script logs at ${vars.LOG_FILE_LOCATION}`)
         const envProvider = async () => {
             return { [sshAgentSocketVariable]: await startSshAgent(), ...vars }
         }

--- a/packages/core/src/awsService/ec2/utils.ts
+++ b/packages/core/src/awsService/ec2/utils.ts
@@ -8,6 +8,7 @@ import { copyToClipboard } from '../../shared/utilities/messages'
 import { Ec2Selection } from './prompter'
 import { sshLogFileLocation } from '../../shared/sshConfig'
 import { SSM } from 'aws-sdk'
+import { globals } from '../../shared'
 
 export function getIconCode(instance: SafeEc2Instance) {
     if (instance.LastSeenStatus === 'running') {
@@ -42,6 +43,7 @@ export function getEc2SsmEnv(
             STREAM_URL: session.StreamUrl,
             SESSION_ID: session.SessionId,
             TOKEN: session.TokenValue,
+            LOG_LEVEL: globals.logOutputChannel.logLevel,
         },
         process.env
     )

--- a/packages/core/src/shared/extensionGlobals.ts
+++ b/packages/core/src/shared/extensionGlobals.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ExtensionContext, OutputChannel, Uri } from 'vscode'
+import { ExtensionContext, LogOutputChannel, OutputChannel, Uri } from 'vscode'
 import { LoginManager } from '../auth/deprecated/loginManager'
 import { AwsResourceManager } from '../dynamicResources/awsResourceManager'
 import { AWSClientBuilder } from './awsClientBuilder'
@@ -191,7 +191,7 @@ export interface ToolkitGlobals {
     /**
      * Log messages. Use `outputChannel` for application messages.
      */
-    logOutputChannel: OutputChannel
+    logOutputChannel: LogOutputChannel
     loginManager: LoginManager
     awsContextCommands: AwsContextCommands
     awsContext: AwsContext


### PR DESCRIPTION
## Problem
We want to only log file paths when in debug mode, but the connect script has no way of determining this. 

## Solution
- pass log level to connect script. 
- use it to determine what to log. 
- 
Example logs:
``` 
2024/12/05 15:50:24 ==============================================================================
2024/12/05 15:50:24 LOG_LEVEL=3
2024/12/05 15:50:24 AWS_REGION=us-east-1
2024/12/05 15:50:24 SESSION_ID=...
2024/12/05 15:51:11 ==============================================================================
2024/12/05 15:51:11 LOG_LEVEL=1
2024/12/05 15:51:11 AWS_REGION=us-east-1
2024/12/05 15:51:11 SESSION_ID=...
2024/12/05 15:51:11 AWS_SSM_CLI=.../Amazon/sessionmanagerplugin/bin/session-manager-plugin
2024/12/05 15:51:11 LOG_FILE_LOCATION=/.../ec2.{instanceId}.log
2024/12/05 15:51:55 ==============================================================================
2024/12/05 15:51:55 LOG_LEVEL=2
2024/12/05 15:51:55 AWS_REGION=us-east-1
2024/12/05 15:51:55 SESSION_ID=default-uk9cv4h86y5rdbrzarlkj9opci
2024/12/05 15:51:56 AWS_SSM_CLI=../Amazon/sessionmanagerplugin/bin/session-manager-plugin
2024/12/05 15:51:56 LOG_FILE_LOCATION=/.../ec2.{instanceId}.log
```

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
