### PR TITLE
fix(amazonq): Improved LLM code review for file review

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-0c35b577-da17-4132-a0b7-e0d630e73cb9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-0c35b577-da17-4132-a0b7-e0d630e73cb9.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Imrpoved LLm code review for file review."
+	"description": "Improved LLM code review for file review."
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-0c35b577-da17-4132-a0b7-e0d630e73cb9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-0c35b577-da17-4132-a0b7-e0d630e73cb9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Imrpoved LLm code review for file review."
+}

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -120,12 +120,8 @@ export class ZipUtil {
             zip.addFile(zipEntryPath, Buffer.from(content, 'utf-8'))
 
             if (scope === CodeWhispererConstants.CodeAnalysisScope.FILE_ON_DEMAND) {
-                await this.processCombinedGitDiff(
-                    zip,
-                    [workspaceFolder.uri.fsPath],
-                    uri.fsPath,
-                    CodeWhispererConstants.CodeAnalysisScope.FILE_ON_DEMAND
-                )
+                const gitDiffContent = `+++ b/${zipEntryPath}`
+                zip.addFile(ZipConstants.codeDiffFilePath, Buffer.from(gitDiffContent, 'utf-8'))
             }
         } else {
             zip.addFile(uri.fsPath, Buffer.from(content, 'utf-8'))

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -120,7 +120,7 @@ export class ZipUtil {
             zip.addFile(zipEntryPath, Buffer.from(content, 'utf-8'))
 
             if (scope === CodeWhispererConstants.CodeAnalysisScope.FILE_ON_DEMAND) {
-                const gitDiffContent = `+++ b/${zipEntryPath}`
+                const gitDiffContent = `+++ b/${path.normalize(zipEntryPath)}` // Sending file path in payload for LLM code review
                 zip.addFile(ZipConstants.codeDiffFilePath, Buffer.from(gitDiffContent, 'utf-8'))
             }
         } else {


### PR DESCRIPTION
## Problem
- Code diff for file review format has changed in payload to improve LLM based code review accuracy and is dependent on git.

## Solution
- We are currently send entire file in diff format and run git commands to extract it. This change will remove git dependency for LLM based code review issues.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
