### PR TITLE
fix(auth): malformed SSO cache didn't prompt reauth

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-a243e8d5-b494-46a1-9ec0-c8c6af3cbf35.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-a243e8d5-b494-46a1-9ec0-c8c6af3cbf35.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth: SSO session was bad, but no reauth prompt given"
+}

--- a/packages/core/src/auth/sso/cache.ts
+++ b/packages/core/src/auth/sso/cache.ts
@@ -15,7 +15,7 @@ import { SsoToken, ClientRegistration } from './model'
 import { DevSettings } from '../../shared/settings'
 import { onceChanged } from '../../shared/utilities/functionUtils'
 import globals from '../../shared/extensionGlobals'
-import { ToolkitError } from '../../shared'
+import { ToolkitError } from '../../shared/errors'
 
 interface RegistrationKey {
     readonly startUrl: string

--- a/packages/core/src/shared/regions/regionProvider.ts
+++ b/packages/core/src/shared/regions/regionProvider.ts
@@ -15,7 +15,7 @@ import { AwsContext } from '../awsContext'
 import { getIdeProperties, isAmazonQ, isCloud9 } from '../extensionUtilities'
 import { ResourceFetcher } from '../resourcefetcher/resourcefetcher'
 import { isSsoConnection } from '../../auth/connection'
-import { Auth } from '../../auth'
+import { Auth } from '../../auth/auth'
 
 export const defaultRegion = 'us-east-1'
 export const defaultPartition = 'aws'

--- a/packages/core/src/shared/utilities/cacheUtils.ts
+++ b/packages/core/src/shared/utilities/cacheUtils.ts
@@ -116,10 +116,23 @@ export function createDiskCache<V, K>(
                 log('loaded', key)
                 return result
             } catch (error) {
+                // Non-recoverable errors mean there is no usable data.
+                // Recoverable errors mean we can possibly use the data for something like
+                // an SSO token refresh, or to just retry.
+                // Returning undefined implies non-recoverable.
+
+                // -- Non-recoverable Errors --
                 if (isFileNotFoundError(error)) {
                     log('read failed (file not found)', key)
                     return
                 }
+                if (error instanceof SyntaxError) {
+                    // file content was malformed or empty
+                    log(`read failed (invalid JSON)`, key)
+                    return
+                }
+
+                // -- Recoverable Errors --
                 log(`read failed ${error}`, key)
                 throw createDiskCacheError(error, 'LOAD', target, key)
             }

--- a/packages/core/src/test/credentials/sso/cache.test.ts
+++ b/packages/core/src/test/credentials/sso/cache.test.ts
@@ -8,6 +8,7 @@ import * as path from 'path'
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../../shared/filesystemUtilities'
 import { getRegistrationCache, getTokenCache } from '../../../auth/sso/cache'
 import { fs } from '../../../shared'
+import { SsoToken } from '../../../auth/sso/model'
 
 describe('SSO Cache', function () {
     const region = 'dummyRegion'
@@ -26,7 +27,8 @@ describe('SSO Cache', function () {
     const validToken = {
         accessToken: 'longstringofrandomcharacters',
         expiresAt: new Date(Date.now() + hourInMs),
-    }
+        refreshToken: 'dummyRefreshToken',
+    } as SsoToken
 
     beforeEach(async function () {
         testDir = await makeTemporaryToolkitFolder()

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -45,6 +45,7 @@ describe('SsoAccessTokenProvider', function () {
         return {
             accessToken: 'dummyAccessToken',
             expiresAt: new clock.Date(clock.Date.now() + timeDelta),
+            refreshToken: 'dummyRefreshToken',
             ...extras,
         }
     }

--- a/packages/toolkit/.changes/next-release/Bug Fix-868c7cda-80c1-4947-a498-3792f88622ad.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-868c7cda-80c1-4947-a498-3792f88622ad.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth: SSO session was bad, but no reauth prompt given"
+}


### PR DESCRIPTION
## Problem:

When we loaded sso cache from disk, we would only invalidate (leading to a reauth prompt) if the cache file was missing.

But if the cache file was present, though its content was malformed, we would incorrectly treat it as recoverable by throwing instead of returning undefined. Users would get stuck in a state where all future api calls would fail, and they'd never get a prompt to reauth to fix their SSO session.

## Solution:

If we detect a SyntaxError treat it as non-recoverable, meaning it will trigger a reauth.

Also added some code to validate the content of the SSO cache we loaded from disk to ensure it is what we expected.

Fixes #6140

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
