### PR TITLE
fix(amazonq): improve welcome page opening detection

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-49ee4921-044b-48b0-b51c-4e7054e84e6a.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-49ee4921-044b-48b0-b51c-4e7054e84e6a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Improve when the welcome page is shown in amazon q chat"
+}

--- a/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
+++ b/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
@@ -74,6 +74,11 @@ export function dispatchWebViewMessagesToApps(
                 globals.globalState.tryUpdate('aws.amazonq.disclaimerAcknowledged', true)
                 return
             }
+            case 'update-welcome-count': {
+                const currentLoadCount = globals.globalState.tryGet('aws.amazonq.welcomeChatShowCount', Number, 0)
+                void globals.globalState.tryUpdate('aws.amazonq.welcomeChatShowCount', currentLoadCount + 1)
+                return
+            }
         }
 
         if (msg.type === 'error') {

--- a/packages/core/src/amazonq/webview/ui/commands.ts
+++ b/packages/core/src/amazonq/webview/ui/commands.ts
@@ -41,5 +41,6 @@ type MessageCommand =
     | 'review'
     | 'open-user-guide'
     | 'send-telemetry'
+    | 'update-welcome-count'
 
 export type ExtensionMessage = Record<string, any> & { command: MessageCommand }

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -33,11 +33,17 @@ import { agentWalkthroughDataModel } from './walkthrough/agent'
 import { createClickTelemetry, createOpenAgentTelemetry } from './telemetry/actions'
 import { disclaimerAcknowledgeButtonId, disclaimerCard } from './texts/disclaimer'
 
+/**
+ * The number of welcome chat tabs that can be opened before the NEXT one will become
+ * a regular chat tab.
+ */
+const welcomeCountThreshold = 3
+
 export const createMynahUI = (
     ideApi: any,
     amazonQEnabled: boolean,
     featureConfigsSerialized: [string, FeatureContext][],
-    showWelcomePage: boolean,
+    welcomeCount: number,
     disclaimerAcknowledged: boolean,
     disabledCommands?: string[]
 ) => {
@@ -70,11 +76,23 @@ export const createMynahUI = (
             })
         },
     })
+
+    const showWelcomePage = () => {
+        return welcomeCount < welcomeCountThreshold
+    }
+
+    const updateWelcomeCount = () => {
+        ideApi.postMessage({
+            command: 'update-welcome-count',
+        })
+        welcomeCount += 1
+    }
+
     // Adding the first tab as CWC tab
     tabsStorage.addTab({
         id: 'tab-1',
         status: 'free',
-        type: showWelcomePage ? 'welcome' : 'cwc',
+        type: showWelcomePage() ? 'welcome' : 'cwc',
         isSelected: true,
     })
 
@@ -541,6 +559,25 @@ export const createMynahUI = (
     mynahUI = new MynahUI({
         onReady: connector.uiReady,
         onTabAdd: (tabID: string) => {
+            /**
+             * If the next tab opening will cross the welcome count threshold then
+             * update the next tabs defaults
+             */
+            if (welcomeCount + 1 >= welcomeCountThreshold) {
+                tabsStorage.updateTabTypeFromUnknown(tabID, 'cwc')
+                mynahUI?.updateTabDefaults({
+                    store: {
+                        ...tabDataGenerator.getTabData('cwc', true),
+                        tabHeaderDetails: void 0,
+                        compactMode: false,
+                        tabBackground: false,
+                    },
+                })
+            } else {
+                // we haven't reached the welcome count limit yet
+                updateWelcomeCount()
+            }
+
             // If featureDev has changed availability inbetween the default store settings and now
             // make sure to show/hide it accordingly
             mynahUI.updateStore(tabID, {
@@ -812,7 +849,7 @@ export const createMynahUI = (
             'tab-1': {
                 isSelected: true,
                 store: {
-                    ...(showWelcomePage
+                    ...(showWelcomePage()
                         ? welcomeScreenTabData(tabDataGenerator).store
                         : tabDataGenerator.getTabData('cwc', true)),
                     ...(disclaimerCardActive ? { promptInputStickyCard: disclaimerCard } : {}),
@@ -820,7 +857,9 @@ export const createMynahUI = (
             },
         },
         defaults: {
-            store: tabDataGenerator.getTabData('cwc', true),
+            store: showWelcomePage()
+                ? welcomeScreenTabData(tabDataGenerator).store
+                : tabDataGenerator.getTabData('cwc', true),
         },
         config: {
             maxTabs: 10,
@@ -828,6 +867,14 @@ export const createMynahUI = (
             texts: uiComponentsTexts,
         },
     })
+
+    /**
+     * Update the welcome count if we've initially shown
+     * the welcome page
+     */
+    if (showWelcomePage()) {
+        updateWelcomeCount()
+    }
 
     followUpsInteractionHandler = new FollowUpInteractionHandler({
         mynahUI,

--- a/packages/core/src/amazonq/webview/webView.ts
+++ b/packages/core/src/amazonq/webview/webView.ts
@@ -22,11 +22,6 @@ import { TabType } from './ui/storages/tabsStorage'
 import { deactivateInitialViewBadge, shouldShowBadge } from '../util/viewBadgeHandler'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { amazonqMark } from '../../shared/performance/marks'
-import { globals } from '../../shared'
-import { AuthUtil } from '../../codewhisperer/util/authUtil'
-
-// The max number of times we should show the welcome to q chat panel before moving them to the regular one
-const maxWelcomeWebviewLoads = 3
 
 export class AmazonQChatViewProvider implements WebviewViewProvider {
     public static readonly viewType = 'aws.AmazonQChatView'
@@ -65,33 +60,10 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
 
         dispatchAppsMessagesToWebView(webviewView.webview, this.appsMessagesListener)
 
-        /**
-         * Show the welcome to q chat ${maxWelcomeWebviewLoads} times before showing the normal panel
-         */
-        const welcomeLoadCount = globals.globalState.tryGet('aws.amazonq.welcomeChatShowCount', Number, 0)
-        if (welcomeLoadCount < maxWelcomeWebviewLoads) {
-            webviewView.webview.html = await this.webViewContentGenerator.generate(
-                this.extensionContext.extensionUri,
-                webviewView.webview,
-                true
-            )
-
-            /**
-             * resolveWebviewView gets called even when the user isn't logged in and the auth page is showing.
-             * We don't want to incremenent the show count until the user has fully logged in and resolveWebviewView
-             * gets called again
-             */
-            const authenticated = (await AuthUtil.instance.getChatAuthState()).amazonQ === 'connected'
-            if (authenticated) {
-                await globals.globalState.update('aws.amazonq.welcomeChatShowCount', welcomeLoadCount + 1)
-            }
-        } else {
-            webviewView.webview.html = await this.webViewContentGenerator.generate(
-                this.extensionContext.extensionUri,
-                webviewView.webview,
-                false
-            )
-        }
+        webviewView.webview.html = await this.webViewContentGenerator.generate(
+            this.extensionContext.extensionUri,
+            webviewView.webview
+        )
 
         performance.mark(amazonqMark.open)
 


### PR DESCRIPTION
## Problem
- the current implementation only opens the first tab as a welcome tab for the next 3 times you open vscode

## Solution
- the new implementation shows the welcome tab 3 total times, either when you open a new chat tab or a new vscode window or both

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
