### PR TITLE
fix(cwl): Update metric definitions for TailLogGroup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.284",
+                "@aws-toolkits/telemetry": "^1.0.287",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@types/he": "^1.2.3",
                 "@types/vscode": "^1.68.0",
@@ -6046,13 +6046,14 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.284",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.284.tgz",
-            "integrity": "sha512-+3uHmr4St2cw8yuvVZOUY4Recv0wmzendGODCeUPIIUjsjCANF3H7G/qzIKRN3BHCoedcvzA/eSI+l4ENRXtiA==",
+            "version": "1.0.287",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.287.tgz",
+            "integrity": "sha512-qK2l8Fv5Cvs865ap2evf4ikBREg33/jGw0lgxolqZLdHwm5zm/DkR9vNyqwhDlqDRlSgSlros3Z8zaiSBVRYVQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^6.12.6",
+                "cross-spawn": "^7.0.6",
                 "fs-extra": "^11.1.0",
                 "lodash": "^4.17.20",
                 "prettier": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "generateNonCodeFiles": "npm run generateNonCodeFiles -w packages/ --if-present"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.284",
+        "@aws-toolkits/telemetry": "^1.0.287",
         "@playwright/browser-chromium": "^1.43.1",
         "@types/he": "^1.2.3",
         "@types/vscode": "^1.68.0",


### PR DESCRIPTION
## Problem
Updating telemetry to accommodate changes in https://github.com/aws/aws-toolkit-common/pull/932

## Solution
Update package version for telemetry. 
Add validation on the LogStreamFilter submenu's response for filter type. This is needed to allow the type returned from the LogStreamFilterSubmenu to be convertible to the type in the metric definition for filterPattern. In any case, this is a good validation to have since the 'menu' placeholder value isn't valid for starting a LiveTail session anyways.  

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
