### PR TITLE
fix(amazonq): use fsPath for project name

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-56306583-37cf-4364-ba41-ac69d0ffdf44.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-56306583-37cf-4364-ba41-ac69d0ffdf44.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Code Review: Fixed a bug where some issues are missing from the code issues view for workspaces with custom names"
+}

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -114,7 +114,9 @@ export class ZipUtil {
 
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
         if (workspaceFolder) {
-            const projectName = workspaceFolder.name
+            // Note: workspaceFolder.name is not the same as the file system folder name,
+            // use the fsPath value instead
+            const projectName = path.basename(workspaceFolder.uri.fsPath)
             const relativePath = vscode.workspace.asRelativePath(uri)
             const zipEntryPath = this.getZipEntryPath(projectName, relativePath)
             zip.addFile(zipEntryPath, Buffer.from(content, 'utf-8'))


### PR DESCRIPTION
## Problem

Issues reported in chat sometimes does not match issues tree.

![image](https://github.com/user-attachments/assets/67efa05e-6fd5-4b15-9002-7e7d04c76069)

This is happening because the zip artifact uses workspace name (custom name could be different from fsPath) while git diff output uses fsPath. This causes the findings to come back as two filePaths that end up overwriting each other.



## Solution

Update zip to use project name from fsPath instead of `workspaceFolder.name`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
