### PR TITLE
fix(amazonq): prompt user to choose a folder in the chat for /doc

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-570a8c06-4da6-4585-b589-be1fba2ce20f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-570a8c06-4da6-4585-b589-be1fba2ce20f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /doc: Prompt user to choose a folder in chat"
+}

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -374,6 +374,8 @@
     "AWS.amazonq.doc.answer.generating": "Generating documentation",
     "AWS.amazonq.doc.answer.creating": "Okay, I'm creating a README for your project. This may take a few minutes.",
     "AWS.amazonq.doc.answer.updating": "Okay, I'm updating the README to reflect your code changes. This may take a few minutes.",
+    "AWS.amazonq.doc.answer.chooseFolder": "Choose a folder to continue.",
+    "AWS.amazonq.doc.error.noFolderSelected": "It looks like you didn't choose a folder. Choose a folder to continue.",
     "AWS.amazonq.doc.error.contentLengthError": "Your workspace is too large for me to review. Your workspace must be within the quota, even if you choose a smaller folder. For more information on quotas, see the <a href=\"https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/doc-generation.html#quotas\" target=\"_blank\">Amazon Q Developer documentation.</a>",
     "AWS.amazonq.doc.error.readmeTooLarge": "The README in your folder is too large for me to review. Try reducing the size of your README, or choose a folder with a smaller README. For more information on quotas, see the <a href=\"https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/doc-generation.html#quotas\" target=\"_blank\">Amazon Q Developer documentation.</a>",
     "AWS.amazonq.doc.error.workspaceEmpty": "The folder you chose did not contain any source files in a supported language. Choose another folder and try again. For more information on supported languages, see the <a href=\"https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/doc-generation.html\" target=\"_blank\">Amazon Q Developer documentation.</a>",

--- a/packages/core/src/amazonqDoc/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqDoc/controllers/chat/controller.ts
@@ -116,10 +116,17 @@ export class DocController {
     }
 
     /** Prompts user to choose a folder in current workspace for README creation/update.
-     * After user chooses a folder, displays confimraiton message to user with selected path.
+     * After user chooses a folder, displays confirmation message to user with selected path.
      *
      */
     private async folderSelector(data: any) {
+        this.messenger.sendAnswer({
+            type: 'answer',
+            tabID: data.tabID,
+            message: i18n('AWS.amazonq.doc.answer.chooseFolder'),
+            disableChatInput: true,
+        })
+
         const uri = await createSingleFileDialog({
             canSelectFolders: true,
             canSelectFiles: false,
@@ -133,7 +140,7 @@ export class DocController {
             this.messenger.sendAnswer({
                 type: 'answer',
                 tabID: data.tabID,
-                message: 'No folder was selected, please try again.',
+                message: i18n('AWS.amazonq.doc.error.noFolderSelected'),
                 followUps: retryFollowUps,
                 disableChatInput: true,
             })


### PR DESCRIPTION
## Problem
When a user clicks the "Change folder" button when creating or updating a README, the "Generating answer..." loading text appears, even though there is no answer being generated, since we are waiting for the user to choose a folder. 

This is an especially confusing UX if the user is connected to an SSH host:
![Existing UX](https://github.com/user-attachments/assets/6f21504a-9a0c-468d-be6d-4de1b1f09953)



## Solution
When the user clicks the "Change folder" button, send a "Choose a folder to continue" message in the chat.


![Fix](https://github.com/user-attachments/assets/3ab78c92-81d5-492c-90e2-143ebcfaef9a)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
