### PR TITLE
telemetry(amazonq): Adding requestId for amazonq_utgGenerateTests event

### DIFF
--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -246,6 +246,7 @@ export class TestController {
             cwsprChatProgrammingLanguage: session.fileLanguage ?? 'plaintext',
             jobId: session.listOfTestGenerationJobId[0], // For RIV, UTG does only one StartTestGeneration API call
             jobGroup: session.testGenerationJobGroupName,
+            requestId: session.requestId,
             hasUserPromptSupplied: session.hasUserPromptSupplied,
             isCodeBlockSelected: session.isCodeBlockSelected,
             buildPayloadBytes: session.srcPayloadSize,
@@ -725,6 +726,7 @@ export class TestController {
             cwsprChatProgrammingLanguage: session.fileLanguage ?? 'plaintext',
             jobId: session.listOfTestGenerationJobId[0], // For RIV, UTG does only one StartTestGeneration API call so jobId = session.listOfTestGenerationJobId[0]
             jobGroup: session.testGenerationJobGroupName,
+            requestId: session.requestId,
             buildPayloadBytes: session.srcPayloadSize,
             buildZipFileBytes: session.srcZipFileSize,
             artifactsUploadDuration: session.artifactsUploadDuration,
@@ -848,6 +850,7 @@ export class TestController {
                 cwsprChatProgrammingLanguage: session.fileLanguage ?? 'plaintext',
                 jobId: session.listOfTestGenerationJobId[0], // For RIV, UTG does only one StartTestGeneration API call so jobId = session.listOfTestGenerationJobId[0]
                 jobGroup: session.testGenerationJobGroupName,
+                requestId: session.requestId,
                 buildPayloadBytes: session.srcPayloadSize,
                 buildZipFileBytes: session.srcZipFileSize,
                 artifactsUploadDuration: session.artifactsUploadDuration,

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -246,7 +246,7 @@ export class TestController {
             cwsprChatProgrammingLanguage: session.fileLanguage ?? 'plaintext',
             jobId: session.listOfTestGenerationJobId[0], // For RIV, UTG does only one StartTestGeneration API call
             jobGroup: session.testGenerationJobGroupName,
-            requestId: session.requestId,
+            requestId: session.startTestGenerationRequestId,
             hasUserPromptSupplied: session.hasUserPromptSupplied,
             isCodeBlockSelected: session.isCodeBlockSelected,
             buildPayloadBytes: session.srcPayloadSize,
@@ -726,7 +726,7 @@ export class TestController {
             cwsprChatProgrammingLanguage: session.fileLanguage ?? 'plaintext',
             jobId: session.listOfTestGenerationJobId[0], // For RIV, UTG does only one StartTestGeneration API call so jobId = session.listOfTestGenerationJobId[0]
             jobGroup: session.testGenerationJobGroupName,
-            requestId: session.requestId,
+            requestId: session.startTestGenerationRequestId,
             buildPayloadBytes: session.srcPayloadSize,
             buildZipFileBytes: session.srcZipFileSize,
             artifactsUploadDuration: session.artifactsUploadDuration,
@@ -850,7 +850,7 @@ export class TestController {
                 cwsprChatProgrammingLanguage: session.fileLanguage ?? 'plaintext',
                 jobId: session.listOfTestGenerationJobId[0], // For RIV, UTG does only one StartTestGeneration API call so jobId = session.listOfTestGenerationJobId[0]
                 jobGroup: session.testGenerationJobGroupName,
-                requestId: session.requestId,
+                requestId: session.startTestGenerationRequestId,
                 buildPayloadBytes: session.srcPayloadSize,
                 buildZipFileBytes: session.srcZipFileSize,
                 artifactsUploadDuration: session.artifactsUploadDuration,

--- a/packages/core/src/amazonqTest/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqTest/chat/controller/messenger/messenger.ts
@@ -187,7 +187,7 @@ export class Messenger {
         fileName: string
     ) {
         let message = ''
-        const messageId = response.$metadata.requestId ?? ''
+        let messageId = response.$metadata.requestId ?? ''
         let codeReference: CodeReference[] = []
 
         if (response.generateAssistantResponseResponse === undefined) {
@@ -267,6 +267,7 @@ export class Messenger {
                 }
 
                 if (requestID !== undefined) {
+                    messageId = requestID
                     message += `\n\nRequest ID: ${requestID}`
                 }
                 this.sendMessage(message.trim(), tabID, 'answer')
@@ -282,6 +283,7 @@ export class Messenger {
                         reasonDesc: getTelemetryReasonDesc(CodeWhispererConstants.unitTestGenerationCancelMessage),
                         isSupportedLanguage: false,
                         credentialStartUrl: AuthUtil.instance.startUrl,
+                        requestId: messageId,
                     })
 
                     this.dispatcher.sendUpdatePromptProgress(
@@ -296,6 +298,7 @@ export class Messenger {
                         result: 'Succeeded',
                         isSupportedLanguage: false,
                         credentialStartUrl: AuthUtil.instance.startUrl,
+                        requestId: messageId,
                     })
                     this.dispatcher.sendUpdatePromptProgress(
                         new UpdatePromptProgressMessage(tabID, testGenCompletedField)

--- a/packages/core/src/amazonqTest/chat/session/session.ts
+++ b/packages/core/src/amazonqTest/chat/session/session.ts
@@ -31,6 +31,7 @@ export class Session {
     //This is unique per each test generation cycle
     public testGenerationJobGroupName: string | undefined = undefined
     public listOfTestGenerationJobId: string[] = []
+    public requestId: string | undefined = undefined
     public testGenerationJob: TestGenerationJob | undefined
 
     // Start Test generation

--- a/packages/core/src/amazonqTest/chat/session/session.ts
+++ b/packages/core/src/amazonqTest/chat/session/session.ts
@@ -31,7 +31,7 @@ export class Session {
     //This is unique per each test generation cycle
     public testGenerationJobGroupName: string | undefined = undefined
     public listOfTestGenerationJobId: string[] = []
-    public requestId: string | undefined = undefined
+    public startTestGenerationRequestId: string | undefined = undefined
     public testGenerationJob: TestGenerationJob | undefined
 
     // Start Test generation

--- a/packages/core/src/codewhisperer/service/testGenHandler.ts
+++ b/packages/core/src/codewhisperer/service/testGenHandler.ts
@@ -94,13 +94,13 @@ export async function createTestJob(
     logger.debug('target line range end: %O', firstTargetLineRangeList?.end)
 
     const resp = await codewhispererClient.codeWhispererClient.startTestGeneration(req).catch((err) => {
-        ChatSessionManager.Instance.getSession().requestId = err.requestId
+        ChatSessionManager.Instance.getSession().startTestGenerationRequestId = err.requestId
         logger.error(`Failed creating test job. Request id: ${err.requestId}`)
         throw err
     })
     logger.info('Unit test generation request id: %s', resp.$response.requestId)
     logger.debug('Unit test generation data: %O', resp.$response.data)
-    ChatSessionManager.Instance.getSession().requestId = resp.$response.requestId
+    ChatSessionManager.Instance.getSession().startTestGenerationRequestId = resp.$response.requestId
     if (resp.$response.error) {
         logger.error('Unit test generation error: %O', resp.$response.error)
     }

--- a/packages/core/src/codewhisperer/service/testGenHandler.ts
+++ b/packages/core/src/codewhisperer/service/testGenHandler.ts
@@ -94,11 +94,13 @@ export async function createTestJob(
     logger.debug('target line range end: %O', firstTargetLineRangeList?.end)
 
     const resp = await codewhispererClient.codeWhispererClient.startTestGeneration(req).catch((err) => {
+        ChatSessionManager.Instance.getSession().requestId = err.requestId
         logger.error(`Failed creating test job. Request id: ${err.requestId}`)
         throw err
     })
     logger.info('Unit test generation request id: %s', resp.$response.requestId)
     logger.debug('Unit test generation data: %O', resp.$response.data)
+    ChatSessionManager.Instance.getSession().requestId = resp.$response.requestId
     if (resp.$response.error) {
         logger.error('Unit test generation error: %O', resp.$response.error)
     }


### PR DESCRIPTION
## Problem
- Missing data if job fails at `StartTestGeneration` API.

## Solution
- Adding requestId for `amazonq_utgGenerateTests` event, which helps ti debug the reason for job failures from the backend.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
