### PR TITLE
fix(amazonq): always use projectName in zipEntryPath

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-d5c39800-ce37-4f6c-be23-9cc4035d0cef.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-d5c39800-ce37-4f6c-be23-9cc4035d0cef.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Code Review: Fixed a bug where projects with nested folder names did not scan properly."
+	"description": "Code Review: Fixed a bug where projects with repeated path names did not scan properly."
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-d5c39800-ce37-4f6c-be23-9cc4035d0cef.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-d5c39800-ce37-4f6c-be23-9cc4035d0cef.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Code Review: Fixed a bug where projects with nested folder names did not scan properly."
+}

--- a/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
@@ -114,7 +114,7 @@ describe('zipUtil', function () {
             assert.equal(zipMetadata2.lines, zipMetadata.lines + 1)
         })
 
-        it('should handle path with repeated project name', async function () {
+        it('should handle path with repeated project name for file scan', async function () {
             const appCodePathWithRepeatedProjectName = join(workspaceFolder, 'workspaceFolder', 'App.java')
             const zipMetadata = await zipUtil.generateZip(
                 vscode.Uri.file(appCodePathWithRepeatedProjectName),
@@ -125,6 +125,20 @@ describe('zipUtil', function () {
             const zip = await JSZip.loadAsync(zipFileData)
             const files = Object.keys(zip.files)
             assert.equal(files.length, 2)
+            assert.ok(files.includes('codeDiff/code.diff'))
+            assert.ok(files.includes('workspaceFolder/workspaceFolder/App.java'))
+        })
+
+        it('should handle path with repeated project name for project scan', async function () {
+            const appCodePathWithRepeatedProjectName = join(workspaceFolder, 'workspaceFolder', 'App.java')
+            const zipMetadata = await zipUtil.generateZip(
+                vscode.Uri.file(appCodePathWithRepeatedProjectName),
+                CodeAnalysisScope.PROJECT
+            )
+
+            const zipFileData = await fs.readFileBytes(zipMetadata.zipFilePath)
+            const zip = await JSZip.loadAsync(zipFileData)
+            const files = Object.keys(zip.files)
             assert.ok(files.includes('codeDiff/code.diff'))
             assert.ok(files.includes('workspaceFolder/workspaceFolder/App.java'))
         })

--- a/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
@@ -124,9 +124,7 @@ describe('zipUtil', function () {
             const zipFileData = await fs.readFileBytes(zipMetadata.zipFilePath)
             const zip = await JSZip.loadAsync(zipFileData)
             const files = Object.keys(zip.files)
-            assert.equal(files.length, 2)
-            assert.ok(files.includes('codeDiff/code.diff'))
-            assert.ok(files.includes('workspaceFolder/workspaceFolder/App.java'))
+            assert.ok(files.includes(join('workspaceFolder', 'workspaceFolder', 'App.java')))
         })
 
         it('should handle path with repeated project name for project scan', async function () {
@@ -139,8 +137,7 @@ describe('zipUtil', function () {
             const zipFileData = await fs.readFileBytes(zipMetadata.zipFilePath)
             const zip = await JSZip.loadAsync(zipFileData)
             const files = Object.keys(zip.files)
-            assert.ok(files.includes('codeDiff/code.diff'))
-            assert.ok(files.includes('workspaceFolder/workspaceFolder/App.java'))
+            assert.ok(files.includes(join('workspaceFolder', 'workspaceFolder', 'App.java')))
         })
     })
 

--- a/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
@@ -20,6 +20,7 @@ describe('zipUtil', function () {
     const workspaceFolder = getTestWorkspaceFolder()
     const appRoot = join(workspaceFolder, 'java11-plain-maven-sam-app')
     const appCodePath = join(appRoot, 'HelloWorldFunction', 'src', 'main', 'java', 'helloworld', 'App.java')
+    const appCodePathWithRepeatedProjectName = join(workspaceFolder, 'workspaceFolder', 'App.java')
 
     describe('getProjectPaths', function () {
         it('Should return the correct project paths', function () {
@@ -115,7 +116,6 @@ describe('zipUtil', function () {
         })
 
         it('should handle path with repeated project name for file scan', async function () {
-            const appCodePathWithRepeatedProjectName = join(workspaceFolder, 'workspaceFolder', 'App.java')
             const zipMetadata = await zipUtil.generateZip(
                 vscode.Uri.file(appCodePathWithRepeatedProjectName),
                 CodeAnalysisScope.FILE_ON_DEMAND
@@ -128,7 +128,6 @@ describe('zipUtil', function () {
         })
 
         it('should handle path with repeated project name for project scan', async function () {
-            const appCodePathWithRepeatedProjectName = join(workspaceFolder, 'workspaceFolder', 'App.java')
             const zipMetadata = await zipUtil.generateZip(
                 vscode.Uri.file(appCodePathWithRepeatedProjectName),
                 CodeAnalysisScope.PROJECT

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -141,14 +141,8 @@ export class ZipUtil {
         return zipFilePath
     }
 
-    protected getZipEntryPath(projectName: string, relativePath: string, useCase?: ZipUseCase) {
-        // Workspaces with multiple folders have the folder names as the root folder,
-        // but workspaces with only a single folder don't. So prepend the workspace folder name
-        // if it is not present.
-        if (useCase === ZipUseCase.TEST_GENERATION) {
-            return path.join(projectName, relativePath)
-        }
-        return relativePath.split('/').shift() === projectName ? relativePath : path.join(projectName, relativePath)
+    protected getZipEntryPath(projectName: string, relativePath: string) {
+        return path.join(projectName, relativePath)
     }
 
     /**
@@ -423,7 +417,8 @@ export class ZipUtil {
             this.getProjectScanPayloadSizeLimitInBytes()
         )
         for (const file of sourceFiles) {
-            const zipEntryPath = this.getZipEntryPath(file.workspaceFolder.name, file.relativeFilePath, useCase)
+            const projectName = path.basename(file.workspaceFolder.uri.fsPath)
+            const zipEntryPath = this.getZipEntryPath(projectName, file.relativeFilePath)
 
             if (ZipConstants.knownBinaryFileExts.includes(path.extname(file.fileUri.fsPath))) {
                 if (useCase === ZipUseCase.TEST_GENERATION) {

--- a/packages/core/src/testFixtures/workspaceFolder/workspaceFolder/App.java
+++ b/packages/core/src/testFixtures/workspaceFolder/workspaceFolder/App.java
@@ -1,0 +1,48 @@
+package helloworld;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+
+/**
+ * Handler for requests to Lambda function.
+ */
+public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/json");
+        headers.put("X-Custom-Header", "application/json");
+
+        APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent()
+                .withHeaders(headers);
+        try {
+            final String pageContents = this.getPageContents("https://checkip.amazonaws.com");
+            String output = String.format("{ \"message\": \"hello world\", \"location\": \"%s\" }", pageContents);
+
+            return response
+                    .withStatusCode(200)
+                    .withBody(output);
+        } catch (IOException e) {
+            return response
+                    .withBody("{}")
+                    .withStatusCode(500);
+        }
+    }
+
+    private String getPageContents(String address) throws IOException{
+        URL url = new URL(address);
+        try(BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream()))) {
+            return br.lines().collect(Collectors.joining(System.lineSeparator()));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Projects with a nested folder of the same name does not scan properly.

For example if the project name is `foo`, and there exists a folder `foo/foo/` then the zip artifact only contains the inner `foo/` folder.


## Solution

Always include the project name in the zip artifact instead of conditionally adding it.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
