### PR TITLE
test(perf): increase thresholds of perf tests. 

### DIFF
--- a/packages/core/src/testInteg/perf/prepareRepoData.test.ts
+++ b/packages/core/src/testInteg/perf/prepareRepoData.test.ts
@@ -28,7 +28,7 @@ type setupResult = {
 function performanceTestWrapper(numFiles: number, fileSize: number) {
     return performanceTest(
         getEqualOSTestOptions({
-            userCpuUsage: 150,
+            userCpuUsage: 200,
             systemCpuUsage: 35,
             heapTotal: 4,
         }),

--- a/packages/core/src/testInteg/perf/registerNewFiles.test.ts
+++ b/packages/core/src/testInteg/perf/registerNewFiles.test.ts
@@ -30,7 +30,7 @@ function performanceTestWrapper(label: string, numFiles: number, fileSize: numbe
     const conversationId = 'test-conversation'
     return performanceTest(
         getEqualOSTestOptions({
-            userCpuUsage: 200,
+            userCpuUsage: 300,
             systemCpuUsage: 35,
             heapTotal: 20,
         }),

--- a/packages/core/src/testInteg/perf/zipcode.test.ts
+++ b/packages/core/src/testInteg/perf/zipcode.test.ts
@@ -40,7 +40,7 @@ async function setup(numberOfFiles: number, fileSize: number): Promise<SetupResu
 function performanceTestWrapper(numberOfFiles: number, fileSize: number) {
     return performanceTest(
         getEqualOSTestOptions({
-            userCpuUsage: 300,
+            userCpuUsage: 350,
             systemCpuUsage: 50,
             heapTotal: 4,
         }),


### PR DESCRIPTION
## Problem
Some of the performance tests have been flaky on CI, and is more noticeable lately with reduction in overall flakiness. 

## Solution
bump the thresholds up. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
