### PR TITLE
fix(stepfunctions): integration test after ASL service update

### DIFF
--- a/packages/core/src/testInteg/stepFunctions/init.test.ts
+++ b/packages/core/src/testInteg/stepFunctions/init.test.ts
@@ -35,7 +35,7 @@ describe('stepFunctions ASL LSP', async function () {
         )) as vscode.CompletionList
         assert.deepStrictEqual(
             result.items.map((item) => item.label),
-            ['Comment', 'StartAt', 'States', 'TimeoutSeconds', 'Version']
+            ['Comment', 'QueryLanguage', 'StartAt', 'States', 'TimeoutSeconds', 'Version']
         )
     })
 })


### PR DESCRIPTION
## Problem
Integration test for SFN was broken after updating amazon-states-language-service package to 1.13.0 ([relevant PR](https://github.com/aws/aws-toolkit-vscode/pull/6139))

## Solution
Updating integration test to account for the new `QueryLanguage` variable introduced in the new version of the package

---


License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
