### PR TITLE
build(ci): only validate branch name on pull request

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,6 +33,7 @@ jobs:
               with:
                   node-version: '20'
             - name: Check Branch title
+              if: ${{ github.event_name == 'pull_request'}}
               env:
                   BRANCH_NAME: ${{ github.head_ref }}
               run: |


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
