### PR TITLE
fix(amazonq): revert disable event handler

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-64bec56a-f152-4345-b036-0c5ddb0ce5a2.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-64bec56a-f152-4345-b036-0c5ddb0ce5a2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Code Review: Fixed a bug where applying a fix did not update the positions of other issues in the same file."
+}

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -464,7 +464,6 @@ export const applySecurityFix = Commands.declare(
                 new vscode.Range(document.lineAt(0).range.start, document.lineAt(document.lineCount - 1).range.end),
                 updatedContent
             )
-            SecurityIssueProvider.instance.disableEventHandler()
             const isApplied = await vscode.workspace.applyEdit(edit)
             if (isApplied) {
                 void document.save().then((didSave) => {

--- a/packages/core/src/codewhisperer/service/securityIssueProvider.ts
+++ b/packages/core/src/codewhisperer/service/securityIssueProvider.ts
@@ -12,7 +12,6 @@ export class SecurityIssueProvider {
     }
 
     private _issues: AggregatedCodeScanIssue[] = []
-    private _disableEventHandler: boolean = false
     public get issues() {
         return this._issues
     }
@@ -21,17 +20,9 @@ export class SecurityIssueProvider {
         this._issues = issues
     }
 
-    public disableEventHandler() {
-        this._disableEventHandler = true
-    }
-
     public handleDocumentChange(event: vscode.TextDocumentChangeEvent) {
         // handleDocumentChange function may be triggered while testing by our own code generation.
         if (!event.contentChanges || event.contentChanges.length === 0) {
-            return
-        }
-        if (this._disableEventHandler) {
-            this._disableEventHandler = false
             return
         }
         const { changedRange, lineOffset } = event.contentChanges.reduce(


### PR DESCRIPTION
## Problem

Applying a fix does not update the position of other issues in the same file.


## Solution

Revert disabling event handler on apply fix command


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
