### PR TITLE
fix(logs): suppress git output

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-53ead65f-187e-47d9-9432-a48200b604d6.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-53ead65f-187e-47d9-9432-a48200b604d6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Code Review: Cleaned up output logs when running /review"
+}

--- a/packages/core/src/codewhisperer/util/gitUtil.ts
+++ b/packages/core/src/codewhisperer/util/gitUtil.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { showOutputMessage } from '../../shared/utilities/messages'
-import { getLogger, globals, removeAnsi } from '../../shared'
+import { getLogger, removeAnsi } from '../../shared'
 import { ChildProcess, ChildProcessOptions } from '../../shared/utilities/processUtils'
 import { Uri } from 'vscode'
 
@@ -17,10 +16,10 @@ export async function isGitRepo(folder: Uri): Promise<boolean> {
         rejectOnErrorCode: true,
         onStdout: (text) => {
             output += text
-            showOutputMessage(removeAnsi(text), globals.outputChannel)
+            getLogger().verbose(removeAnsi(text))
         },
         onStderr: (text) => {
-            showOutputMessage(removeAnsi(text), globals.outputChannel)
+            getLogger().error(removeAnsi(text))
         },
         spawnOptions: {
             cwd: folder.fsPath,

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -22,8 +22,7 @@ import {
 } from '../models/errors'
 import { ZipUseCase } from '../models/constants'
 import { ChildProcess, ChildProcessOptions } from '../../shared/utilities/processUtils'
-import { showOutputMessage } from '../../shared/utilities/messages'
-import { globals, removeAnsi } from '../../shared'
+import { removeAnsi } from '../../shared'
 
 export interface ZipMetadata {
     rootDir: string
@@ -303,10 +302,10 @@ export class ZipUtil {
             rejectOnErrorCode: false,
             onStdout: (text) => {
                 diffContent += text
-                showOutputMessage(removeAnsi(text), globals.outputChannel)
+                getLogger().verbose(removeAnsi(text))
             },
             onStderr: (text) => {
-                showOutputMessage(removeAnsi(text), globals.outputChannel)
+                getLogger().error(removeAnsi(text))
             },
             spawnOptions: {
                 cwd: projectPath,
@@ -340,10 +339,10 @@ export class ZipUtil {
             rejectOnErrorCode: true,
             onStdout: (text) => {
                 diffContent += text
-                showOutputMessage(removeAnsi(text), globals.outputChannel)
+                getLogger().verbose(removeAnsi(text))
             },
             onStderr: (text) => {
-                showOutputMessage(removeAnsi(text), globals.outputChannel)
+                getLogger().error(removeAnsi(text))
             },
             spawnOptions: {
                 cwd: projectPath,


### PR DESCRIPTION
## Problem

Git commands are too noisy; running /review always opens Amazon Q output channel with git command output


## Solution

- Output to the Amazon Q Logs channel instead
- Make it verbose level so it won't show by default


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
