### PR TITLE
config(amazonq): code issues collapsed by default

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -210,7 +210,8 @@
                     "type": "tree",
                     "id": "aws.amazonq.SecurityIssuesTree",
                     "name": "%AWS.amazonq.security%",
-                    "when": "!aws.isSageMaker && !aws.isWebExtHost && !aws.amazonq.showLoginView"
+                    "when": "!aws.isSageMaker && !aws.isWebExtHost && !aws.amazonq.showLoginView",
+                    "visibility": "collapsed"
                 },
                 {
                     "type": "webview",


### PR DESCRIPTION
## Problem

Code issues tree view takes up too much space away from chat view


## Solution

Set `visibility` to `collapsed` (will only take effect for new installations)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
