### PR TITLE
fix(amazonq): reduce system status poll freq

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-c685f18f-0c30-49a0-b4d8-e4eab0cf3bc6.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-c685f18f-0c30-49a0-b4d8-e4eab0cf3bc6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Reduce frequency of system status poll"
+}

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -58,7 +58,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.29']
+const supportedLspServerVersions = ['0.1.32']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 


### PR DESCRIPTION
## Problem

The system status (battery, CPU usage) was polled very frequently. https://github.com/aws/aws-toolkit-vscode/issues/6134

## Solution

Only poll system status (battery, CPU usage) when vector indexing is in progress, this is to make the vector index pause when system load is high to protect system resources. 


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
