### PR TITLE
refactor(amazonq): fix duplicate code block in test file

### DIFF
--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -46,7 +46,7 @@ import { convertDateToTimestamp, convertToTimeString } from '../../../shared/dat
 
 describe('transformByQ', function () {
     let tempDir: string
-    let validSctFile = `<?xml version="1.0" encoding="UTF-8"?>
+    const validSctFile = `<?xml version="1.0" encoding="UTF-8"?>
     <tree>
     <instances>
         <ProjectModel>

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -46,6 +46,48 @@ import { convertDateToTimestamp, convertToTimeString } from '../../../shared/dat
 
 describe('transformByQ', function () {
     let tempDir: string
+    let validSctFile = `<?xml version="1.0" encoding="UTF-8"?>
+    <tree>
+    <instances>
+        <ProjectModel>
+        <entities>
+            <sources>
+            <DbServer vendor="oracle" name="sample.rds.amazonaws.com">
+            </DbServer>
+            </sources>
+            <targets>
+            <DbServer vendor="aurora_postgresql" />
+            </targets>
+        </entities>
+        <relations>
+            <server-node-location>
+            <FullNameNodeInfoList>
+                <nameParts>
+                <FullNameNodeInfo typeNode="schema" nameNode="schema1"/>
+                <FullNameNodeInfo typeNode="table" nameNode="table1"/>
+                </nameParts>
+            </FullNameNodeInfoList>
+            </server-node-location>
+            <server-node-location>
+            <FullNameNodeInfoList>
+                <nameParts>
+                <FullNameNodeInfo typeNode="schema" nameNode="schema2"/>
+                <FullNameNodeInfo typeNode="table" nameNode="table2"/>
+                </nameParts>
+            </FullNameNodeInfoList>
+            </server-node-location>
+            <server-node-location>
+            <FullNameNodeInfoList>
+                <nameParts>
+                <FullNameNodeInfo typeNode="schema" nameNode="schema3"/>
+                <FullNameNodeInfo typeNode="table" nameNode="table3"/>
+                </nameParts>
+            </FullNameNodeInfoList>
+            </server-node-location>
+        </relations>
+        </ProjectModel>
+    </instances>
+    </tree>`
 
     beforeEach(async function () {
         tempDir = (await TestFolder.create()).path
@@ -401,49 +443,7 @@ describe('transformByQ', function () {
     })
 
     it(`WHEN validateMetadataFile on fully valid .sct file THEN passes validation`, async function () {
-        const sampleFileContents = `<?xml version="1.0" encoding="UTF-8"?>
-        <tree>
-        <instances>
-            <ProjectModel>
-            <entities>
-                <sources>
-                <DbServer vendor="oracle" name="sample.rds.amazonaws.com">
-                </DbServer>
-                </sources>
-                <targets>
-                <DbServer vendor="aurora_postgresql" />
-                </targets>
-            </entities>
-            <relations>
-                <server-node-location>
-                <FullNameNodeInfoList>
-                    <nameParts>
-                    <FullNameNodeInfo typeNode="schema" nameNode="schema1"/>
-                    <FullNameNodeInfo typeNode="table" nameNode="table1"/>
-                    </nameParts>
-                </FullNameNodeInfoList>
-                </server-node-location>
-                <server-node-location>
-                <FullNameNodeInfoList>
-                    <nameParts>
-                    <FullNameNodeInfo typeNode="schema" nameNode="schema2"/>
-                    <FullNameNodeInfo typeNode="table" nameNode="table2"/>
-                    </nameParts>
-                </FullNameNodeInfoList>
-                </server-node-location>
-                <server-node-location>
-                <FullNameNodeInfoList>
-                    <nameParts>
-                    <FullNameNodeInfo typeNode="schema" nameNode="schema3"/>
-                    <FullNameNodeInfo typeNode="table" nameNode="table3"/>
-                    </nameParts>
-                </FullNameNodeInfoList>
-                </server-node-location>
-            </relations>
-            </ProjectModel>
-        </instances>
-        </tree>`
-        const isValidMetadata = await validateSQLMetadataFile(sampleFileContents, { tabID: 'abc123' })
+        const isValidMetadata = await validateSQLMetadataFile(validSctFile, { tabID: 'abc123' })
         assert.strictEqual(isValidMetadata, true)
         assert.strictEqual(transformByQState.getSourceDB(), DB.ORACLE)
         assert.strictEqual(transformByQState.getTargetDB(), DB.AURORA_POSTGRESQL)
@@ -455,96 +455,14 @@ describe('transformByQ', function () {
     })
 
     it(`WHEN validateMetadataFile on .sct file with unsupported source DB THEN fails validation`, async function () {
-        const sampleFileContents = `<?xml version="1.0" encoding="UTF-8"?>
-        <tree>
-        <instances>
-            <ProjectModel>
-            <entities>
-                <sources>
-                <DbServer vendor="not-oracle" name="sample.rds.amazonaws.com">
-                </DbServer>
-                </sources>
-                <targets>
-                <DbServer vendor="aurora_postgresql" />
-                </targets>
-            </entities>
-            <relations>
-                <server-node-location>
-                <FullNameNodeInfoList>
-                    <nameParts>
-                    <FullNameNodeInfo typeNode="schema" nameNode="schema1"/>
-                    <FullNameNodeInfo typeNode="table" nameNode="table1"/>
-                    </nameParts>
-                </FullNameNodeInfoList>
-                </server-node-location>
-                <server-node-location>
-                <FullNameNodeInfoList>
-                    <nameParts>
-                    <FullNameNodeInfo typeNode="schema" nameNode="schema2"/>
-                    <FullNameNodeInfo typeNode="table" nameNode="table2"/>
-                    </nameParts>
-                </FullNameNodeInfoList>
-                </server-node-location>
-                <server-node-location>
-                <FullNameNodeInfoList>
-                    <nameParts>
-                    <FullNameNodeInfo typeNode="schema" nameNode="schema3"/>
-                    <FullNameNodeInfo typeNode="table" nameNode="table3"/>
-                    </nameParts>
-                </FullNameNodeInfoList>
-                </server-node-location>
-            </relations>
-            </ProjectModel>
-        </instances>
-        </tree>`
-        const isValidMetadata = await validateSQLMetadataFile(sampleFileContents, { tabID: 'abc123' })
+        const sctFileWithInvalidSource = validSctFile.replace('oracle', 'not-oracle')
+        const isValidMetadata = await validateSQLMetadataFile(sctFileWithInvalidSource, { tabID: 'abc123' })
         assert.strictEqual(isValidMetadata, false)
     })
 
     it(`WHEN validateMetadataFile on .sct file with unsupported target DB THEN fails validation`, async function () {
-        const sampleFileContents = `<?xml version="1.0" encoding="UTF-8"?>
-        <tree>
-        <instances>
-            <ProjectModel>
-            <entities>
-                <sources>
-                <DbServer vendor="oracle" name="sample.rds.amazonaws.com">
-                </DbServer>
-                </sources>
-                <targets>
-                <DbServer vendor="not-postgresql" />
-                </targets>
-            </entities>
-            <relations>
-                <server-node-location>
-                <FullNameNodeInfoList>
-                    <nameParts>
-                    <FullNameNodeInfo typeNode="schema" nameNode="schema1"/>
-                    <FullNameNodeInfo typeNode="table" nameNode="table1"/>
-                    </nameParts>
-                </FullNameNodeInfoList>
-                </server-node-location>
-                <server-node-location>
-                <FullNameNodeInfoList>
-                    <nameParts>
-                    <FullNameNodeInfo typeNode="schema" nameNode="schema2"/>
-                    <FullNameNodeInfo typeNode="table" nameNode="table2"/>
-                    </nameParts>
-                </FullNameNodeInfoList>
-                </server-node-location>
-                <server-node-location>
-                <FullNameNodeInfoList>
-                    <nameParts>
-                    <FullNameNodeInfo typeNode="schema" nameNode="schema3"/>
-                    <FullNameNodeInfo typeNode="table" nameNode="table3"/>
-                    </nameParts>
-                </FullNameNodeInfoList>
-                </server-node-location>
-            </relations>
-            </ProjectModel>
-        </instances>
-        </tree>`
-        const isValidMetadata = await validateSQLMetadataFile(sampleFileContents, { tabID: 'abc123' })
+        const sctFileWithInvalidTarget = validSctFile.replace('postgresql', 'not-postgresql')
+        const isValidMetadata = await validateSQLMetadataFile(sctFileWithInvalidTarget, { tabID: 'abc123' })
         assert.strictEqual(isValidMetadata, false)
     })
 })

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -461,7 +461,7 @@ describe('transformByQ', function () {
     })
 
     it(`WHEN validateMetadataFile on .sct file with unsupported target DB THEN fails validation`, async function () {
-        const sctFileWithInvalidTarget = validSctFile.replace('postgresql', 'not-postgresql')
+        const sctFileWithInvalidTarget = validSctFile.replace('aurora_postgresql', 'not-postgresql')
         const isValidMetadata = await validateSQLMetadataFile(sctFileWithInvalidTarget, { tabID: 'abc123' })
         assert.strictEqual(isValidMetadata, false)
     })


### PR DESCRIPTION
## Problem

`jscpd` detected a duplicate code block in a `/transform`-related test file.


## Solution

Use a shared variable so as not to duplicate.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
