### PR TITLE
telemetry(amazonq): folder level telemetry data undefined issue

### DIFF
--- a/packages/core/src/amazonqDoc/controllers/docGenerationTask.ts
+++ b/packages/core/src/amazonqDoc/controllers/docGenerationTask.ts
@@ -20,7 +20,7 @@ export class DocGenerationTask {
     public interactionType?: DocGenerationInteractionType
     public userIdentity?: string
     public numberOfNavigation = 0
-    public folderLevel?: DocGenerationFolderLevel
+    public folderLevel: DocGenerationFolderLevel = 'ENTIRE_WORKSPACE'
 
     constructor(conversationId?: string) {
         this.conversationId = conversationId
@@ -57,6 +57,6 @@ export class DocGenerationTask {
         this.interactionType = undefined
         this.userIdentity = undefined
         this.numberOfNavigation = 0
-        this.folderLevel = undefined
+        this.folderLevel = 'ENTIRE_WORKSPACE'
     }
 }


### PR DESCRIPTION
## Problem
When users don't choose a different folder during document generation, the current telemetry will log folder level as undefined

## Solution
 Change the default workspace value to "Entire Workspace" to match the default behavior of the UX flow.