### PR TITLE
ci: drop codecov "tests" coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -81,11 +81,6 @@ coverage:
                 target: 80
                 threshold: 5
                 only_pulls: true
-            tests:
-                # Most code in test/ should always be "covered"!
-                target: 95
-                paths:
-                    - '**/test/**'
         patch:
             default:
                 # Note: `default` measures the entire project.


### PR DESCRIPTION
# Problem:
The "tests" codecov target always reports 0%, probably because the test code is ignored.

# Solution:
The "tests" target is not useful without more configuration, so drop it for now.

<img width="541" alt="image" src="https://github.com/user-attachments/assets/9e632292-664d-4ab8-bd8c-35b3a4d0ed88">




---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
