### PR TITLE
ci(core): add syntax error to confirm that ci doesn't fail fast

### DIFF
--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -46,6 +46,9 @@ export const amazonQContextPrefix = 'amazonq'
  * Activation code for Amazon Q that will we want in all environments (eg Node.js, web mode)
  */
 export async function activateAmazonQCommon(context: vscode.ExtensionContext, isWeb: boolean) {
+
+    some test syntax error
+
     initialize(context, isWeb)
     const homeDirLogs = await fs.init(context, (homeDir) => {
         void messages.showViewLogsMessage(`Invalid home directory (check $HOME): "${homeDir}"`)

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -46,9 +46,6 @@ export const amazonQContextPrefix = 'amazonq'
  * Activation code for Amazon Q that will we want in all environments (eg Node.js, web mode)
  */
 export async function activateAmazonQCommon(context: vscode.ExtensionContext, isWeb: boolean) {
-
-    some test syntax error
-
     initialize(context, isWeb)
     const homeDirLogs = await fs.init(context, (homeDir) => {
         void messages.showViewLogsMessage(`Invalid home directory (check $HOME): "${homeDir}"`)

--- a/packages/amazonq/test/unit/amazonq/apps/initContext.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/initContext.test.ts
@@ -19,6 +19,7 @@ describe('DefaultAmazonQAppInitContext', () => {
             const publisher = new MessagePublisher(new EventEmitter())
             context.registerWebViewToAppMessagePublisher(publisher, 'unknown')
             assert.strictEqual(context.getWebViewToAppsMessagePublishers().get('unknown'), publisher)
+            assert.fail('foo')
         })
     })
 


### PR DESCRIPTION
## Problem
test to confirm that if amazon q fails due to a syntax error, wrong import, etc it doesn't fail the actual build. I think this is because npm workspaces don't fail fast. See https://github.com/npm/rfcs/issues/575

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
