### PR TITLE
telemetry(amazonq): Removing session cleanUp before emitting the telemetry event

### DIFF
--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -317,7 +317,6 @@ export class TestController {
             case ButtonActions.STOP_TEST_GEN:
                 testGenState.setToCancelling()
                 telemetry.ui_click.emit({ elementId: 'unitTestGeneration_cancelTestGenerationProgress' })
-                await this.sessionCleanUp()
                 break
             case ButtonActions.STOP_BUILD:
                 cancelBuild()


### PR DESCRIPTION
## Problem
- If user clicks on Cancel button, IDE do `this.sessionCleanUp()` before emitting the metrics

## Solution
- Removed this function `this.sessionCleanUp()`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
