### PR TITLE
fix(amazonq): diagnostics code is incorrect

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-8331f6fe-6955-4a49-91ac-e4ca3fbe4165.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-8331f6fe-6955-4a49-91ac-e4ca3fbe4165.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/review: Diagnostics in the problems panel are mapped to the wrong code"
+}

--- a/packages/amazonq/test/unit/codewhisperer/service/diagnosticsProvider.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/diagnosticsProvider.test.ts
@@ -12,6 +12,8 @@ import {
     removeDiagnostic,
     disposeSecurityDiagnostic,
     SecurityDiagnostic,
+    createSecurityDiagnostic,
+    codewhispererDiagnosticSourceLabel,
 } from 'aws-core-vscode/codewhisperer'
 import { createCodeScanIssue, createMockDocument, createTextDocumentChangeEvent } from 'aws-core-vscode/test'
 
@@ -82,5 +84,17 @@ describe('diagnosticsProvider', function () {
         assert.strictEqual(actual[0].range.end.line, 4)
         assert.strictEqual(actual[1].range.start.line, 5)
         assert.strictEqual(actual[1].range.end.line, 6)
+    })
+
+    it('should create securityDiagnostic from codeScanIssue', function () {
+        const codeScanIssue = createCodeScanIssue()
+        const securityDiagnostic = createSecurityDiagnostic(codeScanIssue)
+        assert.strictEqual(securityDiagnostic.findingId, codeScanIssue.findingId)
+        assert.strictEqual(securityDiagnostic.message, codeScanIssue.title)
+        assert.strictEqual(securityDiagnostic.range.start.line, codeScanIssue.startLine)
+        assert.strictEqual(securityDiagnostic.range.end.line, codeScanIssue.endLine)
+        assert.strictEqual(securityDiagnostic.severity, vscode.DiagnosticSeverity.Warning)
+        assert.strictEqual(securityDiagnostic.source, codewhispererDiagnosticSourceLabel)
+        assert.strictEqual(securityDiagnostic.code, codeScanIssue.ruleId)
     })
 })

--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -74,14 +74,7 @@ export function createSecurityDiagnostic(securityIssue: CodeScanIssue) {
         vscode.DiagnosticSeverity.Warning
     )
     securityDiagnostic.source = codewhispererDiagnosticSourceLabel
-    // const detectorUrl = securityIssue.recommendation.url
-    securityDiagnostic.code = securityIssue.findingId
-    // securityDiagnostic.code = detectorUrl
-    //     ? {
-    //           value: securityIssue.detectorId,
-    //           target: vscode.Uri.parse(detectorUrl),
-    //       }
-    //     : securityIssue.detectorId
+    securityDiagnostic.code = securityIssue.ruleId
     securityDiagnostic.findingId = securityIssue.findingId
     return securityDiagnostic
 }


### PR DESCRIPTION
## Problem

Diagnostics in problems panel show findingId as code which doesn't add any value


## Solution

Use ruleId instead


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
