### PR TITLE
telemetry(amazonq): sending metric data in `onCodeGeneration`

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-06bf59c2-da3f-4ab5-ab86-634b3c25bd5e.json
+++ b/packages/amazonq/.changes/next-release/Feature-06bf59c2-da3f-4ab5-ab86-634b3c25bd5e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "send metric data in onCodeGeneration"
+}

--- a/packages/amazonq/.changes/next-release/Feature-06bf59c2-da3f-4ab5-ab86-634b3c25bd5e.json
+++ b/packages/amazonq/.changes/next-release/Feature-06bf59c2-da3f-4ab5-ab86-634b3c25bd5e.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "send metric data in onCodeGeneration"
-}

--- a/packages/core/src/amazonqFeatureDev/client/featureDev.ts
+++ b/packages/core/src/amazonqFeatureDev/client/featureDev.ts
@@ -25,12 +25,7 @@ import { createCodeWhispererChatStreamingClient } from '../../shared/clients/cod
 import { getClientId, getOptOutPreference, getOperatingSystem } from '../../shared/telemetry/util'
 import { extensionVersion } from '../../shared/vscode/env'
 import apiConfig = require('./codewhispererruntime-2022-11-11.json')
-import {
-    FeatureDevCodeAcceptanceEvent,
-    FeatureDevCodeGenerationEvent,
-    MetricData,
-    TelemetryEvent,
-} from './featuredevproxyclient'
+import { FeatureDevCodeAcceptanceEvent, FeatureDevCodeGenerationEvent, TelemetryEvent } from './featuredevproxyclient'
 
 // Re-enable once BE is able to handle retries.
 const writeAPIRetryOptions = {
@@ -304,15 +299,9 @@ export class FeatureDevClient {
         await this.sendFeatureDevEvent('featureDevCodeAcceptanceEvent', event)
     }
 
-    public async sendMetricDataRaw(event: MetricData) {
-        getLogger().debug(
-            `featureDevCodeGenerationMetricData: metricName: ${event.metricName} metricValue: ${event.metricValue} dimensions: ${event.dimensions}`
-        )
-        await this.sendFeatureDevEvent('metricData', event)
-    }
-
     public async sendMetricData(operationName: string, result: string) {
-        await this.sendMetricDataRaw({
+        getLogger().debug(`featureDevCodeGenerationMetricData: operationName: ${operationName} result: ${result}`)
+        await this.sendFeatureDevEvent('metricData', {
             metricName: 'Operation',
             metricValue: 1,
             timestamp: new Date(Date.now()),

--- a/packages/core/src/amazonqFeatureDev/client/featureDev.ts
+++ b/packages/core/src/amazonqFeatureDev/client/featureDev.ts
@@ -25,7 +25,12 @@ import { createCodeWhispererChatStreamingClient } from '../../shared/clients/cod
 import { getClientId, getOptOutPreference, getOperatingSystem } from '../../shared/telemetry/util'
 import { extensionVersion } from '../../shared/vscode/env'
 import apiConfig = require('./codewhispererruntime-2022-11-11.json')
-import { FeatureDevCodeAcceptanceEvent, FeatureDevCodeGenerationEvent, TelemetryEvent } from './featuredevproxyclient'
+import {
+    FeatureDevCodeAcceptanceEvent,
+    FeatureDevCodeGenerationEvent,
+    MetricData,
+    TelemetryEvent,
+} from './featuredevproxyclient'
 
 // Re-enable once BE is able to handle retries.
 const writeAPIRetryOptions = {
@@ -297,6 +302,32 @@ export class FeatureDevClient {
             `featureDevCodeAcceptanceEvent: conversationId: ${event.conversationId} charactersOfCodeAccepted: ${event.charactersOfCodeAccepted} linesOfCodeAccepted: ${event.linesOfCodeAccepted}`
         )
         await this.sendFeatureDevEvent('featureDevCodeAcceptanceEvent', event)
+    }
+
+    public async sendMetricDataRaw(event: MetricData) {
+        getLogger().debug(
+            `featureDevCodeGenerationMetricData: metricName: ${event.metricName} metricValue: ${event.metricValue} dimensions: ${event.dimensions}`
+        )
+        await this.sendFeatureDevEvent('metricData', event)
+    }
+
+    public async sendMetricData(operationName: string, result: string) {
+        await this.sendMetricDataRaw({
+            metricName: 'Operation',
+            metricValue: 1,
+            timestamp: new Date(Date.now()),
+            product: 'Amazon Q For VS Code',
+            dimensions: [
+                {
+                    name: 'operationName',
+                    value: operationName,
+                },
+                {
+                    name: 'result',
+                    value: result,
+                },
+            ],
+        })
     }
 
     public async sendFeatureDevEvent<T extends keyof TelemetryEvent>(

--- a/packages/core/src/amazonqFeatureDev/client/featureDev.ts
+++ b/packages/core/src/amazonqFeatureDev/client/featureDev.ts
@@ -25,7 +25,12 @@ import { createCodeWhispererChatStreamingClient } from '../../shared/clients/cod
 import { getClientId, getOptOutPreference, getOperatingSystem } from '../../shared/telemetry/util'
 import { extensionVersion } from '../../shared/vscode/env'
 import apiConfig = require('./codewhispererruntime-2022-11-11.json')
-import { FeatureDevCodeAcceptanceEvent, FeatureDevCodeGenerationEvent, TelemetryEvent } from './featuredevproxyclient'
+import {
+    FeatureDevCodeAcceptanceEvent,
+    FeatureDevCodeGenerationEvent,
+    MetricData,
+    TelemetryEvent,
+} from './featuredevproxyclient'
 
 // Re-enable once BE is able to handle retries.
 const writeAPIRetryOptions = {
@@ -299,24 +304,9 @@ export class FeatureDevClient {
         await this.sendFeatureDevEvent('featureDevCodeAcceptanceEvent', event)
     }
 
-    public async sendMetricData(operationName: string, result: string) {
-        getLogger().debug(`featureDevCodeGenerationMetricData: operationName: ${operationName} result: ${result}`)
-        await this.sendFeatureDevEvent('metricData', {
-            metricName: 'Operation',
-            metricValue: 1,
-            timestamp: new Date(Date.now()),
-            product: 'Amazon Q For VS Code',
-            dimensions: [
-                {
-                    name: 'operationName',
-                    value: operationName,
-                },
-                {
-                    name: 'result',
-                    value: result,
-                },
-            ],
-        })
+    public async sendMetricData(event: MetricData) {
+        getLogger().debug(`featureDevCodeGenerationMetricData: dimensions: ${event.dimensions}`)
+        await this.sendFeatureDevEvent('metricData', event)
     }
 
     public async sendFeatureDevEvent<T extends keyof TelemetryEvent>(

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -488,10 +488,6 @@ export class FeatureDevController {
                 })
                 await session.updateChatAnswer(tabID, i18n('AWS.amazonq.featureDev.pillText.acceptAllChanges'))
                 await session.sendLinesOfCodeGeneratedTelemetry()
-                await session.sendMetricDataTelemetry(
-                    MetricDataOperationName.END_CODE_GENERATION,
-                    MetricDataResult.SUCCESS
-                )
             }
             this.messenger.sendUpdatePlaceholder(tabID, i18n('AWS.amazonq.featureDev.pillText.selectOption'))
         } catch (err: any) {
@@ -504,10 +500,15 @@ export class FeatureDevController {
                             MetricDataOperationName.END_CODE_GENERATION,
                             MetricDataResult.LLMFAILURE
                         )
-                    } else {
+                    } else if (err.code === 'GuardrailsException' || err.code === 'ThrottlingException') {
                         await session.sendMetricDataTelemetry(
                             MetricDataOperationName.END_CODE_GENERATION,
                             MetricDataResult.ERROR
+                        )
+                    } else {
+                        await session.sendMetricDataTelemetry(
+                            MetricDataOperationName.END_CODE_GENERATION,
+                            MetricDataResult.FAULT
                         )
                     }
                     break
@@ -558,6 +559,7 @@ export class FeatureDevController {
                 }
             }
         }
+        await session.sendMetricDataTelemetry(MetricDataOperationName.END_CODE_GENERATION, MetricDataResult.SUCCESS)
     }
 
     private sendUpdateCodeMessage(tabID: string) {

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -289,7 +289,7 @@ export class Session {
         await this.proxyClient.sendMetricData({
             metricName: 'Operation',
             metricValue: 1,
-            timestamp: new Date(Date.now()),
+            timestamp: new Date(),
             product: 'FeatureDev',
             dimensions: [
                 {

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -290,7 +290,7 @@ export class Session {
             metricName: 'Operation',
             metricValue: 1,
             timestamp: new Date(Date.now()),
-            product: 'Amazon Q For VS Code',
+            product: 'FeatureDev',
             dimensions: [
                 {
                     name: 'operationName',

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -285,6 +285,10 @@ export class Session {
         return { leftPath, rightPath, ...diff }
     }
 
+    public async sendMetricDataTelemetry(operationName: string, result: string) {
+        await this.proxyClient.sendMetricData(operationName, result)
+    }
+
     public async sendLinesOfCodeGeneratedTelemetry() {
         let charactersOfCodeGenerated = 0
         let linesOfCodeGenerated = 0

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -286,7 +286,22 @@ export class Session {
     }
 
     public async sendMetricDataTelemetry(operationName: string, result: string) {
-        await this.proxyClient.sendMetricData(operationName, result)
+        await this.proxyClient.sendMetricData({
+            metricName: 'Operation',
+            metricValue: 1,
+            timestamp: new Date(Date.now()),
+            product: 'Amazon Q For VS Code',
+            dimensions: [
+                {
+                    name: 'operationName',
+                    value: operationName,
+                },
+                {
+                    name: 'result',
+                    value: result,
+                },
+            ],
+        })
     }
 
     public async sendLinesOfCodeGeneratedTelemetry() {

--- a/packages/core/src/amazonqFeatureDev/types.ts
+++ b/packages/core/src/amazonqFeatureDev/types.ts
@@ -115,3 +115,15 @@ export interface UpdateFilesPathsParams {
     messageId: string
     disableFileActions?: boolean
 }
+
+export enum MetricDataOperationName {
+    START_CODE_GENERATION = 'StartCodeGeneration',
+    END_CODE_GENERATION = 'EndCodeGeneration',
+}
+
+export enum MetricDataResult {
+    SUCCESS = 'Success',
+    FAULT = 'Fault',
+    ERROR = 'Error',
+    LLMFAILURE = 'LLMFailure',
+}

--- a/packages/core/src/amazonqFeatureDev/types.ts
+++ b/packages/core/src/amazonqFeatureDev/types.ts
@@ -117,13 +117,13 @@ export interface UpdateFilesPathsParams {
 }
 
 export enum MetricDataOperationName {
-    START_CODE_GENERATION = 'StartCodeGeneration',
-    END_CODE_GENERATION = 'EndCodeGeneration',
+    StartCodeGeneration = 'StartCodeGeneration',
+    EndCodeGeneration = 'EndCodeGeneration',
 }
 
 export enum MetricDataResult {
-    SUCCESS = 'Success',
-    FAULT = 'Fault',
-    ERROR = 'Error',
-    LLMFAILURE = 'LLMFailure',
+    Success = 'Success',
+    Fault = 'Fault',
+    Error = 'Error',
+    LlmFailure = 'LLMFailure',
 }

--- a/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -462,16 +462,16 @@ describe('Controller', () => {
             let sendMetricDataTelemetrySpy: sinon.SinonStub
 
             const errorResultMapping = new Map([
-                ['EmptyPatchException', MetricDataResult.LLMFAILURE],
-                [PromptRefusalException.name, MetricDataResult.ERROR],
-                [NoChangeRequiredException.name, MetricDataResult.ERROR],
+                ['EmptyPatchException', MetricDataResult.LlmFailure],
+                [PromptRefusalException.name, MetricDataResult.Error],
+                [NoChangeRequiredException.name, MetricDataResult.Error],
             ])
 
             function getMetricResult(error: ToolkitError): MetricDataResult {
                 if (error instanceof FeatureDevServiceError && error.code) {
-                    return errorResultMapping.get(error.code) ?? MetricDataResult.ERROR
+                    return errorResultMapping.get(error.code) ?? MetricDataResult.Error
                 }
-                return errorResultMapping.get(error.constructor.name) ?? MetricDataResult.FAULT
+                return errorResultMapping.get(error.constructor.name) ?? MetricDataResult.Fault
             }
 
             async function createCodeGenState() {
@@ -512,13 +512,13 @@ describe('Controller', () => {
                 await verifyMetricsCalled()
                 assert.ok(
                     sendMetricDataTelemetrySpy.calledWith(
-                        MetricDataOperationName.START_CODE_GENERATION,
-                        MetricDataResult.SUCCESS
+                        MetricDataOperationName.StartCodeGeneration,
+                        MetricDataResult.Success
                     )
                 )
                 const metricResult = getMetricResult(error)
                 assert.ok(
-                    sendMetricDataTelemetrySpy.calledWith(MetricDataOperationName.END_CODE_GENERATION, metricResult)
+                    sendMetricDataTelemetrySpy.calledWith(MetricDataOperationName.EndCodeGeneration, metricResult)
                 )
             }
 
@@ -541,14 +541,14 @@ describe('Controller', () => {
 
                 assert.ok(
                     sendMetricDataTelemetrySpy.calledWith(
-                        MetricDataOperationName.START_CODE_GENERATION,
-                        MetricDataResult.SUCCESS
+                        MetricDataOperationName.StartCodeGeneration,
+                        MetricDataResult.Success
                     )
                 )
                 assert.ok(
                     sendMetricDataTelemetrySpy.calledWith(
-                        MetricDataOperationName.END_CODE_GENERATION,
-                        MetricDataResult.SUCCESS
+                        MetricDataOperationName.EndCodeGeneration,
+                        MetricDataResult.Success
                     )
                 )
             })


### PR DESCRIPTION
## Problem
This is a part of the task to implement client side alarms in order to track success rate for the client.

## Solution
- Emit metric data telemetry on success/failure.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
