### PR TITLE
test(core): unskip e2e test failures

### DIFF
--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -37,7 +37,7 @@ phases:
         commands:
             - export HOME=/home/codebuild-user
             # Ignore failure until throttling issues are fixed.
-            - xvfb-run npm run testE2E || true
+            - xvfb-run npm run testE2E
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g')
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"


### PR DESCRIPTION
## Problem
- For the last 8 months or so we've skipped e2e test results, now they're becoming a lot more crucial and used by other teams

## Solution
- remove the skipping


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
