### PR TITLE
fix(auth): SSO failed to get token due to missing 'refreshToken'

### DIFF
--- a/packages/core/src/auth/sso/cache.ts
+++ b/packages/core/src/auth/sso/cache.ts
@@ -10,7 +10,7 @@ import { getLogger } from '../../shared/logger/logger'
 import fs from '../../shared/fs/fs'
 import { createDiskCache, KeyedCache, mapCache } from '../../shared/utilities/cacheUtils'
 import { stripUndefined } from '../../shared/utilities/collectionUtils'
-import { getMissingProps, hasProps, selectFrom } from '../../shared/utilities/tsUtils'
+import { hasProps, selectFrom } from '../../shared/utilities/tsUtils'
 import { SsoToken, ClientRegistration } from './model'
 import { DevSettings } from '../../shared/settings'
 import { onceChanged } from '../../shared/utilities/functionUtils'
@@ -79,6 +79,11 @@ export function getTokenCache(directory = getCacheDir()): KeyedCache<SsoAccess> 
         }
 
     function read(data: StoredToken): SsoAccess {
+        // Validate data is not missing. Since the input data is passed directly from whatever is on disk.
+        if (!hasProps(data, 'accessToken')) {
+            throw new ToolkitError(`SSO cache data looks malformed`)
+        }
+
         const registration = hasProps(data, 'clientId', 'clientSecret', 'registrationExpiresAt')
             ? {
                   ...selectFrom(data, 'clientId', 'clientSecret', 'scopes', 'startUrl'),
@@ -92,12 +97,6 @@ export function getTokenCache(directory = getCacheDir()): KeyedCache<SsoAccess> 
         }
 
         stripUndefined(token)
-
-        // Validate data is not missing.
-        const missingProps = getMissingProps(token, 'accessToken', 'refreshToken')
-        if (missingProps.length > 0) {
-            throw new ToolkitError(`SSO cache data unexpectedly missing props: ${JSON.stringify(missingProps)}`)
-        }
 
         return {
             token,

--- a/packages/core/src/test/credentials/sso/cache.test.ts
+++ b/packages/core/src/test/credentials/sso/cache.test.ts
@@ -27,7 +27,6 @@ describe('SSO Cache', function () {
     const validToken = {
         accessToken: 'longstringofrandomcharacters',
         expiresAt: new Date(Date.now() + hourInMs),
-        refreshToken: 'dummyRefreshToken',
     } as SsoToken
 
     beforeEach(async function () {

--- a/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/packages/core/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -45,7 +45,6 @@ describe('SsoAccessTokenProvider', function () {
         return {
             accessToken: 'dummyAccessToken',
             expiresAt: new clock.Date(clock.Date.now() + timeDelta),
-            refreshToken: 'dummyRefreshToken',
             ...extras,
         }
     }

--- a/packages/toolkit/.changes/next-release/Bug Fix-7cb802f6-498a-4442-ae88-399eaec1d9a5.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-7cb802f6-498a-4442-ae88-399eaec1d9a5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth: SSO failed to missing refreshToken"
+}


### PR DESCRIPTION
## Problem:

Error users were seeing was:

```
Error: SSO cache data unexpectedly missing props: ["refreshToken"]
```

This was due to a change from a previous PR that assumed the refreshToken was always present in SSO cache.

## Solution:

It looks like the refreshToken does not exist for all cases, so some research needs to be done.

But for now this reverts the validation that the refreshToken exists. Though it keeps the validation that the accessToken exists since that is always guaranteed.

**A temporary workaround should be to sign out/in and things should start working. If not please downgrade 3.38.0 until we release this fix next week.**

Fixes #6230 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
