### PR TITLE
fix(amazonq): apply fix removes other issues

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-1fd5992c-cc2e-49ac-8afc-360d7f0a3966.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-1fd5992c-cc2e-49ac-8afc-360d7f0a3966.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/review: Apply fix removes other issues in the same file."
+}

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -670,27 +670,28 @@ export async function activate(context: ExtContext): Promise<void> {
     function setSubscriptionsForCodeIssues() {
         context.extensionContext.subscriptions.push(
             vscode.workspace.onDidChangeTextDocument(async (e) => {
-                // verify the document is something with a finding
-                for (const issue of SecurityIssueProvider.instance.issues) {
-                    if (issue.filePath === e.document.uri.fsPath) {
-                        disposeSecurityDiagnostic(e)
-
-                        SecurityIssueProvider.instance.handleDocumentChange(e)
-                        SecurityIssueTreeViewProvider.instance.refresh()
-                        await syncSecurityIssueWebview(context)
-
-                        toggleIssuesVisibility((issue, filePath) =>
-                            filePath !== e.document.uri.fsPath
-                                ? issue.visible
-                                : !detectCommentAboveLine(
-                                      e.document,
-                                      issue.startLine,
-                                      CodeWhispererConstants.amazonqIgnoreNextLine
-                                  )
-                        )
-                        break
-                    }
+                if (e.document.uri.scheme !== 'file') {
+                    return
                 }
+                const diagnostics = securityScanRender.securityDiagnosticCollection?.get(e.document.uri)
+                if (!diagnostics || diagnostics.length === 0) {
+                    return
+                }
+                disposeSecurityDiagnostic(e)
+
+                SecurityIssueProvider.instance.handleDocumentChange(e)
+                SecurityIssueTreeViewProvider.instance.refresh()
+                await syncSecurityIssueWebview(context)
+
+                toggleIssuesVisibility((issue, filePath) =>
+                    filePath !== e.document.uri.fsPath
+                        ? issue.visible
+                        : !detectCommentAboveLine(
+                              e.document,
+                              issue.startLine,
+                              CodeWhispererConstants.amazonqIgnoreNextLine
+                          )
+                )
             })
         )
     }

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -672,6 +672,81 @@ describe('CodeWhisperer-basicCommands', function () {
                 reasonDesc: 'Failed to apply edit to the workspace.',
             })
         })
+
+        it('should apply the edit at the correct range', async function () {
+            const fileName = 'sample.py'
+            const textDocumentMock = createMockDocument(
+                `from flask import app
+
+
+@app.route('/')
+def execute_input_noncompliant():
+    from flask import request
+    module_version = request.args.get("module_version")
+    # Noncompliant: executes unsanitized inputs.
+    exec("import urllib%s as urllib" % module_version)
+# {/fact}
+
+
+# {fact rule=code-injection@v1.0 defects=0}
+from flask import app
+
+
+@app.route('/')
+def execute_input_compliant():
+    from flask import request
+    module_version = request.args.get("module_version")
+    # Compliant: executes sanitized inputs.
+    exec("import urllib%d as urllib" % int(module_version))
+# {/fact}`,
+                fileName
+            )
+            openTextDocumentMock.resolves(textDocumentMock)
+            sandbox.stub(vscode.workspace, 'openTextDocument').value(openTextDocumentMock)
+
+            sandbox.stub(vscode.WorkspaceEdit.prototype, 'replace').value(replaceMock)
+            applyEditMock.resolves(true)
+            sandbox.stub(vscode.workspace, 'applyEdit').value(applyEditMock)
+            sandbox.stub(diagnosticsProvider, 'removeDiagnostic').value(removeDiagnosticMock)
+            sandbox.stub(SecurityIssueProvider.instance, 'removeIssue').value(removeIssueMock)
+            sandbox.stub(vscode.window, 'showTextDocument').value(showTextDocumentMock)
+
+            targetCommand = testCommand(applySecurityFix)
+            codeScanIssue.suggestedFixes = [
+                {
+                    code: `@@ -6,4 +6,5 @@
+     from flask import request
+     module_version = request.args.get("module_version")
+     # Noncompliant: executes unsanitized inputs.
+-    exec("import urllib%d as urllib" % int(module_version))
++    __import__("urllib" + module_version)
++#import importlib`,
+                    description: 'dummy',
+                },
+            ]
+            await targetCommand.execute(codeScanIssue, fileName, 'webview')
+            assert.ok(
+                replaceMock.calledOnceWith(
+                    textDocumentMock.uri,
+                    new vscode.Range(5, 0, 8, 54),
+                    `    from flask import request
+    module_version = request.args.get("module_version")
+    # Noncompliant: executes unsanitized inputs.
+    __import__("urllib" + module_version)
+#import importlib`
+                )
+            )
+            assert.ok(applyEditMock.calledOnce)
+            assert.ok(removeDiagnosticMock.calledOnceWith(textDocumentMock.uri, codeScanIssue))
+            assert.ok(removeIssueMock.calledOnce)
+
+            assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
+                detectorId: codeScanIssue.detectorId,
+                findingId: codeScanIssue.findingId,
+                component: 'webview',
+                result: 'Succeeded',
+            })
+        })
     })
 
     // describe('generateFix', function () {


### PR DESCRIPTION
## Problem

Apply fix removes other issues in the same file. This is happening because apply fix command will always replace the entire file contents which triggers a document change event that intersects with all issues in the file.


## Solution

Look through the diff hunks and apply them in a range.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
