### PR TITLE
feat(amazonq): Adds capability to send new context commands to AB groups

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-37eb706c-57a1-4751-888d-220b2f68ee4d.json
+++ b/packages/amazonq/.changes/next-release/Feature-37eb706c-57a1-4751-888d-220b2f68ee4d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Adds capability to send new context commands to AB groups"
+}

--- a/packages/amazonq/test/e2e/amazonq/welcome.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/welcome.test.ts
@@ -9,6 +9,7 @@ import sinon from 'sinon'
 import { Messenger } from './framework/messenger'
 import { MynahUIDataModel } from '@aws/mynah-ui'
 import { assertQuickActions } from './assert'
+import { FeatureContext } from 'aws-core-vscode/shared'
 
 describe('Amazon Q Welcome page', function () {
     let framework: qTestingFramework
@@ -17,8 +18,15 @@ describe('Amazon Q Welcome page', function () {
 
     const availableCommands = ['/dev', '/test', '/review', '/doc', '/transform']
 
+    const highlightCommand: FeatureContext = {
+        name: 'highlightCommand',
+        value: {
+            stringValue: '@highlight',
+        },
+        variation: 'highlight command desc',
+    }
     beforeEach(() => {
-        framework = new qTestingFramework('welcome', true, [], 0)
+        framework = new qTestingFramework('welcome', true, [['highlightCommand', highlightCommand]], 0)
         tab = framework.getTabs()[0] // use the default tab that gets created
         store = tab.getStore()
     })
@@ -33,13 +41,13 @@ describe('Amazon Q Welcome page', function () {
         assertQuickActions(tab, availableCommands)
     })
 
-    it('Shows @workspace', async () => {
+    it('Shows context commands', async () => {
         assert.deepStrictEqual(
             store.contextCommands
                 ?.map((x) => x.commands)
                 .flat()
                 .map((x) => x.command),
-            ['@workspace']
+            ['@workspace', '@highlight']
         )
     })
 

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -106,6 +106,10 @@ export const createMynahUI = (
 
     let isDocEnabled = amazonQEnabled
 
+    let featureConfigs: Map<string, FeatureContext> = tryNewMap(featureConfigsSerialized)
+
+    const highlightCommand = featureConfigs.get('highlightCommand')
+
     let tabDataGenerator = new TabDataGenerator({
         isFeatureDevEnabled,
         isGumbyEnabled,
@@ -113,6 +117,7 @@ export const createMynahUI = (
         isTestEnabled,
         isDocEnabled,
         disabledCommands,
+        commandHighlight: highlightCommand,
     })
 
     // eslint-disable-next-line prefer-const
@@ -123,9 +128,6 @@ export const createMynahUI = (
     let textMessageHandler: TextMessageHandler
     // eslint-disable-next-line prefer-const
     let messageController: MessageController
-
-    // @ts-ignore
-    let featureConfigs: Map<string, FeatureContext> = tryNewMap(featureConfigsSerialized)
 
     function getCodeBlockActions(messageData: any) {
         // Show ViewDiff and AcceptDiff for allowedCommands in CWC
@@ -199,6 +201,7 @@ export const createMynahUI = (
                 isTestEnabled,
                 isDocEnabled,
                 disabledCommands,
+                commandHighlight: highlightCommand,
             })
 
             featureConfigs = tryNewMap(featureConfigsSerialized)

--- a/packages/core/src/amazonq/webview/ui/tabs/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/generator.ts
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatItemType, MynahUIDataModel } from '@aws/mynah-ui'
+import { ChatItemType, MynahUIDataModel, QuickActionCommandGroup } from '@aws/mynah-ui'
 import { TabType } from '../storages/tabsStorage'
 import { FollowUpGenerator } from '../followUps/generator'
 import { QuickActionGenerator } from '../quickActions/generator'
 import { TabTypeDataMap } from './constants'
 import { agentWalkthroughDataModel } from '../walkthrough/agent'
+import { FeatureContext } from '../../../../shared'
 
 export interface TabDataGeneratorProps {
     isFeatureDevEnabled: boolean
@@ -17,11 +18,13 @@ export interface TabDataGeneratorProps {
     isTestEnabled: boolean
     isDocEnabled: boolean
     disabledCommands?: string[]
+    commandHighlight?: FeatureContext
 }
 
 export class TabDataGenerator {
     private followUpsGenerator: FollowUpGenerator
     public quickActionsGenerator: QuickActionGenerator
+    private highlightCommand?: FeatureContext
 
     constructor(props: TabDataGeneratorProps) {
         this.followUpsGenerator = new FollowUpGenerator()
@@ -33,6 +36,7 @@ export class TabDataGenerator {
             isDocEnabled: props.isDocEnabled,
             disableCommands: props.disabledCommands,
         })
+        this.highlightCommand = props.commandHighlight
     }
 
     public getTabData(tabType: TabType, needWelcomeMessages: boolean, taskName?: string): MynahUIDataModel {
@@ -50,7 +54,7 @@ export class TabDataGenerator {
                 'Amazon Q Developer uses generative AI. You may need to verify responses. See the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
             quickActionCommands: this.quickActionsGenerator.generateForTab(tabType),
             promptInputPlaceholder: TabTypeDataMap[tabType].placeholder,
-            contextCommands: TabTypeDataMap[tabType].contextCommands,
+            contextCommands: this.getContextCommands(tabType),
             chatItems: needWelcomeMessages
                 ? [
                       {
@@ -65,5 +69,33 @@ export class TabDataGenerator {
                 : [],
         }
         return tabData
+    }
+
+    private getContextCommands(tabType: TabType): QuickActionCommandGroup[] | undefined {
+        if (tabType === 'agentWalkthrough' || tabType === 'welcome') {
+            return
+        }
+
+        const commandName = this.highlightCommand?.value.stringValue
+        if (commandName === undefined || commandName === '') {
+            return TabTypeDataMap[tabType].contextCommands
+        } else {
+            const commandHighlight: QuickActionCommandGroup = {
+                groupName: 'Additional Commands',
+                commands: [
+                    {
+                        command: commandName,
+                        description: this.highlightCommand?.variation,
+                    },
+                ],
+            }
+
+            const contextCommands = TabTypeDataMap[tabType].contextCommands
+            if (contextCommands === undefined) {
+                return [commandHighlight]
+            } else {
+                return [...contextCommands, commandHighlight]
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

When working on new features available to AB groups, the new action are not easily discoverable to users

## Solution

Add the ability to send a new command that will appear when a user types @ in the chat window

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
