### PR TITLE
fix(amazonq): add jobId to all metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.287",
+                "@aws-toolkits/telemetry": "^1.0.289",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -6047,11 +6047,10 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.287",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.287.tgz",
-            "integrity": "sha512-qK2l8Fv5Cvs865ap2evf4ikBREg33/jGw0lgxolqZLdHwm5zm/DkR9vNyqwhDlqDRlSgSlros3Z8zaiSBVRYVQ==",
+            "version": "1.0.289",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.289.tgz",
+            "integrity": "sha512-srzr3JGMprOX2rrUAhribVBrUMfvR6uOhwksaxu63/GMTBjEWjwfcKzpgQzxu1+InmGioBa4zKdKKV/hAaUCmw==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^6.12.6",
                 "cross-spawn": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "generateNonCodeFiles": "npm run generateNonCodeFiles -w packages/ --if-present"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.287",
+        "@aws-toolkits/telemetry": "^1.0.289",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -263,6 +263,7 @@ export async function preTransformationUploadCode() {
 
             transformByQState.setPayloadFilePath(payloadFilePath)
             uploadId = await uploadPayload(payloadFilePath)
+            telemetry.record({ codeTransformJobId: uploadId }) // uploadId is re-used as jobId
         })
     } catch (err) {
         const errorMessage = (err as Error).message
@@ -825,6 +826,7 @@ export async function stopTransformByQ(jobId: string) {
     await telemetry.codeTransform_jobIsCancelledByUser.run(async () => {
         telemetry.record({
             codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+            codeTransformJobId: jobId,
         })
         if (transformByQState.isRunning()) {
             getLogger().info('CodeTransformation: User requested to stop transformation. Stopping transformation.')

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -736,15 +736,15 @@ export async function postTransformationJob() {
         const mavenVersionInfoMessage = `${versionInfo[0]} (${transformByQState.getMavenName()})`
         const javaVersionInfoMessage = `${versionInfo[1]} (${transformByQState.getMavenName()})`
 
-        // Note: IntelliJ implementation of ResultStatusMessage includes additional metadata such as jobId.
         telemetry.codeTransform_totalRunTime.emit({
             buildSystemVersion: mavenVersionInfoMessage,
             codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+            codeTransformJobId: transformByQState.getJobId(),
             codeTransformResultStatusMessage: resultStatusMessage,
             codeTransformRunTimeLatency: durationInMs,
             codeTransformLocalJavaVersion: javaVersionInfoMessage,
             result: resultStatusMessage === TransformByQStatus.Succeeded ? MetadataResult.Pass : MetadataResult.Fail,
-            reason: resultStatusMessage,
+            reason: `${resultStatusMessage}-${chatMessage}`,
         })
     }
 

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -536,9 +536,9 @@ export class ProposedTransformationExplorer {
             diffModel.saveChanges()
             telemetry.codeTransform_submitSelection.emit({
                 codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                codeTransformJobId: transformByQState.getJobId(),
                 userChoice: `acceptChanges-${patchFilesDescriptions?.content[diffModel.currentPatchIndex].name}`,
             })
-            telemetry.ui_click.emit({ elementId: 'transformationHub_acceptChanges' })
             if (transformByQState.getMultipleDiffs()) {
                 void vscode.window.showInformationMessage(
                     CodeWhispererConstants.changesAppliedNotificationMultipleDiffs(
@@ -596,7 +596,6 @@ export class ProposedTransformationExplorer {
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.rejectChanges', async () => {
             diffModel.rejectChanges()
             await reset()
-            telemetry.ui_click.emit({ elementId: 'transformationHub_rejectChanges' })
 
             transformByQState.getChatControllers()?.transformationFinished.fire({
                 tabID: ChatSessionManager.Instance.getSession().tabID,


### PR DESCRIPTION
## Problem

`jobId` missing in some metrics.


## Solution

Add it.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
