### PR TITLE
telemetry(inline-suggestion): fine tune supplemental context strategy telemetry

### DIFF
--- a/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -18,7 +18,11 @@ import { isTestFile } from './codeParsingUtil'
 import { getFileDistance } from '../../../shared/filesystemUtilities'
 import { getOpenFilesInWindow } from '../../../shared/utilities/editorUtilities'
 import { getLogger } from '../../../shared/logger/logger'
-import { CodeWhispererSupplementalContext, CodeWhispererSupplementalContextItem } from '../../models/model'
+import {
+    CodeWhispererSupplementalContext,
+    CodeWhispererSupplementalContextItem,
+    SupplementalContextStrategy,
+} from '../../models/model'
 import { LspController } from '../../../amazonq/lsp/lspController'
 import { waitUntil } from '../../../shared/utilities/timeoutUtils'
 
@@ -75,14 +79,18 @@ export async function fetchSupplementalContextForSrc(
 
     // opentabs context will use bm25 and users' open tabs to fetch supplemental context
     if (supplementalContextConfig === 'opentabs') {
+        const supContext = (await fetchOpentabsContext(editor, cancellationToken)) ?? []
         return {
-            supplementalContextItems: (await fetchOpentabsContext(editor, cancellationToken)) ?? [],
-            strategy: 'opentabs',
+            supplementalContextItems: supContext,
+            strategy: supContext.length === 0 ? 'Empty' : 'opentabs',
         }
     }
 
     // codemap will use opentabs context plus repomap if it's present
     if (supplementalContextConfig === 'codemap') {
+        let strategy: SupplementalContextStrategy = 'Empty'
+        let hasCodemap: boolean = false
+        let hasOpentabs: boolean = false
         const opentabsContextAndCodemap = await waitUntil(
             async function () {
                 const result: CodeWhispererSupplementalContextItem[] = []
@@ -91,10 +99,12 @@ export async function fetchSupplementalContextForSrc(
 
                 if (codemap && codemap.length > 0) {
                     result.push(...codemap)
+                    hasCodemap = true
                 }
 
                 if (opentabsContext && opentabsContext.length > 0) {
                     result.push(...opentabsContext)
+                    hasOpentabs = true
                 }
 
                 return result
@@ -102,9 +112,17 @@ export async function fetchSupplementalContextForSrc(
             { timeout: supplementalContextTimeoutInMs, interval: 5, truthy: false }
         )
 
+        if (hasCodemap) {
+            strategy = 'codemap'
+        } else if (hasOpentabs) {
+            strategy = 'opentabs'
+        } else {
+            strategy = 'Empty'
+        }
+
         return {
             supplementalContextItems: opentabsContextAndCodemap ?? [],
-            strategy: 'codemap',
+            strategy: strategy,
         }
     }
 
@@ -133,9 +151,10 @@ export async function fetchSupplementalContextForSrc(
             }
         }
 
+        const supContext = opentabsContext ?? []
         return {
-            supplementalContextItems: opentabsContext ?? [],
-            strategy: 'opentabs',
+            supplementalContextItems: supContext,
+            strategy: supContext.length === 0 ? 'Empty' : 'opentabs',
         }
     }
 


### PR DESCRIPTION
## Problem
Current `supplementalContextStrategy ` only reflect what group the user is in, however by doing this it won't help much on our data analysis. What we need is the context strategy being used so that we know how much % of users have repomap or opentabs and how % of users have empty supplemental context etc.

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
