### PR TITLE
test(techdebt): delay timer to new year. 

### DIFF
--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -46,6 +46,6 @@ describe('tech debt', function () {
         // Monitor telemtry to determine removal or snooze
         // toolkit_showNotification.id = sessionSeparation
         // auth_modifyConnection.action = deleteProfile OR auth_modifyConnection.source contains CodeCatalyst
-        fixByDate('2024-12-15', 'Remove the edge case code from the commit that this test is a part of.')
+        fixByDate('2025-01-06', 'Remove the edge case code from the commit that this test is a part of.')
     })
 })


### PR DESCRIPTION
## Problem
Techdebt test is failing CI. This is unlikely to be addressed atm. 

## Solution
- Delay until 2025. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
