### PR TITLE
fix(amazonq): code block extends beyond margins

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-c0428af9-a9e5-4f7f-a4f3-9cfe4ea851c9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-c0428af9-a9e5-4f7f-a4f3-9cfe4ea851c9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/review: Code block extends beyond page margins in code issue detail view"
+}

--- a/packages/core/resources/css/securityIssue.css
+++ b/packages/core/resources/css/securityIssue.css
@@ -586,11 +586,6 @@ pre.error {
     }
 }
 
-.code-block {
-    max-width: fit-content;
-    min-width: 500px;
-}
-
 .code-block pre {
     border-radius: 3px 3px 0 0;
 }


### PR DESCRIPTION
## Problem

Code block extends beyond margins followed by the rest of the document.

## Solution

Remove css styles

Before:
![Screenshot 2024-12-16 at 10 41 38 AM](https://github.com/user-attachments/assets/c958c32f-5220-4ea6-8e72-0832a794cde1)



After:
![Screenshot 2024-12-16 at 10 41 17 AM](https://github.com/user-attachments/assets/0131e16c-4541-488b-a8c6-fea348b66993)



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
