### PR TITLE
refactor(settings): make isPromptEnabled non-async

### DIFF
--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -808,7 +808,7 @@ class DiskCacheErrorMessage {
             : ToolkitPromptSettings.instance
 
         // We know 'ssoCacheError' is in all extension prompt settings
-        if (await promptSettings.isPromptEnabled('ssoCacheError')) {
+        if (promptSettings.isPromptEnabled('ssoCacheError')) {
             const result = await showMessage()
             if (result === dontShow) {
                 await promptSettings.disablePrompt('ssoCacheError')

--- a/packages/core/src/awsService/apprunner/commands/pauseService.ts
+++ b/packages/core/src/awsService/apprunner/commands/pauseService.ts
@@ -18,7 +18,7 @@ export async function pauseService(node: AppRunnerServiceNode): Promise<void> {
 
     try {
         const prompts = ToolkitPromptSettings.instance
-        const shouldNotify = await prompts.isPromptEnabled('apprunnerNotifyPause')
+        const shouldNotify = prompts.isPromptEnabled('apprunnerNotifyPause')
         const notifyPrompt = localize(
             'aws.apprunner.pauseService.notify',
             'Your service will be unavailable while paused. ' +

--- a/packages/core/src/awsService/apprunner/wizards/deploymentButton.ts
+++ b/packages/core/src/awsService/apprunner/wizards/deploymentButton.ts
@@ -32,7 +32,7 @@ function makeDeployButtons() {
 async function showDeploymentCostNotification(): Promise<void> {
     const settings = ToolkitPromptSettings.instance
 
-    if (await settings.isPromptEnabled('apprunnerNotifyPricing')) {
+    if (settings.isPromptEnabled('apprunnerNotifyPricing')) {
         const notice = localize(
             'aws.apprunner.createService.priceNotice.message',
             'App Runner automatic deployments incur an additional cost.'

--- a/packages/core/src/awsService/ecs/commands.ts
+++ b/packages/core/src/awsService/ecs/commands.ts
@@ -32,7 +32,7 @@ async function runCommandWizard(
 
     const wizard = new CommandWizard(
         container,
-        await ToolkitPromptSettings.instance.isPromptEnabled('ecsRunCommand'),
+        ToolkitPromptSettings.instance.isPromptEnabled('ecsRunCommand'),
         command
     )
     const response = await wizard.run()

--- a/packages/core/src/awsService/ecs/commands.ts
+++ b/packages/core/src/awsService/ecs/commands.ts
@@ -75,7 +75,7 @@ export async function toggleExecuteCommandFlag(
               'Disabling command execution will change the state of resources in your AWS account, including but not limited to stopping and restarting the service.\n Continue?'
           )
 
-    if (await settings.isPromptEnabled(prompt)) {
+    if (settings.isPromptEnabled(prompt)) {
         const choice = await window.showWarningMessage(warningMessage, yes, yesDontAskAgain, no)
         if (choice === undefined || choice === no) {
             throw new CancellationError('user')

--- a/packages/core/src/awsService/s3/fileViewerManager.ts
+++ b/packages/core/src/awsService/s3/fileViewerManager.ts
@@ -346,7 +346,7 @@ export class S3FileViewerManager {
     }
 
     private async showEditNotification(): Promise<void> {
-        if (!(await this.settings.isPromptEnabled(promptOnEditKey))) {
+        if (!this.settings.isPromptEnabled(promptOnEditKey)) {
             return
         }
 

--- a/packages/core/src/codecatalyst/activation.ts
+++ b/packages/core/src/codecatalyst/activation.ts
@@ -128,7 +128,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
         await showReadmeFileOnFirstLoad(ctx.extensionContext.workspaceState)
 
         const settings = ToolkitPromptSettings.instance
-        if (await settings.isPromptEnabled('remoteConnected')) {
+        if (settings.isPromptEnabled('remoteConnected')) {
             const message = localize(
                 'AWS.codecatalyst.connectedMessage',
                 'Welcome to your Amazon CodeCatalyst Dev Environment. For more options and information, view Dev Environment settings ({0} Extension > CodeCatalyst).',

--- a/packages/core/src/codewhisperer/commands/gettingStartedPageCommands.ts
+++ b/packages/core/src/codewhisperer/commands/gettingStartedPageCommands.ts
@@ -20,7 +20,7 @@ export class CodeWhispererCommandBackend {
 
         const prompts = AmazonQPromptSettings.instance
         // To check the condition If the user has already seen the welcome message
-        if (!(await prompts.isPromptEnabled('codeWhispererNewWelcomeMessage'))) {
+        if (!prompts.isPromptEnabled('codeWhispererNewWelcomeMessage')) {
             telemetry.ui_click.emit({ elementId: 'codewhisperer_Learn_ButtonClick', passive: true })
         }
         return showCodeWhispererWebview(this.extContext, source)

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -366,7 +366,7 @@ export class AuthUtil {
     public async notifySessionConfiguration() {
         const suppressId = 'amazonQSessionConfigurationMessage'
         const settings = AmazonQPromptSettings.instance
-        const shouldShow = await settings.isPromptEnabled(suppressId)
+        const shouldShow = settings.isPromptEnabled(suppressId)
         if (!shouldShow) {
             return
         }

--- a/packages/core/src/codewhisperer/vue/backend.ts
+++ b/packages/core/src/codewhisperer/vue/backend.ts
@@ -161,7 +161,7 @@ export async function showCodeWhispererWebview(
         ]
         const prompts = AmazonQPromptSettings.instance
         // To check the condition If the user has already seen the welcome message
-        if (await prompts.isPromptEnabled('codeWhispererNewWelcomeMessage')) {
+        if (prompts.isPromptEnabled('codeWhispererNewWelcomeMessage')) {
             telemetry.ui_click.emit({ elementId: 'codewhisperer_Learn_PageOpen', passive: true })
         } else {
             telemetry.ui_click.emit({ elementId: 'codewhisperer_Learn_PageOpen', passive: false })

--- a/packages/core/src/shared/awsContextCommands.ts
+++ b/packages/core/src/shared/awsContextCommands.ts
@@ -65,7 +65,7 @@ export class AwsContextCommands {
         await this.editCredentials()
         if (
             credentialsFiles.length === 0 &&
-            (await ToolkitPromptSettings.instance.isPromptEnabled('createCredentialsProfile')) &&
+            ToolkitPromptSettings.instance.isPromptEnabled('createCredentialsProfile') &&
             (await this.promptCredentialsSetup())
         ) {
             await this.onCommandCreateCredentialsProfile()

--- a/packages/core/src/shared/extensionStartup.ts
+++ b/packages/core/src/shared/extensionStartup.ts
@@ -24,7 +24,7 @@ const localize = nls.loadMessageBundle()
  */
 export async function maybeShowMinVscodeWarning(minVscode: string) {
     const settings = isAmazonQ() ? AmazonQPromptSettings.instance : ToolkitPromptSettings.instance
-    if (!(await settings.isPromptEnabled('minIdeVersion'))) {
+    if (!settings.isPromptEnabled('minIdeVersion')) {
         return
     }
     const updateButton = `Update ${vscode.env.appName}`

--- a/packages/core/src/shared/sam/activation.ts
+++ b/packages/core/src/shared/sam/activation.ts
@@ -323,7 +323,7 @@ async function createYamlExtensionPrompt(): Promise<void> {
     // Show this only in VSCode since other VSCode-like IDEs (e.g. Theia) may
     // not have a marketplace or contain the YAML plugin.
     if (
-        (await settings.isPromptEnabled('yamlExtPrompt')) &&
+        settings.isPromptEnabled('yamlExtPrompt') &&
         getIdeType() === 'vscode' &&
         !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)
     ) {

--- a/packages/core/src/shared/sam/sync.ts
+++ b/packages/core/src/shared/sam/sync.ts
@@ -580,7 +580,7 @@ async function updateSyncRecentResponse(region: string, key: string, value: stri
 }
 
 export async function confirmDevStack() {
-    const canPrompt = await ToolkitPromptSettings.instance.isPromptEnabled('samcliConfirmDevStack')
+    const canPrompt = ToolkitPromptSettings.instance.isPromptEnabled('samcliConfirmDevStack')
     if (!canPrompt) {
         return
     }

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -600,7 +600,7 @@ export function fromExtensionManifest<T extends TypeDescriptor & Partial<Section
  *
  * ### Usage:
  * ```
- * if (await settings.isPromptEnabled('myPromptName')) {
+ * if (settings.isPromptEnabled('myPromptName')) {
  *     // Show some sort of prompt
  *     const userResponse = await promptUser()
  *
@@ -627,19 +627,19 @@ export class ToolkitPromptSettings
     )
     implements PromptSettings
 {
-    public async isPromptEnabled(promptName: toolkitPromptName): Promise<boolean> {
+    public isPromptEnabled(promptName: toolkitPromptName): boolean {
         try {
             return !this._getOrThrow(promptName, false)
         } catch (e) {
             this._log('prompt check for "%s" failed: %s', promptName, (e as Error).message)
-            await this.reset()
+            this.reset().catch((e) => getLogger().error(`failed to reset prompt settings: %O`, (e as Error).message))
 
             return true
         }
     }
 
     public async disablePrompt(promptName: toolkitPromptName): Promise<void> {
-        if (await this.isPromptEnabled(promptName)) {
+        if (this.isPromptEnabled(promptName)) {
             await this.update(promptName, true)
         }
     }
@@ -660,19 +660,19 @@ export class AmazonQPromptSettings
     )
     implements PromptSettings
 {
-    public async isPromptEnabled(promptName: amazonQPromptName): Promise<boolean> {
+    public isPromptEnabled(promptName: amazonQPromptName): boolean {
         try {
             return !this._getOrThrow(promptName, false)
         } catch (e) {
             this._log('prompt check for "%s" failed: %s', promptName, (e as Error).message)
-            await this.reset()
+            this.reset().catch((e) => getLogger().error(`failed to reset prompt settings: %O`, (e as Error).message))
 
             return true
         }
     }
 
     public async disablePrompt(promptName: amazonQPromptName): Promise<void> {
-        if (await this.isPromptEnabled(promptName)) {
+        if (this.isPromptEnabled(promptName)) {
             await this.update(promptName, true)
         }
     }
@@ -692,7 +692,7 @@ export class AmazonQPromptSettings
 type AllPromptNames = amazonQPromptName | toolkitPromptName
 
 export interface PromptSettings {
-    isPromptEnabled(promptName: AllPromptNames): Promise<boolean>
+    isPromptEnabled(promptName: AllPromptNames): boolean
     disablePrompt(promptName: AllPromptNames): Promise<void>
 }
 

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -665,7 +665,7 @@ export class AmazonQPromptSettings
             return !this._getOrThrow(promptName, false)
         } catch (e) {
             this._log('prompt check for "%s" failed: %s', promptName, (e as Error).message)
-            this.reset().catch((e) => getLogger().error(`failed to reset prompt settings: %O`, (e as Error).message))
+            this.reset().catch((e) => getLogger().error(`isPromptEnabled: reset() failed: %O`, (e as Error).message))
 
             return true
         }

--- a/packages/core/src/shared/utilities/messages.ts
+++ b/packages/core/src/shared/utilities/messages.ts
@@ -194,7 +194,7 @@ export async function showReauthenticateMessage({
     reauthFunc: () => Promise<void>
     source?: string
 }) {
-    const shouldShow = await settings.isPromptEnabled(suppressId as any)
+    const shouldShow = settings.isPromptEnabled(suppressId as any)
     if (!shouldShow) {
         return
     }

--- a/packages/core/src/test/shared/settings.test.ts
+++ b/packages/core/src/test/shared/settings.test.ts
@@ -498,7 +498,7 @@ describe('PromptSetting', function () {
             it(scenario.desc, async () => {
                 await settings.update(promptSettingKey, scenario.testValue)
                 const before = settings.get(promptSettingKey, Object, {})
-                const result = await sut.isPromptEnabled(promptName)
+                const result = sut.isPromptEnabled(promptName)
 
                 assert.deepStrictEqual(result, scenario.expected)
                 assert.deepStrictEqual(


### PR DESCRIPTION
## Problem
There is no real reason this needs to be async. It is also now inconsistent with `isExperimentEnabled`. 

## Solution
Make non-async and add logged error if the promise rejects. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
