### PR TITLE
feat(amazon q): adding view transformation summary to chat when code transformation complete and summary available

### DIFF
--- a/packages/core/src/amazonqGumby/app.ts
+++ b/packages/core/src/amazonqGumby/app.ts
@@ -13,7 +13,7 @@ import { Messenger } from './chat/controller/messenger/messenger'
 import { UIMessageListener } from './chat/views/actions/uiMessageListener'
 import { debounce } from 'lodash'
 import { AuthUtil } from '../codewhisperer/util/authUtil'
-import { showTransformationHub } from './commands'
+import { showTransformationHub, showTransformationSummary } from './commands'
 import { transformByQState } from '../codewhisperer/models/model'
 import { ChatSessionManager } from './chat/storages/chatSession'
 
@@ -69,6 +69,7 @@ export function init(appContext: AmazonQAppInitContext) {
     })
 
     showTransformationHub.register()
+    showTransformationSummary.register()
 
     transformByQState.setChatControllers(gumbyChatControllerEventEmitters)
     transformByQState.setChatMessenger(messenger)

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -17,7 +17,7 @@ import { featureName } from '../../models/constants'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import {
     cleanupTransformationJob,
-    // compileProject,
+    compileProject,
     finishHumanInTheLoop,
     getValidLanguageUpgradeCandidateProjects,
     postTransformationJob,
@@ -534,7 +534,7 @@ export class GumbyController {
         try {
             this.sessionStorage.getSession().conversationState = ConversationState.COMPILING
             this.messenger.sendCompilationInProgress(message.tabID)
-            // await compileProject()
+            await compileProject()
         } catch (err: any) {
             this.messenger.sendUnrecoverableErrorResponse('could-not-compile-project', message.tabID)
             // reset state to allow "Start a new transformation" button to work

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -17,7 +17,7 @@ import { featureName } from '../../models/constants'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import {
     cleanupTransformationJob,
-    compileProject,
+    // compileProject,
     finishHumanInTheLoop,
     getValidLanguageUpgradeCandidateProjects,
     postTransformationJob,
@@ -395,6 +395,17 @@ export class GumbyController {
                 this.messenger.sendCommandMessage({ ...message, command: GumbyCommands.CLEAR_CHAT })
                 await this.transformInitiated(message)
                 break
+            case ButtonActions.CONFIRM_VIEW_TRANSFORMATION_SUMMARY:
+                await vscode.commands.executeCommand(
+                    GumbyCommands.SHOW_TRANSFORMATION_SUMMARY,
+                    CancelActionPositions.Chat
+                )
+                this.messenger.sendJobFinishedMessage(
+                    message.tabID,
+                    CodeWhispererConstants.viewProposedChangesChatMessage
+                )
+                telemetry.ui_click.emit({ elementId: 'transformationHub_viewSummary' })
+                break
             case ButtonActions.CONFIRM_DEPENDENCY_FORM:
                 await this.continueJobWithSelectedDependency(message)
                 break
@@ -523,7 +534,7 @@ export class GumbyController {
         try {
             this.sessionStorage.getSession().conversationState = ConversationState.COMPILING
             this.messenger.sendCompilationInProgress(message.tabID)
-            await compileProject()
+            // await compileProject()
         } catch (err: any) {
             this.messenger.sendUnrecoverableErrorResponse('could-not-compile-project', message.tabID)
             // reset state to allow "Start a new transformation" button to work

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -509,6 +509,14 @@ export class Messenger {
 
     public sendJobFinishedMessage(tabID: string, message: string, includeStartNewTransformationButton: boolean = true) {
         const buttons: ChatItemButton[] = []
+        // We only want to show this button when the proposed changes were downloaded (ie the summary is available)
+        if (transformByQState.getSummaryFilePath() !== '') {
+            buttons.push({
+                keepCardAfterClick: false,
+                text: CodeWhispererConstants.viewTransformationSummaryButtonText,
+                id: ButtonActions.CONFIRM_VIEW_TRANSFORMATION_SUMMARY,
+            })
+        }
         if (includeStartNewTransformationButton) {
             buttons.push({
                 keepCardAfterClick: false,

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
@@ -26,6 +26,7 @@ export enum ButtonActions {
     CONFIRM_JAVA_HOME_FORM = 'gumbyJavaHomeFormConfirm',
     CANCEL_JAVA_HOME_FORM = 'gumbyJavaHomeFormCancel',
     CONFIRM_START_TRANSFORMATION_FLOW = 'gumbyStartTransformation',
+    CONFIRM_VIEW_TRANSFORMATION_SUMMARY = 'gumbyViewSummary',
     OPEN_FILE = 'gumbyOpenFile',
     OPEN_BUILD_LOG = 'gumbyOpenBuildLog',
 }
@@ -34,6 +35,7 @@ export enum GumbyCommands {
     CLEAR_CHAT = 'aws.awsq.clearchat',
     START_TRANSFORMATION_FLOW = 'aws.awsq.transform',
     FOCUS_TRANSFORMATION_HUB = 'aws.amazonq.showTransformationHub',
+    SHOW_TRANSFORMATION_SUMMARY = 'aws.amazonq.transformationHub.summary.reveal',
 }
 
 export default class MessengerUtils {

--- a/packages/core/src/amazonqGumby/commands.ts
+++ b/packages/core/src/amazonqGumby/commands.ts
@@ -5,10 +5,23 @@
 
 import * as vscode from 'vscode'
 import { Commands } from '../shared/vscode/commands2'
+import { transformByQState } from '../codewhisperer'
 
 export const showTransformationHub = Commands.declare(
     { id: 'aws.amazonq.showTransformationHub', compositeKey: { 0: 'source' } },
     () => async (source: string) => {
         await vscode.commands.executeCommand('workbench.view.extension.aws-codewhisperer-transformation-hub')
+    }
+)
+
+export const showTransformationSummary = Commands.declare(
+    { id: 'aws.amazonq.transformationHub.summary.reveal', compositeKey: { 0: 'source' } },
+    () => async (source: string) => {
+        if (transformByQState.getSummaryFilePath() !== '') {
+            await vscode.commands.executeCommand(
+                'markdown.showPreview',
+                vscode.Uri.file(String(transformByQState.getSummaryFilePath()))
+            )
+        }
     }
 )

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -76,7 +76,7 @@ import { dependencyNoAvailableVersions } from '../../amazonqGumby/models/constan
 import { HumanInTheLoopManager } from '../service/transformByQ/humanInTheLoopManager'
 import { setContext } from '../../shared/vscode/setContext'
 import { makeTemporaryToolkitFolder } from '../../shared'
-import globals from '../../shared/extensionGlobals'
+// import globals from '../../shared/extensionGlobals'
 import { convertDateToTimestamp } from '../../shared/datetime'
 import { findStringInDirectory } from '../../shared/utilities/workspaceUtils'
 
@@ -164,7 +164,7 @@ export function startInterval() {
 
 export async function startTransformByQ() {
     // Set the default state variables for our store and the UI
-    const transformStartTime = globals.clock.Date.now()
+    // const transformStartTime = globals.clock.Date.now()
     await setTransformationToRunningState()
 
     try {
@@ -172,16 +172,16 @@ export async function startTransformByQ() {
         startInterval()
 
         // step 1: CreateUploadUrl and upload code
-        const uploadId = await preTransformationUploadCode()
+        // const uploadId = await preTransformationUploadCode()
 
         // step 2: StartJob and store the returned jobId in TransformByQState
-        const jobId = await startTransformationJob(uploadId, transformStartTime)
+        // const jobId = await startTransformationJob(uploadId, transformStartTime)
 
         // step 3 (intermediate step): show transformation-plan.md file
-        await pollTransformationStatusUntilPlanReady(jobId)
+        // await pollTransformationStatusUntilPlanReady(jobId)
 
         // step 4: poll until artifacts are ready to download
-        await humanInTheLoopRetryLogic(jobId)
+        await humanInTheLoopRetryLogic('jobId')
     } catch (error: any) {
         await transformationJobErrorHandler(error)
     } finally {
@@ -200,7 +200,8 @@ export async function startTransformByQ() {
 export async function humanInTheLoopRetryLogic(jobId: string) {
     let status = ''
     try {
-        status = await pollTransformationStatusUntilComplete(jobId)
+        // status = await pollTransformationStatusUntilComplete(jobId)
+        status = 'COMPLETED'
         if (status === 'PAUSED') {
             const hilStatusFailure = await initiateHumanInTheLoopPrompt(jobId)
             if (hilStatusFailure) {

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -76,7 +76,7 @@ import { dependencyNoAvailableVersions } from '../../amazonqGumby/models/constan
 import { HumanInTheLoopManager } from '../service/transformByQ/humanInTheLoopManager'
 import { setContext } from '../../shared/vscode/setContext'
 import { makeTemporaryToolkitFolder } from '../../shared'
-// import globals from '../../shared/extensionGlobals'
+import globals from '../../shared/extensionGlobals'
 import { convertDateToTimestamp } from '../../shared/datetime'
 import { findStringInDirectory } from '../../shared/utilities/workspaceUtils'
 
@@ -164,7 +164,7 @@ export function startInterval() {
 
 export async function startTransformByQ() {
     // Set the default state variables for our store and the UI
-    // const transformStartTime = globals.clock.Date.now()
+    const transformStartTime = globals.clock.Date.now()
     await setTransformationToRunningState()
 
     try {
@@ -172,16 +172,16 @@ export async function startTransformByQ() {
         startInterval()
 
         // step 1: CreateUploadUrl and upload code
-        // const uploadId = await preTransformationUploadCode()
+        const uploadId = await preTransformationUploadCode()
 
         // step 2: StartJob and store the returned jobId in TransformByQState
-        // const jobId = await startTransformationJob(uploadId, transformStartTime)
+        const jobId = await startTransformationJob(uploadId, transformStartTime)
 
         // step 3 (intermediate step): show transformation-plan.md file
-        // await pollTransformationStatusUntilPlanReady(jobId)
+        await pollTransformationStatusUntilPlanReady(jobId)
 
         // step 4: poll until artifacts are ready to download
-        await humanInTheLoopRetryLogic('jobId')
+        await humanInTheLoopRetryLogic(jobId)
     } catch (error: any) {
         await transformationJobErrorHandler(error)
     } finally {
@@ -200,8 +200,7 @@ export async function startTransformByQ() {
 export async function humanInTheLoopRetryLogic(jobId: string) {
     let status = ''
     try {
-        // status = await pollTransformationStatusUntilComplete(jobId)
-        status = 'COMPLETED'
+        status = await pollTransformationStatusUntilComplete(jobId)
         if (status === 'PAUSED') {
             const hilStatusFailure = await initiateHumanInTheLoopPrompt(jobId)
             if (hilStatusFailure) {

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -563,6 +563,8 @@ export const openTransformationHubButtonText = 'Open Transformation Hub'
 
 export const startTransformationButtonText = 'Start a new transformation'
 
+export const viewTransformationSummaryButtonText = 'View transformation summary'
+
 export const stopTransformationButtonText = 'Stop transformation'
 
 export const checkingForProjectsChatMessage = 'Checking for eligible projects...'

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import AdmZip from 'adm-zip'
+// import AdmZip from 'adm-zip'
 import os from 'os'
 import fs from 'fs' // eslint-disable-line no-restricted-imports
 import { parsePatch, applyPatches, ParsedDiff } from 'diff'
 import path from 'path'
 import vscode from 'vscode'
-import { ExportIntent } from '@amzn/codewhisperer-streaming'
+// import { ExportIntent } from '@amzn/codewhisperer-streaming'
 import {
     TransformByQReviewStatus,
     transformByQState,
@@ -17,13 +17,13 @@ import {
     DescriptionContent,
     TransformationType,
 } from '../../models/model'
-import { ExportResultArchiveStructure, downloadExportResultArchive } from '../../../shared/utilities/download'
+import { ExportResultArchiveStructure } from '../../../shared/utilities/download'
 import { getLogger } from '../../../shared/logger'
 import { telemetry } from '../../../shared/telemetry/telemetry'
 import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/codeTransformTelemetryState'
 import { MetadataResult } from '../../../shared/telemetry/telemetryClient'
 import * as CodeWhispererConstants from '../../models/constants'
-import { createCodeWhispererChatStreamingClient } from '../../../shared/clients/codewhispererChatClient'
+// import { createCodeWhispererChatStreamingClient } from '../../../shared/clients/codewhispererChatClient'
 import { ChatSessionManager } from '../../../amazonqGumby/chat/storages/chatSession'
 import { setContext } from '../../../shared/vscode/setContext'
 import * as codeWhisperer from '../../client/codewhisperer'
@@ -364,28 +364,28 @@ export class ProposedTransformationExplorer {
             }
         })
 
-        vscode.commands.registerCommand('aws.amazonq.transformationHub.summary.reveal', async () => {
-            if (transformByQState.getSummaryFilePath() !== '') {
-                await vscode.commands.executeCommand(
-                    'markdown.showPreview',
-                    vscode.Uri.file(transformByQState.getSummaryFilePath())
-                )
-                telemetry.ui_click.emit({ elementId: 'transformationHub_viewSummary' })
-            }
-        })
+        // vscode.commands.registerCommand('aws.amazonq.transformationHub.summary.reveal', async () => {
+        //     if (transformByQState.getSummaryFilePath() !== '') {
+        //         await vscode.commands.executeCommand(
+        //             'markdown.showPreview',
+        //             vscode.Uri.file(transformByQState.getSummaryFilePath())
+        //         )
+        //         telemetry.ui_click.emit({ elementId: 'transformationHub_viewSummary' })
+        //     }
+        // })
 
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.startReview', async () => {
             await setContext('gumby.reviewState', TransformByQReviewStatus.PreparingReview)
 
-            const pathToArchive = path.join(
-                ProposedTransformationExplorer.TmpDir,
-                transformByQState.getJobId(),
-                'ExportResultsArchive.zip'
-            )
-            let exportResultsArchiveSize = 0
+            // const pathToArchive = path.join(
+            //     ProposedTransformationExplorer.TmpDir,
+            //     transformByQState.getJobId(),
+            //     'ExportResultsArchive.zip'
+            // )
+            const exportResultsArchiveSize = 0
             let downloadErrorMessage = undefined
 
-            const cwStreamingClient = await createCodeWhispererChatStreamingClient()
+            // const cwStreamingClient = await createCodeWhispererChatStreamingClient()
             try {
                 await telemetry.codeTransform_downloadArtifact.run(async () => {
                     telemetry.record({
@@ -394,17 +394,17 @@ export class ProposedTransformationExplorer {
                         codeTransformJobId: transformByQState.getJobId(),
                     })
 
-                    await downloadExportResultArchive(
-                        cwStreamingClient,
-                        {
-                            exportId: transformByQState.getJobId(),
-                            exportIntent: ExportIntent.TRANSFORMATION,
-                        },
-                        pathToArchive
-                    )
+                    // await downloadExportResultArchive(
+                    //     cwStreamingClient,
+                    //     {
+                    //         exportId: transformByQState.getJobId(),
+                    //         exportIntent: ExportIntent.TRANSFORMATION,
+                    //     },
+                    //     pathToArchive
+                    // )
 
                     // Update downloaded artifact size
-                    exportResultsArchiveSize = (await fs.promises.stat(pathToArchive)).size
+                    // exportResultsArchiveSize = (await fs.promises.stat(pathToArchive)).size
 
                     telemetry.record({ codeTransformTotalByteSize: exportResultsArchiveSize })
                 })
@@ -425,7 +425,7 @@ export class ProposedTransformationExplorer {
                 getLogger().error(`CodeTransformation: ExportResultArchive error = ${downloadErrorMessage}`)
                 throw new Error('Error downloading diff')
             } finally {
-                cwStreamingClient.destroy()
+                // cwStreamingClient.destroy()
             }
 
             let deserializeErrorMessage = undefined
@@ -433,9 +433,9 @@ export class ProposedTransformationExplorer {
             patchFiles = [] // reset patchFiles if there was a previous transformation
             try {
                 // Download and deserialize the zip
-                pathContainingArchive = path.dirname(pathToArchive)
-                const zip = new AdmZip(pathToArchive)
-                zip.extractAllTo(pathContainingArchive)
+                // pathContainingArchive = path.dirname(pathToArchive)
+                // const zip = new AdmZip(pathToArchive)
+                // zip.extractAllTo(pathContainingArchive)
                 const files = fs.readdirSync(path.join(pathContainingArchive, ExportResultArchiveStructure.PathToPatch))
                 if (files.length === 1) {
                     singlePatchFile = path.join(
@@ -491,7 +491,7 @@ export class ProposedTransformationExplorer {
                     message: CodeWhispererConstants.viewProposedChangesChatMessage,
                     tabID: ChatSessionManager.Instance.getSession().tabID,
                 })
-                await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
+                // await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
             } catch (e: any) {
                 deserializeErrorMessage = (e as Error).message
                 getLogger().error(`CodeTransformation: ParseDiff error = ${deserializeErrorMessage}`)

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -325,11 +325,7 @@ export class ProposedTransformationExplorer {
             treeDataProvider: transformDataProvider,
         })
 
-<<<<<<< HEAD
         let patchFiles: string[] = []
-=======
-        const patchFiles: string[] = []
->>>>>>> d92cadc19 (remove short circuiting steps)
         let singlePatchFile: string = ''
         let patchFilesDescriptions: DescriptionContent | undefined = undefined
 
@@ -434,10 +430,7 @@ export class ProposedTransformationExplorer {
 
             let deserializeErrorMessage = undefined
             let pathContainingArchive = ''
-<<<<<<< HEAD
             patchFiles = [] // reset patchFiles if there was a previous transformation
-=======
->>>>>>> d92cadc19 (remove short circuiting steps)
             try {
                 // Download and deserialize the zip
                 pathContainingArchive = path.dirname(pathToArchive)

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// import AdmZip from 'adm-zip'
+import AdmZip from 'adm-zip'
 import os from 'os'
 import fs from 'fs' // eslint-disable-line no-restricted-imports
 import { parsePatch, applyPatches, ParsedDiff } from 'diff'
 import path from 'path'
 import vscode from 'vscode'
-// import { ExportIntent } from '@amzn/codewhisperer-streaming'
+import { ExportIntent } from '@amzn/codewhisperer-streaming'
 import {
     TransformByQReviewStatus,
     transformByQState,
@@ -17,13 +17,13 @@ import {
     DescriptionContent,
     TransformationType,
 } from '../../models/model'
-import { ExportResultArchiveStructure } from '../../../shared/utilities/download'
+import { ExportResultArchiveStructure, downloadExportResultArchive } from '../../../shared/utilities/download'
 import { getLogger } from '../../../shared/logger'
 import { telemetry } from '../../../shared/telemetry/telemetry'
 import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/codeTransformTelemetryState'
 import { MetadataResult } from '../../../shared/telemetry/telemetryClient'
 import * as CodeWhispererConstants from '../../models/constants'
-// import { createCodeWhispererChatStreamingClient } from '../../../shared/clients/codewhispererChatClient'
+import { createCodeWhispererChatStreamingClient } from '../../../shared/clients/codewhispererChatClient'
 import { ChatSessionManager } from '../../../amazonqGumby/chat/storages/chatSession'
 import { setContext } from '../../../shared/vscode/setContext'
 import * as codeWhisperer from '../../client/codewhisperer'
@@ -325,7 +325,11 @@ export class ProposedTransformationExplorer {
             treeDataProvider: transformDataProvider,
         })
 
+<<<<<<< HEAD
         let patchFiles: string[] = []
+=======
+        const patchFiles: string[] = []
+>>>>>>> d92cadc19 (remove short circuiting steps)
         let singlePatchFile: string = ''
         let patchFilesDescriptions: DescriptionContent | undefined = undefined
 
@@ -377,15 +381,15 @@ export class ProposedTransformationExplorer {
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.startReview', async () => {
             await setContext('gumby.reviewState', TransformByQReviewStatus.PreparingReview)
 
-            // const pathToArchive = path.join(
-            //     ProposedTransformationExplorer.TmpDir,
-            //     transformByQState.getJobId(),
-            //     'ExportResultsArchive.zip'
-            // )
-            const exportResultsArchiveSize = 0
+            const pathToArchive = path.join(
+                ProposedTransformationExplorer.TmpDir,
+                transformByQState.getJobId(),
+                'ExportResultsArchive.zip'
+            )
+            let exportResultsArchiveSize = 0
             let downloadErrorMessage = undefined
 
-            // const cwStreamingClient = await createCodeWhispererChatStreamingClient()
+            const cwStreamingClient = await createCodeWhispererChatStreamingClient()
             try {
                 await telemetry.codeTransform_downloadArtifact.run(async () => {
                     telemetry.record({
@@ -394,17 +398,17 @@ export class ProposedTransformationExplorer {
                         codeTransformJobId: transformByQState.getJobId(),
                     })
 
-                    // await downloadExportResultArchive(
-                    //     cwStreamingClient,
-                    //     {
-                    //         exportId: transformByQState.getJobId(),
-                    //         exportIntent: ExportIntent.TRANSFORMATION,
-                    //     },
-                    //     pathToArchive
-                    // )
+                    await downloadExportResultArchive(
+                        cwStreamingClient,
+                        {
+                            exportId: transformByQState.getJobId(),
+                            exportIntent: ExportIntent.TRANSFORMATION,
+                        },
+                        pathToArchive
+                    )
 
                     // Update downloaded artifact size
-                    // exportResultsArchiveSize = (await fs.promises.stat(pathToArchive)).size
+                    exportResultsArchiveSize = (await fs.promises.stat(pathToArchive)).size
 
                     telemetry.record({ codeTransformTotalByteSize: exportResultsArchiveSize })
                 })
@@ -425,17 +429,20 @@ export class ProposedTransformationExplorer {
                 getLogger().error(`CodeTransformation: ExportResultArchive error = ${downloadErrorMessage}`)
                 throw new Error('Error downloading diff')
             } finally {
-                // cwStreamingClient.destroy()
+                cwStreamingClient.destroy()
             }
 
             let deserializeErrorMessage = undefined
             let pathContainingArchive = ''
+<<<<<<< HEAD
             patchFiles = [] // reset patchFiles if there was a previous transformation
+=======
+>>>>>>> d92cadc19 (remove short circuiting steps)
             try {
                 // Download and deserialize the zip
-                // pathContainingArchive = path.dirname(pathToArchive)
-                // const zip = new AdmZip(pathToArchive)
-                // zip.extractAllTo(pathContainingArchive)
+                pathContainingArchive = path.dirname(pathToArchive)
+                const zip = new AdmZip(pathToArchive)
+                zip.extractAllTo(pathContainingArchive)
                 const files = fs.readdirSync(path.join(pathContainingArchive, ExportResultArchiveStructure.PathToPatch))
                 if (files.length === 1) {
                     singlePatchFile = path.join(


### PR DESCRIPTION
## Problem
We want to be able to have a button that is able to show the transformation summary when it is available. Currently the summary is automatically loaded when the proposed changes are downloaded. 

## Solution
In this way, we don't need to have the summary.md and associated icons in the proposed changes and the user can click on this button to view the transformation summary.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
