### PR TITLE
test(iinline-suggestion): fix crossFileContextUtil.test failure caused by using real clock and test timeouts

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -322,9 +322,7 @@ describe('crossFileContextUtil', function () {
     })
 
     describe('full support', function () {
-        // TODO: fix it
         const fileExtLists = ['java', 'js', 'ts', 'py', 'tsx', 'jsx']
-        // const fileExtLists = ['java']
 
         before(async function () {
             this.timeout(60000)

--- a/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/crossFileContextUtil.test.ts
@@ -4,10 +4,11 @@
  */
 
 import assert from 'assert'
+import * as FakeTimers from '@sinonjs/fake-timers'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import * as crossFile from 'aws-core-vscode/codewhisperer'
-import { aStringWithLineCount, createMockTextEditor } from 'aws-core-vscode/test'
+import { aStringWithLineCount, createMockTextEditor, installFakeClock } from 'aws-core-vscode/test'
 import { FeatureConfigProvider, crossFileContextConfig } from 'aws-core-vscode/codewhisperer'
 import {
     assertTabCount,
@@ -30,6 +31,15 @@ describe('crossFileContextUtil', function () {
     }
 
     let mockEditor: vscode.TextEditor
+    let clock: FakeTimers.InstalledClock
+
+    before(function () {
+        clock = installFakeClock()
+    })
+
+    after(function () {
+        clock.uninstall()
+    })
 
     afterEach(function () {
         sinon.restore()
@@ -313,8 +323,8 @@ describe('crossFileContextUtil', function () {
 
     describe('full support', function () {
         // TODO: fix it
-        // const fileExtLists = ['java', 'js', 'ts', 'py', 'tsx', 'jsx']
-        const fileExtLists = ['java']
+        const fileExtLists = ['java', 'js', 'ts', 'py', 'tsx', 'jsx']
+        // const fileExtLists = ['java']
 
         before(async function () {
             this.timeout(60000)


### PR DESCRIPTION
## Problem
#6252

As test previously was using real system clock, it's likely to timeout due to heavy computation in an undeterministic way


## Solution
Use fake clock

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
