### PR TITLE
test(core): supress Failure to parse stylesheet message from e2e test logs

### DIFF
--- a/packages/amazonq/test/e2e/amazonq/framework/jsdomInjector.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/jsdomInjector.ts
@@ -3,15 +3,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { JSDOM } from 'jsdom'
+import { JSDOM, VirtualConsole } from 'jsdom'
 
+/**
+ * JSDOM is used to help hoist MynahUI to running in a node environment vs in the browser (which is what it's made for)
+ */
 export function injectJSDOM() {
-    /**
-     * JSDOM is used to help hoist MynahUI to running in a node environment vs in the browser (which is what it's made for)
-     */
+    const virtualConsole = new VirtualConsole()
+    virtualConsole.on('error', (error) => {
+        // JSDOM can't load scss from mynah UI, just skip it
+        if (!error.includes('Could not parse CSS stylesheet')) {
+            console.error(error)
+        }
+    })
+
     const dom = new JSDOM(undefined, {
         pretendToBeVisual: true,
         includeNodeLocations: true,
+        virtualConsole,
     })
     global.window = dom.window as unknown as Window & typeof globalThis
     global.document = dom.window.document


### PR DESCRIPTION
## Problem
- JSDOM logs non-critical CSS parsing errors during E2E tests. These warnings occur when mynah-ui loads SCSS files in [main.ts](https://github.com/aws/mynah-ui/blob/8058f86ed370f5268ba6e0993b2436dca0e09b30/src/main.ts#L37). These errors appear the test logs but they do not affect test functionality or results.


## Solution
- Suppress the errors

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
