### PR TITLE
test(codecatalyst): only fail test if message is more than a minute off. 

### DIFF
--- a/packages/core/src/testInteg/codecatalyst/devEnv.test.ts
+++ b/packages/core/src/testInteg/codecatalyst/devEnv.test.ts
@@ -141,6 +141,12 @@ describe('InactivityMessage', function () {
                 message: expectedMessages[i][0],
                 minute: expectedMessages[i][1],
             }
+            assert.deepStrictEqual(actualMessages[i].message, expected.message)
+            // Avoid flakiness in the timing by looking within a minute rather than exact.
+            assert.ok(
+                Math.abs(actualMessages[i].minute - expected.minute) <= 1,
+                `Expected to be within 60 seconds of minute ${expected.minute}, but instead was at minute ${actualMessages[i].minute}`
+            )
             assert.deepStrictEqual(actualMessages[i], expected)
         }
     }


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/issues/6213

## Solution
- The important part of this test is that the message comes after being inactive. If the message comes slightly early/late, that is okay. If it doesn't come at all, then we have problems and should fail. 
- Pass test if message comes within a minute of expected. 

## Alternatives
- skip the test. 
- Re-do test setup since its flaky. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
