### PR TITLE
test(cwl): Fix TailLogGroup test not disposing its event listeners

### DIFF
--- a/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts
@@ -56,7 +56,7 @@ describe('TailLogGroup', function () {
             getSessionUpdateFrame(false, `${testMessage}-2`, startTimestamp + 2000),
             getSessionUpdateFrame(false, `${testMessage}-3`, startTimestamp + 3000),
         ]
-        // Returns the configured update frames and then blocks until an AbortCcontroller is signaled.
+        // Returns the configured update frames and then blocks until an AbortController is signaled.
         // This keeps the stream 'open', simulating an open network stream waiting for new events.
         // If the stream were to close, the event listeners in the TailLogGroup command would dispose,
         // breaking the 'closes tab closes session' assertions this test makes.
@@ -95,7 +95,10 @@ describe('TailLogGroup', function () {
         void tailLogGroup(registry, testSource, codeLensProvider, {
             groupName: testLogGroup,
             regionName: testRegion,
-        }).catch((e) => {})
+        }).catch((e) => {
+            const err = e as Error
+            assert.strictEqual(err.message.startsWith('Unexpected on-stream exception while tailing session:'), true)
+        })
         await waitUntil(async () => registry.size !== 0, { interval: 100, timeout: 1000 })
 
         // registry is asserted to have only one entry, so this is assumed to be the session that was


### PR DESCRIPTION
## Problem
Currently, the TailLogGroup tests are passing, but emitting noisy errors in the CI logs:
```
<...>
No LiveTail session found for URI: test-region:test-log-group:all: Error: No LiveTail session found for URI: test-region:test-log-group:all
    at D:\a\aws-toolkit-vscode\aws-toolkit-vscode\packages\core\src\awsService\cloudWatchLogs\commands\tailLogGroup.ts:94:19
    at AsyncLocalStorage.run (node:async_hooks:346:14)
<...>
```

The cause for this, is that the event listener for closing the tailing session when Editor tabs close in TailLogGroup is not being disposed of. Disposal happens [here](https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts#L80). However, currently the "mock response stream" in the test blocks indefinitely on an [un-resolvable promise](https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/test/awsService/cloudWatchLogs/commands/tailLogGroup.test.ts#L67). So the test ends, and this finally block never triggers.

## Solution
Instead of using an un-resolving promise to keep the mock responseStream open, use an AbortController. When the tests no longer need the functionality of the disposables, the test can fire the AbortController. This causes the stream to exit exceptionally, which triggers the `finally` block in TailLogGroup and runs disposal. 

This stops the event listeners from running after the test is completed, and has eliminated the noisy logs. I have tested this by running `npm run test` from the CLI. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
