### PR TITLE
test(inline-suggestion): fix supplementalContextUtil.test failure #6266

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/supplemetalContextUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/supplemetalContextUtil.test.ts
@@ -4,21 +4,31 @@
  */
 
 import assert from 'assert'
+import * as FakeTimers from '@sinonjs/fake-timers'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import * as crossFile from 'aws-core-vscode/codewhisperer'
-import { TestFolder, assertTabCount } from 'aws-core-vscode/test'
+import { TestFolder, assertTabCount, installFakeClock } from 'aws-core-vscode/test'
 import { FeatureConfigProvider } from 'aws-core-vscode/codewhisperer'
 import { toTextEditor } from 'aws-core-vscode/test'
 import { LspController } from 'aws-core-vscode/amazonq'
 
 describe('supplementalContextUtil', function () {
     let testFolder: TestFolder
+    let clock: FakeTimers.InstalledClock
 
     const fakeCancellationToken: vscode.CancellationToken = {
         isCancellationRequested: false,
         onCancellationRequested: sinon.spy(),
     }
+
+    before(function () {
+        clock = installFakeClock()
+    })
+
+    after(function () {
+        clock.uninstall()
+    })
 
     beforeEach(async function () {
         testFolder = await TestFolder.create()


### PR DESCRIPTION
## Problem
patch #6258 
fix #6266

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
