### PR TITLE
feat(amazonq): add view summary button in chat

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-1e7f3af5-7c94-4c60-8909-a61c0b06e02e.json
+++ b/packages/amazonq/.changes/next-release/Feature-1e7f3af5-7c94-4c60-8909-a61c0b06e02e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q Code Transformation: add view summary button in chat"
+}

--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -12,7 +12,6 @@ import { GumbyController, setMaven, startTransformByQ, TabsStorage } from 'aws-c
 import { using, registerAuthHook, TestFolder } from 'aws-core-vscode/test'
 import { loginToIdC } from './utils/setup'
 import { fs } from 'aws-core-vscode/shared'
-import * as os from 'os'
 import path from 'path'
 
 describe('Amazon Q Code Transformation', function () {
@@ -155,7 +154,9 @@ describe('Amazon Q Code Transformation', function () {
             // this 'Sorry' message is OK - just making sure that the UI components are working correctly
             assert.strictEqual(jdkPathResponse?.body?.includes("Sorry, I couldn't locate your Java installation"), true)
 
-            transformByQState.setSummaryFilePath(path.join(os.tmpdir(), 'summary.md'))
+            const tmpDir = (await TestFolder.create()).path
+
+            transformByQState.setSummaryFilePath(path.join(tmpDir, 'summary.md'))
 
             tab.clickCustomFormButton({
                 id: 'gumbyViewSummary',

--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -12,6 +12,7 @@ import { GumbyController, setMaven, startTransformByQ, TabsStorage } from 'aws-c
 import { using, registerAuthHook, TestFolder } from 'aws-core-vscode/test'
 import { loginToIdC } from './utils/setup'
 import { fs } from 'aws-core-vscode/shared'
+import * as os from 'os'
 import path from 'path'
 
 describe('Amazon Q Code Transformation', function () {
@@ -153,6 +154,21 @@ describe('Amazon Q Code Transformation', function () {
             const jdkPathResponse = tab.getChatItems().pop()
             // this 'Sorry' message is OK - just making sure that the UI components are working correctly
             assert.strictEqual(jdkPathResponse?.body?.includes("Sorry, I couldn't locate your Java installation"), true)
+
+            transformByQState.setSummaryFilePath(path.join(os.tmpdir(), 'summary.md'))
+
+            tab.clickCustomFormButton({
+                id: 'gumbyViewSummary',
+                text: 'View summary',
+            })
+
+            await tab.waitForEvent(() => tab.getChatItems().length > 14, {
+                waitTimeoutInMs: 5000,
+                waitIntervalInMs: 1000,
+            })
+
+            const viewSummaryChatItem = tab.getChatItems().pop()
+            assert.strictEqual(viewSummaryChatItem?.body?.includes('view a summary'), true)
         })
 
         it('Can provide metadata file for a SQL conversion', async () => {

--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -7,7 +7,12 @@ import assert from 'assert'
 import { qTestingFramework } from './framework/framework'
 import sinon from 'sinon'
 import { Messenger } from './framework/messenger'
-import { JDKVersion, TransformationType, transformByQState } from 'aws-core-vscode/codewhisperer'
+import {
+    CodeWhispererConstants,
+    JDKVersion,
+    TransformationType,
+    transformByQState,
+} from 'aws-core-vscode/codewhisperer'
 import { GumbyController, setMaven, startTransformByQ, TabsStorage } from 'aws-core-vscode/amazonqGumby'
 import { using, registerAuthHook, TestFolder } from 'aws-core-vscode/test'
 import { loginToIdC } from './utils/setup'
@@ -157,6 +162,10 @@ describe('Amazon Q Code Transformation', function () {
             const tmpDir = (await TestFolder.create()).path
 
             transformByQState.setSummaryFilePath(path.join(tmpDir, 'summary.md'))
+
+            transformByQState
+                .getChatMessenger()
+                ?.sendJobFinishedMessage(tab.tabID, CodeWhispererConstants.viewProposedChangesChatMessage)
 
             tab.clickCustomFormButton({
                 id: 'gumbyViewSummary',

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -383,15 +383,9 @@ export class GumbyController {
                 break
             case ButtonActions.VIEW_TRANSFORMATION_HUB:
                 await vscode.commands.executeCommand(GumbyCommands.FOCUS_TRANSFORMATION_HUB, CancelActionPositions.Chat)
-                this.messenger.sendJobSubmittedMessage(message.tabID)
                 break
             case ButtonActions.VIEW_SUMMARY:
                 await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
-                this.transformationFinished({
-                    message: CodeWhispererConstants.viewProposedChangesChatMessage,
-                    tabID: message.tabID,
-                    includeStartNewTransformationButton: true,
-                })
                 break
             case ButtonActions.STOP_TRANSFORMATION_JOB:
                 await stopTransformByQ(transformByQState.getJobId())

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -385,6 +385,14 @@ export class GumbyController {
                 await vscode.commands.executeCommand(GumbyCommands.FOCUS_TRANSFORMATION_HUB, CancelActionPositions.Chat)
                 this.messenger.sendJobSubmittedMessage(message.tabID)
                 break
+            case ButtonActions.VIEW_SUMMARY:
+                await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
+                this.transformationFinished({
+                    message: CodeWhispererConstants.viewProposedChangesChatMessage,
+                    tabID: message.tabID,
+                    includeStartNewTransformationButton: true,
+                })
+                break
             case ButtonActions.STOP_TRANSFORMATION_JOB:
                 await stopTransformByQ(transformByQState.getJobId())
                 await postTransformationJob()

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -376,19 +376,20 @@ export class Messenger {
     ) {
         const buttons: ChatItemButton[] = []
 
+        // don't show these buttons when server build fails
         if (!disableJobActions) {
-            // Note: buttons can only be clicked once.
-            // To get around this, we remove the card after it's clicked and then resubmit the message.
             buttons.push({
                 keepCardAfterClick: true,
                 text: CodeWhispererConstants.openTransformationHubButtonText,
                 id: ButtonActions.VIEW_TRANSFORMATION_HUB,
+                disabled: false, // allow button to be re-clicked
             })
 
             buttons.push({
                 keepCardAfterClick: true,
                 text: CodeWhispererConstants.stopTransformationButtonText,
                 id: ButtonActions.STOP_TRANSFORMATION_JOB,
+                disabled: false,
             })
         }
 
@@ -514,6 +515,7 @@ export class Messenger {
                 keepCardAfterClick: false,
                 text: CodeWhispererConstants.startTransformationButtonText,
                 id: ButtonActions.CONFIRM_START_TRANSFORMATION_FLOW,
+                disabled: false,
             })
         }
 
@@ -522,6 +524,7 @@ export class Messenger {
                 keepCardAfterClick: true,
                 text: CodeWhispererConstants.viewSummaryButtonText,
                 id: ButtonActions.VIEW_SUMMARY,
+                disabled: false,
             })
         }
 

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -243,8 +243,8 @@ export class Messenger {
             mandatory: true,
             options: [
                 {
-                    value: JDKVersion.JDK17.toString(),
-                    label: JDKVersion.JDK17.toString(),
+                    value: JDKVersion.JDK17,
+                    label: JDKVersion.JDK17,
                 },
             ],
         })
@@ -514,6 +514,14 @@ export class Messenger {
                 keepCardAfterClick: false,
                 text: CodeWhispererConstants.startTransformationButtonText,
                 id: ButtonActions.CONFIRM_START_TRANSFORMATION_FLOW,
+            })
+        }
+
+        if (transformByQState.getSummaryFilePath()) {
+            buttons.push({
+                keepCardAfterClick: true,
+                text: CodeWhispererConstants.viewSummaryButtonText,
+                id: ButtonActions.VIEW_SUMMARY,
             })
         }
 

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
@@ -13,6 +13,7 @@ import DependencyVersions from '../../../models/dependencies'
 export enum ButtonActions {
     STOP_TRANSFORMATION_JOB = 'gumbyStopTransformationJob',
     VIEW_TRANSFORMATION_HUB = 'gumbyViewTransformationHub',
+    VIEW_SUMMARY = 'gumbyViewSummary',
     CONFIRM_LANGUAGE_UPGRADE_TRANSFORMATION_FORM = 'gumbyLanguageUpgradeTransformFormConfirm',
     CONFIRM_SQL_CONVERSION_TRANSFORMATION_FORM = 'gumbySQLConversionTransformFormConfirm',
     CANCEL_TRANSFORMATION_FORM = 'gumbyTransformFormCancel', // shared between Language Upgrade & SQL Conversion

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import path from 'path'
 import { getLogger } from '../../shared/logger'
 import * as CodeWhispererConstants from '../models/constants'
+import * as localizedText from '../../shared/localizedText'
 import {
     transformByQState,
     StepProgress,
@@ -233,7 +234,7 @@ export async function preTransformationUploadCode() {
     await vscode.commands.executeCommand('aws.amazonq.transformationHub.focus')
 
     void vscode.window.showInformationMessage(CodeWhispererConstants.jobStartedNotification, {
-        title: CodeWhispererConstants.jobStartedTitle,
+        title: localizedText.ok,
     })
 
     let uploadId = ''
@@ -750,7 +751,7 @@ export async function postTransformationJob() {
 
     if (transformByQState.isSucceeded()) {
         void vscode.window.showInformationMessage(CodeWhispererConstants.jobCompletedNotification(diffMessage), {
-            title: CodeWhispererConstants.transformationCompletedTitle,
+            title: localizedText.ok,
         })
     } else if (transformByQState.isPartiallySucceeded()) {
         void vscode.window

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -554,14 +554,14 @@ export const noOngoingJobMessage = 'No ongoing job.'
 
 export const nothingToShowMessage = 'Nothing to show'
 
-export const jobStartedTitle = 'Transformation started'
-
 export const jobStartedNotification =
     'Amazon Q is transforming your code. It can take 10 to 30 minutes to upgrade your code, depending on the size of your project. To monitor progress, go to the Transformation Hub.'
 
 export const openTransformationHubButtonText = 'Open Transformation Hub'
 
 export const startTransformationButtonText = 'Start a new transformation'
+
+export const viewSummaryButtonText = 'View summary'
 
 export const stopTransformationButtonText = 'Stop transformation'
 
@@ -637,8 +637,6 @@ export const jobCancelledChatMessage =
     'I cancelled your transformation. If you want to start another transformation, choose **Start a new transformation**.'
 
 export const jobCancelledNotification = 'You cancelled the transformation.'
-
-export const transformationCompletedTitle = 'Transformation complete'
 
 export const diffMessage = (multipleDiffs: boolean) => {
     return multipleDiffs

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -365,7 +365,7 @@ export class ProposedTransformationExplorer {
         })
 
         vscode.commands.registerCommand('aws.amazonq.transformationHub.summary.reveal', async () => {
-            if (transformByQState.getSummaryFilePath() !== '') {
+            if (fs.existsSync(transformByQState.getSummaryFilePath())) {
                 await vscode.commands.executeCommand(
                     'markdown.showPreview',
                     vscode.Uri.file(transformByQState.getSummaryFilePath())

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -370,7 +370,6 @@ export class ProposedTransformationExplorer {
                     'markdown.showPreview',
                     vscode.Uri.file(transformByQState.getSummaryFilePath())
                 )
-                telemetry.ui_click.emit({ elementId: 'transformationHub_viewSummary' })
             }
         })
 


### PR DESCRIPTION
## Problem

A "View summary" button was missing in the chat, which made it difficult for users to re-open their transformation summary once they closed it.

## Solution

Add the button.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
