### PR TITLE
fix(amazonq): respond in chat right away when user enters JDK path

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-a9be5502-257b-4c77-b632-94515dd68bf0.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-a9be5502-257b-4c77-b632-94515dd68bf0.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Code Transformation: respond immediately when entering JAVA_HOME path"
+}

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -570,6 +570,9 @@ export const checkingForProjectsChatMessage = 'Checking for eligible projects...
 export const buildStartedChatMessage =
     'I am building your project. This can take up to 10 minutes, depending on the size of your project.'
 
+export const buildStartedNotification =
+    'Amazon Q is building your project. This can take up to 10 minutes, depending on the size of your project.'
+
 export const buildSucceededChatMessage = 'I was able to build your project and will start transforming your code soon.'
 
 export const buildSucceededNotification =

--- a/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
@@ -13,7 +13,6 @@ import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/cod
 import { ToolkitError } from '../../../shared/errors'
 import { writeLogs } from './transformFileHandler'
 import { throwIfCancelled } from './transformApiHandler'
-import { sleep } from '../../../shared/utilities/timeoutUtils'
 
 // run 'install' with either 'mvnw.cmd', './mvnw', or 'mvn' (if wrapper exists, we use that, otherwise we use regular 'mvn')
 function installProjectDependencies(dependenciesFolder: FolderInfo, modulePath: string) {
@@ -109,8 +108,8 @@ function copyProjectDependencies(dependenciesFolder: FolderInfo, modulePath: str
 }
 
 export async function prepareProjectDependencies(dependenciesFolder: FolderInfo, rootPomPath: string) {
-    // sleep for 0.5s to allow QCT to 1) process JAVA_HOME path and 2) send multiple chat messages
-    await sleep(500)
+    // use await to allow other chat messages to send as well, before the build starts
+    await vscode.window.showInformationMessage(CodeWhispererConstants.buildStartedNotification)
     try {
         copyProjectDependencies(dependenciesFolder, rootPomPath)
     } catch (err) {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
@@ -13,6 +13,7 @@ import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/cod
 import { ToolkitError } from '../../../shared/errors'
 import { writeLogs } from './transformFileHandler'
 import { throwIfCancelled } from './transformApiHandler'
+import { sleep } from '../../../shared/utilities/timeoutUtils'
 
 // run 'install' with either 'mvnw.cmd', './mvnw', or 'mvn' (if wrapper exists, we use that, otherwise we use regular 'mvn')
 function installProjectDependencies(dependenciesFolder: FolderInfo, modulePath: string) {
@@ -108,6 +109,8 @@ function copyProjectDependencies(dependenciesFolder: FolderInfo, modulePath: str
 }
 
 export async function prepareProjectDependencies(dependenciesFolder: FolderInfo, rootPomPath: string) {
+    // sleep for 0.5s to allow QCT to 1) process JAVA_HOME path and 2) send multiple chat messages
+    await sleep(500)
     try {
         copyProjectDependencies(dependenciesFolder, rootPomPath)
     } catch (err) {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
@@ -108,8 +108,7 @@ function copyProjectDependencies(dependenciesFolder: FolderInfo, modulePath: str
 }
 
 export async function prepareProjectDependencies(dependenciesFolder: FolderInfo, rootPomPath: string) {
-    // use await to allow other chat messages to send as well, before the build starts
-    await vscode.window.showInformationMessage(CodeWhispererConstants.buildStartedNotification)
+    void vscode.window.showInformationMessage(CodeWhispererConstants.buildStartedNotification)
     try {
         copyProjectDependencies(dependenciesFolder, rootPomPath)
     } catch (err) {


### PR DESCRIPTION
## Problem

On a VS Code instance backed by CloudFront, when users enter their JDK path, it takes our chat 30+ seconds to respond.

## Solution

Send a notification just before the build starts to also allow the other multiple chat messages to be sent.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
