### PR TITLE
deps(amazonq): update mynah ui to 4.21.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6083,11 +6083,10 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.2.tgz",
-            "integrity": "sha512-zC/ck/m5nYXRwTs3EoiGNYR0jTfbrnovRloqlD07fmvTt9OpbWLhagg14Jr/+mqoYX3YWpqbLs9U56mqCLwHHQ==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.3.tgz",
+            "integrity": "sha512-iHFGmLg8fZgoqiHHDP94m6+ZmBsIiP7NBte/WId3iv+1344+Sipm/nNoZlczx5mIV1qhD+r/IZKG4c9Er4sHuA==",
             "hasInstallScript": true,
-            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
@@ -21163,7 +21162,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.21.2",
+                "@aws/mynah-ui": "^4.21.3",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -508,7 +508,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.21.2",
+        "@aws/mynah-ui": "^4.21.3",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
- mynah ui 4.21.3 contains a fix needed for tests: https://github.com/aws/mynah-ui/releases/tag/v4.21.3

## Solution
- update to it. No public facing changes are needed

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
