### PR TITLE
telemetry(amazonq): add metric for transformation type

### DIFF
--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -680,6 +680,14 @@ export class GumbyController {
 
             case ConversationState.WAITING_FOR_TRANSFORMATION_OBJECTIVE: {
                 const objective = data.message.trim().toLowerCase()
+                // since we're prompting the user, their project(s) must be eligible for both types of transformations, so track how often this happens here
+                if (objective === 'language upgrade' || objective === 'sql conversion') {
+                    telemetry.codeTransform_submitSelection.emit({
+                        codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                        userChoice: objective,
+                        result: 'Succeeded',
+                    })
+                }
                 if (objective === 'language upgrade') {
                     await this.handleLanguageUpgrade(data)
                 } else if (objective === 'sql conversion') {

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -269,29 +269,41 @@ export class GumbyController {
     }
 
     private async handleLanguageUpgrade(message: any) {
-        try {
-            await this.beginTransformation(message)
-            const validProjects = await this.validateLanguageUpgradeProjects(message)
-            if (validProjects.length > 0) {
-                this.sessionStorage.getSession().updateCandidateProjects(validProjects)
-                await this.messenger.sendLanguageUpgradeProjectPrompt(validProjects, message.tabID)
+        await telemetry.codeTransform_submitSelection.run(async () => {
+            telemetry.record({
+                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                userChoice: 'language upgrade',
+            })
+            try {
+                await this.beginTransformation(message)
+                const validProjects = await this.validateLanguageUpgradeProjects(message)
+                if (validProjects.length > 0) {
+                    this.sessionStorage.getSession().updateCandidateProjects(validProjects)
+                    await this.messenger.sendLanguageUpgradeProjectPrompt(validProjects, message.tabID)
+                }
+            } catch (err: any) {
+                getLogger().error(`Error handling language upgrade: ${err}`)
             }
-        } catch (err: any) {
-            getLogger().error(`Error handling language upgrade: ${err}`)
-        }
+        })
     }
 
     private async handleSQLConversion(message: any) {
-        try {
-            await this.beginTransformation(message)
-            const validProjects = await this.validateSQLConversionProjects(message)
-            if (validProjects.length > 0) {
-                this.sessionStorage.getSession().updateCandidateProjects(validProjects)
-                await this.messenger.sendSelectSQLMetadataFileMessage(message.tabID)
+        await telemetry.codeTransform_submitSelection.run(async () => {
+            telemetry.record({
+                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                userChoice: 'sql conversion',
+            })
+            try {
+                await this.beginTransformation(message)
+                const validProjects = await this.validateSQLConversionProjects(message)
+                if (validProjects.length > 0) {
+                    this.sessionStorage.getSession().updateCandidateProjects(validProjects)
+                    await this.messenger.sendSelectSQLMetadataFileMessage(message.tabID)
+                }
+            } catch (err: any) {
+                getLogger().error(`Error handling SQL conversion: ${err}`)
             }
-        } catch (err: any) {
-            getLogger().error(`Error handling SQL conversion: ${err}`)
-        }
+        })
     }
 
     private async validateLanguageUpgradeProjects(message: any) {

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -269,41 +269,41 @@ export class GumbyController {
     }
 
     private async handleLanguageUpgrade(message: any) {
-        await telemetry.codeTransform_submitSelection.run(async () => {
-            telemetry.record({
-                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                userChoice: 'language upgrade',
-            })
-            try {
+        await telemetry.codeTransform_submitSelection
+            .run(async () => {
+                telemetry.record({
+                    codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                    userChoice: 'language upgrade',
+                })
                 await this.beginTransformation(message)
                 const validProjects = await this.validateLanguageUpgradeProjects(message)
                 if (validProjects.length > 0) {
                     this.sessionStorage.getSession().updateCandidateProjects(validProjects)
                     await this.messenger.sendLanguageUpgradeProjectPrompt(validProjects, message.tabID)
                 }
-            } catch (err: any) {
+            })
+            .catch((err) => {
                 getLogger().error(`Error handling language upgrade: ${err}`)
-            }
-        })
+            })
     }
 
     private async handleSQLConversion(message: any) {
-        await telemetry.codeTransform_submitSelection.run(async () => {
-            telemetry.record({
-                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                userChoice: 'sql conversion',
-            })
-            try {
+        await telemetry.codeTransform_submitSelection
+            .run(async () => {
+                telemetry.record({
+                    codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                    userChoice: 'sql conversion',
+                })
                 await this.beginTransformation(message)
                 const validProjects = await this.validateSQLConversionProjects(message)
                 if (validProjects.length > 0) {
                     this.sessionStorage.getSession().updateCandidateProjects(validProjects)
                     await this.messenger.sendSelectSQLMetadataFileMessage(message.tabID)
                 }
-            } catch (err: any) {
+            })
+            .catch((err) => {
                 getLogger().error(`Error handling SQL conversion: ${err}`)
-            }
-        })
+            })
     }
 
     private async validateLanguageUpgradeProjects(message: any) {

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -680,14 +680,6 @@ export class GumbyController {
 
             case ConversationState.WAITING_FOR_TRANSFORMATION_OBJECTIVE: {
                 const objective = data.message.trim().toLowerCase()
-                // since we're prompting the user, their project(s) must be eligible for both types of transformations, so track how often this happens here
-                if (objective === 'language upgrade' || objective === 'sql conversion') {
-                    telemetry.codeTransform_submitSelection.emit({
-                        codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                        userChoice: objective,
-                        result: 'Succeeded',
-                    })
-                }
                 if (objective === 'language upgrade') {
                     await this.handleLanguageUpgrade(data)
                 } else if (objective === 'sql conversion') {

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -650,19 +650,14 @@ export async function getValidSQLConversionCandidateProjects() {
         })
         const openProjects = await getOpenProjects()
         const javaProjects = await getJavaProjects(openProjects)
-        let resultLog = ''
         for (const project of javaProjects) {
             // as long as at least one of these strings is found, project contains embedded SQL statements
             const searchStrings = ['oracle.jdbc.OracleDriver', 'jdbc:oracle:thin:@', 'jdbc:oracle:oci:@', 'jdbc:odbc:']
             for (const str of searchStrings) {
                 const spawnResult = await findStringInDirectory(str, project.path)
-                // just for telemetry purposes
-                if (spawnResult.error || spawnResult.stderr) {
-                    resultLog += `search failed: ${JSON.stringify(spawnResult)}`
-                } else {
-                    resultLog += `search succeeded: ${spawnResult.exitCode}`
-                }
-                getLogger().info(`CodeTransformation: searching for ${str} in ${project.path}, result = ${resultLog}`)
+                getLogger().info(
+                    `CodeTransformation: searching for ${str} in ${project.path}, status code = ${spawnResult.exitCode}`
+                )
                 if (spawnResult.exitCode === 0) {
                     embeddedSQLProjects.push(project)
                     break
@@ -673,7 +668,7 @@ export async function getValidSQLConversionCandidateProjects() {
             `CodeTransformation: found ${embeddedSQLProjects.length} projects with embedded SQL statements`
         )
         telemetry.record({
-            codeTransformMetadata: resultLog,
+            codeTransformMetadata: `Found ${embeddedSQLProjects.length} projects with embedded SQL`,
         })
     })
     return embeddedSQLProjects


### PR DESCRIPTION
## Problem

Be able to tell when a language upgrade vs sql conversion happens.

## Solution

Add metric.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
