### PR TITLE
test(amazonq): generateZipTestGen is unreliable

### DIFF
--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -178,8 +178,6 @@ export class ZipUtil {
 
         // Recursive function to process directories
         const processDirectory = async (dirPath: string) => {
-            // eslint-disable-next-line aws-toolkits/no-console-log
-            console.log('processDirectory', dirPath)
             const entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(dirPath))
             addEmptyDirectory(dirPath)
 

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -178,6 +178,8 @@ export class ZipUtil {
 
         // Recursive function to process directories
         const processDirectory = async (dirPath: string) => {
+            // eslint-disable-next-line aws-toolkits/no-console-log
+            console.log('processDirectory', dirPath)
             const entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(dirPath))
             addEmptyDirectory(dirPath)
 


### PR DESCRIPTION
## Problem

Flaky test `generateZipTestGen` sometimes fails with
```
  1) zipUtil
       generateZipTestGen
         Should generate zip for test generation successfully:
     Error: done() called multiple times in test <zipUtil generateZipTestGen Should generate zip for test generation successfully> of file /Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/packages/amazonq/dist/test/unit/codewhisperer/util/zipUtil.test.js; in addition, done() received error: EntryNotFound (FileSystemError): Error: ENOENT: no such file or directory, scandir '/test/zip/utgRequiredArtifactsDir'
    at Function.e (/private/tmp/.vscode-test/vscode-darwin-arm64-1.83.0/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:127:26740)
    at Object.readDirectory (/private/tmp/.vscode-test/vscode-darwin-arm64-1.83.0/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:127:24744)
    at async processDirectory (/Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/packages/core/src/codewhisperer/util/zipUtil.ts:190:29)
    at async ZipUtil.processMetadataDir (/Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/packages/core/src/codewhisperer/util/zipUtil.ts:212:9)
    at async ZipUtil.zipProject (/Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/packages/core/src/codewhisperer/util/zipUtil.ts:230:13)
    at async ZipUtil.generateZipTestGen (/Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/packages/core/src/codewhisperer/util/zipUtil.ts:602:41)
    at async Context.<anonymous> (/Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts:159:28) {
  code: 'FileNotFound'
```

Issue: https://github.com/aws/aws-toolkit-vscode/issues/6160


## Solution

Based on the error, the test is trying to readdir on a mock dirpath even though the entire `zipProject` method should be stubbed. This can be confirmed by commenting out the following line:

https://github.com/aws/aws-toolkit-vscode/blob/aa332da854c9d17ba258b459c622500911b1b0d9/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts#L135

which will give the same error

```
Error: ENOENT: no such file or directory, scandir '/test/zip/utgRequiredArtifactsDir'
```

So instead of stubbing which seems to be unreliable, we can let the test actually create the zip file.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
