### PR TITLE
telemetry(amazonq): attach stack trace in onCodeGeneration failures

### DIFF
--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -501,6 +501,10 @@ export class FeatureDevController {
                         result = MetricDataResult.Fault
                     }
                     break
+                case ContentLengthError.name:
+                case MonthlyConversationLimitError.name:
+                case CodeIterationLimitError.name:
+                case UploadURLExpired.name:
                 case PromptRefusalException.name:
                 case NoChangeRequiredException.name:
                     result = MetricDataResult.Error
@@ -510,7 +514,7 @@ export class FeatureDevController {
                     break
             }
 
-            await session.sendMetricDataTelemetry(MetricDataOperationName.EndCodeGeneration, result)
+            await session.sendMetricDataTelemetry(MetricDataOperationName.EndCodeGeneration, result, err.stack)
             throw err
         } finally {
             // Finish processing the event

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -285,7 +285,7 @@ export class Session {
         return { leftPath, rightPath, ...diff }
     }
 
-    public async sendMetricDataTelemetry(operationName: string, result: string) {
+    public async sendMetricDataTelemetry(operationName: string, result: string, log?: string) {
         await this.proxyClient.sendMetricData({
             metricName: 'Operation',
             metricValue: 1,
@@ -300,6 +300,16 @@ export class Session {
                     name: 'result',
                     value: result,
                 },
+
+                // The log dimension will not be emitted to CloudWatch
+                ...(log
+                    ? [
+                          {
+                              name: 'log',
+                              value: log,
+                          },
+                      ]
+                    : []),
             ],
         })
     }

--- a/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -463,6 +463,10 @@ describe('Controller', () => {
 
             const errorResultMapping = new Map([
                 ['EmptyPatchException', MetricDataResult.LlmFailure],
+                [ContentLengthError.name, MetricDataResult.Error],
+                [MonthlyConversationLimitError.name, MetricDataResult.Error],
+                [CodeIterationLimitError.name, MetricDataResult.Error],
+                [UploadURLExpired.name, MetricDataResult.Error],
                 [PromptRefusalException.name, MetricDataResult.Error],
                 [NoChangeRequiredException.name, MetricDataResult.Error],
             ])
@@ -518,7 +522,13 @@ describe('Controller', () => {
                 )
                 const metricResult = getMetricResult(error)
                 assert.ok(
-                    sendMetricDataTelemetrySpy.calledWith(MetricDataOperationName.EndCodeGeneration, metricResult)
+                    sendMetricDataTelemetrySpy.calledWith(
+                        MetricDataOperationName.EndCodeGeneration,
+                        metricResult,
+
+                        // Stack trace should include the name of the test framework
+                        sinon.match((str) => typeof str === 'string' && str.includes('Mocha'))
+                    )
                 )
             }
 


### PR DESCRIPTION
## Problem
To further find issues in onCodeGeneration, need to attach stack trace when sending metrics

## Solution
Attach stack trace when sending metrics

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
