### PR TITLE
fix(amazonq): increase maxRetries for GetPlan

### DIFF
--- a/packages/core/src/codewhisperer/client/codewhisperer.ts
+++ b/packages/core/src/codewhisperer/client/codewhisperer.ts
@@ -318,7 +318,8 @@ export class DefaultCodeWhispererClient {
     public async codeModernizerGetCodeTransformationPlan(
         request: CodeWhispererUserClient.GetTransformationPlanRequest
     ): Promise<PromiseResult<CodeWhispererUserClient.GetTransformationPlanResponse, AWSError>> {
-        return (await this.createUserSdkClient()).getTransformationPlan(request).promise()
+        // instead of the default of 3 retries, use 8 retries for this API which is polled every 5 seconds
+        return (await this.createUserSdkClient(8)).getTransformationPlan(request).promise()
     }
 
     public async startCodeFixJob(


### PR DESCRIPTION
## Problem

We previously increased the maxRetries for GetTransformationJob from 3 to 8 since it's polled every 5 seconds; we should do the same for GetTransformationPlan since it too is polled every 5 seconds.

## Solution

Increase maxRetries from 3 to 8.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
