### PR TITLE
telemetry(amazonq): use run block instead of emit

### DIFF
--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -50,7 +50,6 @@ import {
     CodeTransformJavaTargetVersionsAllowed,
     CodeTransformJavaSourceVersionsAllowed,
 } from '../../../shared/telemetry/telemetry'
-import { MetadataResult } from '../../../shared/telemetry/telemetryClient'
 import { CodeTransformTelemetryState } from '../../telemetry/codeTransformTelemetryState'
 import DependencyVersions from '../../models/dependencies'
 import { getStringHash } from '../../../shared/utilities/textUtilities'
@@ -364,15 +363,16 @@ export class GumbyController {
                 await this.handleUserLanguageUpgradeProjectChoice(message)
                 break
             case ButtonActions.CANCEL_TRANSFORMATION_FORM:
-                telemetry.codeTransform_submitSelection.emit({
-                    codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                    userChoice: 'Cancel',
-                    result: MetadataResult.Pass,
-                })
-                this.transformationFinished({
-                    message: CodeWhispererConstants.jobCancelledChatMessage,
-                    tabID: message.tabID,
-                    includeStartNewTransformationButton: true,
+                telemetry.codeTransform_submitSelection.run(() => {
+                    telemetry.record({
+                        codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                        userChoice: 'Cancel',
+                    })
+                    this.transformationFinished({
+                        message: CodeWhispererConstants.jobCancelledChatMessage,
+                        tabID: message.tabID,
+                        includeStartNewTransformationButton: true,
+                    })
                 })
                 break
             case ButtonActions.CONFIRM_SKIP_TESTS_FORM:

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -21,7 +21,6 @@ import { ExportResultArchiveStructure, downloadExportResultArchive } from '../..
 import { getLogger } from '../../../shared/logger'
 import { telemetry } from '../../../shared/telemetry/telemetry'
 import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/codeTransformTelemetryState'
-import { MetadataResult } from '../../../shared/telemetry/telemetryClient'
 import * as CodeWhispererConstants from '../../models/constants'
 import { createCodeWhispererChatStreamingClient } from '../../../shared/clients/codewhispererChatClient'
 import { ChatSessionManager } from '../../../amazonqGumby/chat/storages/chatSession'
@@ -532,11 +531,13 @@ export class ProposedTransformationExplorer {
         })
 
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.acceptChanges', async () => {
-            diffModel.saveChanges()
-            telemetry.codeTransform_submitSelection.emit({
-                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                codeTransformJobId: transformByQState.getJobId(),
-                userChoice: `acceptChanges-${patchFilesDescriptions?.content[diffModel.currentPatchIndex].name}`,
+            telemetry.codeTransform_submitSelection.run(() => {
+                diffModel.saveChanges()
+                telemetry.record({
+                    codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                    codeTransformJobId: transformByQState.getJobId(),
+                    userChoice: `acceptChanges-${patchFilesDescriptions?.content[diffModel.currentPatchIndex].name}`,
+                })
             })
             if (transformByQState.getMultipleDiffs()) {
                 void vscode.window.showInformationMessage(
@@ -580,34 +581,20 @@ export class ProposedTransformationExplorer {
                 // All patches have been applied, reset the state
                 await reset()
             }
-
-            telemetry.codeTransform_viewArtifact.emit({
-                codeTransformArtifactType: 'ClientInstructions',
-                codeTransformVCSViewerSrcComponents: 'toastNotification',
-                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                codeTransformJobId: transformByQState.getJobId(),
-                codeTransformStatus: transformByQState.getStatus(),
-                userChoice: 'Submit',
-                result: MetadataResult.Pass,
-            })
         })
 
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.rejectChanges', async () => {
-            diffModel.rejectChanges()
-            await reset()
-
+            telemetry.codeTransform_submitSelection.run(async () => {
+                diffModel.rejectChanges()
+                await reset()
+                telemetry.record({
+                    codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
+                    codeTransformJobId: transformByQState.getJobId(),
+                    userChoice: 'rejectChanges',
+                })
+            })
             transformByQState.getChatControllers()?.transformationFinished.fire({
                 tabID: ChatSessionManager.Instance.getSession().tabID,
-            })
-
-            telemetry.codeTransform_viewArtifact.emit({
-                codeTransformArtifactType: 'ClientInstructions',
-                codeTransformVCSViewerSrcComponents: 'toastNotification',
-                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                codeTransformJobId: transformByQState.getJobId(),
-                codeTransformStatus: transformByQState.getStatus(),
-                userChoice: 'Cancel',
-                result: MetadataResult.Pass,
             })
         })
     }

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -584,7 +584,7 @@ export class ProposedTransformationExplorer {
         })
 
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.rejectChanges', async () => {
-            telemetry.codeTransform_submitSelection.run(async () => {
+            await telemetry.codeTransform_submitSelection.run(async () => {
                 diffModel.rejectChanges()
                 await reset()
                 telemetry.record({


### PR DESCRIPTION
## Problem

`run` > `emit`

## Solution

Fix

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
