### PR TITLE
revert: old codepaths from session separation/standalone

### DIFF
--- a/packages/amazonq/.changes/next-release/Removal-aa696d15-306f-4af5-aa4b-ab48c44f0a5e.json
+++ b/packages/amazonq/.changes/next-release/Removal-aa696d15-306f-4af5-aa4b-ab48c44f0a5e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Settings: No longer migrate old CodeWhisperer settings or initialize telemetry setting from AWS Toolkit."
+}

--- a/packages/core/src/amazonq/explorer/amazonQTreeNode.ts
+++ b/packages/core/src/amazonq/explorer/amazonQTreeNode.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { ResourceTreeDataProvider, TreeNode } from '../../shared/treeview/resourceTreeDataProvider'
-import { AuthState, isPreviousQUser } from '../../codewhisperer/util/authUtil'
+import { AuthState } from '../../codewhisperer/util/authUtil'
 import { createLearnMoreNode, createInstallQNode, createDismissNode } from './amazonQChildrenNodes'
 import { Commands } from '../../shared/vscode/commands2'
 
@@ -40,10 +40,7 @@ export class AmazonQNode implements TreeNode {
     }
 
     public getChildren() {
-        const children = [createInstallQNode(), createLearnMoreNode()]
-        if (!isPreviousQUser()) {
-            children.push(createDismissNode())
-        }
+        const children = [createInstallQNode(), createLearnMoreNode(), createDismissNode()]
         return children
     }
 

--- a/packages/core/src/codecatalyst/activation.ts
+++ b/packages/core/src/codecatalyst/activation.ts
@@ -26,7 +26,6 @@ import { DevEnvActivityStarter } from './devEnv'
 import { learnMoreCommand, onboardCommand, reauth } from './explorer'
 import { isInDevEnv } from '../shared/vscode/env'
 import { hasScopes, scopesCodeWhispererCore, getTelemetryMetadataForConn } from '../auth/connection'
-import { SessionSeparationPrompt } from '../auth/auth'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { asStringifiedStack } from '../shared/telemetry/spans'
 
@@ -64,7 +63,6 @@ export async function activate(ctx: ExtContext): Promise<void> {
                     })
 
                     await authProvider.secondaryAuth.forgetConnection()
-                    await SessionSeparationPrompt.instance.showForCommand('aws.codecatalyst.manageConnections')
                 })
             },
             { emit: false, functionId: { name: 'activate', class: 'CodeCatalyst' } }

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -106,9 +106,6 @@ export async function activate(context: ExtContext): Promise<void> {
     localize = nls.loadMessageBundle()
     const codewhispererSettings = CodeWhispererSettings.instance
 
-    // Import old CodeWhisperer settings into Amazon Q
-    await CodeWhispererSettings.instance.importSettings()
-
     // initialize AuthUtil earlier to make sure it can listen to connection change events.
     const auth = AuthUtil.instance
     auth.initCodeWhispererHooks()

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -501,30 +501,6 @@ export class AuthUtil {
     }
 }
 
-/**
- * Returns true if an SSO connection with AmazonQ and CodeWhisperer scopes are found,
- * even if the connection is expired.
- *
- * Note: This function will become irrelevant if/when the Amazon Q view tree is removed
- * from the toolkit.
- */
-export function isPreviousQUser() {
-    const auth = AuthUtil.instance
-
-    if (!auth.isConnected() || !isSsoConnection(auth.conn)) {
-        return false
-    }
-    const missingScopes =
-        (auth.isEnterpriseSsoInUse() && !hasScopes(auth.conn, amazonQScopes)) ||
-        !hasScopes(auth.conn, codeWhispererChatScopes)
-
-    if (missingScopes) {
-        return false
-    }
-
-    return true
-}
-
 export type FeatureAuthState = { [feature in Feature]: AuthState }
 export type Feature = (typeof Features)[keyof typeof Features]
 export type AuthState = (typeof AuthStates)[keyof typeof AuthStates]

--- a/packages/core/src/codewhisperer/util/codewhispererSettings.ts
+++ b/packages/core/src/codewhisperer/util/codewhispererSettings.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { fromExtensionManifest, migrateSetting } from '../../shared/settings'
+import { fromExtensionManifest } from '../../shared/settings'
 import { ArrayConstructor } from '../../shared/utilities/typeConstructors'
 
 const description = {
@@ -17,22 +17,6 @@ const description = {
 }
 
 export class CodeWhispererSettings extends fromExtensionManifest('amazonQ', description) {
-    // TODO: Remove after a few releases
-    public async importSettings() {
-        await migrateSetting(
-            { key: 'aws.codeWhisperer.includeSuggestionsWithCodeReferences', type: Boolean },
-            { key: 'amazonQ.showInlineCodeSuggestionsWithCodeReferences' }
-        )
-        await migrateSetting(
-            { key: 'aws.codeWhisperer.importRecommendation', type: Boolean },
-            { key: 'amazonQ.importRecommendationForInlineCodeSuggestions' }
-        )
-        await migrateSetting(
-            { key: 'aws.codeWhisperer.shareCodeWhispererContentWithAWS', type: Boolean },
-            { key: 'amazonQ.shareContentWithAWS' }
-        )
-    }
-
     public isSuggestionsWithCodeReferencesEnabled(): boolean {
         return this.get(`showInlineCodeSuggestionsWithCodeReferences`, false)
     }

--- a/packages/core/src/extensionNode.ts
+++ b/packages/core/src/extensionNode.ts
@@ -46,12 +46,12 @@ import globals from './shared/extensionGlobals'
 import { Experiments, Settings, showSettingsFailedMsg } from './shared/settings'
 import { isReleaseVersion } from './shared/vscode/env'
 import { AuthStatus, AuthUserState, telemetry } from './shared/telemetry/telemetry'
-import { Auth, SessionSeparationPrompt } from './auth/auth'
+import { Auth } from './auth/auth'
 import { getTelemetryMetadataForConn } from './auth/connection'
 import { registerSubmitFeedback } from './feedback/vue/submitFeedback'
 import { activateCommon, deactivateCommon } from './extension'
 import { learnMoreAmazonQCommand, qExtensionPageCommand, dismissQTree } from './amazonq/explorer/amazonQChildrenNodes'
-import { AuthUtil, codeWhispererCoreScopes } from './codewhisperer/util/authUtil'
+import { codeWhispererCoreScopes } from './codewhisperer/util/authUtil'
 import { installAmazonQExtension } from './codewhisperer/commands/basicCommands'
 import { isExtensionInstalled, VSCODE_EXTENSION_ID } from './shared/utilities'
 import { ExtensionUse, getAuthFormIdsFromConnection, initializeCredentialsProviderManager } from './auth/utils'
@@ -139,16 +139,8 @@ export async function activate(context: vscode.ExtensionContext) {
                             conn.scopes
                         )
                         await Auth.instance.forgetConnection(conn)
-                        await SessionSeparationPrompt.instance.showForCommand('aws.toolkit.auth.manageConnections')
                     }
                 }
-
-                // Display last prompt if connections were forgotten in prior sessions
-                // but the user did not interact or sign in again. Useful in case the user misses it the first time.
-                await SessionSeparationPrompt.instance.showAnyPreviousPrompt()
-
-                // MUST restore CW/Q auth so that we can see if this user is already a Q user.
-                await AuthUtil.instance.restore()
             },
             { emit: false, functionId: { name: 'activate', class: 'ExtensionNodeCore' } }
         )

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -44,8 +44,6 @@ export type globalKey =
     | 'aws.toolkit.amazonq.dismissed'
     | 'aws.toolkit.amazonqInstall.dismissed'
     | 'aws.amazonq.workspaceIndexToggleOn'
-    | 'aws.toolkit.separationPromptCommand'
-    | 'aws.toolkit.separationPromptDismissed'
     // Deprecated/legacy names. New keys should start with "aws.".
     | '#sessionCreationDates' // Legacy name from `ssoAccessTokenProvider.ts`.
     | 'CODECATALYST_RECONNECT'

--- a/packages/core/src/shared/telemetry/activation.ts
+++ b/packages/core/src/shared/telemetry/activation.ts
@@ -40,7 +40,6 @@ export async function activate(
     productName: AWSProduct
 ) {
     const config = new TelemetryConfig(settings)
-    await config.initAmazonQSetting() // TODO: Remove after a few releases.
 
     DefaultTelemetryClient.productName = productName
     globals.telemetry = await DefaultTelemetryService.create(awsContext, getComputeRegion())

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import { env, version } from 'vscode'
 import * as os from 'os'
 import { getLogger } from '../logger'
-import { fromExtensionManifest, migrateSetting, Settings } from '../settings'
+import { fromExtensionManifest, Settings } from '../settings'
 import { memoize, once } from '../utilities/functionUtils'
 import {
     isInDevEnv,
@@ -64,16 +64,6 @@ export class TelemetryConfig {
 
     public isEnabled(): boolean {
         return (isAmazonQ() ? this.amazonQConfig : this.toolkitConfig).get(`telemetry`, true)
-    }
-
-    public async initAmazonQSetting() {
-        if (!isAmazonQ() || globals.globalState.tryGet('amazonq.telemetry.migrated', Boolean, false)) {
-            return
-        }
-        // aws.telemetry isn't deprecated, we are just initializing amazonQ.telemetry with its value.
-        // This is also why we need to check that we only try this migration once.
-        await migrateSetting({ key: 'aws.telemetry', type: Boolean }, { key: 'amazonQ.telemetry' })
-        await globals.globalState.update('amazonq.telemetry.migrated', true)
     }
 }
 

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -10,6 +10,7 @@ import * as env from '../shared/vscode/env'
 // Checks project config and dependencies, to remind us to remove old things
 // when possible.
 describe('tech debt', function () {
+    // @ts-ignore
     function fixByDate(date: string, msg: string) {
         const now = Date.now()
         const cutoffDate = Date.parse(date)
@@ -37,15 +38,5 @@ describe('tech debt', function () {
         )
         // This is relevant for the use of `fs.cpSync` in the copyFiles scripts.
         assert.ok(semver.lt(minNodejs, '18.0.0'), 'with node18+, we can remove the dependency on @types/node@18')
-    })
-
-    it('remove separate sessions login edge cases', async function () {
-        // src/auth/auth.ts:SessionSeparationPrompt
-        // forgetConnection() function and calls
-
-        // Monitor telemtry to determine removal or snooze
-        // toolkit_showNotification.id = sessionSeparation
-        // auth_modifyConnection.action = deleteProfile OR auth_modifyConnection.source contains CodeCatalyst
-        fixByDate('2025-06-06', 'Remove the edge case code from the commit that this test is a part of.')
     })
 })

--- a/packages/toolkit/.changes/next-release/Removal-1c5617ae-50c9-4de1-a191-a2d57dce5bd7.json
+++ b/packages/toolkit/.changes/next-release/Removal-1c5617ae-50c9-4de1-a191-a2d57dce5bd7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Amazon Q: No longer autoinstall Amazon Q if the user had used CodeWhisperer in old Toolkit versions."
+}

--- a/packages/toolkit/.changes/next-release/Removal-6703e62b-3835-402b-b187-b327c58f425b.json
+++ b/packages/toolkit/.changes/next-release/Removal-6703e62b-3835-402b-b187-b327c58f425b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Auth: No longer inform users that Amazon Q and Toolkit extensions have separate auth sessions."
+}


### PR DESCRIPTION
[revert: amazon q standalone special handling](https://github.com/aws/aws-toolkit-vscode/commit/7ae5405b3797ba1b5342dfd7a6de2df4ad453c92) 

Removes code that should no longer be necessary anymore.

- Remove autoinstall Amazon Q if you were a CodeWhisperer user on 2.x versions of toolkit
    - The prompt to install Amazon Q will still appear, if you don't have it. It has been slightly reworded.
    - If Amazon Q is installed, then you uninstall, it you will not see the prompt again in toolkit (previously you could).
- Remove settings migrations from codewhisperer settings
- Remove amazon Q telemetry enabled setting being initialized by the value from toolkit.

We are still getting hits in telemetry for people getting auto install (172 in last 2 months). However, they are mostly on old versions.
Let's simplify our codebase by removing support for these dated codepaths.

[revert(toolkit): Q <--> Toolkit auth separation notification](https://github.com/aws/aws-toolkit-vscode/commit/4c747afe8ad048e72e079c8bf5105d19f254f34c) 

Removes the prompt shown in Toolkit that Amazon Q no longer shares connections with it. Some time has passed, active users should have been informed by now. We are still getting telemetry hits indicating that this is being used though.

NOTE: Does not revert or remove any separation logic itself. We continue to have separate sessions and also remove any connections in either extension that are extra or don't match the required scopes for that extension. That logic helps us catch auth edge cases.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
