### PR TITLE
fix(amazonq): Skip including deleted files for FeatureDev context.

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-4f85fc73-11cd-4033-bc93-b49ff3c3e45e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-4f85fc73-11cd-4033-bc93-b49ff3c3e45e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /dev: Fix issue when files are deleted while preparing context"
+}

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -599,7 +599,7 @@ export function isAwsError(error: unknown): error is AWSError & { error_descript
     return error instanceof Error && hasCode(error) && hasTime(error)
 }
 
-function hasCode<T>(error: T): error is T & { code: string } {
+export function hasCode<T>(error: T): error is T & { code: string } {
     return typeof (error as { code?: unknown }).code === 'string'
 }
 


### PR DESCRIPTION
## Problem
When zipping context for /dev, customer build processes (file watchers, etc.) may delete build artifacts we’ve already enumerated but have not added to the archive. As a best practice, customers should `.gitignore` these types of files, but in the event they don't, this has the potential to block /dev from running.

## Solution
Skip affected files, which are not found when adding to zip context for Feature Dev.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
