### PR TITLE
deps(amazonq): bump mynahui to 4.21.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6083,23 +6083,23 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.3.tgz",
-            "integrity": "sha512-iHFGmLg8fZgoqiHHDP94m6+ZmBsIiP7NBte/WId3iv+1344+Sipm/nNoZlczx5mIV1qhD+r/IZKG4c9Er4sHuA==",
+            "version": "4.21.4",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.4.tgz",
+            "integrity": "sha512-sYeQHJ8yEQQQsre1soXQFebbqZFcXerIxJ/d9kg/YzZUauCirW7v/0f/kHs9y7xYkYGa8y3exV6b6e4+juO1DQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "escape-html": "^1.0.3",
+                "highlight.js": "^11.11.0",
                 "just-clone": "^6.2.0",
                 "marked": "^14.1.0",
-                "prismjs": "1.29.0",
                 "sanitize-html": "^2.12.1",
                 "unescape-html": "^1.1.0"
             },
             "peerDependencies": {
                 "escape-html": "^1.0.3",
+                "highlight.js": "^11.11.0",
                 "just-clone": "^6.2.0",
-                "marked": "^12.0.2",
-                "prismjs": "1.29.0",
+                "marked": "^14.1.0",
                 "sanitize-html": "^2.12.1",
                 "unescape-html": "^1.1.0"
             }
@@ -14102,8 +14102,9 @@
             }
         },
         "node_modules/highlight.js": {
-            "version": "11.9.0",
-            "license": "BSD-3-Clause",
+            "version": "11.11.1",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+            "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -17330,13 +17331,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/prismjs": {
-            "version": "1.29.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/private": {
@@ -21162,7 +21156,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.21.3",
+                "@aws/mynah-ui": "^4.21.4",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-8434a098-361d-4e8d-9de4-c616da38ccbf.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-8434a098-361d-4e8d-9de4-c616da38ccbf.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix context menu displaying when typing @, even though input is disallowed"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-acf80397-e84d-430e-b7e2-fec67736338b.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-acf80397-e84d-430e-b7e2-fec67736338b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Up/down history navigation only triggering on first/last line of prompt input"
+}

--- a/packages/amazonq/.changes/next-release/Feature-6e3400cd-def4-4a63-b344-fd7ffa7fa509.json
+++ b/packages/amazonq/.changes/next-release/Feature-6e3400cd-def4-4a63-b344-fd7ffa7fa509.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q: new code syntax highlighter for improved accuracy"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -508,7 +508,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.21.3",
+        "@aws/mynah-ui": "^4.21.4",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Description
Bumped MynahUI to version 4.21.4 from 4.21.2. This includes two bug fixes and one feature, as described by the changelog commits and by the [MynahUI release notes](https://github.com/aws/mynah-ui/releases).

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
