### PR TITLE
fix(amazonq): Prevent customization override if user has manually selected a customization

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-d8c02c38-bdc4-492a-bf8c-6c35e35087be.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-d8c02c38-bdc4-492a-bf8c-6c35e35087be.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "User-selected customizations are sometimes not being persisted."
+}

--- a/packages/core/src/codewhisperer/index.ts
+++ b/packages/core/src/codewhisperer/index.ts
@@ -26,6 +26,7 @@ export type {
     SendTelemetryEventResponse,
     TelemetryEvent,
     InlineChatEvent,
+    Customization,
 } from './client/codewhispereruserclient.d.ts'
 export type { default as CodeWhispererUserClient } from './client/codewhispereruserclient.d.ts'
 export { SecurityPanelViewProvider } from './views/securityPanelViewProvider'
@@ -98,6 +99,6 @@ export * as diagnosticsProvider from './service/diagnosticsProvider'
 export * from './ui/codeWhispererNodes'
 export { SecurityScanError } from '../codewhisperer/models/errors'
 export * as CodeWhispererConstants from '../codewhisperer/models/constants'
-export { getSelectedCustomization } from './util/customizationUtil'
+export { getSelectedCustomization, setSelectedCustomization, baseCustomization } from './util/customizationUtil'
 export { Container } from './service/serviceContainer'
 export * from './util/gitUtil'

--- a/packages/core/src/test/amazonq/customizationUtil.test.ts
+++ b/packages/core/src/test/amazonq/customizationUtil.test.ts
@@ -1,0 +1,94 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as sinon from 'sinon'
+import assert from 'assert'
+import { tryRegister } from '../testUtil'
+import {
+    amazonQScopes,
+    AuthUtil,
+    baseCustomization,
+    Customization,
+    FeatureConfigProvider,
+    getSelectedCustomization,
+    refreshStatusBar,
+    setSelectedCustomization,
+} from '../../codewhisperer'
+import { FeatureContext, globals } from '../../shared'
+import { resetCodeWhispererGlobalVariables } from '../codewhisperer/testUtil'
+import { createSsoProfile, createTestAuth } from '../credentials/testUtil'
+import { SsoConnection } from '../../auth'
+
+const enterpriseSsoStartUrl = 'https://enterprise.awsapps.com/start'
+
+describe('CodeWhisperer-customizationUtils', function () {
+    let auth: ReturnType<typeof createTestAuth>
+    let ssoConn: SsoConnection
+    let featureCustomization: FeatureContext
+
+    before(async function () {
+        createTestAuth(globals.globalState)
+        tryRegister(refreshStatusBar)
+    })
+
+    beforeEach(async function () {
+        auth = createTestAuth(globals.globalState)
+        ssoConn = await auth.createInvalidSsoConnection(
+            createSsoProfile({ startUrl: enterpriseSsoStartUrl, scopes: amazonQScopes })
+        )
+        featureCustomization = {
+            name: 'featureCustomizationName',
+            value: {
+                stringValue: 'featureCustomizationArn',
+            },
+            variation: 'featureCustomizationName',
+        }
+        sinon.stub(FeatureConfigProvider, 'getFeature').returns(featureCustomization)
+
+        sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
+        sinon.stub(AuthUtil.instance, 'isConnected').returns(true)
+        sinon.stub(AuthUtil.instance, 'isCustomizationFeatureEnabled').value(true)
+        sinon.stub(AuthUtil.instance, 'conn').value(ssoConn)
+
+        await resetCodeWhispererGlobalVariables()
+    })
+
+    afterEach(function () {
+        sinon.restore()
+    })
+
+    it('Returns baseCustomization when not SSO', async function () {
+        sinon.stub(AuthUtil.instance, 'isValidEnterpriseSsoInUse').returns(false)
+        const customization = getSelectedCustomization()
+
+        assert.strictEqual(customization.name, baseCustomization.name)
+    })
+
+    it('Returns selectedCustomization when customization manually selected', async function () {
+        sinon.stub(AuthUtil.instance, 'isValidEnterpriseSsoInUse').returns(true)
+
+        const selectedCustomization: Customization = {
+            arn: 'selectedCustomizationArn',
+            name: 'selectedCustomizationName',
+            description: 'selectedCustomizationDescription',
+        }
+
+        await setSelectedCustomization(selectedCustomization)
+
+        const actualCustomization = getSelectedCustomization()
+
+        assert.strictEqual(actualCustomization.name, selectedCustomization.name)
+    })
+
+    it('Returns AB customization', async function () {
+        sinon.stub(AuthUtil.instance, 'isValidEnterpriseSsoInUse').returns(true)
+
+        await setSelectedCustomization(baseCustomization)
+
+        const returnedCustomization = getSelectedCustomization()
+
+        assert.strictEqual(returnedCustomization.name, featureCustomization.name)
+    })
+})


### PR DESCRIPTION
## Problem

If a user was part of an AB group with a customization override, they could only ever use the customization from the override regardless of personal choice. 

## Solution

Changes the logic for when a customization will be overridden if the user is part of an AB group that has a customization override. With this change, if the user has manually selected a customization, it will not be overridden by the AB customization.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
