### PR TITLE
test(amazonq): add edit README E2E test case for /doc

### DIFF
--- a/packages/amazonq/test/e2e/amazonq/doc.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/doc.test.ts
@@ -108,6 +108,43 @@ describe('Amazon Q Doc', async function () {
                 FollowUpTypes.MakeChanges,
                 FollowUpTypes.RejectChanges,
             ])
+
+            tab.clickButton(FollowUpTypes.AcceptChanges)
+
+            await tab.waitForButtons([FollowUpTypes.NewTask, FollowUpTypes.CloseSession])
+        })
+    })
+
+    describe('Edits a README', () => {
+        beforeEach(async function () {
+            tab.addChatMessage({ command: '/doc' })
+            await tab.waitForChatFinishesLoading()
+        })
+
+        it('Make specific change in README', async () => {
+            await tab.waitForButtons([FollowUpTypes.UpdateDocumentation])
+
+            tab.clickButton(FollowUpTypes.UpdateDocumentation)
+
+            await tab.waitForButtons([FollowUpTypes.SynchronizeDocumentation, FollowUpTypes.EditDocumentation])
+
+            tab.clickButton(FollowUpTypes.EditDocumentation)
+
+            await tab.waitForButtons([FollowUpTypes.ProceedFolderSelection])
+
+            tab.clickButton(FollowUpTypes.ProceedFolderSelection)
+
+            tab.addChatMessage({ prompt: 'remove the repository structure section' })
+
+            await tab.waitForText(
+                `${i18n('AWS.amazonq.doc.answer.readmeUpdated')} ${i18n('AWS.amazonq.doc.answer.codeResult')}`
+            )
+
+            await tab.waitForButtons([
+                FollowUpTypes.AcceptChanges,
+                FollowUpTypes.MakeChanges,
+                FollowUpTypes.RejectChanges,
+            ])
         })
     })
 })


### PR DESCRIPTION
Add E2E test case for /doc: Making a specific change to the README

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
