### PR TITLE
fix(amazonq): fix for /test for files outside of workspace.

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b071ef14-0566-4efa-9a16-43362b87639f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b071ef14-0566-4efa-9a16-43362b87639f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /test: Fix to redirect /test to generate tests in chat for external files out of workspace scope."
+}

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -439,16 +439,24 @@ export class TestController {
 
             const language = await this.getLanguageForFilePath(filePath)
             session.fileLanguage = language
+            const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileEditorToTest.document.uri)
 
             /*
                 For Re:Invent 2024 we are supporting only java and python for unit test generation, rest of the languages shows the similar experience as CWC
             */
-            if (language !== 'java' && language !== 'python') {
-                const unsupportedLanguage = language.charAt(0).toUpperCase() + language.slice(1)
-                let unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> While ${unsupportedLanguage} is not supported, I will generate a suggestion below. `
-                // handle the case when language is undefined
-                if (!unsupportedLanguage) {
-                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> I will still generate a suggestion below. `
+            if (!['java', 'python'].includes(language) || workspaceFolder == undefined) {
+                let unsupportedMessage: string
+                const unsupportedLanguage = language ? language.charAt(0).toUpperCase() + language.slice(1) : ''
+                if (!workspaceFolder) {
+                    // File is outside of workspace
+                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>External File Detected:</b> ${fileName} is outside of workspace scope.<br></span> However, I can still help you create unit tests for ${fileName} here.`
+                } else {
+                    // File is in workspace, check language support
+                    if (unsupportedLanguage) {
+                        unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> While ${unsupportedLanguage} is not supported, I will generate a suggestion below.`
+                    } else {
+                        unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> I will still generate a suggestion below.`
+                    }
                 }
                 this.messenger.sendMessage(unsupportedMessage, tabID, 'answer')
                 await this.onCodeGeneration(session, message.prompt, tabID, fileName, filePath)

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -450,13 +450,10 @@ export class TestController {
                 if (!workspaceFolder) {
                     // File is outside of workspace
                     unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I can't generate tests for because ${fileName} is outside of workspace scope.</b><br></span> I can still provide examples, instructions and code suggestions.`
+                } else if (unsupportedLanguage) {
+                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> While ${unsupportedLanguage} is not supported, I will generate a suggestion below.`
                 } else {
-                    // File is in workspace, check language support
-                    if (unsupportedLanguage) {
-                        unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> While ${unsupportedLanguage} is not supported, I will generate a suggestion below.`
-                    } else {
-                        unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> I will still generate a suggestion below.`
-                    }
+                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> I will still generate a suggestion below.`
                 }
                 this.messenger.sendMessage(unsupportedMessage, tabID, 'answer')
                 await this.onCodeGeneration(session, message.prompt, tabID, fileName, filePath)

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -449,7 +449,7 @@ export class TestController {
                 const unsupportedLanguage = language ? language.charAt(0).toUpperCase() + language.slice(1) : ''
                 if (!workspaceFolder) {
                     // File is outside of workspace
-                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>External File Detected:</b> ${fileName} is outside of workspace scope.<br></span> However, I can still help you create unit tests for ${fileName} here.`
+                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I can't generate tests for because ${fileName} is outside of workspace scope.</b><br></span> I can still provide examples, instructions and code suggestions.`
                 } else {
                     // File is in workspace, check language support
                     if (unsupportedLanguage) {

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -444,12 +444,12 @@ export class TestController {
             /*
                 For Re:Invent 2024 we are supporting only java and python for unit test generation, rest of the languages shows the similar experience as CWC
             */
-            if (!['java', 'python'].includes(language) || workspaceFolder == undefined) {
+            if (!['java', 'python'].includes(language) || workspaceFolder === undefined) {
                 let unsupportedMessage: string
                 const unsupportedLanguage = language ? language.charAt(0).toUpperCase() + language.slice(1) : ''
                 if (!workspaceFolder) {
                     // File is outside of workspace
-                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I can't generate tests for because ${fileName} is outside of workspace scope.</b><br></span> I can still provide examples, instructions and code suggestions.`
+                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I can't generate tests for ${fileName}</b> because the file is outside of workspace scope.<br></span> I can still provide examples, instructions and code suggestions.`
                 } else if (unsupportedLanguage) {
                     unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> While ${unsupportedLanguage} is not supported, I will generate a suggestion below.`
                 } else {


### PR DESCRIPTION



## Problem
/test test generation jobs failed for files open in workspace which do not belong to workspace because of path discrepancies.

## Solution
Redirecting the test generation for external files with a warning and generating tests for users in chat using conversation APIs instead of test generation workflow.

https://github.com/user-attachments/assets/6cc92ca4-f5ed-40a9-b720-ae2517de51ae

Telemtery will added in followup PR once toolkit common merge happens.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
