### PR TITLE
feat(amazonq): Add lsp downloading support for windows/linux

### DIFF
--- a/packages/core/src/shared/fs/fs.ts
+++ b/packages/core/src/shared/fs/fs.ts
@@ -16,7 +16,7 @@ import {
     isPermissionsError,
     scrubNames,
 } from '../errors'
-import globals from '../extensionGlobals'
+import globals, { isWeb } from '../extensionGlobals'
 import { isWin } from '../vscode/env'
 import { resolvePath } from '../utilities/pathUtils'
 import crypto from 'crypto'
@@ -549,6 +549,15 @@ export class FileSystem {
      * Follows the cache_dir convention outlined in https://crates.io/crates/dirs
      */
     getCacheDir(): string {
+        if (isWeb()) {
+            const homeDir = this.#homeDir
+            if (!homeDir) {
+                throw new ToolkitError('Web home directory not found', {
+                    code: 'WebHomeDirectoryNotFound',
+                })
+            }
+            return homeDir
+        }
         switch (process.platform) {
             case 'darwin': {
                 return _path.join(this.getUserHomeDir(), 'Library/Caches')
@@ -566,7 +575,7 @@ export class FileSystem {
                 return _path.join(this.getUserHomeDir(), '.cache')
             }
             default: {
-                throw new Error(`Unsupported platform: ${process.platform}. Expected 'darwin', 'win32', or 'linux'.`)
+                throw new Error(`Unsupported platform: ${process.platform}. Expected 'darwin', 'win32', 'linux'.`)
             }
         }
     }

--- a/packages/core/src/shared/fs/fs.ts
+++ b/packages/core/src/shared/fs/fs.ts
@@ -544,6 +544,34 @@ export class FileSystem {
     }
 
     /**
+     * Gets the application cache folder for the current platform
+     *
+     * Follows the cache_dir convention outlined in https://crates.io/crates/dirs
+     */
+    getCacheDir(): string {
+        switch (process.platform) {
+            case 'darwin': {
+                return _path.join(this.getUserHomeDir(), 'Library/Caches')
+            }
+            case 'win32': {
+                const localAppData = process.env.LOCALAPPDATA
+                if (!localAppData) {
+                    throw new ToolkitError('LOCALAPPDATA environment variable not set', {
+                        code: 'LocalAppDataNotFound',
+                    })
+                }
+                return localAppData
+            }
+            case 'linux': {
+                return _path.join(this.getUserHomeDir(), '.cache')
+            }
+            default: {
+                throw new Error(`Unsupported platform: ${process.platform}. Expected 'darwin', 'win32', or 'linux'.`)
+            }
+        }
+    }
+
+    /**
      * Gets the (cached) username for this session, or "webuser" in web-mode, or "unknown-user" if
      * a username could not be resolved.
      *

--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -10,7 +10,6 @@ import * as path from 'path'
 import { FileType } from 'vscode'
 import AdmZip from 'adm-zip'
 import { TargetContent, logger, LspResult, LspVersion, Manifest } from './types'
-import { getApplicationSupportFolder } from '../vscode/env'
 import { createHash } from '../crypto'
 import { lspSetupStage, StageResolver, tryStageResolvers } from './utils/setupStage'
 import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
@@ -394,7 +393,7 @@ export class LanguageServerResolver {
 
     // lazy calls to `getApplicationSupportFolder()` to avoid failure on windows.
     public static get defaultDir() {
-        return path.join(getApplicationSupportFolder(), `aws/toolkits/language-servers`)
+        return path.join(fs.getCacheDir(), `aws/toolkits/language-servers`)
     }
 
     defaultDownloadFolder() {

--- a/packages/core/src/shared/vscode/env.ts
+++ b/packages/core/src/shared/vscode/env.ts
@@ -12,7 +12,6 @@ import { onceChanged } from '../utilities/functionUtils'
 import { ChildProcess } from '../utilities/processUtils'
 import globals, { isWeb } from '../extensionGlobals'
 import * as devConfig from '../../dev/config'
-import path from 'path'
 
 /**
  * Returns true if the current build is running on CI (build server).
@@ -270,15 +269,4 @@ export async function getMachineId(): Promise<string> {
     const proc = new ChildProcess('hostname', [], { collect: true, logging: 'no' })
     // TODO: check exit code.
     return (await proc.run()).stdout.trim() ?? 'unknown-host'
-}
-
-export function getApplicationSupportFolder() {
-    switch (process.platform) {
-        case 'darwin': {
-            return path.join(os.homedir(), 'Library/Application Support')
-        }
-        default: {
-            throw new Error('Only mac is supported right now')
-        }
-    }
 }


### PR DESCRIPTION
## Problem
- Language servers are only being downloaded on macs

## Solution
- Download on windows/linux as well

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
