### PR TITLE
telemetry(amazonq): Remove unused Telemetry metric for /doc 

### DIFF
--- a/packages/core/src/amazonqDoc/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqDoc/controllers/chat/controller.ts
@@ -20,7 +20,6 @@ import { getLogger } from '../../../shared/logger'
 
 import { Session } from '../../session/session'
 import { i18n } from '../../../shared/i18n-helper'
-import { telemetry } from '../../../shared/telemetry'
 import path from 'path'
 import { createSingleFileDialog } from '../../../shared/ui/common/openDialog'
 import { MynahIcons } from '@aws/mynah-ui'
@@ -187,12 +186,6 @@ export class DocController {
         const codeGenerationId: string = message.messageId
         const zipFilePath: string = message.filePath
         const session = await this.sessionStorage.getSession(tabId)
-        telemetry.amazonq_isReviewedChanges.emit({
-            amazonqConversationId: session.conversationId,
-            enabled: true,
-            result: 'Succeeded',
-            credentialStartUrl: AuthUtil.instance.startUrl,
-        })
 
         const workspacePrefixMapping = getWorkspaceFoldersByPrefixes(session.config.workspaceFolders)
         const pathInfos = getPathsFromZipFilePath(zipFilePath, workspacePrefixMapping, session.config.workspaceFolders)
@@ -357,7 +350,6 @@ export class DocController {
     }
 
     private async fileClicked(message: any) {
-        // TODO: add Telemetry here
         const tabId: string = message.tabID
         const messageId = message.messageId
         const filePathToUpdate: string = message.filePath
@@ -397,12 +389,6 @@ export class DocController {
     private async newTask(message: any) {
         // Old session for the tab is ending, delete it so we can create a new one for the message id
         this.docGenerationTask = new DocGenerationTask()
-        const session = await this.sessionStorage.getSession(message.tabID)
-        telemetry.amazonq_endChat.emit({
-            amazonqConversationId: session.conversationId,
-            amazonqEndOfTheConversationLatency: performance.now() - session.telemetry.sessionStartTime,
-            result: 'Succeeded',
-        })
         this.sessionStorage.deleteSession(message.tabID)
 
         // Re-run the opening flow, where we check auth + create a session
@@ -419,14 +405,7 @@ export class DocController {
         this.messenger.sendUpdatePlaceholder(message.tabID, i18n('AWS.amazonq.featureDev.placeholder.sessionClosed'))
         this.messenger.sendChatInputEnabled(message.tabID, false)
 
-        const session = await this.sessionStorage.getSession(message.tabID)
         this.docGenerationTask.reset()
-
-        telemetry.amazonq_endChat.emit({
-            amazonqConversationId: session.conversationId,
-            amazonqEndOfTheConversationLatency: performance.now() - session.telemetry.sessionStartTime,
-            result: 'Succeeded',
-        })
     }
 
     private processErrorChatMessage = (err: any, message: any, session: Session | undefined) => {
@@ -492,7 +471,6 @@ export class DocController {
     }
 
     private async stopResponse(message: any) {
-        telemetry.ui_click.emit({ elementId: 'amazonq_stopCodeGeneration' })
         this.messenger.sendAnswer({
             message: i18n('AWS.amazonq.featureDev.pillText.stoppingCodeGeneration'),
             type: 'answer-part',
@@ -679,18 +657,6 @@ export class DocController {
         try {
             session = await this.sessionStorage.getSession(message.tabID)
 
-            const acceptedFiles = (paths?: { rejected: boolean }[]) => (paths || []).filter((i) => !i.rejected).length
-
-            const amazonqNumberOfFilesAccepted =
-                acceptedFiles(session.state.filePaths) + acceptedFiles(session.state.deletedFiles)
-
-            telemetry.amazonq_isAcceptedCodeChanges.emit({
-                credentialStartUrl: AuthUtil.instance.startUrl,
-                amazonqConversationId: session.conversationId,
-                amazonqNumberOfFilesAccepted,
-                enabled: true,
-                result: 'Succeeded',
-            })
             await session.insertChanges()
 
             const readmePath = findReadmePath(session.state.filePaths)


### PR DESCRIPTION
## Problem
/doc has adopted another telemetry service, and we need to clean up these unused telemetry methods

## Solution

Remove unused telemetry methods
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
