### PR TITLE
refactor(amazonq): remove unused strings

### DIFF
--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -731,11 +731,6 @@ export const linkToDocsHome = 'https://docs.aws.amazon.com/amazonq/latest/aws-bu
 
 export const linkToBillingInfo = 'https://aws.amazon.com/q/developer/pricing/'
 
-export const linkToUploadZipTooLarge =
-    'https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/troubleshooting-code-transformation.html#project-size-limit'
-
-export const linkToDownloadZipTooLarge = ''
-
 export const dependencyFolderName = 'transformation_dependencies_temp_'
 
 export const cleanInstallErrorChatMessage = `Sorry, I couldn\'t run the Maven clean install command to build your project. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootMvnFailure}).`


### PR DESCRIPTION
## Problem

Have 2 unused strings

## Solution

Remove them

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
