### PR TITLE
ci(amazonq): fix linting issue on language server child process

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -5,7 +5,7 @@
 
 import vscode, { env, version } from 'vscode'
 import * as nls from 'vscode-nls'
-import * as cp from 'child_process'
+import * as cp from 'child_process' // eslint-disable-line no-restricted-imports -- language server options expect actual child process
 import * as crypto from 'crypto'
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient'
 import { registerInlineCompletion } from '../inline/completion'


### PR DESCRIPTION
## Problem
In a recent PR we disabled using child_process in favour of our internal one. This started flagging lsp/client.ts, since it wasn't skipped.

## Solution
Skip eslint for child_process in this case, since the language server options expect the actual child process. The same is done for the workspace context language server: https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/amazonq/lsp/lspClient.ts#L13

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
