### PR TITLE
fix(amazonq): Overrides should reference assets directly

### DIFF
--- a/packages/amazonq/src/lsp/activation.ts
+++ b/packages/amazonq/src/lsp/activation.ts
@@ -12,7 +12,11 @@ import path from 'path'
 export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     try {
         const installResult = await new AmazonQLSPResolver().resolve()
-        await startLanguageServer(ctx, path.join(installResult.assetDirectory, 'servers/aws-lsp-codewhisperer.js'))
+        const serverLocation =
+            installResult.location === 'override'
+                ? installResult.assetDirectory
+                : path.join(installResult.assetDirectory, 'servers/aws-lsp-codewhisperer.js')
+        await startLanguageServer(ctx, serverLocation)
     } catch (err) {
         const e = err as ToolkitError
         void vscode.window.showInformationMessage(`Unable to launch amazonq language server: ${e.message}`)


### PR DESCRIPTION
## Problem
The language server initialization logic incorrectly handles custom server paths. When users specify a custom language server location through an environment variable, the code still appends `servers/aws-lsp-codewhisperer.js` to the path, leading to incorrect server resolution.

## Solution
When a custom language server path is provided via environment variable (indicated by `location === 'override'`), use the specified asset directory path directly instead of appending the default server path. This allows users to have full control over the language server location.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
