### PR TITLE
fix(e2e): failing Auth Lambda

### DIFF
--- a/packages/core/src/test/setupUtil.ts
+++ b/packages/core/src/test/setupUtil.ts
@@ -223,12 +223,16 @@ export function registerAuthHook(secret: string, lambdaId = process.env['AUTH_UT
 
             const openStub = patchObject(vscode.env, 'openExternal', async (target) => {
                 try {
-                    const url = new URL(target.toString(true))
-                    const userCode = url.searchParams.get('user_code')
+                    // Latest eg: 'https://nkomonen.awsapps.com/start/#/device?user_code=JXZC-NVRK'
+                    const urlString = target.toString(true)
 
-                    // TODO: Update this to just be the full URL if the authorizer lambda ever
-                    // supports the verification URI with user code embedded (VerificationUriComplete).
-                    const verificationUri = url.origin
+                    // Drop the user_code parameter since the auth lambda does not support it yet, and keeping it
+                    // would trigger a slightly different UI flow which breaks the automation.
+                    // TODO: If the auth lambda supports user_code in the parameters then we can skip this step
+                    const verificationUri = urlString.split('?')[0]
+
+                    const params = urlString.split('?')[1]
+                    const userCode = new URLSearchParams(params).get('user_code')
 
                     await invokeLambda(lambdaId, {
                         secret,


### PR DESCRIPTION
## Problem

The CC tests are failing in the auth lambda step, saying that the `user_code` value is not a string

## Solution

See code for solution

NOTE: This part is now fixed, but the auth lambda itself has its own separate issue that needs to first be fixed

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
