### PR TITLE
fix(wizard): wizard remains in "not ready" state if a custom init() was provided

### DIFF
--- a/packages/core/src/shared/wizards/wizard.ts
+++ b/packages/core/src/shared/wizards/wizard.ts
@@ -146,11 +146,10 @@ export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
         this._ready = !this.init
 
         if (typeof this.init === 'function') {
-            // eslint-disable-next-line @typescript-eslint/unbound-method
-            const _init = this.init
+            const _init = this.init.bind(this)
             this.init = () => {
                 this._ready = true
-                return _init.apply(this)
+                return _init()
             }
         }
     }

--- a/packages/core/src/test/shared/wizards/wizardTestUtils.ts
+++ b/packages/core/src/test/shared/wizards/wizardTestUtils.ts
@@ -65,9 +65,7 @@ function failIf(cond: boolean, message?: string): void {
 export async function createWizardTester<T extends Partial<T>>(wizard: Wizard<T> | WizardForm<T>): Promise<Tester<T>> {
     if (wizard instanceof Wizard && wizard.init) {
         // Ensure that init() was called. Needed because createWizardTester() does not call run().
-        ;(wizard as any)._ready = true
         await wizard.init()
-        delete wizard.init
     }
 
     const form = wizard instanceof Wizard ? wizard.boundForm : wizard


### PR DESCRIPTION
## Problem
The wizard remained in a "not ready" state if a custom `init()` was provided, requiring manual toggles in the test code.

## Solution

- Wrap the user’s init() with a small decorator that sets _ready = true.
- Remove the manual toggles in wizardTestUtils.ts, letting the wizard handle readiness on its own.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
