### PR TITLE
deps: Update "aws-sdk" to v2.1692.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10480,8 +10480,10 @@
             "link": true
         },
         "node_modules/aws-sdk": {
-            "version": "2.1384.0",
-            "license": "Apache-2.0",
+            "version": "2.1692.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1692.0.tgz",
+            "integrity": "sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==",
+            "hasInstallScript": true,
             "dependencies": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
@@ -10492,7 +10494,7 @@
                 "url": "0.10.3",
                 "util": "^0.12.4",
                 "uuid": "8.0.0",
-                "xml2js": "0.5.0"
+                "xml2js": "0.6.2"
             },
             "engines": {
                 "node": ">= 10.0.0"
@@ -10503,17 +10505,6 @@
             "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
-            }
-        },
-        "node_modules/aws-sdk/node_modules/xml2js": {
-            "version": "0.5.0",
-            "license": "MIT",
-            "dependencies": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
-            },
-            "engines": {
-                "node": ">=4.0.0"
             }
         },
         "node_modules/aws-ssm-document-language-service": {
@@ -20820,8 +20811,9 @@
             }
         },
         "node_modules/xml2js": {
-            "version": "0.6.1",
-            "license": "MIT",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "dependencies": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -21169,7 +21161,7 @@
                 "adm-zip": "^0.5.10",
                 "amazon-states-language-service": "^1.13.0",
                 "async-lock": "^1.4.0",
-                "aws-sdk": "^2.1384.0",
+                "aws-sdk": "^2.1692.0",
                 "aws-ssm-document-language-service": "^1.0.0",
                 "bytes": "^3.1.2",
                 "cross-fetch": "^4.0.0",

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -50,7 +50,7 @@ const buildMockListCodeScanFindingsResponse = (
 ): Awaited<Promise<PromiseResult<ListCodeScanFindingsResponse, AWSError>>> => ({
     $response: {
         hasNextPage: () => false,
-        nextPage: () => undefined,
+        nextPage: () => null, // eslint-disable-line unicorn/no-null
         data: undefined,
         error: undefined,
         requestId: '',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -521,7 +521,7 @@
         "adm-zip": "^0.5.10",
         "amazon-states-language-service": "^1.13.0",
         "async-lock": "^1.4.0",
-        "aws-sdk": "^2.1384.0",
+        "aws-sdk": "^2.1692.0",
         "aws-ssm-document-language-service": "^1.0.0",
         "bytes": "^3.1.2",
         "cross-fetch": "^4.0.0",

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -224,7 +224,7 @@ describe('transformByQ', function () {
                 requestId: 'requestId',
                 hasNextPage: () => false,
                 error: undefined,
-                nextPage: () => undefined,
+                nextPage: () => null, // eslint-disable-line unicorn/no-null
                 redirectCount: 0,
                 retryCount: 0,
                 httpResponse: new HttpResponse(),

--- a/packages/core/src/test/codewhisperer/testUtil.ts
+++ b/packages/core/src/test/codewhisperer/testUtil.ts
@@ -226,7 +226,7 @@ export const mockGetCodeScanResponse = {
         requestId: 'requestId',
         hasNextPage: () => false,
         error: undefined,
-        nextPage: () => undefined,
+        nextPage: () => null, // eslint-disable-line unicorn/no-null
         redirectCount: 0,
         retryCount: 0,
         httpResponse: new HttpResponse(),
@@ -246,7 +246,7 @@ export function createClient() {
             requestId: 'requestId',
             hasNextPage: () => false,
             error: undefined,
-            nextPage: () => undefined,
+            nextPage: () => null, // eslint-disable-line unicorn/no-null
             redirectCount: 0,
             retryCount: 0,
             httpResponse: new HttpResponse(),
@@ -263,7 +263,7 @@ export function createClient() {
             requestId: 'requestId',
             hasNextPage: () => false,
             error: undefined,
-            nextPage: () => undefined,
+            nextPage: () => null, // eslint-disable-line unicorn/no-null
             redirectCount: 0,
             retryCount: 0,
             httpResponse: new HttpResponse(),
@@ -306,7 +306,7 @@ export function createClient() {
             requestId: 'requestId',
             hasNextPage: () => false,
             error: undefined,
-            nextPage: () => undefined,
+            nextPage: () => null, // eslint-disable-line unicorn/no-null
             redirectCount: 0,
             retryCount: 0,
             httpResponse: new HttpResponse(),


### PR DESCRIPTION
Update `aws-sdk` to v2.1692.0

The `Response` class in AWS SDK changed the signature of the `nextPage` method, so some tests that were mocking this method had to be updated accordingly (changing the response from `undefined` to `null`).

The definition changed from 
```
    nextPage(callback?: (err: E, data: D) => void): Request<D, E>|void;
```
(callback optional, can return `void`)

To 
```
    nextPage(): Request<D, E> | null;
    nextPage(callback: (err: E, data: D) => void): void;
```
(can return `null` if no callback. only when a callback is passed returns `void`)

## Problem

The version of the AWSK SDK v2 was outdated 1.5 years, so some newer functionality was not available.

## Solution

Update the version of `aws-sdk` package to the latest version.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
