### PR TITLE
telemetry(amazonq): numberOfTestsGenerated correctly emits as 0

### DIFF
--- a/packages/core/src/codewhisperer/commands/startTestGeneration.ts
+++ b/packages/core/src/codewhisperer/commands/startTestGeneration.ts
@@ -120,6 +120,7 @@ export async function startTestGenerationProcess(
         )
         // TODO: Send status to test summary
         if (jobStatus === TestGenerationJobStatus.FAILED) {
+            session.numberOfTestsGenerated = 0
             logger.verbose(`Test generation failed.`)
             throw new TestGenFailedError()
         }

--- a/packages/core/src/codewhisperer/service/testGenHandler.ts
+++ b/packages/core/src/codewhisperer/service/testGenHandler.ts
@@ -222,6 +222,8 @@ export async function exportResultsArchive(
     await fs.mkdir(pathToArchiveDir)
 
     let downloadErrorMessage = undefined
+
+    const session = ChatSessionManager.Instance.getSession()
     try {
         const pathToArchive = path.join(pathToArchiveDir, 'QTestGeneration.zip')
         // Download and deserialize the zip
@@ -248,6 +250,7 @@ export async function exportResultsArchive(
             })
         }
     } catch (e) {
+        session.numberOfTestsGenerated = 0
         downloadErrorMessage = (e as Error).message
         getLogger().error(`Unit Test Generation: ExportResultArchive error = ${downloadErrorMessage}`)
         throw new Error('Error downloading test generation result artifacts: ' + downloadErrorMessage)


### PR DESCRIPTION
## Problem
- NumOfUnitTestCasesGenerated shows non 0 value when LinesOfCodeGenerated and CharsOfCodeGenerated are 0
- Occurs only when ExportResultArchive API did not have any generated code or when the job fails

## Solution
- Reset NumOfUnitTestCasesGenerated to 0 when one of these cases occur 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
