### PR TITLE
fix(dev): Q developer menu opening wrong auth state

### DIFF
--- a/packages/core/src/dev/activation.ts
+++ b/packages/core/src/dev/activation.ts
@@ -334,7 +334,7 @@ class ObjectEditor {
                 return this.openState(targetContext.secrets, key)
             case 'auth':
                 // Auth memento is determined in a different way
-                return this.openState(getEnvironmentSpecificMemento(), key)
+                return this.openState(getEnvironmentSpecificMemento(globalState), key)
         }
     }
 

--- a/packages/core/src/shared/utilities/mementos.ts
+++ b/packages/core/src/shared/utilities/mementos.ts
@@ -37,19 +37,19 @@ export function partition(memento: vscode.Memento, key: string): vscode.Memento 
  *   with the local globalState. We want certain functionality to be isolated to
  *   the remote instance.
  */
-export function getEnvironmentSpecificMemento(): vscode.Memento {
+export function getEnvironmentSpecificMemento(globalState?: vscode.Memento): vscode.Memento {
     if (!vscode.env.remoteName) {
         // local compute: no further partitioning
-        return globals.globalState
+        return globalState ?? globals.globalState
     }
 
     const devEnvId = getCodeCatalystDevEnvId()
 
     if (devEnvId !== undefined) {
         // dev env: partition to dev env ID (compute backend might not always be the same)
-        return partition(globals.globalState, devEnvId)
+        return partition(globalState ?? globals.globalState, devEnvId)
     }
 
     // remote env: keeps a shared "global state" for all workspaces that report the same machine ID
-    return partition(globals.globalState, globals.machineId)
+    return partition(globalState ?? globals.globalState, globals.machineId)
 }


### PR DESCRIPTION
It's opening the toolkit global state value instead.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
