### PR TITLE
telemetry(amazonq): conditionally include classifier fields in telemetry

### DIFF
--- a/packages/core/src/codewhisperer/util/telemetryHelper.ts
+++ b/packages/core/src/codewhisperer/util/telemetryHelper.ts
@@ -177,8 +177,10 @@ export class TelemetryHelper {
 
         telemetry.codewhisperer_userTriggerDecision.emit({
             codewhispererAutomatedTriggerType: session.autoTriggerType,
-            codewhispererClassifierResult: this.classifierResult,
-            codewhispererClassifierThreshold: this.classifierThreshold,
+            ...(this.classifierResult !== undefined ? { codewhispererClassifierResult: this.classifierResult } : {}),
+            ...(this.classifierThreshold !== undefined
+                ? { codewhispererClassifierThreshold: this.classifierThreshold }
+                : {}),
             codewhispererCompletionType: 'Line',
             codewhispererCursorOffset: session.startCursorOffset,
             codewhispererCustomizationArn: selectedCustomization.arn === '' ? undefined : selectedCustomization.arn,
@@ -388,8 +390,10 @@ export class TelemetryHelper {
         const aggregated: CodewhispererUserTriggerDecision = {
             codewhispererAutomatedTriggerType: autoTriggerType,
             codewhispererCharactersAccepted: acceptedRecommendationContent.length,
-            codewhispererClassifierResult: this.classifierResult,
-            codewhispererClassifierThreshold: this.classifierThreshold,
+            ...(this.classifierResult !== undefined ? { codewhispererClassifierResult: this.classifierResult } : {}),
+            ...(this.classifierThreshold !== undefined
+                ? { codewhispererClassifierThreshold: this.classifierThreshold }
+                : {}),
             codewhispererCompletionType: aggregatedCompletionType,
             codewhispererCursorOffset: this.sessionDecisions[0].codewhispererCursorOffset,
             codewhispererCustomizationArn: selectedCustomization.arn === '' ? undefined : selectedCustomization.arn,


### PR DESCRIPTION
telemetry(amazonq): conditionally include classifierResult and classifierThreshold in pojo emitted in telemetry

## Problem
Some fields in the POJO emitted in the telemetry were causing parsing errors when values are undefined. 
These fields are the following: 
- classifierResult
- classifierThreshold

## Solution
This change aims to conditionally include the aforementioned fields based on whether or not their values undefined. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
