### PR TITLE
build(os-compatibility): normalize file paths and enforce eol consistency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -209,5 +209,7 @@ module.exports = {
                 ],
             },
         ],
+
+        'prettier/prettier': ['error', { endOfLine: 'auto' }],
     },
 }

--- a/packages/core/src/test/testRunner.ts
+++ b/packages/core/src/test/testRunner.ts
@@ -84,7 +84,8 @@ export async function runTests(
     })
 
     const dist = path.resolve(root, 'dist')
-    const testFile = process.env['TEST_FILE']?.replace('.ts', '.js')
+    const rawTestFile = process.env['TEST_FILE']
+    const testFile = rawTestFile?.replace(/\\/g, '/').replace('.ts', '.js')
     let testFilePath: string | undefined
     if (testFile?.includes('../core/')) {
         testFilePath = path.resolve(root, testFile.replace('../core/', '../core/dist/'))


### PR DESCRIPTION
## Problem

- Tests were failing or behaving inconsistently on different operating systems due to improper file path normalization.
- End-of-line (EOL) conflicts were causing unnecessary formatting diffs in collaborative workflows.

## Solution

- Updated the testFile variable in the test runner to normalize paths by replacing backslashes (\) with forward slashes, ensuring cross-platform compatibility.
- Added the Prettier rule 'prettier/prettier': ['error', { endOfLine: 'auto' }] to align EOL behavior with the host environment, avoiding platform-specific conflicts.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
