### PR TITLE
fix(amazonq): broaden search strings

### DIFF
--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -654,14 +654,14 @@ export async function getValidSQLConversionCandidateProjects() {
         let resultLog = ''
         for (const project of javaProjects) {
             // as long as at least one of these strings is found, project contains embedded SQL statements
-            const searchStrings = ['oracle.jdbc.OracleDriver', 'jdbc:oracle:thin:@', 'jdbc:oracle:oci:@', 'jdbc:odbc:']
+            const searchStrings = ['oracle.jdbc.', 'jdbc:oracle:', 'jdbc:odbc:']
             for (const str of searchStrings) {
                 const spawnResult = await findStringInDirectory(str, project.path)
                 // just for telemetry purposes
                 if (spawnResult.error || spawnResult.stderr) {
-                    resultLog += `search failed: ${JSON.stringify(spawnResult)}`
+                    resultLog += `search error: ${JSON.stringify(spawnResult)}--`
                 } else {
-                    resultLog += `search succeeded: ${spawnResult.exitCode}`
+                    resultLog += `search complete (exit code: ${spawnResult.exitCode})--`
                 }
                 getLogger().info(`CodeTransformation: searching for ${str} in ${project.path}, result = ${resultLog}`)
                 if (spawnResult.exitCode === 0) {


### PR DESCRIPTION
## Problem

We search for 4 strings to indicate/infer Oracle SQL is present, including `oracle.jdbc.OracleDriver`, but legacy software can instead contain `oracle.jdbc.driver.OracleDriver`.

## Solution

Broaden/loosen the validation/search.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
