### PR TITLE
fix(amazonq): unsupported languages test generation query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.289",
+                "@aws-toolkits/telemetry": "^1.0.293",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -6047,9 +6047,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.289",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.289.tgz",
-            "integrity": "sha512-srzr3JGMprOX2rrUAhribVBrUMfvR6uOhwksaxu63/GMTBjEWjwfcKzpgQzxu1+InmGioBa4zKdKKV/hAaUCmw==",
+            "version": "1.0.294",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.294.tgz",
+            "integrity": "sha512-Hy/yj93pFuHhKCqAA9FgNjdJHRi4huUnyl13dZLzzICDlFVl/AHlm9iWmm9LR22KOuXUyu3uX40VtXLdExIHqw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "mergeReports": "ts-node ./scripts/mergeReports.ts"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.289",
+        "@aws-toolkits/telemetry": "^1.0.293",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",

--- a/packages/amazonq/.changes/next-release/Bug Fix-cb743d9a-67da-41a2-bda3-9bc8bfa19b75.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-cb743d9a-67da-41a2-bda3-9bc8bfa19b75.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q: /test for unsupported languages was sometimes unreliable"
+	"description": "/test: for unsupported languages was sometimes unreliable"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-cb743d9a-67da-41a2-bda3-9bc8bfa19b75.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-cb743d9a-67da-41a2-bda3-9bc8bfa19b75.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q: fix for test generation unsupported languages query"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-cb743d9a-67da-41a2-bda3-9bc8bfa19b75.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-cb743d9a-67da-41a2-bda3-9bc8bfa19b75.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q: fix for test generation unsupported languages query"
+	"description": "Amazon Q: test generation for unsupported was sometimes unreliable"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-cb743d9a-67da-41a2-bda3-9bc8bfa19b75.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-cb743d9a-67da-41a2-bda3-9bc8bfa19b75.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q: test generation for unsupported was sometimes unreliable"
+	"description": "Amazon Q: /test for unsupported languages was sometimes unreliable"
 }

--- a/packages/core/src/amazonqTest/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqTest/chat/controller/messenger/messenger.ts
@@ -183,7 +183,8 @@ export class Messenger {
         tabID: string,
         triggerID: string,
         triggerPayload: TriggerPayload,
-        fileName: string
+        fileName: string,
+        fileInWorkspace: boolean
     ) {
         let message = ''
         let messageId = response.$metadata.requestId ?? ''
@@ -277,6 +278,7 @@ export class Messenger {
                     TelemetryHelper.instance.sendTestGenerationToolkitEvent(
                         session,
                         false,
+                        fileInWorkspace,
                         'Cancelled',
                         messageId,
                         performance.now() - session.testGenerationStartTime,
@@ -291,6 +293,7 @@ export class Messenger {
                     TelemetryHelper.instance.sendTestGenerationToolkitEvent(
                         session,
                         false,
+                        fileInWorkspace,
                         'Succeeded',
                         messageId,
                         performance.now() - session.testGenerationStartTime

--- a/packages/core/src/codewhisperer/util/telemetryHelper.ts
+++ b/packages/core/src/codewhisperer/util/telemetryHelper.ts
@@ -70,6 +70,7 @@ export class TelemetryHelper {
     public sendTestGenerationToolkitEvent(
         session: Session,
         isSupportedLanguage: boolean,
+        isFileInWorkspace: boolean,
         result: 'Succeeded' | 'Failed' | 'Cancelled',
         requestId?: string,
         perfClientLatency?: number,
@@ -90,6 +91,7 @@ export class TelemetryHelper {
             cwsprChatProgrammingLanguage: session.fileLanguage ?? 'plaintext',
             hasUserPromptSupplied: session.hasUserPromptSupplied,
             isSupportedLanguage: isSupportedLanguage,
+            isFileInWorkspace: isFileInWorkspace,
             result: result,
             artifactsUploadDuration: artifactsUploadDuration,
             buildPayloadBytes: buildPayloadBytes,


### PR DESCRIPTION
## Problem
- The test generation for unsupported language files and external files is unreliable and flaky.
- Telemetry updated to include new metadata for existing metadata.

## Solution
- Fix to add file name as fallback in case of empty prompt or no code selection.
- Telemetry updated and values passed to it in controller and messenger. Essentially same PR : https://github.com/aws/aws-toolkit-vscode/pull/6323 was closed last week due to build issues.
---
Before:
https://github.com/user-attachments/assets/90ed6629-4753-41e6-9d11-b6d4dd0d6e7c

After fix:

https://github.com/user-attachments/assets/d0993345-cd2c-47ac-a8b5-1e9badf8fbac




- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
