### PR TITLE
fix(amazonq): add message after accept/reject action

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b6d52b75-69e6-47bb-939b-5ddede03f977.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b6d52b75-69e6-47bb-939b-5ddede03f977.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /test: Unit test generation completed message shows after accept/reject action"
+}

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -717,6 +717,9 @@ export class TestController {
         await vscode.window.showTextDocument(document)
         // TODO: send the message once again once build is enabled
         // this.messenger.sendMessage('Accepted', message.tabID, 'prompt')
+
+        this.messenger.sendMessage('Unit test generation completed', message.tabID, 'answer')
+
         telemetry.ui_click.emit({ elementId: 'unitTestGeneration_acceptDiff' })
 
         TelemetryHelper.instance.sendTestGenerationToolkitEvent(
@@ -840,6 +843,8 @@ export class TestController {
     private async endSession(data: any, step: FollowUpTypes) {
         const session = this.sessionStorage.getSession()
         if (step === FollowUpTypes.RejectCode) {
+            this.messenger.sendMessage('Unit test generation completed.', data.tabID, 'answer')
+
             TelemetryHelper.instance.sendTestGenerationToolkitEvent(
                 session,
                 true,

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -717,9 +717,6 @@ export class TestController {
         await vscode.window.showTextDocument(document)
         // TODO: send the message once again once build is enabled
         // this.messenger.sendMessage('Accepted', message.tabID, 'prompt')
-
-        this.messenger.sendMessage('Unit test generation completed', message.tabID, 'answer')
-
         telemetry.ui_click.emit({ elementId: 'unitTestGeneration_acceptDiff' })
 
         TelemetryHelper.instance.sendTestGenerationToolkitEvent(
@@ -841,10 +838,10 @@ export class TestController {
 
     // TODO: Check if there are more cases to endSession if yes create a enum or type for step
     private async endSession(data: any, step: FollowUpTypes) {
+        this.messenger.sendMessage('Unit test generation completed.', data.tabID, 'answer')
+
         const session = this.sessionStorage.getSession()
         if (step === FollowUpTypes.RejectCode) {
-            this.messenger.sendMessage('Unit test generation completed.', data.tabID, 'answer')
-
             TelemetryHelper.instance.sendTestGenerationToolkitEvent(
                 session,
                 true,


### PR DESCRIPTION
## Problem
- Should show a completed message after user completes accept/reject process (just like JB)
- This message does not currently show in VSC

## Solution
- Show completed message after user completes accept/reject process 




https://github.com/user-attachments/assets/e6e65268-b851-4298-afa6-a784e75dd0a3


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
