### PR TITLE
fix(sso): login with custom startUrl not allowed

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-71c6bbc1-67ae-4318-a7f0-c594e097ebc4.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-71c6bbc1-67ae-4318-a7f0-c594e097ebc4.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth: Valid StartURL not accepted at login"
+}

--- a/packages/core/src/auth/sso/constants.ts
+++ b/packages/core/src/auth/sso/constants.ts
@@ -11,8 +11,15 @@
 export const builderIdStartUrl = 'https://view.awsapps.com/start'
 export const internalStartUrl = 'https://amzn.awsapps.com/start'
 
+/**
+ * Doc: https://docs.aws.amazon.com/singlesignon/latest/userguide/howtochangeURL.html
+ */
 export const ssoUrlFormatRegex =
     /^(https?:\/\/(.+)\.awsapps\.com\/start|https?:\/\/identitycenter\.amazonaws\.com\/ssoins-[\da-zA-Z]{16})\/?$/
 
+/**
+ * It is possible for a start url to be a completely custom url that redirects to something that matches the format
+ * below, so this message is only a warning.
+ */
 export const ssoUrlFormatMessage =
-    'URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start'
+    'URL possibly invalid. It typically follows the pattern: https://xxxxxxxxxx.awsapps.com/start'

--- a/packages/core/src/auth/sso/constants.ts
+++ b/packages/core/src/auth/sso/constants.ts
@@ -21,5 +21,4 @@ export const ssoUrlFormatRegex =
  * It is possible for a start url to be a completely custom url that redirects to something that matches the format
  * below, so this message is only a warning.
  */
-export const ssoUrlFormatMessage =
-    'URL possibly invalid. It typically follows the pattern: https://xxxxxxxxxx.awsapps.com/start'
+export const ssoUrlFormatMessage = 'URL possibly invalid. Expected format: https://xxxxxxxxxx.awsapps.com/start'

--- a/packages/core/src/auth/sso/constants.ts
+++ b/packages/core/src/auth/sso/constants.ts
@@ -22,3 +22,4 @@ export const ssoUrlFormatRegex =
  * below, so this message is only a warning.
  */
 export const ssoUrlFormatMessage = 'URL possibly invalid. Expected format: https://xxxxxxxxxx.awsapps.com/start'
+export const urlInvalidFormatMessage = 'URL format invalid. Expected format: https://xxxxxxxxxx.com/yyyy'

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -31,6 +31,7 @@ import { AuthEnabledFeatures, AuthError, AuthFlowState, AuthUiClick, userCancell
 import { DevSettings } from '../../../shared/settings'
 import { AuthSSOServer } from '../../../auth/sso/server'
 import { getLogger } from '../../../shared/logger/logger'
+import { isValidUrl } from '../../../shared/utilities/uriUtils'
 
 export abstract class CommonAuthWebview extends VueWebview {
     private readonly className = 'CommonAuthWebview'
@@ -275,5 +276,9 @@ export abstract class CommonAuthWebview extends VueWebview {
 
     cancelAuthFlow() {
         AuthSSOServer.lastInstance?.cancelCurrentFlow()
+    }
+
+    validateUrl(url: string) {
+        return isValidUrl(url)
     }
 }

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -279,7 +279,7 @@ import { LoginOption } from './types'
 import { CommonAuthWebview } from './backend'
 import { WebviewClientFactory } from '../../../webviews/client'
 import { Region } from '../../../shared/regions/endpoints'
-import { ssoUrlFormatRegex, ssoUrlFormatMessage } from '../../../auth/sso/constants'
+import { ssoUrlFormatRegex, ssoUrlFormatMessage, urlInvalidFormatMessage } from '../../../auth/sso/constants'
 
 const client = WebviewClientFactory.create<CommonAuthWebview>()
 
@@ -504,7 +504,7 @@ export default defineComponent({
                         console.log('After Validate')
                         return { error: '', warning: ssoUrlFormatMessage }
                     } else {
-                        return { error: 'URL format invalid. Must follow eg: https://xxxxx.com/yyyy', warning: '' }
+                        return { error: urlInvalidFormatMessage, warning: '' }
                     }
                 }
 

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -193,6 +193,7 @@
                     @keydown.enter="handleContinueClick()"
                 />
                 <h4 class="start-url-error">{{ startUrlError }}</h4>
+                <h4 class="start-url-warning">{{ startUrlWarning }}</h4>
                 <div class="title topMargin">Region</div>
                 <div class="hint">AWS Region that hosts identity directory</div>
                 <select
@@ -340,6 +341,7 @@ export default defineComponent({
             stage: 'START' as Stage,
             regions: [] as Region[],
             startUrlError: '',
+            startUrlWarning: '',
             selectedRegion: 'us-east-1',
             startUrl: '',
             app: this.app,
@@ -365,7 +367,7 @@ export default defineComponent({
 
         // Pre-select the first available login option
         await this.preselectLoginOption()
-        this.handleUrlInput() // validate the default startUrl
+        await this.handleUrlInput() // validate the default startUrl
     },
     methods: {
         toggleItemSelection(itemId: number) {
@@ -475,17 +477,47 @@ export default defineComponent({
                 this.stage = 'CONNECTED'
             }
         },
-        handleUrlInput() {
-            if (this.startUrl && !ssoUrlFormatRegex.test(this.startUrl)) {
-                this.startUrlError = ssoUrlFormatMessage
-            } else if (this.startUrl && this.existingStartUrls.some((url) => url === this.startUrl)) {
-                this.startUrlError =
-                    'A connection for this start URL already exists. Sign out before creating a new one.'
-            } else {
-                this.startUrlError = ''
+        async handleUrlInput() {
+            const messages = await resolveStartUrlMessages(this.startUrl, this.existingStartUrls)
+            this.startUrlError = messages.error
+            this.startUrlWarning = messages.warning
+
+            if (!messages.error && !messages.warning) {
                 void client.storeMetricMetadata({
                     credentialStartUrl: this.startUrl,
                 })
+            }
+
+            async function resolveStartUrlMessages(
+                startUrl: string | undefined,
+                existingStartUrls: string[]
+            ): Promise<{ warning: string; error: string }> {
+                // No URL
+                if (!startUrl) {
+                    return { error: '', warning: '' }
+                }
+
+                // Validate URL format
+                if (!ssoUrlFormatRegex.test(startUrl)) {
+                    console.log('Before Validate')
+                    if (await client.validateUrl(startUrl)) {
+                        console.log('After Validate')
+                        return { error: '', warning: ssoUrlFormatMessage }
+                    } else {
+                        return { error: 'URL format invalid. Must follow eg: https://xxxxx.com/yyyy', warning: '' }
+                    }
+                }
+
+                // Ensure that URL does not exist yet
+                if (existingStartUrls.some((url) => url === startUrl)) {
+                    return {
+                        error: 'A connection for this start URL already exists. Sign out before creating a new one.',
+                        warning: '',
+                    }
+                }
+
+                // URL is valid
+                return { error: '', warning: '' }
             }
         },
         handleRegionInput(event: any) {
@@ -741,6 +773,10 @@ body.vscode-high-contrast:not(body.vscode-high-contrast-light) .regionSelect {
 }
 .start-url-error {
     color: #ff0000;
+    font-size: var(--font-size-sm);
+}
+.start-url-warning {
+    color: #dfe216;
     font-size: var(--font-size-sm);
 }
 #logo {

--- a/packages/core/src/shared/utilities/uriUtils.ts
+++ b/packages/core/src/shared/utilities/uriUtils.ts
@@ -58,3 +58,15 @@ export function toUri(path: string | vscode.Uri): vscode.Uri {
     }
     return vscode.Uri.file(path)
 }
+
+export function isValidUrl(string: string): boolean {
+    try {
+        const url = new URL(string)
+        // handle case where, eg: 'https://test', would be considered valid. At a minimum
+        // we'll require a top-level domain, eg: 'https://test.com'.
+        const hostParts = url.hostname.split('.').filter((part) => !!part)
+        return hostParts.length > 1
+    } catch (err) {
+        return false
+    }
+}

--- a/packages/core/src/test/shared/utilities/uriUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/uriUtils.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { fromQueryToParameters } from '../../../shared/utilities/uriUtils'
+import { fromQueryToParameters, isValidUrl } from '../../../shared/utilities/uriUtils'
 
 describe('uriUtils', function () {
     it('returns empty when no query parameters are present', function () {
@@ -32,5 +32,17 @@ describe('uriUtils', function () {
                 ['param3', 'value3'],
             ])
         )
+    })
+
+    it('isValidUrl()', function () {
+        assert.strictEqual(isValidUrl(''), false)
+        assert.strictEqual(isValidUrl('test.com'), false)
+        assert.strictEqual(isValidUrl('https://test'), false)
+        assert.strictEqual(isValidUrl('http://test.'), false)
+        assert.strictEqual(isValidUrl('https://test.com http://test2.com'), false)
+
+        assert.strictEqual(isValidUrl('https://test.com'), true)
+        assert.strictEqual(isValidUrl('http://test.com'), true)
+        assert.strictEqual(isValidUrl('http://test.com/path'), true)
     })
 })

--- a/packages/toolkit/.changes/next-release/Bug Fix-29e6ef4c-536b-47bb-ae27-26b802ccdb65.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-29e6ef4c-536b-47bb-ae27-26b802ccdb65.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Auth: Valid StartURL not accepted at login"
+}


### PR DESCRIPTION
## Problem:

A user reported that a non-standard start url is technically
valid. This is because it can redirect to the underlying valid
start url that matches the pattern: https://xxxxxxxx.awsapps.com/start

## Solution:

Allow any URL, but warn users if they are using a non-standard one.
We will show a yellow warning message in this case.
The red error message is still shown when the input does not match a
URL in general.

## Examples 

### Invalid URL
<img width="315" alt="Screenshot 2025-01-14 at 4 33 58 PM" src="https://github.com/user-attachments/assets/a5b2cb8a-c4fc-4678-a711-2f3f00bbe084" />

### Possibly valid since it may redirect to a valid URL
<img width="302" alt="Screenshot 2025-01-14 at 4 34 13 PM" src="https://github.com/user-attachments/assets/0690f818-f4ba-4eae-b037-f856f5a2b2a0" />

### Missing the trailing `/start`
<img width="295" alt="Screenshot 2025-01-14 at 4 34 29 PM" src="https://github.com/user-attachments/assets/8bcf3a4b-eba3-4bd8-8c68-24b709ee854d" />

### URL that also matches expected pattern
<img width="286" alt="Screenshot 2025-01-14 at 4 34 35 PM" src="https://github.com/user-attachments/assets/eea2f2cb-6500-469c-9836-96ffc9cb5794" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
