### PR TITLE
test(amazonq): update tests for messages at different remaining iteration counts

### DIFF
--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -566,7 +566,7 @@ export class FeatureDevController {
         if (isStoppedGeneration) {
             this.messenger.sendAnswer({
                 message: ((remainingIterations) => {
-                    if (remainingIterations && totalIterations) {
+                    if (totalIterations !== undefined) {
                         if (remainingIterations <= 0) {
                             return "I stopped generating your code. You don't have more iterations left, however, you can start a new session."
                         } else if (remainingIterations <= 2) {


### PR DESCRIPTION
## Problem

Previously the logic of showing different messages at different remaining iteration counts are tested manually.

## Solution

Adding tests to automate the process.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
