### PR TITLE
fix(amazonq): User can view file diff by file click

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-34e877a1-d2ca-4c93-9dee-5dd2019769fe.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-34e877a1-d2ca-4c93-9dee-5dd2019769fe.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Enabled users to view diffs by clicking files in the file tree, aligning the behavior with the 'View Diff' button."
+	"description": "`/test`: view diffs by clicking files in the file tree, aligning the behavior with the 'View Diff' button."
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-34e877a1-d2ca-4c93-9dee-5dd2019769fe.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-34e877a1-d2ca-4c93-9dee-5dd2019769fe.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Enabled users to view diffs by clicking files in the file tree, aligning the behavior with the 'View Diff' button."
+}

--- a/packages/core/src/amazonq/webview/ui/apps/testChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/testChatConnector.ts
@@ -13,6 +13,7 @@ import { TabsStorage, TabType } from '../storages/tabsStorage'
 import { TestMessageType } from '../../../../amazonqTest/chat/views/connector/connector'
 import { ChatPayload } from '../connector'
 import { BaseConnector, BaseConnectorProps } from './baseConnector'
+import { FollowUpTypes } from '../../../commons/types'
 
 export interface ConnectorProps extends BaseConnectorProps {
     sendMessageToExtension: (message: ExtensionMessage) => void
@@ -35,6 +36,7 @@ export interface MessageData {
 }
 // TODO: Refactor testChatConnector, scanChatConnector and other apps connector files post RIV
 export class Connector extends BaseConnector {
+    connector: any
     override getTabType(): TabType {
         return 'testgen'
     }
@@ -107,15 +109,40 @@ export class Connector extends BaseConnector {
     }
 
     onFileDiff = (tabID: string, filePath: string, deleted: boolean, messageId?: string): void => {
-        // TODO: add this back once we can advance flow from here
-        // this.sendMessageToExtension({
-        //     command: 'open-diff',
-        //     tabID,
-        //     filePath,
-        //     deleted,
-        //     messageId,
-        //     tabType: 'testgen',
-        // })
+        // Open diff view
+        this.sendMessageToExtension({
+            command: 'open-diff',
+            tabID,
+            filePath,
+            deleted,
+            messageId,
+            tabType: 'testgen',
+        })
+        this.onChatAnswerReceived?.(
+            tabID,
+            {
+                type: ChatItemType.ANSWER,
+                messageId: messageId,
+                followUp: {
+                    text: ' ',
+                    options: [
+                        {
+                            type: FollowUpTypes.AcceptCode,
+                            pillText: 'Accept',
+                            status: 'success',
+                            icon: MynahIcons.OK,
+                        },
+                        {
+                            type: FollowUpTypes.RejectCode,
+                            pillText: 'Reject',
+                            status: 'error',
+                            icon: MynahIcons.REVERT,
+                        },
+                    ],
+                },
+            },
+            {}
+        )
     }
 
     private processChatMessage = async (messageData: any): Promise<void> => {

--- a/packages/core/src/amazonq/webview/ui/apps/testChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/testChatConnector.ts
@@ -36,7 +36,6 @@ export interface MessageData {
 }
 // TODO: Refactor testChatConnector, scanChatConnector and other apps connector files post RIV
 export class Connector extends BaseConnector {
-    connector: any
     override getTabType(): TabType {
         return 'testgen'
     }
@@ -109,6 +108,9 @@ export class Connector extends BaseConnector {
     }
 
     onFileDiff = (tabID: string, filePath: string, deleted: boolean, messageId?: string): void => {
+        if (this.onChatAnswerReceived === undefined) {
+            return
+        }
         // Open diff view
         this.sendMessageToExtension({
             command: 'open-diff',
@@ -118,7 +120,7 @@ export class Connector extends BaseConnector {
             messageId,
             tabType: 'testgen',
         })
-        this.onChatAnswerReceived?.(
+        this.onChatAnswerReceived(
             tabID,
             {
                 type: ChatItemType.ANSWER,


### PR DESCRIPTION
## Problem
User can only view file diff by clicking the viewdiff button. This fix allows user view the file diff by clicking the file in file tree and update UI accordingly. 


https://github.com/user-attachments/assets/bd521c11-b881-4c52-80d9-5db225067ef6



## Solution
Update the onFileDiff function on testChatConnector. Send the file diff open request there and implement the onChatAnswerReceived function to handle the followup functionality. 

---


- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
