### PR TITLE
fix(amazonq): setMaven correctly

### DIFF
--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -53,11 +53,9 @@ import {
 import { CodeTransformTelemetryState } from '../../telemetry/codeTransformTelemetryState'
 import DependencyVersions from '../../models/dependencies'
 import { getStringHash } from '../../../shared/utilities/textUtilities'
-import { getVersionData } from '../../../codewhisperer/service/transformByQ/transformMavenHandler'
 import AdmZip from 'adm-zip'
 import { AuthError } from '../../../auth/sso/server'
 import {
-    setMaven,
     openBuildLogFile,
     parseBuildFile,
     validateSQLMetadataFile,
@@ -321,12 +319,6 @@ export class GumbyController {
                     telemetryJavaVersion = JDKToTelemetryValue(javaVersion) as CodeTransformJavaSourceVersionsAllowed
                 }
                 telemetry.record({ codeTransformLocalJavaVersion: telemetryJavaVersion })
-
-                await setMaven()
-                const versionInfo = await getVersionData()
-                const mavenVersionInfoMessage = `${versionInfo[0]} (${transformByQState.getMavenName()})`
-                telemetry.record({ buildSystemVersion: mavenVersionInfoMessage })
-
                 return validProjects
             })
             return validProjects

--- a/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
@@ -11,7 +11,7 @@ import { spawnSync } from 'child_process' // eslint-disable-line no-restricted-i
 import { CodeTransformBuildCommand, telemetry } from '../../../shared/telemetry/telemetry'
 import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/codeTransformTelemetryState'
 import { ToolkitError } from '../../../shared/errors'
-import { writeLogs } from './transformFileHandler'
+import { setMaven, writeLogs } from './transformFileHandler'
 import { throwIfCancelled } from './transformApiHandler'
 
 // run 'install' with either 'mvnw.cmd', './mvnw', or 'mvn' (if wrapper exists, we use that, otherwise we use regular 'mvn')
@@ -108,6 +108,10 @@ function copyProjectDependencies(dependenciesFolder: FolderInfo, modulePath: str
 }
 
 export async function prepareProjectDependencies(dependenciesFolder: FolderInfo, rootPomPath: string) {
+    await setMaven()
+    getLogger().info(
+        `CodeTransformation: about to build project locally with Maven ${transformByQState.getMavenName()}`
+    )
     try {
         copyProjectDependencies(dependenciesFolder, rootPomPath)
     } catch (err) {
@@ -134,9 +138,9 @@ export async function prepareProjectDependencies(dependenciesFolder: FolderInfo,
 
 export async function getVersionData() {
     const baseCommand = transformByQState.getMavenName() // will be one of: 'mvnw.cmd', './mvnw', 'mvn'
-    const modulePath = transformByQState.getProjectPath()
+    const projectPath = transformByQState.getProjectPath()
     const args = ['-v']
-    const spawnResult = spawnSync(baseCommand, args, { cwd: modulePath, shell: true, encoding: 'utf-8' })
+    const spawnResult = spawnSync(baseCommand, args, { cwd: projectPath, shell: true, encoding: 'utf-8' })
 
     let localMavenVersion: string | undefined = ''
     let localJavaVersion: string | undefined = ''


### PR DESCRIPTION
## Problem

`setMaven` is being executed unnecessarily.

## Solution

Move the call to happen just before the local build starts.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
