### PR TITLE
refactor(util): merge withRetries and waitUntil

### DIFF
--- a/packages/core/src/shared/utilities/functionUtils.ts
+++ b/packages/core/src/shared/utilities/functionUtils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { sleep, Timeout } from './timeoutUtils'
+import { Timeout } from './timeoutUtils'
 
 /**
  * Creates a function that always returns a 'shared' Promise.
@@ -143,36 +143,5 @@ export function cancellableDebounce<T, U extends any[]>(
             }))
         },
         cancel: cancel,
-    }
-}
-
-/**
- * Executes the given function, retrying if it throws.
- *
- * @param opts - if no opts given, defaults are used
- */
-export async function withRetries<T>(
-    fn: () => Promise<T>,
-    opts?: { maxRetries?: number; delay?: number; backoff?: number }
-): Promise<T> {
-    const maxRetries = opts?.maxRetries ?? 3
-    const delay = opts?.delay ?? 0
-    const backoff = opts?.backoff ?? 1
-
-    let retryCount = 0
-    let latestDelay = delay
-    while (true) {
-        try {
-            return await fn()
-        } catch (err) {
-            retryCount++
-            if (retryCount >= maxRetries) {
-                throw err
-            }
-            if (latestDelay > 0) {
-                await sleep(latestDelay)
-                latestDelay = latestDelay * backoff
-            }
-        }
     }
 }

--- a/packages/core/src/shared/utilities/timeoutUtils.ts
+++ b/packages/core/src/shared/utilities/timeoutUtils.ts
@@ -222,9 +222,9 @@ interface WaitUntilOptions {
     /** A backoff multiplier for how long the next interval will be (default: None, i.e 1) */
     readonly backoff?: number
     /**
-     * Only retries when an error is thrown, otherwise returning the result regardless of truthiness.
-     * - Ignores 'truthy' arg
-     * - If the timeout is reached it will throw the last error
+     * Only retries when an error is thrown, otherwise returning the immediate result.
+     * - 'truthy' arg is ignored
+     * - If the timeout is reached it throws the last error
      * - default: false
      */
     readonly retryOnFail?: boolean
@@ -234,14 +234,13 @@ export const waitUntilDefaultTimeout = 2000
 export const waitUntilDefaultInterval = 500
 
 /**
- * Invokes `fn()` until it returns a truthy value (or non-undefined if `truthy:false`).
- *
- * Also look at {@link withRetries} to be able to retry on failures.
+ * Invokes `fn()` on an interval based on the given arguments. This can be used for retries, or until
+ * an expected result is given. Read {@link WaitUntilOptions} carefully.
  *
  * @param fn  Function whose result is checked
  * @param options  See {@link WaitUntilOptions}
  *
- * @returns Result of `fn()`, or `undefined` if timeout was reached.
+ * @returns Result of `fn()`, or possibly `undefined` depending on the arguments.
  */
 export async function waitUntil<T>(fn: () => Promise<T>, options: WaitUntilOptions & { retryOnFail: true }): Promise<T>
 export async function waitUntil<T>(
@@ -308,7 +307,7 @@ export async function waitUntil<T>(fn: () => Promise<T>, options: WaitUntilOptio
             throw lastError
         }
 
-        // when testing, this saves the need to progress the stubbed clock
+        // when testing, this avoids the need to progress the stubbed clock
         if (interval > 0) {
             await sleep(interval)
         }

--- a/packages/core/src/test/notifications/controller.test.ts
+++ b/packages/core/src/test/notifications/controller.test.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import * as FakeTimers from '@sinonjs/fake-timers'
 import assert from 'assert'
-import sinon from 'sinon'
+import sinon, { createSandbox } from 'sinon'
 import globals from '../../shared/extensionGlobals'
 import { randomUUID } from '../../shared/crypto'
 import { getContext } from '../../shared/vscode/setContext'
@@ -27,6 +27,7 @@ import {
 import { HttpResourceFetcher } from '../../shared/resourcefetcher/httpResourceFetcher'
 import { NotificationsNode } from '../../notifications/panelNode'
 import { RuleEngine } from '../../notifications/rules'
+import Sinon from 'sinon'
 
 // one test node to use across different tests
 export const panelNode: NotificationsNode = NotificationsNode.instance
@@ -512,13 +513,16 @@ describe('Notifications Controller', function () {
 
 describe('RemoteFetcher', function () {
     let clock: FakeTimers.InstalledClock
+    let sandbox: Sinon.SinonSandbox
 
     before(function () {
         clock = installFakeClock()
+        sandbox = createSandbox()
     })
 
     afterEach(function () {
         clock.reset()
+        sandbox.restore()
     })
 
     after(function () {
@@ -526,29 +530,29 @@ describe('RemoteFetcher', function () {
     })
 
     it('retries and throws error', async function () {
-        const httpStub = sinon.stub(HttpResourceFetcher.prototype, 'getNewETagContent')
+        // Setup
+        const httpStub = sandbox.stub(HttpResourceFetcher.prototype, 'getNewETagContent')
         httpStub.throws(new Error('network error'))
 
-        const runClock = (async () => {
-            await clock.tickAsync(1)
-            for (let n = 1; n <= RemoteFetcher.retryNumber; n++) {
-                assert.equal(httpStub.callCount, n)
-                await clock.tickAsync(RemoteFetcher.retryIntervalMs)
-            }
+        // Start function under test
+        const fetcher = new RemoteFetcher().fetch('startUp', 'any').then(() => assert.fail('Did not throw exception.'))
 
-            // Stop trying
-            await clock.tickAsync(RemoteFetcher.retryNumber)
-            assert.equal(httpStub.callCount, RemoteFetcher.retryNumber)
-        })()
+        // Progresses the clock, allowing the fetcher logic to break out of sleep for each iteration of withRetries()
+        assert.strictEqual(httpStub.callCount, 1) // 0
+        await clock.tickAsync(RemoteFetcher.retryIntervalMs)
+        assert.strictEqual(httpStub.callCount, 2) // 30_000
+        await clock.tickAsync(RemoteFetcher.retryIntervalMs)
+        assert.strictEqual(httpStub.callCount, 3) // 60_000
+        await clock.tickAsync(RemoteFetcher.retryIntervalMs)
+        assert.strictEqual(httpStub.callCount, 4) // 120_000
+        httpStub.throws(new Error('last error'))
+        await clock.tickAsync(RemoteFetcher.retryIntervalMs)
+        assert.strictEqual(httpStub.callCount, 5) // 150_000
 
-        const fetcher = new RemoteFetcher()
-        await fetcher
-            .fetch('startUp', 'any')
-            .then(() => assert.ok(false, 'Did not throw exception.'))
-            .catch(() => assert.ok(true))
-        await runClock
-
-        httpStub.restore()
+        // We hit timeout so the last error will be thrown
+        await assert.rejects(fetcher, (e) => {
+            return e instanceof Error && e.message === 'last error'
+        })
     })
 })
 

--- a/packages/core/src/test/notifications/controller.test.ts
+++ b/packages/core/src/test/notifications/controller.test.ts
@@ -535,7 +535,9 @@ describe('RemoteFetcher', function () {
         httpStub.throws(new Error('network error'))
 
         // Start function under test
-        const fetcher = new RemoteFetcher().fetch('startUp', 'any').then(() => assert.fail('Did not throw exception.'))
+        const fetcher = assert.rejects(new RemoteFetcher().fetch('startUp', 'any'), (e) => {
+            return e instanceof Error && e.message === 'last error'
+        })
 
         // Progresses the clock, allowing the fetcher logic to break out of sleep for each iteration of withRetries()
         assert.strictEqual(httpStub.callCount, 1) // 0
@@ -550,9 +552,7 @@ describe('RemoteFetcher', function () {
         assert.strictEqual(httpStub.callCount, 5) // 150_000
 
         // We hit timeout so the last error will be thrown
-        await assert.rejects(fetcher, (e) => {
-            return e instanceof Error && e.message === 'last error'
-        })
+        await fetcher
     })
 })
 

--- a/packages/core/src/test/shared/utilities/functionUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/functionUtils.test.ts
@@ -4,10 +4,8 @@
  */
 
 import assert from 'assert'
-import { once, onceChanged, debounce, withRetries } from '../../../shared/utilities/functionUtils'
+import { once, onceChanged, debounce } from '../../../shared/utilities/functionUtils'
 import { installFakeClock } from '../../testUtil'
-import { stub, SinonStub } from 'sinon'
-import { InstalledClock } from '@sinonjs/fake-timers'
 
 describe('functionUtils', function () {
     it('once()', function () {
@@ -107,84 +105,5 @@ describe('debounce', function () {
             assert.strictEqual(counter, 2)
             assert.strictEqual(calls.length, 4)
         })
-    })
-})
-
-// function to test the withRetries method. It passes in a stub function as the argument and has different tests that throw on different iterations
-describe('withRetries', function () {
-    let clock: InstalledClock
-    let fn: SinonStub
-
-    beforeEach(function () {
-        fn = stub()
-        clock = installFakeClock()
-    })
-
-    afterEach(function () {
-        clock.uninstall()
-    })
-
-    it('retries the function until it succeeds, using defaults', async function () {
-        fn.onCall(0).throws()
-        fn.onCall(1).throws()
-        fn.onCall(2).resolves('success')
-        assert.strictEqual(await withRetries(fn), 'success')
-    })
-
-    it('retries the function until it succeeds at the final try', async function () {
-        fn.onCall(0).throws()
-        fn.onCall(1).throws()
-        fn.onCall(2).throws()
-        fn.onCall(3).resolves('success')
-        assert.strictEqual(await withRetries(fn, { maxRetries: 4 }), 'success')
-    })
-
-    it('throws the last error if the function always fails, using defaults', async function () {
-        fn.onCall(0).throws()
-        fn.onCall(1).throws()
-        fn.onCall(2).throws()
-        fn.onCall(3).resolves('unreachable')
-        await assert.rejects(async () => {
-            await withRetries(fn)
-        })
-    })
-
-    it('throws the last error if the function always fails', async function () {
-        fn.onCall(0).throws()
-        fn.onCall(1).throws()
-        fn.onCall(2).throws()
-        fn.onCall(3).throws()
-        fn.onCall(4).resolves('unreachable')
-        await assert.rejects(async () => {
-            await withRetries(fn, { maxRetries: 4 })
-        })
-    })
-
-    it('honors retry delay + backoff multiplier', async function () {
-        fn.onCall(0).throws() // 100ms
-        fn.onCall(1).throws() // 200ms
-        fn.onCall(2).throws() // 400ms
-        fn.onCall(3).resolves('success')
-
-        const res = withRetries(fn, { maxRetries: 4, delay: 100, backoff: 2 })
-
-        // Check the call count after each iteration, ensuring the function is called
-        // after the correct delay between retries.
-        await clock.tickAsync(99)
-        assert.strictEqual(fn.callCount, 1)
-        await clock.tickAsync(1)
-        assert.strictEqual(fn.callCount, 2)
-
-        await clock.tickAsync(199)
-        assert.strictEqual(fn.callCount, 2)
-        await clock.tickAsync(1)
-        assert.strictEqual(fn.callCount, 3)
-
-        await clock.tickAsync(399)
-        assert.strictEqual(fn.callCount, 3)
-        await clock.tickAsync(1)
-        assert.strictEqual(fn.callCount, 4)
-
-        assert.strictEqual(await res, 'success')
     })
 })

--- a/packages/core/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/timeoutUtils.test.ts
@@ -388,7 +388,7 @@ export const timeoutUtilsDescribe = describe('timeoutUtils', async function () {
     })
 
     describe('waitUntil w/ retries', function () {
-        let fn: SinonStub
+        let fn: SinonStub<[], Promise<string | boolean>>
 
         beforeEach(function () {
             fn = sandbox.stub()


### PR DESCRIPTION
## Problem:

We had 2 different implementation of similar code, between withRetries and waitUntil.

We couldn't easily merge them though since behavior was slightly different when it came to expected return types, and since one threw and the other did not.

- waitUntil returns undefined if it never properly resolves
- withRetries throws if it never properly resolves

## Solution:

As a solution we keep both methods but they share the same underlying code.

- waitUntil now has a backoff field to increase the delta between intervals
  - withRetries also has this
- withRetries will retry even on a thrown exeception
  - on timeout it will throw the last exception it encountered

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
