### PR TITLE
revert(amazonq): defaultServiceConfig endpoint change

### DIFF
--- a/packages/core/src/codewhisperer/client/codewhisperer.ts
+++ b/packages/core/src/codewhisperer/client/codewhisperer.ts
@@ -31,8 +31,8 @@ export interface CodeWhispererConfig {
 }
 
 export const defaultServiceConfig: CodeWhispererConfig = {
-    region: 'us-west-2',
-    endpoint: 'https://rts.alpha-us-west-2.codewhisperer.ai.aws.dev/',
+    region: 'us-east-1',
+    endpoint: 'https://codewhisperer.us-east-1.amazonaws.com/',
 }
 
 export function getCodewhispererConfig(): CodeWhispererConfig {


### PR DESCRIPTION
Revert endpoint change in previous commit: https://github.com/aws/aws-toolkit-vscode/commit/062d24a8dad43527bf3fd52f80b60fecce876de5


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
