### PR TITLE
ci(core): Request should not throw on 304 status

### DIFF
--- a/packages/core/src/shared/request.ts
+++ b/packages/core/src/shared/request.ts
@@ -99,7 +99,11 @@ class FetchRequest {
     }
 
     async #throwIfBadResponse(request: RequestParams, response: Response, url: string) {
-        if (response.ok) {
+        /**
+         * response.ok only returns true for 200-299.
+         * We need to explicitly allow 304 since it means the cached version is still valid
+         */
+        if (response.ok || response.status === 304) {
             return
         }
 


### PR DESCRIPTION
## Problem
Only 200-299 are treated as "response.ok" responses by fetch. However, 304's (content not modified) are valid response codes as well

## Solution
If the status code is 304 then don't throw

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
