### PR TITLE
fix(notifications): dismiss command visible in command palette

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-a49b3835-40c5-4878-ac0c-c4c613f1bf97.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-a49b3835-40c5-4878-ac0c-c4c613f1bf97.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Notifications: 'Dismiss' command visible in command palette."
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -198,7 +198,7 @@
                 {
                     "id": "aws.amazonq.notifications",
                     "name": "%AWS.notifications.title%",
-                    "when": "!isCloud9 && !aws.isSageMaker && aws.amazonq.notifications.show"
+                    "when": "!(isCloud9 || aws.isSageMaker) && aws.amazonq.notifications.show"
                 },
                 {
                     "type": "webview",
@@ -493,7 +493,7 @@
                 "command": "_aws.amazonq.notifications.dismiss",
                 "title": "%AWS.generic.dismiss%",
                 "category": "%AWS.amazonq.title%",
-                "enablement": "isCloud9 || !aws.isWebExtHost",
+                "enablement": "view == aws.amazonq.notifications",
                 "icon": "$(remove-close)"
             },
             {

--- a/packages/toolkit/.changes/next-release/Bug Fix-f7aec5a8-a21c-4539-9ed4-820dd9887598.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-f7aec5a8-a21c-4539-9ed4-820dd9887598.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Notifications: 'Dismiss' command visible in command palette."
+}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -732,7 +732,7 @@
                 {
                     "id": "aws.toolkit.notifications",
                     "name": "%AWS.notifications.title%",
-                    "when": "!isCloud9 && !aws.isSageMaker && aws.toolkit.notifications.show"
+                    "when": "!(isCloud9 || aws.isSageMaker) && aws.toolkit.notifications.show"
                 },
                 {
                     "id": "aws.amazonq.codewhisperer",
@@ -2231,7 +2231,7 @@
                 "command": "_aws.toolkit.notifications.dismiss",
                 "title": "%AWS.generic.dismiss%",
                 "category": "%AWS.title%",
-                "enablement": "isCloud9 || !aws.isWebExtHost",
+                "enablement": "view == aws.toolkit.notifications",
                 "icon": "$(remove-close)"
             },
             {


### PR DESCRIPTION
Gets rid of these

![image](https://github.com/user-attachments/assets/d0afa2c8-c8c5-43d0-82a0-1ea086be5239)

You can still dismiss by clicking the X button next to non-emergency notifications.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
