### PR TITLE
fix(amazonq): /doc prompt refusal error message text update

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -392,7 +392,7 @@
     "AWS.amazonq.doc.error.promptUnrelated": "These changes don't seem related to documentation. Try describing your changes again, using the following best practices:\n- Changes should relate to how project functionality is reflected in the README\n- Content you refer to should be available in your codebase\n\n For more information on prompt best practices, see the <a href=\"https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/doc-generation.html\" target=\"_blank\">Amazon Q Developer documentation.</a>",
     "AWS.amazonq.doc.error.docGen.default": "I'm sorry, I ran into an issue while trying to generate your documentation. Please try again.",
     "AWS.amazonq.doc.error.noChangeRequiredException": "I couldn't find any code changes to update in the README. Try another documentation task.",
-    "AWS.amazonq.doc.error.promptRefusal": "I'm sorry, I can't generate documentation for this folder. Please make sure your message and code files comply with the Please make sure your message and code files comply with the <a href=\"https://aws.amazon.com/machine-learning/responsible-ai/policy/\">AWS Responsible AI Policy.</a>",
+    "AWS.amazonq.doc.error.promptRefusal": "I'm sorry, I can't generate documentation for this folder. Please make sure your message and code files comply with the <a href=\"https://aws.amazon.com/machine-learning/responsible-ai/policy/\">AWS Responsible AI Policy.</a>",
     "AWS.amazonq.doc.placeholder.editReadme": "Describe documentation changes",
     "AWS.amazonq.doc.pillText.closeSession": "End session",
     "AWS.amazonq.doc.pillText.newTask": "Start a new documentation task",


### PR DESCRIPTION
## Problem
A phrase is repeated in the error message for prompt refusal when updating a README in /doc

## Solution
Fix error message for prompt refusal

Note: changelog is not updated since error message updating already included [in changelog for this release](https://github.com/aws/aws-toolkit-vscode/commit/bcdfcdd5d87e90c2d7bdd6a3f7a9b0112eb7bc00#diff-6edd3b49931bb5d80cf0b6d048305bb4902587900e26fea567efe8a1bca38decR3)



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
