### PR TITLE
refactor(core): Manifest/LSP fetching should use httpResourceFetcher

### DIFF
--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -14,8 +14,6 @@ import { getApplicationSupportFolder } from '../vscode/env'
 import { createHash } from '../crypto'
 import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
 
-const lspFetchRetries = 3
-
 export class LanguageServerResolver {
     constructor(
         private readonly manifest: Manifest,
@@ -167,7 +165,7 @@ export class LanguageServerResolver {
         }
 
         const downloadTasks = contents.map(async (content) => {
-            const res = await new HttpResourceFetcher(content.url, { showUrl: true, retries: lspFetchRetries }).get()
+            const res = await new HttpResourceFetcher(content.url, { showUrl: true }).get()
             if (!res || !res.ok || !res.body) {
                 return false
             }

--- a/packages/core/src/shared/lsp/manifestResolver.ts
+++ b/packages/core/src/shared/lsp/manifestResolver.ts
@@ -21,7 +21,6 @@ type ManifestStorage = Record<string, StorageManifest>
 
 const manifestStorageKey = 'aws.toolkit.lsp.manifest'
 const manifestTimeoutMs = 15000
-const manifestFetchRetries = 3
 
 export class ManifestResolver {
     constructor(
@@ -44,7 +43,6 @@ export class ManifestResolver {
         const resp = await new HttpResourceFetcher(this.manifestURL, {
             showUrl: true,
             timeout: new Timeout(manifestTimeoutMs),
-            retries: manifestFetchRetries,
         }).getNewETagContent(this.getEtag())
 
         if (!resp.content) {

--- a/packages/core/src/shared/lsp/manifestResolver.ts
+++ b/packages/core/src/shared/lsp/manifestResolver.ts
@@ -5,10 +5,10 @@
 
 import { getLogger } from '../logger/logger'
 import { ToolkitError } from '../errors'
-import { RetryableResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
 import { Timeout } from '../utilities/timeoutUtils'
 import globals from '../extensionGlobals'
 import { Manifest } from './types'
+import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
 
 const logger = getLogger('lsp')
 
@@ -21,6 +21,7 @@ type ManifestStorage = Record<string, StorageManifest>
 
 const manifestStorageKey = 'aws.toolkit.lsp.manifest'
 const manifestTimeoutMs = 15000
+const manifestFetchRetries = 3
 
 export class ManifestResolver {
     constructor(
@@ -40,14 +41,12 @@ export class ManifestResolver {
     }
 
     private async fetchRemoteManifest(): Promise<Manifest> {
-        const resourceFetcher = new RetryableResourceFetcher({
-            resource: this.manifestURL,
-            params: {
-                timeout: new Timeout(manifestTimeoutMs),
-            },
-        })
+        const resp = await new HttpResourceFetcher(this.manifestURL, {
+            showUrl: true,
+            timeout: new Timeout(manifestTimeoutMs),
+            retries: manifestFetchRetries,
+        }).getNewETagContent(this.getEtag())
 
-        const resp = await resourceFetcher.getNewETagContent(this.getEtag())
         if (!resp.content) {
             throw new ToolkitError('New content was not downloaded; fallback to the locally stored manifest')
         }

--- a/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -134,50 +134,6 @@ export class HttpResourceFetcher implements ResourceFetcher<Response> {
     }
 }
 
-export class RetryableResourceFetcher extends HttpResourceFetcher {
-    private readonly retryNumber: number
-    private readonly retryIntervalMs: number
-    private readonly resource: string
-
-    constructor({
-        resource,
-        params: { retryNumber = 5, retryIntervalMs = 3000, showUrl = true, timeout = new Timeout(5000) },
-    }: {
-        resource: string
-        params: {
-            retryNumber?: number
-            retryIntervalMs?: number
-            showUrl?: boolean
-            timeout?: Timeout
-        }
-    }) {
-        super(resource, {
-            showUrl,
-            timeout,
-        })
-        this.retryNumber = retryNumber
-        this.retryIntervalMs = retryIntervalMs
-        this.resource = resource
-    }
-
-    fetch(versionTag?: string) {
-        return withRetries(
-            async () => {
-                try {
-                    return await this.getNewETagContent(versionTag)
-                } catch (err) {
-                    getLogger('lsp').error('Failed to fetch at endpoint: %s, err: %s', this.resource, err)
-                    throw err
-                }
-            },
-            {
-                maxRetries: this.retryNumber,
-                delay: this.retryIntervalMs,
-            }
-        )
-    }
-}
-
 /**
  * Retrieves JSON property value from a remote resource
  * @param property property to retrieve

--- a/packages/webpack.web.config.js
+++ b/packages/webpack.web.config.js
@@ -41,7 +41,7 @@ module.exports = (env, argv) => {
              * environments. The following allows compilation to pass in Web mode by never bundling the module in the final output for web mode.
              */
             new webpack.IgnorePlugin({
-                resourceRegExp: /httpResourceFetcher/, // matches the path in the require() statement
+                resourceRegExp: /node\/httpResourceFetcher/, // matches the path in the require() statement
             }),
             /**
              * HACK: the ps-list module breaks Web mode if imported, BUT we still dynamically import this module for non web mode


### PR DESCRIPTION
## Problem
Now that we've refactored the httpResourceFetcher a little bit we can use that for fetching both the manifest and the language server

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
