### PR TITLE
feat(amazonq): java21 support

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-f0b1a42d-ee00-4b68-9160-cbae9bd27873.json
+++ b/packages/amazonq/.changes/next-release/Feature-f0b1a42d-ee00-4b68-9160-cbae9bd27873.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "/transform: support Java 21 transformations"
+}

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -483,6 +483,7 @@ export class GumbyController {
                 message.tabID
             )
 
+            // do not allow downgrades
             if (fromJDKVersion === JDKVersion.JDK21 && toJDKVersion === JDKVersion.JDK17) {
                 this.messenger.sendUnrecoverableErrorResponse('invalid-from-to-jdk', message.tabID)
                 return

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -483,6 +483,11 @@ export class GumbyController {
                 message.tabID
             )
 
+            if (fromJDKVersion === JDKVersion.JDK21 && toJDKVersion === JDKVersion.JDK17) {
+                this.messenger.sendUnrecoverableErrorResponse('invalid-from-to-jdk', message.tabID)
+                return
+            }
+
             await processLanguageUpgradeTransformFormInput(pathToProject, fromJDKVersion, toJDKVersion)
             await this.messenger.sendSkipTestsPrompt(message.tabID)
         })

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -483,7 +483,7 @@ export class GumbyController {
                 message.tabID
             )
 
-            // do not allow downgrades
+            // do not allow downgrades (only this combination can be selected in the UI)
             if (fromJDKVersion === JDKVersion.JDK21 && toJDKVersion === JDKVersion.JDK17) {
                 this.messenger.sendUnrecoverableErrorResponse('invalid-from-to-jdk', message.tabID)
                 return

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -51,6 +51,7 @@ export type UnrecoverableErrorType =
     | 'unsupported-target-db'
     | 'error-parsing-sct-file'
     | 'invalid-zip-no-sct-file'
+    | 'invalid-from-to-jdk'
 
 export enum GumbyNamedMessages {
     COMPILATION_PROGRESS_MESSAGE = 'gumbyProjectCompilationMessage',
@@ -176,7 +177,9 @@ export class Messenger {
         this.dispatcher.sendAsyncEventProgress(
             new AsyncEventProgressMessage(tabID, {
                 inProgress: true,
-                message: CodeWhispererConstants.userPatchDescriptionChatMessage,
+                message: CodeWhispererConstants.userPatchDescriptionChatMessage(
+                    transformByQState.getTargetJDKVersion() ?? ''
+                ),
             })
         )
 
@@ -233,6 +236,10 @@ export class Messenger {
                     value: JDKVersion.JDK17,
                     label: JDKVersion.JDK17,
                 },
+                {
+                    value: JDKVersion.JDK21,
+                    label: JDKVersion.JDK21,
+                },
             ],
         })
 
@@ -245,6 +252,10 @@ export class Messenger {
                 {
                     value: JDKVersion.JDK17,
                     label: JDKVersion.JDK17,
+                },
+                {
+                    value: JDKVersion.JDK21,
+                    label: JDKVersion.JDK21,
                 },
             ],
         })
@@ -480,6 +491,9 @@ export class Messenger {
                 break
             case 'invalid-zip-no-sct-file':
                 message = CodeWhispererConstants.invalidMetadataFileNoSctFile
+                break
+            case 'invalid-from-to-jdk':
+                message = CodeWhispererConstants.invalidFromToJdkChatMessage
                 break
         }
 

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
@@ -52,6 +52,8 @@ export default class MessengerUtils {
                 javaHomePrompt += ` ${CodeWhispererConstants.macJavaVersionHomeHelpChatMessage(11)}`
             } else if (jdkVersion === JDKVersion.JDK17) {
                 javaHomePrompt += ` ${CodeWhispererConstants.macJavaVersionHomeHelpChatMessage(17)}`
+            } else if (jdkVersion === JDKVersion.JDK21) {
+                javaHomePrompt += ` ${CodeWhispererConstants.macJavaVersionHomeHelpChatMessage(21)}`
             }
         } else {
             javaHomePrompt += ` ${CodeWhispererConstants.linuxJavaHomeHelpChatMessage}`

--- a/packages/core/src/codewhisperer/client/user-service-2.json
+++ b/packages/core/src/codewhisperer/client/user-service-2.json
@@ -2606,7 +2606,7 @@
         },
         "TransformationJavaRuntimeEnv": {
             "type": "string",
-            "enum": ["JVM_8", "JVM_11", "JVM_17"]
+            "enum": ["JVM_8", "JVM_11", "JVM_17", "JVM_21"]
         },
         "TransformationJob": {
             "type": "structure",
@@ -2629,7 +2629,7 @@
         },
         "TransformationLanguage": {
             "type": "string",
-            "enum": ["JAVA_8", "JAVA_11", "JAVA_17", "C_SHARP", "COBOL", "PL_I", "JCL"]
+            "enum": ["JAVA_8", "JAVA_11", "JAVA_17", "JAVA_21", "C_SHARP", "COBOL", "PL_I", "JCL"]
         },
         "TransformationLanguages": {
             "type": "list",

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -119,6 +119,8 @@ async function validateJavaHome(): Promise<boolean> {
             javaVersionUsedByMaven = JDKVersion.JDK11
         } else if (javaVersionUsedByMaven === '17.') {
             javaVersionUsedByMaven = JDKVersion.JDK17
+        } else if (javaVersionUsedByMaven === '21.') {
+            javaVersionUsedByMaven = JDKVersion.JDK21
         }
     }
     if (javaVersionUsedByMaven !== transformByQState.getSourceJDKVersion()) {

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -675,7 +675,7 @@ export const noPomXmlFoundChatMessage = `I couldn\'t find a project that I can u
 export const noJavaHomeFoundChatMessage = `Sorry, I couldn\'t locate your Java installation. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const dependencyVersionsErrorMessage =
-    'I could not find any other versions of this dependency in your local Maven repository. Try transforming the dependency to make it compatible with Java 17, and then try transforming this module again.'
+    'I could not find any other versions of this dependency in your local Maven repository. Try transforming the dependency to make it compatible with your target Java version, and then try transforming this module again.'
 
 export const errorUploadingWithExpiredUrl = `The upload error may have been caused by the expiration of the S3 pre-signed URL that was used to upload code artifacts to Q Code Transformation. The S3 pre-signed URL expires in 30 minutes. This could be caused by any delays introduced by intermediate services in your network infrastructure. Please investigate your network configuration and consider allowlisting 'amazonq-code-transformation-us-east-1-c6160f047e0.s3.amazonaws.com' to skip any reviewing that might delay the upload. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootAllowS3Access}).`
 
@@ -725,7 +725,7 @@ export const changesAppliedNotificationMultipleDiffs = (currentPatchIndex: numbe
     }
 }
 
-export const noOpenProjectsFoundChatMessage = `I couldn\'t find a project that I can upgrade. Currently, I support Java 8, Java 11, and Java 17 projects built on Maven. Make sure your project is open in the IDE. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
+export const noOpenProjectsFoundChatMessage = `I couldn\'t find a project that I can upgrade. Currently, I support Java 8, Java 11, Java 17, and Java 21 projects built on Maven. Make sure your project is open in the IDE. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const noOpenFileFoundChatMessage = `Sorry, there isn't a source file open right now that I can generate a test for. Make sure you open a source file so I can generate tests.`
 
@@ -737,7 +737,7 @@ export const unitTestGenerationCancelMessage = 'Unit test generation cancelled.'
 
 export const tooManyRequestErrorMessage = 'Too many requests. Please wait before retrying.'
 
-export const noJavaProjectsFoundChatMessage = `I couldn\'t find a project that I can upgrade. Currently, I support Java 8, Java 11, and Java 17 projects built on Maven. Make sure your project is open in the IDE. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
+export const noJavaProjectsFoundChatMessage = `I couldn\'t find a project that I can upgrade. Currently, I support Java 8, Java 11, Java 17, and Java 21 projects built on Maven. Make sure your project is open in the IDE. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
 export const linkToDocsHome = 'https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html'
 

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -22,9 +22,12 @@ export const AWSTemplateKeyWords = ['AWSTemplateFormatVersion', 'Resources', 'AW
 
 export const AWSTemplateCaseInsensitiveKeyWords = ['cloudformation', 'cfn', 'template', 'description']
 
+// TO-DO: make sure all Strings look good for Java 21
 const patchDescriptions: { [key: string]: string } = {
     'Prepare minimal upgrade to Java 17':
-        'This diff patch covers the set of upgrades for Springboot, JUnit, and PowerMockito frameworks.',
+        'This diff patch covers the set of upgrades for Springboot, JUnit, and PowerMockito frameworks in Java 17.',
+    'Prepare minimal upgrade to Java 21':
+        'This diff patch covers the set of upgrades for Springboot, JUnit, and PowerMockito frameworks in Java 21.',
     'Popular Enterprise Specifications and Application Frameworks upgrade':
         'This diff patch covers the set of upgrades for Jakarta EE 10, Hibernate 6.2, and Micronaut 3.',
     'HTTP Client Utilities, Apache Commons Utilities, and Web Frameworks':
@@ -505,14 +508,14 @@ export const codeTransformLocThreshold = 100000
 export const jobStartedChatMessage =
     'I am starting to transform your code. It can take 10 to 30 minutes to upgrade your code, depending on the size of your project. To monitor progress, go to the Transformation Hub. If I run into any issues, I might pause the transformation to get input from you on how to proceed.'
 
-export const chooseTransformationObjective = `I can help you with the following tasks:\n- Upgrade your Java 8 and Java 11 codebases to Java 17, or upgrade Java 17 code with up to date libraries and other dependencies.\n- Convert embedded SQL code for Oracle to PostgreSQL database migrations in AWS DMS. [Learn more](https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-embedded-sql.html).\n\nWhat would you like to do? You can enter "language upgrade" or "sql conversion".`
+export const chooseTransformationObjective = `I can help you with the following tasks:\n- Upgrade your Java 8, Java 11, and Java 17 codebases to Java 17 or Java 21.\n- Upgrade Java 17 or Java 21 code with up-to-date libraries and other dependencies.\n- Convert embedded SQL code for Oracle to PostgreSQL database migrations in AWS DMS. [Learn more](https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-embedded-sql.html).\n\nWhat would you like to do? You can enter "language upgrade" or "sql conversion".`
 
 export const chooseTransformationObjectivePlaceholder = 'Enter "language upgrade" or "sql conversion"'
 
-export const userPatchDescriptionChatMessage = `
+export const userPatchDescriptionChatMessage = (version: string) => `
 If you'd like to update and test your code with fewer changes at a time, I can divide the transformation results into separate diff patches. If applicable to your application, I can split up the diffs up into the following groups of upgrades. Here are the upgrades included in each diff:
 
-• Minimal Compatible Library Upgrade to Java 17: Dependencies to the minimum compatible versions in Java 17, including Springboot, JUnit, and PowerMockito.
+• Minimal Compatible Library Upgrade to Java ${version}: Dependencies to the minimum compatible versions in Java ${version}, including Springboot, JUnit, and PowerMockito.
 
 • Popular Enterprise Specifications Application Frameworks: Popular enterprise and application frameworks like Jakarta EE, Hibernate, and Micronaut 3.
 
@@ -596,6 +599,9 @@ export const invalidMetadataFileErrorParsing =
 
 export const invalidMetadataFileNoSctFile =
     "An .sct file is required for transformation. Make sure that you've uploaded the .zip file you retrieved from your schema conversion in AWS DMS."
+
+export const invalidFromToJdkChatMessage =
+    "I can't transform a project from Java 21 to Java 17, but I can upgrade Java 21 code with up to date libraries and other dependencies. Try again with a supported language upgrade."
 
 export const sqlMetadataFileReceived =
     'I found the following source database, target database, and host based on the schema conversion metadata you provided:'

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -22,7 +22,6 @@ export const AWSTemplateKeyWords = ['AWSTemplateFormatVersion', 'Resources', 'AW
 
 export const AWSTemplateCaseInsensitiveKeyWords = ['cloudformation', 'cfn', 'template', 'description']
 
-// TO-DO: make sure all Strings look good for Java 21
 const patchDescriptions: { [key: string]: string } = {
     'Prepare minimal upgrade to Java 17':
         'This diff patch covers the set of upgrades for Springboot, JUnit, and PowerMockito frameworks in Java 17.',

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -648,6 +648,7 @@ export enum JDKVersion {
     JDK8 = '8',
     JDK11 = '11',
     JDK17 = '17',
+    JDK21 = '21',
     UNSUPPORTED = 'UNSUPPORTED',
 }
 
@@ -739,7 +740,7 @@ export class TransformByQState {
 
     private sourceJDKVersion: JDKVersion | undefined = undefined
 
-    private targetJDKVersion: JDKVersion = JDKVersion.JDK17
+    private targetJDKVersion: JDKVersion | undefined = undefined
 
     private produceMultipleDiffs: boolean = false
 
@@ -1131,7 +1132,7 @@ export class TransformByQState {
         this.payloadFilePath = ''
         this.metadataPathSQL = ''
         this.sourceJDKVersion = undefined
-        this.targetJDKVersion = JDKVersion.JDK17
+        this.targetJDKVersion = undefined
         this.sourceDB = undefined
         this.targetDB = undefined
         this.sourceServerName = ''

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -436,9 +436,6 @@ export async function zipCode(
 export async function startJob(uploadId: string) {
     const sourceLanguageVersion = `JAVA_${transformByQState.getSourceJDKVersion()}`
     const targetLanguageVersion = `JAVA_${transformByQState.getTargetJDKVersion()}`
-    // TO-DO: remove these logs statements
-    console.log('sourceLanguageVersion', sourceLanguageVersion)
-    console.log('targetLanguageVersion', targetLanguageVersion)
     try {
         const response = await codeWhisperer.codeWhispererClient.codeModernizerStartCodeTransformation({
             workspaceState: {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -436,6 +436,9 @@ export async function zipCode(
 export async function startJob(uploadId: string) {
     const sourceLanguageVersion = `JAVA_${transformByQState.getSourceJDKVersion()}`
     const targetLanguageVersion = `JAVA_${transformByQState.getTargetJDKVersion()}`
+    // TO-DO: remove these logs statements
+    console.log('sourceLanguageVersion', sourceLanguageVersion)
+    console.log('targetLanguageVersion', targetLanguageVersion)
     try {
         const response = await codeWhisperer.codeWhispererClient.codeModernizerStartCodeTransformation({
             workspaceState: {
@@ -445,7 +448,7 @@ export async function startJob(uploadId: string) {
             transformationSpec: {
                 transformationType: CodeWhispererConstants.transformationType, // shared b/w language upgrades & sql conversions for now
                 source: { language: sourceLanguageVersion }, // dummy value of JDK8 used for SQL conversions just so that this API can be called
-                target: { language: targetLanguageVersion }, // always JDK17
+                target: { language: targetLanguageVersion }, // JAVA_17 or JAVA_21
             },
         })
         getLogger().info('CodeTransformation: called startJob API successfully')


### PR DESCRIPTION
## Problem

Support transformations to Java 21.

## Solution

Add support.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
