### PR TITLE
fix(core): Could not fetch endpoints

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -190,12 +190,12 @@ export function registerGenericCommands(extensionContext: vscode.ExtensionContex
  * https://docs.aws.amazon.com/general/latest/gr/rande.html
  */
 export function makeEndpointsProvider() {
-    let localManifestFetcher: ResourceFetcher
-    let remoteManifestFetcher: ResourceFetcher
+    let localManifestFetcher: ResourceFetcher<string>
+    let remoteManifestFetcher: ResourceFetcher<Response>
     if (isWeb()) {
         localManifestFetcher = { get: async () => JSON.stringify(endpoints) }
         // Cannot use HttpResourceFetcher due to web mode breaking on import
-        remoteManifestFetcher = { get: async () => (await fetch(endpointsFileUrl)).text() }
+        remoteManifestFetcher = { get: async () => await fetch(endpointsFileUrl) }
     } else {
         localManifestFetcher = new FileResourceFetcher(globals.manifestPaths.endpoints)
         // HACK: HttpResourceFetcher breaks web mode when imported, so we use webpack.IgnorePlugin()

--- a/packages/core/src/shared/regions/regionProvider.ts
+++ b/packages/core/src/shared/regions/regionProvider.ts
@@ -196,8 +196,11 @@ export class RegionProvider {
     }
 }
 
-export async function getEndpointsFromFetcher(fetcher: ResourceFetcher): Promise<Endpoints> {
-    const endpointsJson = await fetcher.get()
+export async function getEndpointsFromFetcher(
+    fetcher: ResourceFetcher<string> | ResourceFetcher<Response>
+): Promise<Endpoints> {
+    const contents = await fetcher.get()
+    const endpointsJson = typeof contents === 'string' ? contents : await contents?.text()
     if (!endpointsJson) {
         throw new Error('Failed to get resource')
     }


### PR DESCRIPTION
## Problem
While starting the release process we found an problem where the endpoints couldn't be fetched because the resourceFetcher was expecting a string but the httpResourceFetcher was returning a Resource

## Solution
If its a string then return the contents from the resource fetcher directly, otherwise consider it as a response and get the text from the request

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
