### PR TITLE
fix(amazonq): log full error

### DIFF
--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -132,9 +132,7 @@ export async function uploadArtifactToS3(
                 )
             } catch (e: any) {
                 if (response && !retriableCodes.includes(response.status)) {
-                    throw new Error(
-                        `Upload failed with status code = ${response.status}; did not automatically retry; full error = ${JSON.stringify(e)}`
-                    )
+                    throw new Error(`Upload failed with status code = ${response.status}; did not automatically retry`)
                 }
                 if (i !== 3) {
                     await sleep(1000 * Math.pow(2, i))

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -173,7 +173,7 @@ export async function resumeTransformationJob(jobId: string, userActionStatus: T
         }
     } catch (e: any) {
         const errorMessage = `Resuming the job failed due to: ${(e as Error).message}`
-        getLogger().error(`CodeTransformation: ResumeTransformation error = ${JSON.stringify(e)}`)
+        getLogger().error(`CodeTransformation: ResumeTransformation error = %O`, e)
         throw new Error(errorMessage)
     }
 }
@@ -189,7 +189,7 @@ export async function stopJob(jobId: string) {
         })
     } catch (e: any) {
         transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
-        getLogger().error(`CodeTransformation: StopTransformation error = ${JSON.stringify(e)}`)
+        getLogger().error(`CodeTransformation: StopTransformation error = %O`, e)
         throw new Error('Stop job failed')
     }
 }
@@ -210,7 +210,7 @@ export async function uploadPayload(payloadFileName: string, uploadContext?: Upl
     } catch (e: any) {
         const errorMessage = `Creating the upload URL failed due to: ${(e as Error).message}`
         transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
-        getLogger().error(`CodeTransformation: CreateUploadUrl error: = ${JSON.stringify(e)}`)
+        getLogger().error(`CodeTransformation: CreateUploadUrl error: = %O`, e)
         throw new Error(errorMessage)
     }
 
@@ -449,7 +449,7 @@ export async function startJob(uploadId: string) {
     } catch (e: any) {
         const errorMessage = `Starting the job failed due to: ${(e as Error).message}`
         transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
-        getLogger().error(`CodeTransformation: StartTransformation error = ${JSON.stringify(e)}`)
+        getLogger().error(`CodeTransformation: StartTransformation error = %O`, e)
         throw new Error(errorMessage)
     }
 }
@@ -610,7 +610,7 @@ export async function getTransformationPlan(jobId: string) {
     } catch (e: any) {
         const errorMessage = (e as Error).message
         transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
-        getLogger().error(`CodeTransformation: GetTransformationPlan error = ${JSON.stringify(e)}`)
+        getLogger().error(`CodeTransformation: GetTransformationPlan error = %O`, e)
 
         /* Means API call failed
          * If response is defined, means a display/parsing error occurred, so continue transformation
@@ -633,7 +633,7 @@ export async function getTransformationSteps(jobId: string, handleThrottleFlag: 
         return response.transformationPlan.transformationSteps.slice(1) // skip step 0 (contains supplemental info)
     } catch (e: any) {
         transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
-        getLogger().error(`CodeTransformation: GetTransformationPlan error = ${JSON.stringify(e)}`)
+        getLogger().error(`CodeTransformation: GetTransformationPlan error = %O`, e)
         throw e
     }
 }
@@ -694,7 +694,7 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
             }
             await sleep(CodeWhispererConstants.transformationJobPollingIntervalSeconds * 1000)
         } catch (e: any) {
-            getLogger().error(`CodeTransformation: GetTransformation error = ${JSON.stringify(e)}`)
+            getLogger().error(`CodeTransformation: GetTransformation error = %O`, e)
             transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
             throw e
         }
@@ -752,7 +752,7 @@ export async function downloadResultArchive(
             pathToArchive
         )
     } catch (e: any) {
-        getLogger().error(`CodeTransformation: ExportResultArchive error = ${JSON.stringify(e)}`)
+        getLogger().error(`CodeTransformation: ExportResultArchive error = %O`, e)
         throw e
     } finally {
         cwStreamingClient.destroy()
@@ -781,7 +781,7 @@ export async function downloadAndExtractResultArchive(
         zip.extractAllTo(pathToArchiveDir)
     } catch (e) {
         downloadErrorMessage = (e as Error).message
-        getLogger().error(`CodeTransformation: ExportResultArchive error = ${JSON.stringify(e)}`)
+        getLogger().error(`CodeTransformation: ExportResultArchive error = %O`, e)
         throw new Error('Error downloading transformation result artifacts: ' + downloadErrorMessage)
     }
 }

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -127,10 +127,14 @@ export async function uploadArtifactToS3(
                 if (response.status === 200) {
                     break
                 }
-                throw new Error('Upload failed')
+                throw new Error(
+                    `Upload failed, status = ${response.status}; full response: ${JSON.stringify(response)}`
+                )
             } catch (e: any) {
                 if (response && !retriableCodes.includes(response.status)) {
-                    throw new Error(`Upload failed with status code = ${response.status}; did not automatically retry`)
+                    throw new Error(
+                        `Upload failed with status code = ${response.status}; did not automatically retry; full error = ${JSON.stringify(e)}`
+                    )
                 }
                 if (i !== 3) {
                     await sleep(1000 * Math.pow(2, i))
@@ -169,7 +173,7 @@ export async function resumeTransformationJob(jobId: string, userActionStatus: T
         }
     } catch (e: any) {
         const errorMessage = `Resuming the job failed due to: ${(e as Error).message}`
-        getLogger().error(`CodeTransformation: ResumeTransformation error = ${errorMessage}`)
+        getLogger().error(`CodeTransformation: ResumeTransformation error = ${JSON.stringify(e)}`)
         throw new Error(errorMessage)
     }
 }
@@ -180,18 +184,12 @@ export async function stopJob(jobId: string) {
     }
 
     try {
-        const response = await codeWhisperer.codeWhispererClient.codeModernizerStopCodeTransformation({
+        await codeWhisperer.codeWhispererClient.codeModernizerStopCodeTransformation({
             transformationJobId: jobId,
         })
-        if (response !== undefined) {
-            // always store request ID, but it will only show up in a notification if an error occurs
-            if (response.$response.requestId) {
-                transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
-            }
-        }
     } catch (e: any) {
-        const errorMessage = (e as Error).message
-        getLogger().error(`CodeTransformation: StopTransformation error = ${errorMessage}`)
+        transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
+        getLogger().error(`CodeTransformation: StopTransformation error = ${JSON.stringify(e)}`)
         throw new Error('Stop job failed')
     }
 }
@@ -209,12 +207,10 @@ export async function uploadPayload(payloadFileName: string, uploadContext?: Upl
             uploadIntent: CodeWhispererConstants.uploadIntent,
             uploadContext,
         })
-        if (response.$response.requestId) {
-            transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
-        }
     } catch (e: any) {
-        const errorMessage = `The upload failed due to: ${(e as Error).message}`
-        getLogger().error(`CodeTransformation: CreateUploadUrl error: = ${e}`)
+        const errorMessage = `Creating the upload URL failed due to: ${(e as Error).message}`
+        transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
+        getLogger().error(`CodeTransformation: CreateUploadUrl error: = ${JSON.stringify(e)}`)
         throw new Error(errorMessage)
     }
 
@@ -449,13 +445,11 @@ export async function startJob(uploadId: string) {
             },
         })
         getLogger().info('CodeTransformation: called startJob API successfully')
-        if (response.$response.requestId) {
-            transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
-        }
         return response.transformationJobId
     } catch (e: any) {
         const errorMessage = `Starting the job failed due to: ${(e as Error).message}`
-        getLogger().error(`CodeTransformation: StartTransformation error = ${errorMessage}`)
+        transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
+        getLogger().error(`CodeTransformation: StartTransformation error = ${JSON.stringify(e)}`)
         throw new Error(errorMessage)
     }
 }
@@ -573,9 +567,6 @@ export async function getTransformationPlan(jobId: string) {
         response = await codeWhisperer.codeWhispererClient.codeModernizerGetCodeTransformationPlan({
             transformationJobId: jobId,
         })
-        if (response.$response.requestId) {
-            transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
-        }
 
         const stepZeroProgressUpdates = response.transformationPlan.transformationSteps[0].progressUpdates
 
@@ -618,13 +609,14 @@ export async function getTransformationPlan(jobId: string) {
         return plan
     } catch (e: any) {
         const errorMessage = (e as Error).message
-        getLogger().error(`CodeTransformation: GetTransformationPlan error = ${errorMessage}`)
+        transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
+        getLogger().error(`CodeTransformation: GetTransformationPlan error = ${JSON.stringify(e)}`)
 
         /* Means API call failed
          * If response is defined, means a display/parsing error occurred, so continue transformation
          */
         if (response === undefined) {
-            throw new Error('Get plan API call failed')
+            throw new Error(errorMessage)
         }
     }
 }
@@ -638,13 +630,10 @@ export async function getTransformationSteps(jobId: string, handleThrottleFlag: 
         const response = await codeWhisperer.codeWhispererClient.codeModernizerGetCodeTransformationPlan({
             transformationJobId: jobId,
         })
-        if (response.$response.requestId) {
-            transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
-        }
         return response.transformationPlan.transformationSteps.slice(1) // skip step 0 (contains supplemental info)
     } catch (e: any) {
-        const errorMessage = (e as Error).message
-        getLogger().error(`CodeTransformation: GetTransformationPlan error = ${errorMessage}`)
+        transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
+        getLogger().error(`CodeTransformation: GetTransformationPlan error = ${JSON.stringify(e)}`)
         throw e
     }
 }
@@ -682,7 +671,6 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
                 transformByQState.setJobFailureErrorNotification(
                     `${CodeWhispererConstants.failedToCompleteJobGenericNotification} ${errorMessage}`
                 )
-                transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
             }
             if (validStates.includes(status)) {
                 break
@@ -700,14 +688,14 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
              * is called, we break above on validStatesForCheckingDownloadUrl and check final status in finalizeTransformationJob
              */
             if (CodeWhispererConstants.failureStates.includes(status)) {
-                transformByQState.setJobFailureMetadata(` (request ID: ${response.$response.requestId})`)
-                throw new JobStoppedError(response.$response.requestId)
+                throw new JobStoppedError(
+                    response.transformationJob.reason ?? 'no failure reason in GetTransformation response'
+                )
             }
             await sleep(CodeWhispererConstants.transformationJobPollingIntervalSeconds * 1000)
         } catch (e: any) {
-            let errorMessage = (e as Error).message
-            errorMessage += ` -- ${transformByQState.getJobFailureMetadata()}`
-            getLogger().error(`CodeTransformation: GetTransformation error = ${errorMessage}`)
+            getLogger().error(`CodeTransformation: GetTransformation error = ${JSON.stringify(e)}`)
+            transformByQState.setJobFailureMetadata(` (request ID: ${e.requestId ?? 'unavailable'})`)
             throw e
         }
     }
@@ -752,7 +740,6 @@ export async function downloadResultArchive(
     pathToArchive: string,
     downloadArtifactType: TransformationDownloadArtifactType
 ) {
-    let downloadErrorMessage = undefined
     const cwStreamingClient = await createCodeWhispererChatStreamingClient()
 
     try {
@@ -765,8 +752,7 @@ export async function downloadResultArchive(
             pathToArchive
         )
     } catch (e: any) {
-        downloadErrorMessage = (e as Error).message
-        getLogger().error(`CodeTransformation: ExportResultArchive error = ${downloadErrorMessage}`)
+        getLogger().error(`CodeTransformation: ExportResultArchive error = ${JSON.stringify(e)}`)
         throw e
     } finally {
         cwStreamingClient.destroy()
@@ -795,7 +781,7 @@ export async function downloadAndExtractResultArchive(
         zip.extractAllTo(pathToArchiveDir)
     } catch (e) {
         downloadErrorMessage = (e as Error).message
-        getLogger().error(`CodeTransformation: ExportResultArchive error = ${downloadErrorMessage}`)
+        getLogger().error(`CodeTransformation: ExportResultArchive error = ${JSON.stringify(e)}`)
         throw new Error('Error downloading transformation result artifacts: ' + downloadErrorMessage)
     }
 }


### PR DESCRIPTION
## Problem

When API calls fail, it can be difficult to debug without the requestId.

## Solution

Log entire error to ensure we have all relevant details, not just the error message.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
