### PR TITLE
feat(lambda): Connect CW Live Tail to Lambda functions

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -91,6 +91,7 @@
     "AWS.command.appBuilder.deploy": "Deploy SAM Application",
     "AWS.command.appBuilder.build": "Build SAM Template",
     "AWS.command.appBuilder.searchLogs": "Search Logs",
+    "AWS.command.appBuilder.tailLogs": "Tail Logs",
     "AWS.command.refreshappBuilderExplorer": "Refresh Application Builder Explorer",
     "AWS.command.applicationComposer.openDialog": "Open Template with Infrastructure Composer...",
     "AWS.command.auth.addConnection": "Add New Connection",

--- a/packages/core/src/awsService/appBuilder/explorer/nodes/deployedNode.ts
+++ b/packages/core/src/awsService/appBuilder/explorer/nodes/deployedNode.ts
@@ -10,7 +10,6 @@ import { createPlaceholderItem } from '../../../../shared/treeview/utils'
 import * as nls from 'vscode-nls'
 
 import { getLogger } from '../../../../shared/logger/logger'
-import { FunctionConfiguration, LambdaClient, GetFunctionCommand } from '@aws-sdk/client-lambda'
 import { DefaultLambdaClient } from '../../../../shared/clients/lambdaClient'
 import globals from '../../../../shared/extensionGlobals'
 import { defaultPartition } from '../../../../shared/regions/regionProvider'
@@ -28,7 +27,6 @@ import {
     s3BucketType,
 } from '../../../../shared/cloudformation/cloudformation'
 import { ToolkitError } from '../../../../shared'
-import { getIAMConnection } from '../../../../auth/utils'
 
 const localize = nls.loadMessageBundle()
 export interface DeployedResource {
@@ -89,8 +87,6 @@ export async function generateDeployedNode(
                 const defaultClient = new DefaultLambdaClient(regionCode)
                 const lambdaNode = new LambdaNode(regionCode, defaultClient)
                 let configuration: Lambda.FunctionConfiguration
-                let v3configuration
-                let logGroupName
                 try {
                     configuration = (await defaultClient.getFunction(deployedResource.PhysicalResourceId))
                         .Configuration as Lambda.FunctionConfiguration
@@ -101,31 +97,6 @@ export async function generateDeployedNode(
                         code: 'lambdaClientError',
                     })
                 }
-                const connection = await getIAMConnection({ prompt: false })
-                if (!connection || connection.type !== 'iam') {
-                    return [
-                        createPlaceholderItem(
-                            localize(
-                                'AWS.appBuilder.explorerNode.unavailableDeployedResource',
-                                '[Failed to retrive deployed resource. Ensure your AWS account is connected.]'
-                            )
-                        ),
-                    ]
-                }
-                const cred = await connection.getCredentials()
-                const v3Client = new LambdaClient({ region: regionCode, credentials: cred })
-
-                const v3command = new GetFunctionCommand({ FunctionName: deployedResource.PhysicalResourceId })
-                try {
-                    v3configuration = (await v3Client.send(v3command)).Configuration as FunctionConfiguration
-                    logGroupName = v3configuration.LoggingConfig?.LogGroup
-                } catch (error: any) {
-                    getLogger().error('Error getting Lambda V3 configuration: %O', error)
-                }
-                newDeployedResource.configuration = {
-                    ...newDeployedResource.configuration,
-                    logGroupName: logGroupName,
-                } as any
                 break
             }
             case s3BucketType: {

--- a/packages/core/src/awsService/cloudWatchLogs/activation.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/activation.ts
@@ -28,13 +28,13 @@ import { getLogger } from '../../shared/logger/logger'
 import { ToolkitError } from '../../shared'
 import { LiveTailCodeLensProvider } from './document/liveTailCodeLensProvider'
 
+export const liveTailRegistry = LiveTailSessionRegistry.instance
+export const liveTailCodeLensProvider = new LiveTailCodeLensProvider(liveTailRegistry)
 export async function activate(context: vscode.ExtensionContext, configuration: Settings): Promise<void> {
     const registry = LogDataRegistry.instance
-    const liveTailRegistry = LiveTailSessionRegistry.instance
 
     const documentProvider = new LogDataDocumentProvider(registry)
     const liveTailDocumentProvider = new LiveTailDocumentProvider()
-    const liveTailCodeLensProvider = new LiveTailCodeLensProvider(liveTailRegistry)
     context.subscriptions.push(
         vscode.languages.registerCodeLensProvider(
             {
@@ -150,7 +150,7 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
     )
 }
 
-function getFunctionLogGroupName(configuration: any) {
+export function getFunctionLogGroupName(configuration: any) {
     const logGroupPrefix = '/aws/lambda/'
-    return configuration.logGroupName || logGroupPrefix + configuration.FunctionName
+    return configuration.LoggingConfig?.LogGroup || logGroupPrefix + configuration.FunctionName
 }

--- a/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/commands/tailLogGroup.ts
@@ -17,15 +17,17 @@ import {
 import { getLogger, globals, ToolkitError } from '../../../shared'
 import { uriToKey } from '../cloudWatchLogsUtils'
 import { LiveTailCodeLensProvider } from '../document/liveTailCodeLensProvider'
+import { LogStreamFilterResponse } from '../wizard/liveTailLogStreamSubmenu'
 
 export async function tailLogGroup(
     registry: LiveTailSessionRegistry,
     source: string,
     codeLensProvider: LiveTailCodeLensProvider,
-    logData?: { regionName: string; groupName: string }
+    logData?: { regionName: string; groupName: string },
+    logStreamFilterData?: LogStreamFilterResponse
 ): Promise<void> {
     await telemetry.cloudwatchlogs_startLiveTail.run(async (span) => {
-        const wizard = new TailLogGroupWizard(logData)
+        const wizard = new TailLogGroupWizard(logData, logStreamFilterData)
         const wizardResponse = await wizard.run()
         if (!wizardResponse) {
             throw new CancellationError('user')

--- a/packages/core/src/awsService/cloudWatchLogs/wizard/tailLogGroupWizard.ts
+++ b/packages/core/src/awsService/cloudWatchLogs/wizard/tailLogGroupWizard.ts
@@ -24,7 +24,7 @@ export interface TailLogGroupWizardResponse {
 }
 
 export class TailLogGroupWizard extends Wizard<TailLogGroupWizardResponse> {
-    public constructor(logGroupInfo?: CloudWatchLogsGroupInfo) {
+    public constructor(logGroupInfo?: CloudWatchLogsGroupInfo, logStreamInfo?: LogStreamFilterResponse) {
         super({
             initState: {
                 regionLogGroupSubmenuResponse: logGroupInfo
@@ -33,6 +33,7 @@ export class TailLogGroupWizard extends Wizard<TailLogGroupWizardResponse> {
                           region: logGroupInfo.regionName,
                       }
                     : undefined,
+                logStreamFilter: logStreamInfo ?? undefined,
             },
         })
         this.form.regionLogGroupSubmenuResponse.bindPrompter(createRegionLogGroupSubmenu)

--- a/packages/core/src/test/awsService/cloudWatchLogs/wizard/tailLogGroupWizard.test.ts
+++ b/packages/core/src/test/awsService/cloudWatchLogs/wizard/tailLogGroupWizard.test.ts
@@ -44,6 +44,21 @@ describe('TailLogGroupWizard', async function () {
         tester.filterPattern.assertShowSecond()
     })
 
+    it('skips logStream filter when logStream info is provided', async function () {
+        sandbox.stub(DefaultAwsContext.prototype, 'getCredentialAccountId').returns(testAwsAccountId)
+        const wizard = new TailLogGroupWizard(
+            {
+                groupName: testLogGroupName,
+                regionName: testRegion,
+            },
+            { type: 'specific', filter: 'log-group-name' }
+        )
+        const tester = await createWizardTester(wizard)
+        tester.regionLogGroupSubmenuResponse.assertDoesNotShow()
+        tester.logStreamFilter.assertDoesNotShow()
+        tester.filterPattern.assertShowFirst()
+    })
+
     it('builds LogGroup Arn properly', async function () {
         sandbox.stub(DefaultAwsContext.prototype, 'getCredentialAccountId').returns(testAwsAccountId)
         const arn = buildLogGroupArn(testLogGroupName, testRegion)

--- a/packages/toolkit/.changes/next-release/Feature-48c399ea-d42f-4ea1-8f32-d8bc1486a107.json
+++ b/packages/toolkit/.changes/next-release/Feature-48c399ea-d42f-4ea1-8f32-d8bc1486a107.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Support starting CloudWatch Logs Live Tail sessions for a specific Lambda function's log group, without having to find which log group manually, but just starting from the function directly."
+}

--- a/packages/toolkit/.changes/next-release/Feature-48c399ea-d42f-4ea1-8f32-d8bc1486a107.json
+++ b/packages/toolkit/.changes/next-release/Feature-48c399ea-d42f-4ea1-8f32-d8bc1486a107.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Support starting CloudWatch Logs Live Tail sessions for a specific Lambda function's log group, without having to find which log group manually, but just starting from the function directly."
+	"description": "From the Lambda treeview in AWS Explorer, you can now right-click on a function name and start a CloudWatch Logs Live Tail sessions for the selected function."
 }

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -908,6 +908,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.appBuilder.tailLogs",
+                    "when": "false"
+                },
+                {
                     "command": "aws.appBuilder.viewDocs",
                     "when": "false"
                 },
@@ -1671,6 +1675,11 @@
                     "group": "0@3"
                 },
                 {
+                    "command": "aws.appBuilder.tailLogs",
+                    "when": "view =~ /^(aws.explorer|aws.appBuilder|aws.appBuilderForFileExplorer)$/ && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode)$/",
+                    "group": "0@4"
+                },
+                {
                     "command": "aws.deleteCloudFormation",
                     "when": "view == aws.explorer && viewItem == awsCloudFormationNode",
                     "group": "3@5"
@@ -2169,6 +2178,11 @@
                     "command": "aws.appBuilder.searchLogs",
                     "when": "view =~ /^(aws.explorer|aws.appBuilder|aws.appBuilderForFileExplorer)$/ && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode)$/",
                     "group": "inline@2"
+                },
+                {
+                    "command": "aws.appBuilder.tailLogs",
+                    "when": "view =~ /^(aws.explorer|aws.appBuilder|aws.appBuilderForFileExplorer)$/ && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode)$/",
+                    "group": "inline@3"
                 }
             ],
             "aws.toolkit.auth": [
@@ -3777,6 +3791,13 @@
                 "enablement": "isCloud9 || !aws.isWebExtHost",
                 "category": "%AWS.title%",
                 "icon": "$(search-view-icon)"
+            },
+            {
+                "command": "aws.appBuilder.tailLogs",
+                "title": "%AWS.command.appBuilder.tailLogs%",
+                "enablement": "isCloud9 || !aws.isWebExtHost",
+                "category": "%AWS.title%",
+                "icon": "$(search-show-context)"
             },
             {
                 "command": "aws.appBuilder.deploy",


### PR DESCRIPTION
Allow to "Tail Logs" from Lambda functions, which will get the configured Log Group for a particular function and start a Live Tail session in that Log Group.

Some code was removed, because with the recently updated version of the SDK v2, we can take the configured log group directly from the function's configuration and we don't need that extra call using SDK V3 that was being made inside `deployedNode.ts`

## Problem

To start a CloudWatch Live Tail session, a user needs to know their Log Group name and find it in the AWS explorer. For Lambda users, that might not be easy to find or well known all the time

## Solution

We help the Live Tail experience for Lambda customers by allowing them to start a Live Tail session directly from their function in the AWS explorer and in the Application Builder section for deployed functions, without having to search for their Log Group explicitly.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
