### PR TITLE
feat(release): check for marketplace update

### DIFF
--- a/buildspec/release/70checkmarketplace.yml
+++ b/buildspec/release/70checkmarketplace.yml
@@ -1,0 +1,48 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            nodejs: 16
+
+        commands:
+            - apt update
+            - apt install -y wget gpg
+            - wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
+            - install -o root -g root -m 644 packages.microsoft.gpg /etc/apt/trusted.gpg.d/
+            - sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
+            - apt update
+            - apt install -y code
+
+    pre_build:
+        commands:
+            # Check for implicit env vars passed from the release pipeline.x
+            - test -n "${TARGET_EXTENSION}"
+
+    build:
+        commands:
+            - VERSION=$(node -e "console.log(require('./packages/${TARGET_EXTENSION}/package.json').version);")
+            # get extension name
+            - |
+                if [ "${TARGET_EXTENSION}" = "amazonq" ]; then
+                  extension_name="amazonwebservices.amazon-q-vscode"
+                elif [ "${TARGET_EXTENSION}" = "toolkit" ]; then
+                  extension_name="amazonwebservices.aws-toolkit-vscode"
+                else
+                  echo "Unknown TARGET_EXTENSION: ${TARGET_EXTENSION}"
+                  exit 1
+                fi
+            # keep reinstalling the extension until the desired version is updated. Otherwise fail on codebuild timeout (1 hour).
+            - |
+                while true; do
+                  code --uninstall-extension ${extension_name} --no-sandbox --user-data-dir /tmp/vscode
+                  code --install-extension ${extension_name} --no-sandbox --user-data-dir /tmp/vscode
+                  cur_version=$(code --list-extensions --show-versions --no-sandbox --user-data-dir /tmp/vscode | grep ${extension_name} | cut -d'@' -f2)
+                  if [ "${cur_version}" = "${VERSION}" ]; then
+                    echo "Extension ${extension_name} is updated to version ${cur_version}."
+                    break
+                  else
+                    echo "Current version ${cur_version} does not match expected version ${VERSION}. Retrying..."
+                  fi
+                  sleep 120 # Wait for 2 minutes before retrying
+                done

--- a/buildspec/release/70checkmarketplace.yml
+++ b/buildspec/release/70checkmarketplace.yml
@@ -8,7 +8,7 @@ phases:
         commands:
             - apt update
             - apt install -y wget gpg
-            - wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
+            - curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
             - install -o root -g root -m 644 packages.microsoft.gpg /etc/apt/trusted.gpg.d/
             - sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
             - apt update
@@ -16,7 +16,7 @@ phases:
 
     pre_build:
         commands:
-            # Check for implicit env vars passed from the release pipeline.x
+            # Check for implicit env vars passed from the release pipeline.
             - test -n "${TARGET_EXTENSION}"
 
     build:
@@ -29,20 +29,20 @@ phases:
                 elif [ "${TARGET_EXTENSION}" = "toolkit" ]; then
                   extension_name="amazonwebservices.aws-toolkit-vscode"
                 else
-                  echo "Unknown TARGET_EXTENSION: ${TARGET_EXTENSION}"
+                  echo checkmarketplace: "Unknown TARGET_EXTENSION: ${TARGET_EXTENSION}"
                   exit 1
                 fi
             # keep reinstalling the extension until the desired version is updated. Otherwise fail on codebuild timeout (1 hour).
             - |
                 while true; do
-                  code --uninstall-extension ${extension_name} --no-sandbox --user-data-dir /tmp/vscode
+                  code --uninstall-extension "${extension_name}" --no-sandbox --user-data-dir /tmp/vscode
                   code --install-extension ${extension_name} --no-sandbox --user-data-dir /tmp/vscode
                   cur_version=$(code --list-extensions --show-versions --no-sandbox --user-data-dir /tmp/vscode | grep ${extension_name} | cut -d'@' -f2)
                   if [ "${cur_version}" = "${VERSION}" ]; then
-                    echo "Extension ${extension_name} is updated to version ${cur_version}."
+                    echo "checkmarketplace: Extension ${extension_name} is updated to version '${cur_version}.'"
                     break
                   else
-                    echo "Current version ${cur_version} does not match expected version ${VERSION}. Retrying..."
+                    echo "checkmarketplace: Current version '${cur_version}' does not match expected version '${VERSION}'. Retrying..."
                   fi
                   sleep 120 # Wait for 2 minutes before retrying
                 done


### PR DESCRIPTION
## Problem
Our release MCM currently has a step for each extension (Toolkit and Q) that requires the human operator to wait and check for the marketplace publish and then try to install from the marketplace. This uses human time and can easily be automated.

## Solution
Added a final stage in release pipeline: https://code.amazon.com/reviews/CR-173945904/revisions/1#/commits

that runs this YML build script that automatically installs and uninstalls the extension from marketplace on a two minute interval. 

When the version matches the new release version, the code-build succeeds:
<img width="768" alt="Screenshot 2025-01-23 at 2 44 45 PM" src="https://github.com/user-attachments/assets/93f80a6d-573c-4524-995c-6491ecf1fb6f" />


When it doesn't, it keeps retrying until the timeout limit is reached (1 hour):
<img width="694" alt="Screenshot 2025-01-23 at 4 52 07 PM" src="https://github.com/user-attachments/assets/c5433383-1194-4ec4-845a-4e63d8959cf7" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
