### PR TITLE
refactor: mark ExtContext as deprecated

### DIFF
--- a/packages/core/src/shared/extensions.ts
+++ b/packages/core/src/shared/extensions.ts
@@ -31,9 +31,7 @@ export const vscodeExtensionMinVersion = {
     remotessh: '0.74.0',
 }
 
-/**
- * Long-lived, extension-scoped, shared globals.
- */
+/** @deprecated Use `extensionGlobals.ts:globals` instead. */
 export interface ExtContext {
     extensionContext: vscode.ExtensionContext
     awsContext: AwsContext


### PR DESCRIPTION


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
