### PR TITLE
fix(lint): remove extra space so that lint passes. 

### DIFF
--- a/packages/core/src/shared/clients/s3Client.ts
+++ b/packages/core/src/shared/clients/s3Client.ts
@@ -465,7 +465,7 @@ export class DefaultS3Client {
                  * Set '' as the default prefix to ensure that the bucket's content will be displayed
                  * when the user has at least list access to the root of the bucket.
                  * https://github.com/aws/aws-toolkit-vscode/issues/4643
-                 * @default '' 
+                 * @default ''
                  */
                 Prefix: request.folderPath ?? defaultPrefix,
                 ContinuationToken: request.continuationToken,


### PR DESCRIPTION
## Problem
Currently seeing the following error on master 
```
passes eslint:

      AssertionError [ERR_ASSERTION]: ,
/home/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/packages/core/src/shared/clients/s3Client.ts
Error:   468:[31](https://github.com/aws/aws-toolkit-vscode/actions/runs/12991583651/job/36229470175#step:6:32)  error  Delete `·`  prettier/prettier`
```

## Solution
- delete the extra space. 


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
