### PR TITLE
test(sdkv3): add tests for expiring credentials

### DIFF
--- a/packages/core/src/test/shared/awsClientBuilderV3.test.ts
+++ b/packages/core/src/test/shared/awsClientBuilderV3.test.ts
@@ -16,6 +16,7 @@ import { assertTelemetry } from '../testUtil'
 import { telemetry } from '../../shared/telemetry'
 import { CredentialsShim } from '../../auth/deprecated/loginManager'
 import { Credentials } from '@aws-sdk/types'
+import { oneDay } from '../../shared/datetime'
 
 describe('AwsClientBuilderV3', function () {
     let builder: AWSClientBuilderV3
@@ -72,13 +73,13 @@ describe('AwsClientBuilderV3', function () {
                 accessKeyId: 'old',
                 secretAccessKey: 'old',
                 sessionToken: 'old',
-                expiration: new Date(Date.now() + 1000 * 60 * 60 * 24),
+                expiration: new Date(Date.now() + oneDay),
             }
             newCreds = {
                 accessKeyId: 'new',
                 secretAccessKey: 'new',
                 sessionToken: 'new',
-                expiration: new Date(Date.now() + 1000 * 60 * 60 * 24 * 2),
+                expiration: new Date(Date.now() + oneDay),
             }
             mockCredsShim = new MockCredentialsShim(oldCreds, newCreds)
             fakeContext.credentialsShim = mockCredsShim
@@ -99,7 +100,7 @@ describe('AwsClientBuilderV3', function () {
                 accessKeyId: 'old2',
                 secretAccessKey: 'old2',
                 sessionToken: 'old2',
-                expiration: new Date(Date.now() + 1000 * 60 * 60 * 24),
+                expiration: new Date(Date.now() + oneDay),
             }
             mockCredsShim.update(newerCreds)
             assert.strictEqual(await service.config.credentials(), newerCreds)
@@ -135,7 +136,7 @@ class MockCredentialsShim implements CredentialsShim {
     public expire(): void {
         this.credentials = {
             ...this.credentials,
-            expiration: new Date(Date.now() - 1000 * 60 * 60 * 24),
+            expiration: new Date(Date.now() - oneDay),
         }
     }
 

--- a/packages/core/src/test/shared/awsClientBuilderV3.test.ts
+++ b/packages/core/src/test/shared/awsClientBuilderV3.test.ts
@@ -14,6 +14,8 @@ import { Client } from '@aws-sdk/smithy-client'
 import { extensionVersion } from '../../shared'
 import { assertTelemetry } from '../testUtil'
 import { telemetry } from '../../shared/telemetry'
+import { CredentialsShim } from '../../auth/deprecated/loginManager'
+import { Credentials } from '@aws-sdk/types'
 
 describe('AwsClientBuilderV3', function () {
     let builder: AWSClientBuilderV3
@@ -57,6 +59,52 @@ describe('AwsClientBuilderV3', function () {
             assert.strictEqual(service.config.userAgent[0][0], 'CUSTOM USER AGENT')
         })
     })
+
+    describe('clientCredentials', function () {
+        let fakeContext: FakeAwsContext
+        let mockCredsShim: MockCredentialsShim
+        let oldCreds: Credentials
+        let newCreds: Credentials
+
+        beforeEach(function () {
+            fakeContext = new FakeAwsContext()
+            oldCreds = {
+                accessKeyId: 'old',
+                secretAccessKey: 'old',
+                sessionToken: 'old',
+                expiration: new Date(Date.now() + 1000 * 60 * 60 * 24),
+            }
+            newCreds = {
+                accessKeyId: 'new',
+                secretAccessKey: 'new',
+                sessionToken: 'new',
+                expiration: new Date(Date.now() + 1000 * 60 * 60 * 24 * 2),
+            }
+            mockCredsShim = new MockCredentialsShim(oldCreds, newCreds)
+            fakeContext.credentialsShim = mockCredsShim
+            builder = new AWSClientBuilderV3(fakeContext)
+        })
+
+        it('refreshes credentials when they expire', async function () {
+            const service = await builder.createAwsService(Client)
+            assert.strictEqual(await service.config.credentials(), oldCreds)
+            mockCredsShim.expire()
+            assert.strictEqual(await service.config.credentials(), newCreds)
+        })
+
+        it('does not cache stale credentials', async function () {
+            const service = await builder.createAwsService(Client)
+            assert.strictEqual(await service.config.credentials(), oldCreds)
+            const newerCreds = {
+                accessKeyId: 'old2',
+                secretAccessKey: 'old2',
+                sessionToken: 'old2',
+                expiration: new Date(Date.now() + 1000 * 60 * 60 * 24),
+            }
+            mockCredsShim.update(newerCreds)
+            assert.strictEqual(await service.config.credentials(), newerCreds)
+        })
+    })
 })
 
 describe('getServiceId', function () {
@@ -77,3 +125,29 @@ describe('recordErrorTelemetry', function () {
         assertTelemetry('vscode_executeCommand', { requestServiceType: 'aws-service' })
     })
 })
+
+class MockCredentialsShim implements CredentialsShim {
+    public constructor(
+        public credentials: Credentials,
+        public readonly refreshedCredentials: Credentials
+    ) {}
+
+    public expire(): void {
+        this.credentials = {
+            ...this.credentials,
+            expiration: new Date(Date.now() - 1000 * 60 * 60 * 24),
+        }
+    }
+
+    public update(newCreds: Credentials): void {
+        this.credentials = newCreds
+    }
+
+    public async get(): Promise<Credentials> {
+        return this.credentials
+    }
+
+    public async refresh(): Promise<Credentials> {
+        return this.refreshedCredentials
+    }
+}


### PR DESCRIPTION
## Problem
The client should not be making requests with stale credentials so we want test coverage to ensure this

## Solution
- Create a mock credentials shim and insert it into the global context.
- The client builder will then use that shim, and we can manually expire it.
- Ensure client does not cache potentially stale credentials.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
