### PR TITLE
ci: rename "jscpd" job to "lint-duplicate-code"

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -57,7 +57,7 @@ jobs:
             - run: npm run testCompile
             - run: npm run lint
 
-    jscpd:
+    lint-duplicate-code:
         needs: lint-commits
         if: ${{ github.event_name == 'pull_request'}}
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The "jscpd" CI check tends to be ignored by contributors, possibly because its purpose is not clear.

## Solution

Rename it.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
