### PR TITLE
docs(amazonq): Update /dev auto build setting strings

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -127,8 +127,8 @@
                     "markdownDescription": "%AWS.configuration.description.amazonq%",
                     "default": true
                 },
-                "amazonQ.devCommandWorkspaceConfigurations": {
-                    "markdownDescription": "%AWS.configuration.description.devCommandWorkspaceConfigurations%",
+                "amazonQ.allowFeatureDevelopmentToRunCodeAndTests": {
+                    "markdownDescription": "%AWS.configuration.description.featureDevelopment.allowRunningCodeAndTests%",
                     "type": "object",
                     "default": {}
                 },

--- a/packages/amazonq/test/unit/amazonqFeatureDev/util/files.test.ts
+++ b/packages/amazonq/test/unit/amazonqFeatureDev/util/files.test.ts
@@ -43,7 +43,7 @@ const testDevfilePrepareRepo = async (devfileEnabled: boolean) => {
 
     const workspace = getWorkspaceFolder(folder.path)
     sinon
-        .stub(CodeWhispererSettings.instance, 'getDevCommandWorkspaceConfigurations')
+        .stub(CodeWhispererSettings.instance, 'getAutoBuildSetting')
         .returns(devfileEnabled ? { [workspace.uri.fsPath]: true } : {})
 
     await testPrepareRepoData(workspace, expectedFiles)

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -20,7 +20,7 @@
     "AWS.configuration.description.suppressPrompts": "Prompts which ask for confirmation. Checking an item suppresses the prompt.",
     "AWS.configuration.enableCodeLenses": "Enable SAM hints in source code and template.yaml files",
     "AWS.configuration.description.resources.enabledResources": "AWS resources to display in the 'Resources' portion of the explorer.",
-    "AWS.configuration.description.devCommandWorkspaceConfigurations": "Amazon Q: Allow Q /dev to run code and test commands",
+    "AWS.configuration.description.featureDevelopment.allowRunningCodeAndTests": "Allow /dev to run code and test commands",
     "AWS.configuration.description.experiments": "Try experimental features and give feedback. Note that experimental features may be removed at any time.\n * `jsonResourceModification` - Enables basic create, update, and delete support for cloud resources via the JSON Resources explorer component.\n * `ec2RemoteConnect` - Allows interfacing with EC2 instances with options to start, stop, and establish remote connections. Remote connections are done over SSM and can be through a terminal or a remote VSCode window.",
     "AWS.stepFunctions.asl.format.enable.desc": "Enables the default formatter used with Amazon States Language files",
     "AWS.stepFunctions.asl.maxItemsComputed.desc": "The maximum number of outline symbols and folding regions computed (limited for performance reasons).",

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -157,9 +157,9 @@ export class FeatureDevController {
                     this.sendFeedback()
                     break
                 case FollowUpTypes.AcceptAutoBuild:
-                    return this.processDevCommandWorkspaceSetting(true, data)
+                    return this.processAutoBuildSetting(true, data)
                 case FollowUpTypes.DenyAutoBuild:
-                    return this.processDevCommandWorkspaceSetting(false, data)
+                    return this.processAutoBuildSetting(false, data)
                 case FollowUpTypes.GenerateDevFile:
                     this.messenger.sendAnswer({
                         type: 'system-prompt',
@@ -393,7 +393,7 @@ export class FeatureDevController {
             }
 
             const root = session.getWorkspaceRoot()
-            const autoBuildProjectSetting = CodeWhispererSettings.instance.getDevCommandWorkspaceConfigurations()
+            const autoBuildProjectSetting = CodeWhispererSettings.instance.getAutoBuildSetting()
             const hasDevfile = await checkForDevFile(root)
             const isPromptedForAutoBuildFeature = Object.keys(autoBuildProjectSetting).includes(root)
 
@@ -676,9 +676,9 @@ export class FeatureDevController {
         this.messenger.sendUpdatePlaceholder(tabID, i18n('AWS.amazonq.featureDev.placeholder.additionalImprovements'))
     }
 
-    private async processDevCommandWorkspaceSetting(setting: boolean, msg: any) {
+    private async processAutoBuildSetting(setting: boolean, msg: any) {
         const root = (await this.sessionStorage.getSession(msg.tabID)).getWorkspaceRoot()
-        await CodeWhispererSettings.instance.updateDevCommandWorkspaceConfigurations(root, setting)
+        await CodeWhispererSettings.instance.updateAutoBuildSetting(root, setting)
 
         this.messenger.sendAnswer({
             message: i18n('AWS.amazonq.featureDev.answer.settingUpdated'),

--- a/packages/core/src/amazonqFeatureDev/util/files.ts
+++ b/packages/core/src/amazonqFeatureDev/util/files.ts
@@ -40,8 +40,8 @@ export async function prepareRepoData(
     zip: AdmZip = new AdmZip()
 ) {
     try {
-        const devCommandWorkspaceConfigurations = CodeWhispererSettings.instance.getDevCommandWorkspaceConfigurations()
-        const useAutoBuildFeature = devCommandWorkspaceConfigurations[repoRootPaths[0]] ?? false
+        const autoBuildSetting = CodeWhispererSettings.instance.getAutoBuildSetting()
+        const useAutoBuildFeature = autoBuildSetting[repoRootPaths[0]] ?? false
         // We only respect gitignore file rules if useAutoBuildFeature is on, this is to avoid dropping necessary files for building the code (e.g. png files imported in js code)
         const files = await collectFiles(repoRootPaths, workspaceFolders, true, maxRepoSizeBytes, !useAutoBuildFeature)
 

--- a/packages/core/src/codewhisperer/util/codewhispererSettings.ts
+++ b/packages/core/src/codewhisperer/util/codewhispererSettings.ts
@@ -13,7 +13,7 @@ const description = {
     workspaceIndexWorkerThreads: Number,
     workspaceIndexUseGPU: Boolean,
     workspaceIndexMaxSize: Number,
-    devCommandWorkspaceConfigurations: Object,
+    allowFeatureDevelopmentToRunCodeAndTests: Object,
     ignoredSecurityIssues: ArrayConstructor(String),
 }
 
@@ -51,16 +51,16 @@ export class CodeWhispererSettings extends fromExtensionManifest('amazonQ', desc
         return Math.max(this.get('workspaceIndexMaxSize', 250), 1)
     }
 
-    public getDevCommandWorkspaceConfigurations(): { [key: string]: boolean } {
-        return this.get('devCommandWorkspaceConfigurations', {})
+    public getAutoBuildSetting(): { [key: string]: boolean } {
+        return this.get('allowFeatureDevelopmentToRunCodeAndTests', {})
     }
 
-    public async updateDevCommandWorkspaceConfigurations(projectName: string, setting: boolean) {
-        const projects = this.getDevCommandWorkspaceConfigurations()
+    public async updateAutoBuildSetting(projectName: string, setting: boolean) {
+        const projects = this.getAutoBuildSetting()
 
         projects[projectName] = setting
 
-        await this.update('devCommandWorkspaceConfigurations', projects)
+        await this.update('allowFeatureDevelopmentToRunCodeAndTests', projects)
     }
 
     public getIgnoredSecurityIssues(): string[] {

--- a/packages/core/src/shared/clients/s3Client.ts
+++ b/packages/core/src/shared/clients/s3Client.ts
@@ -463,9 +463,9 @@ export class DefaultS3Client {
                 MaxKeys: request.maxResults ?? DEFAULT_MAX_KEYS,
                 /**
                  * Set '' as the default prefix to ensure that the bucket's content will be displayed
-                 * when the user has at least list access to the root of the bucket.
+                 * when the user has at least list access to the root of the bucket
                  * https://github.com/aws/aws-toolkit-vscode/issues/4643
-                 * @default '' 
+                 * @default ''
                  */
                 Prefix: request.folderPath ?? defaultPrefix,
                 ContinuationToken: request.continuationToken,

--- a/packages/core/src/shared/settings-amazonq.gen.ts
+++ b/packages/core/src/shared/settings-amazonq.gen.ts
@@ -21,7 +21,7 @@ export const amazonqSettings = {
         "ssoCacheError": {}
     },
     "amazonQ.showInlineCodeSuggestionsWithCodeReferences": {},
-    "amazonQ.devCommandWorkspaceConfigurations": {},
+    "amazonQ.allowFeatureDevelopmentToRunCodeAndTests": {},
     "amazonQ.importRecommendationForInlineCodeSuggestions": {},
     "amazonQ.shareContentWithAWS": {},
     "amazonQ.workspaceIndex": {},


### PR DESCRIPTION
## Problem
"Dev Command Workspace Configurations" is overly broad and too ambiguous with regards to what this setting enables. 

## Solution
Worked with tech writer to establish a different string to present to customers.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
