### PR TITLE
deps(core): upgrade adm-zip to 0.5.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10202,10 +10202,11 @@
             }
         },
         "node_modules/adm-zip": {
-            "version": "0.5.10",
-            "license": "MIT",
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+            "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
             "engines": {
-                "node": ">=6.0"
+                "node": ">=12.0"
             }
         },
         "node_modules/agent-base": {
@@ -21159,7 +21160,7 @@
                 "@smithy/util-retry": "^2.2.0",
                 "@vscode/debugprotocol": "^1.57.0",
                 "@zip.js/zip.js": "^2.7.41",
-                "adm-zip": "^0.5.10",
+                "adm-zip": "^0.5.16",
                 "amazon-states-language-service": "^1.13.0",
                 "async-lock": "^1.4.0",
                 "aws-sdk": "^2.1692.0",

--- a/packages/amazonq/.changes/next-release/Bug Fix-0fdf9d44-2d93-47a9-8b9f-6c633fa51e0f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-0fdf9d44-2d93-47a9-8b9f-6c633fa51e0f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q: Fix code upload error when using /dev or /doc on Remote SSH"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -518,7 +518,7 @@
         "@smithy/util-retry": "^2.2.0",
         "@vscode/debugprotocol": "^1.57.0",
         "@zip.js/zip.js": "^2.7.41",
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.5.16",
         "amazon-states-language-service": "^1.13.0",
         "async-lock": "^1.4.0",
         "aws-sdk": "^2.1692.0",


### PR DESCRIPTION
## Problem
Some users who tried to use /dev or /doc on a Remote SSH server encountered a `Sorry, I ran into an issue while trying to upload your code` error. Error logs indicated the root cause was an out of range exception thrown by the adm-zip package. A [fix](https://github.com/cthackers/adm-zip/pull/518) was published in a newer version of adm-zip

## Solution
Upgrade to adm-zip v0.5.16

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
