### PR TITLE
fix(amazonq): For security reasons, disabled auto linkify for pure text links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6071,9 +6071,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.21.5",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.5.tgz",
-            "integrity": "sha512-Ge7/XADBx/Phm9k2pVgjtYRoB5UOsNcTwZ0VOsWOc2JBGblEIasiT4pNNfHGKgMkLf79AKYUKRSH5IAuQRKpaQ==",
+            "version": "4.21.6",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.6.tgz",
+            "integrity": "sha512-SpWY997696aMDPwbiBqwkBXUCrguDQsJ3RukmgafjAlQuBJAQTIaVAj4GfsEwuTLOsBNR7CJIj9XxhtDo7PvJQ==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {
@@ -21167,7 +21167,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.21.5",
+                "@aws/mynah-ui": "^4.21.6",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-8212e8e4-f65f-4594-a04f-76d47c61b41e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-8212e8e4-f65f-4594-a04f-76d47c61b41e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "For security reasons, disabled auto linkify for link texts coming in markdown other than [TEXT](URL) format"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -508,7 +508,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.21.5",
+        "@aws/mynah-ui": "^4.21.6",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
- Links incoming from Q responses can redirect to a vulnerable site depending on the used context from the files.

## Solution
- Linkify strategy is updated to only accept links with `[TEXT](URL)` format. (through MynahUI version [4.21.6](https://github.com/aws/mynah-ui/releases/tag/v4.21.6))

MynahUI PR:
https://github.com/aws/mynah-ui/pull/226
<img width="648" alt="Screenshot 2025-01-23 at 20 13 48" src="https://github.com/user-attachments/assets/edfb2429-d8a1-4800-bc1c-ed6434cb0552" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
