### PR TITLE
fix(amazonq): Allow AB users with an overriden customization to go back to the default customization

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-1d7e776d-333a-4f39-a8e6-29ea2ecb19c9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-1d7e776d-333a-4f39-a8e6-29ea2ecb19c9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Allow AB users with an overridden customization to go back to the default customization"
+}

--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -113,7 +113,7 @@ export const getSelectedCustomization = (): Customization => {
     )
     const selectedCustomization = selectedCustomizationArr[AuthUtil.instance.conn.label]
 
-    if (selectedCustomization && selectedCustomization.name !== baseCustomization.name) {
+    if (selectedCustomization && selectedCustomization.name !== '') {
         return selectedCustomization
     } else {
         const customizationFeature = FeatureConfigProvider.getFeature(Features.customizationArnOverride)

--- a/packages/core/src/test/amazonq/customizationUtil.test.ts
+++ b/packages/core/src/test/amazonq/customizationUtil.test.ts
@@ -85,7 +85,10 @@ describe('CodeWhisperer-customizationUtils', function () {
     it('Returns AB customization', async function () {
         sinon.stub(AuthUtil.instance, 'isValidEnterpriseSsoInUse').returns(true)
 
-        await setSelectedCustomization(baseCustomization)
+        await setSelectedCustomization({
+            arn: '',
+            name: '',
+        })
 
         const returnedCustomization = getSelectedCustomization()
 


### PR DESCRIPTION
## Problem
Users that are part of an AB group that have a customization override can't go back to the default customization. This was the original intention but has been relaxed after feedback.

## Solution

Update setSelectedCustomization to no longer check if the user is trying to switch back to the default customization.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
