### PR TITLE
test(flaky): avoid relying on race condition for tested behavior

### DIFF
--- a/packages/core/src/shared/fs/fs.ts
+++ b/packages/core/src/shared/fs/fs.ts
@@ -312,6 +312,11 @@ export class FileSystem {
                 reasonDesc: `After multiple attempts the source path existed: ${scrubbedPath}`,
                 attempts: attempts,
             })
+        } else {
+            telemetry.ide_fileSystem.emit({
+                result: 'Succeeded',
+                action: 'rename',
+            })
         }
 
         return vfs.rename(oldUri, newUri, { overwrite: true }).then(undefined, errHandler)

--- a/packages/core/src/test/shared/fs/fs.test.ts
+++ b/packages/core/src/test/shared/fs/fs.test.ts
@@ -411,16 +411,19 @@ describe('FileSystem', function () {
             const oldPath = testFolder.pathFrom('oldFile.txt')
             const newPath = testFolder.pathFrom('newFile.txt')
 
-            const result = fs.rename(oldPath, newPath)
-            // this file is created after the first "exists" check fails, the following check should pass
-            void testutil.toFile('hello world', oldPath)
-            await result
+            const existsStub = Sinon.stub(FileSystem.prototype, 'exists')
+            existsStub.onFirstCall().resolves(false)
+            existsStub.callThrough()
+
+            await testutil.toFile('hello world', oldPath)
+            await fs.rename(oldPath, newPath)
 
             testutil.assertTelemetry('ide_fileSystem', {
                 action: 'rename',
                 result: 'Succeeded',
-                reason: 'RenameRaceCondition',
             })
+
+            existsStub.restore()
         })
     })
 

--- a/packages/core/src/test/shared/fs/fs.test.ts
+++ b/packages/core/src/test/shared/fs/fs.test.ts
@@ -421,6 +421,7 @@ describe('FileSystem', function () {
             testutil.assertTelemetry('ide_fileSystem', {
                 action: 'rename',
                 result: 'Succeeded',
+                reason: 'RenameRaceCondition',
             })
 
             existsStub.restore()


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/issues/6451

This rename test relies on a specific result of a race condition for the expected result. 
- The test is checking for a telemetry result that is only emitted when `fs.exists` takes more than 1 attempt to resolve to true. 
- Therefore, it wants the first `fs.exists` check to fail, then a subsequent one to succeed. 
- It does this by not awaiting the result, and then writing the file to be renamed. 

Usually this is fine, but it is possible that the write (`toFile`) happens before the read (`fs.exists`) since neither is awaited. This behavior leads to a flaky test as described in the issue. 

## Solution
- use a stub to force the first call to `fs.exists` to fail. 
- allow all other calls to "go through" to the original function. 
- Have rename emit telemetry when it succeeds on the first attempt. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
