### PR TITLE
fix(example): Add closing bracket to Amazon Q inline example

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-e2bb3c83-52e8-4ae9-aedb-844e8780971b.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-e2bb3c83-52e8-4ae9-aedb-844e8780971b.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix the first Amazon Q inline suggestion example"
+	"description": "Inline: Typos in the first example suggestion"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-e2bb3c83-52e8-4ae9-aedb-844e8780971b.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-e2bb3c83-52e8-4ae9-aedb-844e8780971b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix the first Amazon Q inline suggestion example"
+}

--- a/packages/core/src/amazonq/onboardingPage/walkthrough.ts
+++ b/packages/core/src/amazonq/onboardingPage/walkthrough.ts
@@ -50,11 +50,12 @@ export const walkthroughInlineSuggestionsExample = Commands.declare(
     `_aws.amazonq.walkthrough.inlineSuggestionsExample`,
     () => async () => {
         const fileName = 'AmazonQ_generate_suggestion.py'
-        const fileContents = `# TODO: place your cursor at the end of line 5 and press Enter to generate a suggestion.
+        const fileContents = `# TODO: place your cursor at the end of line 6 and press Enter to generate a suggestion.
 # Tip: press tab to accept the suggestion
 
 fake_users = [
-    { "name": "User 1", "id": "user1", "city": "San Francisco", "state": "CA" },`
+    { "name": "User 1", "id": "user1", "city": "San Francisco", "state": "CA" },
+]`
 
         const uri = vscode.Uri.parse(`untitled:${fileName}`)
         const document = await vscode.workspace.openTextDocument(uri)

--- a/packages/core/src/codewhisperer/vue/genSuggestionTab.vue
+++ b/packages/core/src/codewhisperer/vue/genSuggestionTab.vue
@@ -68,7 +68,7 @@ export default defineComponent({
                         {
                             column1: [
                                 'AmazonQ_generate_suggestion.py',
-                                `# TODO: place your cursor at the end of line 5 and press Enter to generate a suggestion.${'\n'}# Tip: press tab to accept the suggestion.${'\n'}${'\n'}fake_users = [${'\n'}    { "name": "User 1", "id": "user1", "city": "San Francisco", "state": "CA" },`,
+                                `# TODO: place your cursor at the end of line 6 and press Enter to generate a suggestion.${'\n'}# Tip: press tab to accept the suggestion.${'\n'}${'\n'}fake_users = [${'\n'}    { "name": "User 1", "id": "user1", "city": "San Francisco", "state": "CA" },\n]`,
                             ],
                             column2: [
                                 'AmazonQ_manual_invoke.py',


### PR DESCRIPTION
## Problem
The first Amazon Q inline suggestion example is missing a closing bracket, and the returned response often excludes it.

## Solution
Simplifying the example by just including the closing bracket.

## Notes
- Failing tests and lints appear to be unrelated to the changes in this PR.
  - "RemoteFetcher" test failed, unrelated.
  - "lint-duplicate-code" is referencing unrelated code.
  - Just updating example code, so 0% code coverage is expected.
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
