### PR TITLE
deps(amazonq): upgrade adm-zip to 0.5.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10202,10 +10202,11 @@
             }
         },
         "node_modules/adm-zip": {
-            "version": "0.5.10",
-            "license": "MIT",
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+            "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
             "engines": {
-                "node": ">=6.0"
+                "node": ">=12.0"
             }
         },
         "node_modules/agent-base": {
@@ -21159,7 +21160,7 @@
                 "@smithy/util-retry": "^2.2.0",
                 "@vscode/debugprotocol": "^1.57.0",
                 "@zip.js/zip.js": "^2.7.41",
-                "adm-zip": "^0.5.10",
+                "adm-zip": "^0.5.16",
                 "amazon-states-language-service": "^1.13.0",
                 "async-lock": "^1.4.0",
                 "aws-sdk": "^2.1692.0",

--- a/packages/amazonq/.changes/next-release/Bug Fix-0fdf9d44-2d93-47a9-8b9f-6c633fa51e0f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-0fdf9d44-2d93-47a9-8b9f-6c633fa51e0f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q: Fix code upload error when using /dev or /doc on Remote SSH"
+}

--- a/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import vscode from 'vscode'
 import sinon from 'sinon'
-import { join } from 'path'
+import { join, posix } from 'path'
 import { getTestWorkspaceFolder } from 'aws-core-vscode/test'
 import { CodeAnalysisScope, CodeWhispererConstants, ZipUtil } from 'aws-core-vscode/codewhisperer'
 import { codeScanTruncDirPrefix } from 'aws-core-vscode/codewhisperer'
@@ -124,7 +124,7 @@ describe('zipUtil', function () {
             const zipFileData = await fs.readFileBytes(zipMetadata.zipFilePath)
             const zip = await JSZip.loadAsync(zipFileData)
             const files = Object.keys(zip.files)
-            assert.ok(files.includes(join('workspaceFolder', 'workspaceFolder', 'App.java')))
+            assert.ok(files.includes(posix.join('workspaceFolder', 'workspaceFolder', 'App.java')))
         })
 
         it('should handle path with repeated project name for project scan', async function () {
@@ -136,7 +136,7 @@ describe('zipUtil', function () {
             const zipFileData = await fs.readFileBytes(zipMetadata.zipFilePath)
             const zip = await JSZip.loadAsync(zipFileData)
             const files = Object.keys(zip.files)
-            assert.ok(files.includes(join('workspaceFolder', 'workspaceFolder', 'App.java')))
+            assert.ok(files.includes(posix.join('workspaceFolder', 'workspaceFolder', 'App.java')))
         })
     })
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -518,7 +518,7 @@
         "@smithy/util-retry": "^2.2.0",
         "@vscode/debugprotocol": "^1.57.0",
         "@zip.js/zip.js": "^2.7.41",
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.5.16",
         "amazon-states-language-service": "^1.13.0",
         "async-lock": "^1.4.0",
         "aws-sdk": "^2.1692.0",


### PR DESCRIPTION
## Problem
Users get an error uploading files when using /dev or /doc if files modified/created time is before the MSDOS epoch. Logs show an out of range exception thrown from the adm-zip package. Adm-zip issue reported [here](https://github.com/cthackers/adm-zip/issues/485)

## Solution
Upgrade adm-zip to the latest version. Use posix join to test paths in a zip, since adm-zip was updated to be POSIX compliant https://github.com/cthackers/adm-zip/issues/438

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
