### PR TITLE
fix(amazonq): Update initializationOptions extension name

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -11,7 +11,7 @@ import { registerInlineCompletion } from '../app/inline/completion'
 import { AmazonQLspAuth, encryptionKey, notificationTypes } from './auth'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { ConnectionMetadata } from '@aws/language-server-runtimes/protocol'
-import { ResourcePaths, Settings, createServerOptions, globals } from 'aws-core-vscode/shared'
+import { ResourcePaths, Settings, clientName, createServerOptions, globals } from 'aws-core-vscode/shared'
 
 const localize = nls.loadMessageBundle()
 
@@ -48,7 +48,7 @@ export async function startLanguageServer(extensionContext: vscode.ExtensionCont
                     name: env.appName,
                     version: version,
                     extension: {
-                        name: `AWS IDE Extensions for VSCode`, // TODO change this to C9/Amazon
+                        name: clientName(),
                         version: '0.0.1',
                     },
                     clientId: crypto.randomUUID(),

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -11,7 +11,7 @@ import { registerInlineCompletion } from '../app/inline/completion'
 import { AmazonQLspAuth, encryptionKey, notificationTypes } from './auth'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { ConnectionMetadata } from '@aws/language-server-runtimes/protocol'
-import { ResourcePaths, Settings, clientName, createServerOptions, globals } from 'aws-core-vscode/shared'
+import { ResourcePaths, Settings, oidcClientName, createServerOptions, globals } from 'aws-core-vscode/shared'
 
 const localize = nls.loadMessageBundle()
 
@@ -48,7 +48,7 @@ export async function startLanguageServer(extensionContext: vscode.ExtensionCont
                     name: env.appName,
                     version: version,
                     extension: {
-                        name: clientName(),
+                        name: oidcClientName(),
                         version: '0.0.1',
                     },
                     clientId: crypto.randomUUID(),

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -26,7 +26,7 @@ import { AwsLoginWithBrowser, AwsRefreshCredentials, telemetry } from '../../sha
 import { indent, toBase64URL } from '../../shared/utilities/textUtilities'
 import { AuthSSOServer } from './server'
 import { CancellationError, sleep } from '../../shared/utilities/timeoutUtils'
-import { getIdeProperties, isAmazonQ, isCloud9 } from '../../shared/extensionUtilities'
+import { clientName, isAmazonQ } from '../../shared/extensionUtilities'
 import { randomBytes, createHash } from 'crypto'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { randomUUID } from '../../shared/crypto'
@@ -438,10 +438,9 @@ function getSessionDuration(id: string) {
  */
 export class DeviceFlowAuthorization extends SsoAccessTokenProvider {
     override async registerClient(): Promise<ClientRegistration> {
-        const companyName = getIdeProperties().company
         return this.oidc.registerClient(
             {
-                clientName: isCloud9() ? `${companyName} Cloud9` : `${companyName} IDE Extensions for VSCode`,
+                clientName: clientName(),
                 clientType: clientRegistrationType,
                 scopes: this.profile.scopes,
             },
@@ -543,11 +542,10 @@ export class DeviceFlowAuthorization extends SsoAccessTokenProvider {
  */
 class AuthFlowAuthorization extends SsoAccessTokenProvider {
     override async registerClient(): Promise<ClientRegistration> {
-        const companyName = getIdeProperties().company
         return this.oidc.registerClient(
             {
                 // All AWS extensions (Q, Toolkit) for a given IDE use the same client name.
-                clientName: isCloud9() ? `${companyName} Cloud9` : `${companyName} IDE Extensions for VSCode`,
+                clientName: clientName(),
                 clientType: clientRegistrationType,
                 scopes: this.profile.scopes,
                 grantTypes: [authorizationGrantType, refreshGrantType],
@@ -653,11 +651,10 @@ class WebAuthorization extends SsoAccessTokenProvider {
     private redirectUri = 'http://127.0.0.1:54321/oauth/callback'
 
     override async registerClient(): Promise<ClientRegistration> {
-        const companyName = getIdeProperties().company
         return this.oidc.registerClient(
             {
                 // All AWS extensions (Q, Toolkit) for a given IDE use the same client name.
-                clientName: isCloud9() ? `${companyName} Cloud9` : `${companyName} IDE Extensions for VSCode`,
+                clientName: clientName(),
                 clientType: clientRegistrationType,
                 scopes: this.profile.scopes,
                 grantTypes: [authorizationGrantType, refreshGrantType],

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -26,7 +26,7 @@ import { AwsLoginWithBrowser, AwsRefreshCredentials, telemetry } from '../../sha
 import { indent, toBase64URL } from '../../shared/utilities/textUtilities'
 import { AuthSSOServer } from './server'
 import { CancellationError, sleep } from '../../shared/utilities/timeoutUtils'
-import { clientName, isAmazonQ } from '../../shared/extensionUtilities'
+import { oidcClientName, isAmazonQ } from '../../shared/extensionUtilities'
 import { randomBytes, createHash } from 'crypto'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { randomUUID } from '../../shared/crypto'
@@ -440,7 +440,7 @@ export class DeviceFlowAuthorization extends SsoAccessTokenProvider {
     override async registerClient(): Promise<ClientRegistration> {
         return this.oidc.registerClient(
             {
-                clientName: clientName(),
+                clientName: oidcClientName(),
                 clientType: clientRegistrationType,
                 scopes: this.profile.scopes,
             },
@@ -545,7 +545,7 @@ class AuthFlowAuthorization extends SsoAccessTokenProvider {
         return this.oidc.registerClient(
             {
                 // All AWS extensions (Q, Toolkit) for a given IDE use the same client name.
-                clientName: clientName(),
+                clientName: oidcClientName(),
                 clientType: clientRegistrationType,
                 scopes: this.profile.scopes,
                 grantTypes: [authorizationGrantType, refreshGrantType],
@@ -654,7 +654,7 @@ class WebAuthorization extends SsoAccessTokenProvider {
         return this.oidc.registerClient(
             {
                 // All AWS extensions (Q, Toolkit) for a given IDE use the same client name.
-                clientName: clientName(),
+                clientName: oidcClientName(),
                 clientType: clientRegistrationType,
                 scopes: this.profile.scopes,
                 grantTypes: [authorizationGrantType, refreshGrantType],

--- a/packages/core/src/shared/extensionUtilities.ts
+++ b/packages/core/src/shared/extensionUtilities.ts
@@ -49,8 +49,8 @@ export function productName() {
 }
 
 /** Gets the client name stored in oidc */
-export const clientName = once(_clientName)
-function _clientName() {
+export const oidcClientName = once(_oidcClientName)
+function _oidcClientName() {
     const companyName = getIdeProperties().company
     return isCloud9() ? `${companyName} Cloud9` : `${companyName} IDE Extensions for VSCode`
 }

--- a/packages/core/src/shared/extensionUtilities.ts
+++ b/packages/core/src/shared/extensionUtilities.ts
@@ -48,6 +48,13 @@ export function productName() {
     return isAmazonQ() ? 'Amazon Q' : `${getIdeProperties().company} Toolkit`
 }
 
+/** Gets the client name stored in oidc */
+export const clientName = once(_clientName)
+function _clientName() {
+    const companyName = getIdeProperties().company
+    return isCloud9() ? `${companyName} Cloud9` : `${companyName} IDE Extensions for VSCode`
+}
+
 export const getExtensionId = () => {
     return isAmazonQ() ? VSCODE_EXTENSION_ID.amazonq : VSCODE_EXTENSION_ID.awstoolkit
 }


### PR DESCRIPTION
## Problem
Initialization name is just dummy text for now. We should consider updating it to the c9/toolkit one

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
