### PR TITLE
feat(amazonq): Add description and github issue link to feedback form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6071,9 +6071,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.21.6",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.6.tgz",
-            "integrity": "sha512-SpWY997696aMDPwbiBqwkBXUCrguDQsJ3RukmgafjAlQuBJAQTIaVAj4GfsEwuTLOsBNR7CJIj9XxhtDo7PvJQ==",
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.22.0.tgz",
+            "integrity": "sha512-uZ7ULKyt5z5NEyI96XpAIPnp5XHPcXVAsZOZ3gICb/KEsHkU/L3ZgNsi7V98Svcqn8WTquRiVoFyJ6FAznvvMQ==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {
@@ -21270,7 +21270,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.21.6",
+                "@aws/mynah-ui": "^4.22.0",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Feature-d4b1f56f-fbfd-43e9-b4e1-e2c972dcf197.json
+++ b/packages/amazonq/.changes/next-release/Feature-d4b1f56f-fbfd-43e9-b4e1-e2c972dcf197.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Added github issue link and description to the chat answer feedback form"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -508,7 +508,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.21.6",
+        "@aws/mynah-ui": "^4.22.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",

--- a/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
+++ b/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
@@ -53,6 +53,11 @@ export function dispatchWebViewMessagesToApps(
                 void openUrl(Uri.parse(userGuideLink))
                 return
             }
+            case 'open-form-link': {
+                const { link } = msg
+                void openUrl(Uri.parse(link))
+                return
+            }
             case 'send-telemetry': {
                 if (isOpenAgentTelemetry(msg)) {
                     telemetry.toolkit_openModule.emit({

--- a/packages/core/src/amazonq/webview/ui/commands.ts
+++ b/packages/core/src/amazonq/webview/ui/commands.ts
@@ -40,6 +40,7 @@ type MessageCommand =
     | 'start-test-gen'
     | 'review'
     | 'open-user-guide'
+    | 'open-form-link'
     | 'send-telemetry'
     | 'update-welcome-count'
 

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -131,6 +131,13 @@ export class Connector {
         }
     }
 
+    onFormLinkClick = (link: string): void => {
+        this.sendMessageToExtension({
+            command: 'open-form-link',
+            link,
+        })
+    }
+
     onResponseBodyLinkClick = (tabID: string, messageId: string, link: string): void => {
         switch (this.tabsStorage.getTab(tabID)?.type) {
             case 'cwc':

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -834,6 +834,12 @@ export const createMynahUI = (
             mouseEvent?.stopImmediatePropagation()
             connector.onResponseBodyLinkClick(tabId, messageId, link)
         },
+        onFormLinkClick: (link, mouseEvent) => {
+            mouseEvent?.preventDefault()
+            mouseEvent?.stopPropagation()
+            mouseEvent?.stopImmediatePropagation()
+            connector.onFormLinkClick(link)
+        },
         onInfoLinkClick: (tabId: string, link: string, mouseEvent?: MouseEvent) => {
             mouseEvent?.preventDefault()
             mouseEvent?.stopPropagation()

--- a/packages/core/src/amazonq/webview/ui/texts/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/texts/constants.ts
@@ -8,6 +8,8 @@ export const uiComponentsTexts = {
     copy: 'Copy',
     insertAtCursorLabel: 'Insert at cursor',
     feedbackFormTitle: 'Report an issue',
+    feedbackFormDescription:
+        '_Feedback is anonymous. For issue updates, please contact us on [GitHub](https://github.com/aws/aws-toolkit-vscode/issues/new/choose)._',
     feedbackFormOptionsLabel: 'What type of issue would you like to report?',
     feedbackFormCommentLabel: 'Description of issue (optional):',
     feedbackThanks: 'Thanks for your feedback!',


### PR DESCRIPTION
## Problem
Users are not able to track their feedback/request through the feedback form. There should be a description for it and a link for Github issue links.

## Solution
- Added description field to the feedback form which accepts markdown strings (through MynahUI [v4.22.0](https://github.com/aws/mynah-ui/releases/tag/v4.22.0))

<img width="532" alt="image" src="https://github.com/user-attachments/assets/0f3fce7c-9efa-423b-9801-89743cfea42e" />

---

_**Notes:** Feel free to change the link, or update the text. Also, if you want to add telemetry records for these link clicks, feel free to add that._

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
