### PR TITLE
fix(amazonq): Fix LSP start failure in al2023 arm64

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-5c9f7fbc-1333-4c28-a049-7b17a17a7cea.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-5c9f7fbc-1333-4c28-a049-7b17a17a7cea.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix language server start failure in AL2023 ARM64"
+}

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -58,7 +58,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.32']
+const supportedLspServerVersions = ['0.1.35']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 


### PR DESCRIPTION
## Problem
The LSP cannot start in AL2023 arm64.

## Solution

Update the binary of linux arm64 to make it compatible with both AL2023 and Ubuntu arm64

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
