### PR TITLE
perf(amazonq): Removing flaky test case in generateZipTestGen function

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
@@ -195,22 +195,5 @@ describe('zipUtil', function () {
 
             await assert.rejects(() => zipUtil.generateZipTestGen(appRoot, false), /Zip failed/)
         })
-
-        it('Should handle file copy to downloads folder error', async function () {
-            // Mock LSP client
-            sinon.stub(LspClient, 'instance').get(() => ({
-                getRepoMapJSON: sinon.stub().resolves('{"mock": "data"}'),
-            }))
-
-            const mkdirSpy = sinon.spy(fs, 'mkdir')
-            sinon.stub(fs, 'exists').resolves(true)
-            sinon.stub(fs, 'copy').rejects(new Error('Copy failed'))
-
-            await assert.rejects(() => zipUtil.generateZipTestGen(appRoot, false), /Copy failed/)
-
-            // Verify mkdir was called for all directories
-            assert(mkdirSpy.called, 'mkdir should have been called')
-            assert.strictEqual(mkdirSpy.callCount, 4, 'mkdir should have been called 4 times')
-        })
     })
 })


### PR DESCRIPTION
## Problem
- Github issue: https://github.com/aws/aws-toolkit-vscode/issues/6160#issuecomment-2581150760

## Solution
- Not able to reproduce this in local machine. Double checked with team and planned to disable this test for now to avoid hassle for partner teams.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
