### PR TITLE
fix(amazonq): Broken citation links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6071,9 +6071,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.21.6",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.6.tgz",
-            "integrity": "sha512-SpWY997696aMDPwbiBqwkBXUCrguDQsJ3RukmgafjAlQuBJAQTIaVAj4GfsEwuTLOsBNR7CJIj9XxhtDo7PvJQ==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.22.1.tgz",
+            "integrity": "sha512-6mWD5Fp4VDVSKIv3sRKopoeh3GeiXEp2gWXmUWSVE9ccnnnavPyKSebV6vJiHJHtuS1da7i6ZLVednpsV9I49Q==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {
@@ -21270,7 +21270,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "^4.21.6",
+                "@aws/mynah-ui": "^4.22.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^2.3.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-22f55c14-bd62-49d7-aa68-3ab3cc8f0929.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-22f55c14-bd62-49d7-aa68-3ab3cc8f0929.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Citation links are not clickable as numbers, but appear as non-clickable texts"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -508,7 +508,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "^4.21.6",
+        "@aws/mynah-ui": "^4.22.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^2.3.1",


### PR DESCRIPTION
## Problem
- The citation links are broken after the [linkify structure change](https://github.com/aws/aws-toolkit-vscode/pull/6449).
<img width="663" alt="Screenshot 2025-02-03 at 13 01 43" src="https://github.com/user-attachments/assets/6b223b58-0c76-4914-8e9f-3e0ad7a8fb2b" />

## Solution
- Updated link check pattern to accept `[[TEXT]](LINK)` format too which is used for citations. **[MynahUI v4.22.1](https://github.com/aws/mynah-ui/releases/tag/v4.22.1)**

[MynahUI PR](https://github.com/aws/mynah-ui/pull/228)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
