### PR TITLE
docs(stepfunctions): add changelog for Workflow Studio and TestState

### DIFF
--- a/packages/toolkit/.changes/next-release/Feature-7dc599c8-77a6-423f-960e-eb32687d7714.json
+++ b/packages/toolkit/.changes/next-release/Feature-7dc599c8-77a6-423f-960e-eb32687d7714.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Step Functions: Added support for calling the TestState API in Workflow Studio"
+}

--- a/packages/toolkit/.changes/next-release/Feature-8fa49dc1-d427-4bff-adb1-7e0f11c3d866.json
+++ b/packages/toolkit/.changes/next-release/Feature-8fa49dc1-d427-4bff-adb1-7e0f11c3d866.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Step Functions: Added support for using Workflow Studio for editing ASL files in JSON and YAML"
+}


### PR DESCRIPTION
## Problem

Changelog is missing for the Step Functions Workflow Studio integration

## Solution

Added Changelog for Workflow Studio integration, and a separate one for TestState in the integration.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
