### PR TITLE
fix(amazonq): /test align placeholder text across IDEs

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-dc78e630-6320-4297-9ae9-7a19891f5357.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-dc78e630-6320-4297-9ae9-7a19891f5357.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/test placeholder text aligned across IDEs"
+}

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -1310,7 +1310,7 @@ export class TestController {
         if (session.tabID) {
             getLogger().debug('Setting input state with tabID: %s', session.tabID)
             this.messenger.sendChatInputEnabled(session.tabID, true)
-            this.messenger.sendUpdatePlaceholder(session.tabID, '/test Generate unit tests') // TODO: Change according to the UX
+            this.messenger.sendUpdatePlaceholder(session.tabID, 'Enter "/" for quick actions') // TODO: Change according to the UX
         }
         getLogger().debug(
             'Deleting output.log and temp result directory. testGenerationLogsDir: %s',

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -1310,7 +1310,7 @@ export class TestController {
         if (session.tabID) {
             getLogger().debug('Setting input state with tabID: %s', session.tabID)
             this.messenger.sendChatInputEnabled(session.tabID, true)
-            this.messenger.sendUpdatePlaceholder(session.tabID, 'Enter "/" for quick actions') // TODO: Change according to the UX
+            this.messenger.sendUpdatePlaceholder(session.tabID, 'Enter "/" for quick actions')
         }
         getLogger().debug(
             'Deleting output.log and temp result directory. testGenerationLogsDir: %s',


### PR DESCRIPTION
## Problem
- Placeholder texts are different between VSC and JB for /test

## Solution
- update placeholder text so it is consistent between the two after UTG Completion, UTG Reject, UTG Cancel



![Screenshot 2025-02-03 at 2 57 24 PM](https://github.com/user-attachments/assets/1b9f34f3-77a7-4702-bcd8-fbc7d8a45a34)
![Screenshot 2025-02-03 at 2 58 12 PM](https://github.com/user-attachments/assets/0402cf93-971c-4879-88d6-608dc908b158)
![Screenshot 2025-02-03 at 2 58 31 PM](https://github.com/user-attachments/assets/b204536e-5cf6-4ffb-bb1c-3bb33c74a366)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
