### PR TITLE
feat(amazonq): Notify users to reload when amazonqLSP experiment flag has changed

### DIFF
--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -154,6 +154,23 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
             void focusAmazonQPanel.execute(placeholder, 'firstStartUp')
         }, 1000)
     }
+
+    context.subscriptions.push(
+        Experiments.instance.onDidChange(async (event) => {
+            if (event.key === 'amazonqLSP') {
+                await vscode.window
+                    .showInformationMessage(
+                        'Amazon Q LSP setting has changed. Please reload VS Code for the changes to take effect.',
+                        'Reload Now'
+                    )
+                    .then(async (selection) => {
+                        if (selection === 'Reload Now') {
+                            await vscode.commands.executeCommand('workbench.action.reloadWindow')
+                        }
+                    })
+            }
+        })
+    )
 }
 
 export async function deactivateCommon() {

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -160,7 +160,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
             if (event.key === 'amazonqLSP') {
                 await vscode.window
                     .showInformationMessage(
-                        'Amazon Q LSP setting has changed. Please reload VS Code for the changes to take effect.',
+                        'Amazon Q LSP setting has changed. Reload VS Code for the changes to take effect.',
                         'Reload Now'
                     )
                     .then(async (selection) => {


### PR DESCRIPTION
## Problem
- The amazonqLSP flag is only checked at start. This sidesteps the amount of work that would be required to enable/disable codewhisperer at runtime. However, its not obvious they need to restart their editor

## Solution
- Notify users that they should reload when they change the experiments setting

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
