### PR TITLE
feat(lsp): status bar message when downloading

### DIFF
--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -229,7 +229,7 @@ export class LspController {
                 getLogger().info(`LspController: LSP already installed`)
                 return true
             }
-            status = vscode.window.setStatusBarMessage('LspController: Installing LSP ...')
+            status = vscode.window.setStatusBarMessage('Language server downloading ...')
             // clean up previous downloaded LSP
             const qserverPath = context.asAbsolutePath(path.join('resources', 'qserver'))
             if (await fs.exists(qserverPath)) {

--- a/packages/core/src/dev/activation.ts
+++ b/packages/core/src/dev/activation.ts
@@ -25,6 +25,7 @@ import { NotificationsController } from '../notifications/controller'
 import { DevNotificationsState } from '../notifications/types'
 import { QuickPickItem } from 'vscode'
 import { ChildProcess } from '../shared/utilities/processUtils'
+import { LspController } from '../amazonq'
 
 interface MenuOption {
     readonly label: string
@@ -464,6 +465,12 @@ const resettableFeatures: readonly ResettableFeature[] = [
         detail: 'Resets memory/global state for the notifications panel (includes dismissed, onReceive).',
         executor: resetNotificationsState,
     },
+    {
+        name: 'lsp',
+        label: 'Lsp',
+        detail: 'Resets (uninstall & reinstall) LSP',
+        executor: resetLspDownload,
+    },
 ] as const
 
 // TODO this is *somewhat* similar to `openStorageFromInput`. If we need another
@@ -550,6 +557,10 @@ export async function updateDevMode() {
 
 async function resetNotificationsState() {
     await targetNotificationsController.reset()
+}
+
+async function resetLspDownload() {
+    await LspController.instance.tryInstallLsp(targetContext, true)
 }
 
 async function editNotifications() {


### PR DESCRIPTION
## Problem
https://taskei.amazon.dev/tasks/IDE-15760
Users want to know that language servers are downloading


## Solution
Add a status bar message when LSP is downloading
Also added a developer command to reset LSP download for testing

https://github.com/user-attachments/assets/a00430a2-9c53-4406-aabe-c13217bc89b5


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
