### PR TITLE
telemetry(auth): debounce `aws_loadCredentials` and add debugging information

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -282,6 +282,7 @@ export class Auth implements AuthService, ConnectionManager {
      *
      * Use {@link Auth.listConnections} to avoid API calls to the SSO service.
      */
+    @withTelemetryContext({ name: 'listAndTraverseConnections', class: authClassName })
     public listAndTraverseConnections(): AsyncCollection<Connection> {
         async function* load(this: Auth) {
             await loadIamProfilesIntoStore(this.store, this.iamProfileProvider)

--- a/packages/core/src/auth/deprecated/loginManager.ts
+++ b/packages/core/src/auth/deprecated/loginManager.ts
@@ -33,7 +33,9 @@ import * as localizedText from '../../shared/localizedText'
 import { DefaultStsClient } from '../../shared/clients/stsClient'
 import { findAsync } from '../../shared/utilities/collectionUtils'
 import { telemetry } from '../../shared/telemetry/telemetry'
+import { withTelemetryContext } from '../../shared/telemetry/util'
 
+const loginManagerClass = 'LoginManager'
 /**
  * @deprecated Replaced by `Auth` in `src/credentials/auth.ts`
  */
@@ -131,6 +133,7 @@ export class LoginManager {
 
     private static didTryAutoConnect = false
 
+    @withTelemetryContext({ name: 'tryAutoConnect', class: loginManagerClass })
     public static async tryAutoConnect(awsContext: AwsContext = globals.awsContext): Promise<boolean> {
         if (isAutomation()) {
             return false

--- a/packages/core/src/auth/providers/credentialsProviderManager.ts
+++ b/packages/core/src/auth/providers/credentialsProviderManager.ts
@@ -51,15 +51,14 @@ export class CredentialsProviderManager {
             if (!providerType) {
                 continue
             }
-            const metadata = {
-                credentialSourceId: credentialsProviderToTelemetryType(providerType),
-                value: refreshed.length,
-            }
             const emitWithDebounce = cancellableDebounce(
                 (m: AwsLoadCredentials) => telemetry.aws_loadCredentials.emit(m),
                 5000
             ).promise
-            void emitWithDebounce(metadata)
+            void emitWithDebounce({
+                credentialSourceId: credentialsProviderToTelemetryType(providerType),
+                value: refreshed.length,
+            })
             providers = providers.concat(refreshed)
         }
 


### PR DESCRIPTION
## Problem
This metric is currently being spammed in telemetry at unusual volume. It is suspected that this is connected to this change: https://github.com/aws/aws-toolkit-vscode/pull/5979/files, but the connection is not yet clear. 

## Solution
- use the `withTelemetryContext` decorator to emit a `function_call` metric to capture additional information. This metric should allow us to determine what is calling this function so much. 
- debounce the current emit line that is causing the high volume emission. 


## Future Work 
- `debounce` reimplements a special case of `debounceWithCancel`, these can be redone to reduce code and improve reliability. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
