### PR TITLE
feat(stepfunctions): Add a setting to opt out of WFS + minor changes

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -27,6 +27,7 @@
     "AWS.stepFunctions.workflowStudio.actions.progressMessage": "Opening asl file in Workflow Studio",
     "AWS.stepFunctions.workflowStudio.actions.saveSuccessMessage": "{0} has been saved",
     "AWS.stepFunctions.workflowStudio.actions.invalidJson": "The Workflow Studio editor was not opened because the JSON in the file is invalid. To access Workflow Studio, please fix the JSON and manually reopen the integration.",
+    "AWS.stepFunctions.workflowStudio.enable.desc": "Open Amazon States Language files in Workflow Studio by default.",
     "AWS.configuration.description.awssam.debug.api": "API Gateway configuration",
     "AWS.configuration.description.awssam.debug.api.clientCertId": "The API Gateway client certificate ID",
     "AWS.configuration.description.awssam.debug.api.headers": "Additional HTTP headers",

--- a/packages/core/src/shared/settings-toolkit.gen.ts
+++ b/packages/core/src/shared/settings-toolkit.gen.ts
@@ -19,6 +19,7 @@ export const toolkitSettings = {
     "aws.samcli.legacyDeploy": {},
     "aws.telemetry": {},
     "aws.stepfunctions.asl.format.enable": {},
+    "aws.stepfunctions.workflowStudio.enable": {},
     "aws.stepfunctions.asl.maxItemsComputed": {},
     "aws.ssmDocument.ssm.maxItemsComputed": {},
     "aws.cwl.limit": {},

--- a/packages/core/src/stepFunctions/workflowStudio/activation.ts
+++ b/packages/core/src/stepFunctions/workflowStudio/activation.ts
@@ -17,7 +17,11 @@ export async function activate(): Promise<void> {
     // Open the file with Workflow Studio editor in a new tab, or focus on the tab with WFS if it is already open
     globals.context.subscriptions.push(
         Commands.register('aws.stepfunctions.openWithWorkflowStudio', async (uri: vscode.Uri) => {
-            await vscode.commands.executeCommand('vscode.openWith', uri, WorkflowStudioEditorProvider.viewType)
+            await vscode.commands.executeCommand(
+                'vscode.openWith',
+                uri.with({ query: 'manual=true' }),
+                WorkflowStudioEditorProvider.viewType
+            )
         })
     )
 
@@ -26,7 +30,11 @@ export async function activate(): Promise<void> {
     globals.context.subscriptions.push(
         Commands.register('aws.stepfunctions.switchToWorkflowStudio', async (uri: vscode.Uri) => {
             await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
-            await vscode.commands.executeCommand('vscode.openWith', uri, WorkflowStudioEditorProvider.viewType)
+            await vscode.commands.executeCommand(
+                'vscode.openWith',
+                uri.with({ query: 'manual=true' }),
+                WorkflowStudioEditorProvider.viewType
+            )
         })
     )
 }

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -146,6 +146,11 @@
                     "default": true,
                     "description": "%AWS.stepFunctions.asl.format.enable.desc%"
                 },
+                "aws.stepfunctions.workflowStudio.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%AWS.stepFunctions.workflowStudio.enable.desc%"
+                },
                 "aws.stepfunctions.asl.maxItemsComputed": {
                     "type": "number",
                     "default": 5000,
@@ -1411,6 +1416,11 @@
                 {
                     "command": "aws.openInApplicationComposer",
                     "when": "isFileSystemResource && !(resourceFilename =~ /^.*\\.tc\\.json$/) && resourceFilename =~ /^.*\\.(json|yml|yaml|template)$/",
+                    "group": "z_aws@1"
+                },
+                {
+                    "command": "aws.stepfunctions.openWithWorkflowStudio",
+                    "when": "isFileSystemResource && resourceFilename =~ /^.*\\.asl\\.(json|yml|yaml)$/",
                     "group": "z_aws@1"
                 }
             ],
@@ -3832,6 +3842,16 @@
                     "dark": "resources/icons/aws/applicationcomposer/icon-dark.svg",
                     "light": "resources/icons/aws/applicationcomposer/icon.svg"
                 },
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.stepfunctions.openWithWorkflowStudio",
+                "title": "%AWS.command.stepFunctions.openWithWorkflowStudio%",
+                "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"


### PR DESCRIPTION
## Problem
1. The feature opens specific file types in a custom editor by default and customers don't have a way to optout while still using toolkit
2. Currently the indentation setting used in the integration defaults to 4 spaces. If it's different in user's VSCode setting, the spacing for the string sent from the integration will not match
3. Currently context menu lacks the command to launch WFS. It [has been added before](https://github.com/aws/aws-toolkit-vscode/pull/5834/files), but it looks it was accidentally added to auto-generated file and was thus removed later

## Solution
1. Adding a setting to opt out of WFS, which will close custom editor and open default editor instead. Note that I did not find a way to completely prevent custom editor panel mount - it looks it's not possible, so it will start mounting first and then (in `resolveCustomTextEditor`) it needs to be witched to default editor. Please advise if that's not the case and the custom editor mount can be prevented earlier (while keeping file format association with the file types)
2. Passing a user setting for tab spacing to be used on the webview side to format JSON/YAML with the right indentation
3. Adding an option to launch WFS from context menu, as it was added before (but this time in the right package.json)
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
