### PR TITLE
fix(amazonq): auto-review doesn't populate treeview

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-c3484e6b-4093-4d35-8964-b5d07fb76469.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-c3484e6b-4093-4d35-8964-b5d07fb76469.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/review: Auto-review issues did not populate code issues list"
+}

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -596,6 +596,9 @@ export async function activate(context: ExtContext): Promise<void> {
                               CodeWhispererConstants.amazonqIgnoreNextLine
                           )
                 )
+            }),
+            vscode.window.createTreeView(SecurityIssueTreeViewProvider.viewType, {
+                treeDataProvider: SecurityIssueTreeViewProvider.instance,
             })
         )
     }

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -47,7 +47,7 @@ import {
     MaximumProjectScanReachedError,
     SecurityScanError,
 } from '../models/errors'
-import { SecurityIssuesTree } from '../service/securityIssueTreeViewProvider'
+import { SecurityIssueTreeViewProvider } from '../service/securityIssueTreeViewProvider'
 import { ChatSessionManager } from '../../amazonqScan/chat/storages/chatSession'
 import { TelemetryHelper } from '../util/telemetryHelper'
 
@@ -385,13 +385,6 @@ export function showSecurityScanResults(
     totalIssues: number
 ) {
     initSecurityScanRender(securityRecommendationCollection, context, editor, scope)
-    if (
-        totalIssues > 0 &&
-        (scope === CodeWhispererConstants.CodeAnalysisScope.PROJECT ||
-            scope === CodeWhispererConstants.CodeAnalysisScope.FILE_ON_DEMAND)
-    ) {
-        SecurityIssuesTree.instance.focus()
-    }
 
     if (scope === CodeWhispererConstants.CodeAnalysisScope.PROJECT) {
         populateCodeScanLogStream(zipMetadata.scannedFiles)
@@ -431,7 +424,7 @@ export function showScanResultsInChat(
 
     initSecurityScanRender(securityRecommendationCollection, context, editor, scope)
     if (totalIssues > 0) {
-        SecurityIssuesTree.instance.focus()
+        SecurityIssueTreeViewProvider.focus()
     }
 
     populateCodeScanLogStream(zipMetadata.scannedFiles)
@@ -531,7 +524,7 @@ function showScanCompletedNotification(total: number, scannedFiles: Set<string>)
     const items = [CodeWhispererConstants.showScannedFilesMessage]
     void vscode.window.showInformationMessage(`Code Review Completed`, ...items).then((value) => {
         if (total > 0 && value === CodeWhispererConstants.showScannedFilesMessage) {
-            SecurityIssuesTree.instance.focus()
+            SecurityIssueTreeViewProvider.focus()
         }
     })
 }

--- a/packages/core/src/codewhisperer/index.ts
+++ b/packages/core/src/codewhisperer/index.ts
@@ -49,7 +49,6 @@ export { SecurityIssueCodeActionProvider } from './service/securityIssueCodeActi
 export {
     SecurityIssueTreeViewProvider,
     SecurityViewTreeItem,
-    SecurityIssuesTree,
     FileItem,
     IssueItem,
     SeverityItem,

--- a/packages/core/src/codewhisperer/service/securityIssueTreeViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/securityIssueTreeViewProvider.ts
@@ -106,6 +106,12 @@ export class SecurityIssueTreeViewProvider implements vscode.TreeDataProvider<Se
     public refresh(): void {
         this._onDidChangeTreeData.fire()
     }
+
+    public static focus() {
+        void vscode.commands.executeCommand('aws.amazonq.SecurityIssuesTree.focus').then(undefined, (e) => {
+            getLogger().error('SecurityIssuesTree focus failed: %s', e.message)
+        })
+    }
 }
 
 enum ContextValue {
@@ -203,24 +209,5 @@ export class IssueItem extends vscode.TreeItem {
         markdown.appendMarkdown(this.issue.recommendation.text)
 
         return markdown
-    }
-}
-
-export class SecurityIssuesTree {
-    static #instance: SecurityIssuesTree
-    public static get instance() {
-        return (this.#instance ??= new this())
-    }
-
-    constructor() {
-        vscode.window.createTreeView(SecurityIssueTreeViewProvider.viewType, {
-            treeDataProvider: SecurityIssueTreeViewProvider.instance,
-        })
-    }
-
-    public focus() {
-        void vscode.commands.executeCommand('aws.amazonq.SecurityIssuesTree.focus').then(undefined, (e) => {
-            getLogger().error('SecurityIssuesTree focus failed: %s', e.message)
-        })
     }
 }

--- a/packages/core/src/test/codewhisperer/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/startSecurityScan.test.ts
@@ -28,7 +28,7 @@ import {
 import * as model from '../../codewhisperer/models/model'
 import * as errors from '../../shared/errors'
 import * as timeoutUtils from '../../shared/utilities/timeoutUtils'
-import { SecurityIssuesTree } from '../../codewhisperer'
+import { SecurityIssueTreeViewProvider } from '../../codewhisperer'
 import { createClient, mockGetCodeScanResponse } from './testUtil'
 
 let extensionContext: FakeExtensionContext
@@ -48,7 +48,7 @@ describe('startSecurityScan', function () {
         editor = await openTestFile(appCodePath)
         await model.CodeScansState.instance.setScansEnabled(false)
         sinon.stub(timeoutUtils, 'sleep')
-        focusStub = sinon.stub(SecurityIssuesTree.instance, 'focus')
+        focusStub = sinon.stub(SecurityIssueTreeViewProvider, 'focus')
     })
     afterEach(function () {
         sinon.restore()
@@ -74,7 +74,7 @@ describe('startSecurityScan', function () {
             createClient(),
             extensionContext,
             CodeAnalysisScope.PROJECT,
-            false
+            true
         )
         assert.ok(focusStub.calledOnce)
         assert.ok(securityScanRenderSpy.calledOnce)


### PR DESCRIPTION
## Problem

Issues detected by auto-review feature are not populating the code issues treeview list unless you run a manual `/review` first.

<img width="1594" alt="Screenshot 2025-02-04 at 3 00 08 PM" src="https://github.com/user-attachments/assets/4b817fad-a17e-4ce6-8374-fb81634f18b1" />

This issue is happening because `vscode.window.createTreeView` is hidden inside `SecurityIssuesTree` class which only gets invoked when you call `SecurityIssuesTree.instance.focus()`. Since we don't want to focus the tree view for auto-reviews, the treeview itself is never created.

## Solution

Move the treeview creation to activation so that it always gets created when the extension is activated


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
