### PR TITLE
refactor(debounce): avoid reimplementations of the same logic. 

### DIFF
--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -21,7 +21,7 @@ import { SsoClient } from './sso/clients'
 import { getLogger } from '../shared/logger'
 import { CredentialsProviderManager } from './providers/credentialsProviderManager'
 import { asString, CredentialsId, CredentialsProvider, fromString } from './providers/credentials'
-import { once } from '../shared/utilities/functionUtils'
+import { keyedDebounce, once } from '../shared/utilities/functionUtils'
 import { CredentialsSettings } from './credentials/utils'
 import {
     extractDataFromSection,
@@ -102,23 +102,6 @@ interface AuthService {
      * **IAM connections are not implemented**
      */
     updateConnection(connection: Pick<Connection, 'id'>, profile: Profile): Promise<Connection>
-}
-
-function keyedDebounce<T, U extends any[], K extends string = string>(
-    fn: (key: K, ...args: U) => Promise<T>
-): typeof fn {
-    const pending = new Map<K, Promise<T>>()
-
-    return (key, ...args) => {
-        if (pending.has(key)) {
-            return pending.get(key)!
-        }
-
-        const promise = fn(key, ...args).finally(() => pending.delete(key))
-        pending.set(key, promise)
-
-        return promise
-    }
 }
 
 export interface ConnectionStateChangeEvent {

--- a/packages/core/src/shared/utilities/functionUtils.ts
+++ b/packages/core/src/shared/utilities/functionUtils.ts
@@ -85,6 +85,10 @@ export function memoize<T, U extends any[]>(fn: (...args: U) => T): (...args: U)
  * Multiple calls made during the debounce window will receive references to the
  * same Promise similar to {@link shared}. The window will also be 'rolled', delaying
  * the execution by another {@link delay} milliseconds.
+ *
+ * This function prevents execution until {@link delay} milliseconds have passed
+ * since the last invocation regardless of arguments. If this should be
+ * argument dependent, look into {@link keyedDebounce}
  */
 export function debounce<Input extends any[], Output>(
     cb: (...args: Input) => Output | Promise<Output>,
@@ -95,7 +99,7 @@ export function debounce<Input extends any[], Output>(
 
 /**
  *
- * Similar to {@link debounce}, but allows the function to be cancelled and allow callbacks to pass function parameters.
+ * Similar to {@link debounce}, but allows the function to be cancelled.
  */
 export function cancellableDebounce<Input extends any[], Output>(
     cb: (...args: Input) => Output | Promise<Output>,
@@ -132,6 +136,10 @@ export function cancellableDebounce<Input extends any[], Output>(
     }
 }
 
+/**
+ *
+ * Similar to {@link debounce}, but uses a key to determine if the function should be called yet rather than a timeout connected to the function itself.
+ */
 export function keyedDebounce<T, U extends any[], K extends string = string>(
     fn: (key: K, ...args: U) => Promise<T>
 ): typeof fn {

--- a/packages/core/src/test/shared/utilities/functionUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/functionUtils.test.ts
@@ -52,7 +52,7 @@ describe('functionUtils', function () {
 
 describe('debounce', function () {
     let counter: number
-    let fn: () => Promise<unknown>
+    let fn: () => Promise<unknown> | unknown
 
     beforeEach(function () {
         counter = 0

--- a/packages/core/src/test/shared/utilities/functionUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/functionUtils.test.ts
@@ -52,7 +52,7 @@ describe('functionUtils', function () {
 
 describe('debounce', function () {
     let counter: number
-    let fn: () => Promise<unknown> | unknown
+    let fn: () => Promise<unknown>
 
     beforeEach(function () {
         counter = 0


### PR DESCRIPTION
## Problem
`debounce` is reimplemented in multiple places. There is `debounce`: https://github.com/aws/aws-toolkit-vscode/blob/100eb0737789d9d5ba4b04e055730b467bd97e14/packages/core/src/shared/utilities/functionUtils.ts#L89-L108
`cancellableDebounce`: https://github.com/aws/aws-toolkit-vscode/blob/100eb0737789d9d5ba4b04e055730b467bd97e14/packages/core/src/shared/utilities/functionUtils.ts#L114-L147
and a very similar function `keyedDebounce`: https://github.com/aws/aws-toolkit-vscode/blob/100eb0737789d9d5ba4b04e055730b467bd97e14/packages/core/src/auth/auth.ts#L107-L122

These functions should share common implementation logic, and live in the same place for easier discoverability. 

## Solution
- reimplement `debounce` in terms of `cancellableDebounce` since its a special case. 
- move these functions to shared, common location. 
- augment `debounce` to allow the callback to take arguments. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
