### PR TITLE
fix(amazonq): debugging amazon q can crash vscode

### DIFF
--- a/packages/amazonq/.vscode/launch.json
+++ b/packages/amazonq/.vscode/launch.json
@@ -9,11 +9,6 @@
             "name": "Extension",
             "type": "extensionHost",
             "request": "launch",
-            "debugWebviews": true,
-            "rendererDebugOptions": {
-                "urlFilter": "*amazonwebservices.amazon-q-vscode*",
-                "webRoot": "${workspaceFolder}"
-            },
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "env": {


### PR DESCRIPTION
## Problem
If you have amazon q locally and start a debugging session, pressing stop can sometimes crash the entirety of vscode

## Solution
remove [debugWebviews](https://github.com/microsoft/vscode-js-debug/blob/main/OPTIONS.md#rendererdebugoptions)/[rendererDebugOptions](https://github.com/microsoft/vscode-js-debug/blob/main/OPTIONS.md#rendererdebugoptions) from amazon q's launch config since they cause the local amazon q webview to attach to the debug instance which coincidentally ends up crashing vscode when extension debugging is stopped

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
