### PR TITLE
feat(amazonq): auto-download results

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-d9128dff-2867-4bf4-9046-2a52a36803d7.json
+++ b/packages/amazonq/.changes/next-release/Feature-d9128dff-2867-4bf4-9046-2a52a36803d7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "/transform: automatically download results when ready"
+}

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -773,6 +773,11 @@ export async function postTransformationJob() {
     if (transformByQState.getPayloadFilePath() !== '') {
         fs.rmSync(transformByQState.getPayloadFilePath(), { recursive: true, force: true }) // delete ZIP if it exists
     }
+
+    // attempt download for user
+    if (transformByQState.isSucceeded() || transformByQState.isPartiallySucceeded()) {
+        await vscode.commands.executeCommand('aws.amazonq.transformationHub.reviewChanges.startReview')
+    }
 }
 
 export async function transformationJobErrorHandler(error: any) {

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -775,6 +775,7 @@ export async function postTransformationJob() {
     }
 
     // attempt download for user
+    // TODO: refactor as explained here https://github.com/aws/aws-toolkit-vscode/pull/6519/files#r1946873107
     if (transformByQState.isSucceeded() || transformByQState.isPartiallySucceeded()) {
         await vscode.commands.executeCommand('aws.amazonq.transformationHub.reviewChanges.startReview')
     }


### PR DESCRIPTION
## Problem

Transformation results/artifacts expire after 24h, and sometimes users forget to manually click the "Download Proposed Changes" button within that time period.

## Solution

Auto-download the results from S3 when ready.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
