### PR TITLE
test(e2e): stabilize Amazon Q feature development tests

### DIFF
--- a/packages/amazonq/test/e2e/amazonq/framework/framework.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/framework.ts
@@ -105,6 +105,16 @@ export class qTestingFramework {
         return Object.entries(tabs).map(([tabId]) => new Messenger(tabId, this.mynahUIProps, this.mynahUI))
     }
 
+    public getSelectedTab() {
+        const selectedTabId = this.mynahUI.getSelectedTabId()
+        const selectedTab = this.getTabs().find((tab) => tab.tabID === selectedTabId)
+
+        if (!selectedTab) {
+            assert.fail('Selected tab not found')
+        }
+        return selectedTab
+    }
+
     public findTab(title: string) {
         return Object.values(this.getTabs()).find((tab) => tab.getStore().tabTitle === title)
     }


### PR DESCRIPTION
## Problem

Amazon Q feature dev e2e test was disabled due to flakiness. Issue: #6513 


## Solution

- Modified test prompt to prevent no change required scenarios that were causing deadend.
- Add `getSelectedTab` function in `qTestingFramework` to access newly created tab by quick action.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
