### PR TITLE
fix(amazonq): remove requestId param

### DIFF
--- a/packages/core/src/amazonqGumby/errors.ts
+++ b/packages/core/src/amazonqGumby/errors.ts
@@ -43,7 +43,7 @@ export class AlternateDependencyVersionsNotFoundError extends Error {
 }
 
 export class JobStoppedError extends Error {
-    constructor(readonly requestId: string) {
+    constructor() {
         super('Job was rejected, stopped, or failed')
     }
 }

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -686,9 +686,7 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
              * is called, we break above on validStatesForCheckingDownloadUrl and check final status in finalizeTransformationJob
              */
             if (CodeWhispererConstants.failureStates.includes(status)) {
-                throw new JobStoppedError(
-                    response.transformationJob.reason ?? 'no failure reason in GetTransformation response'
-                )
+                throw new JobStoppedError()
             }
             await sleep(CodeWhispererConstants.transformationJobPollingIntervalSeconds * 1000)
         } catch (e: any) {


### PR DESCRIPTION
## Problem

1) we already have logic to show the user the request ID of the last failed API call 
2) we also already have logic to show them the failure reason
3) when a job is stopped, we don't expect anything to be present in the `reason` field


## Solution

Remove param

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
