### PR TITLE
fix(amazonq): right click options dont send context if chat not loaded

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-704d175a-a99f-4ce7-bf08-b94d6f7218c0.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-704d175a-a99f-4ce7-bf08-b94d6f7218c0.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "`Send to prompt` and other context menu options not sent if chat was closed"
+}

--- a/packages/core/src/amazonq/apps/initContext.ts
+++ b/packages/core/src/amazonq/apps/initContext.ts
@@ -4,20 +4,20 @@
  */
 
 import { EventEmitter } from 'vscode'
-import { MessagePublisher } from '../messages/messagePublisher'
+import { MessagePublisher, UiMessagePublisher } from '../messages/messagePublisher'
 import { MessageListener } from '../messages/messageListener'
 import { TabType } from '../webview/ui/storages/tabsStorage'
 
 export interface AmazonQAppInitContext {
     registerWebViewToAppMessagePublisher(eventEmitter: MessagePublisher<any>, tabType: TabType): void
-    getAppsToWebViewMessagePublisher(): MessagePublisher<any>
+    getAppsToWebViewMessagePublisher(): UiMessagePublisher<any>
     onDidChangeAmazonQVisibility: EventEmitter<boolean>
 }
 
 export class DefaultAmazonQAppInitContext implements AmazonQAppInitContext {
     private readonly appsToWebViewEventEmitter = new EventEmitter<any>()
     private readonly appsToWebViewMessageListener = new MessageListener<any>(this.appsToWebViewEventEmitter)
-    private readonly appsToWebViewMessagePublisher = new MessagePublisher<any>(this.appsToWebViewEventEmitter)
+    private readonly appsToWebViewMessagePublisher = new UiMessagePublisher<any>(this.appsToWebViewEventEmitter)
     private readonly webViewToAppsMessagePublishers: Map<TabType, MessagePublisher<any>> = new Map()
     public readonly onDidChangeAmazonQVisibility = new EventEmitter<boolean>()
 
@@ -41,7 +41,7 @@ export class DefaultAmazonQAppInitContext implements AmazonQAppInitContext {
         return this.appsToWebViewMessageListener
     }
 
-    getAppsToWebViewMessagePublisher(): MessagePublisher<any> {
+    getAppsToWebViewMessagePublisher(): UiMessagePublisher<any> {
         return this.appsToWebViewMessagePublisher
     }
 }

--- a/packages/core/src/amazonq/messages/messagePublisher.ts
+++ b/packages/core/src/amazonq/messages/messagePublisher.ts
@@ -12,3 +12,48 @@ export class MessagePublisher<T> {
         this.eventEmitter.fire(event)
     }
 }
+
+/**
+ * Same as {@link MessagePublisher}, but will wait until the UI indicates it
+ * is ready to recieve messages, before the message is published.
+ *
+ * This solves a problem when running a right click menu option like
+ * "Send To Prompt" BUT chat is not opened yet, it would result in the prompt failing to
+ * be recieved by chat.
+ */
+export class UiMessagePublisher<T> extends MessagePublisher<T> {
+    private isUiReady: boolean = false
+    private buffer: T[] = []
+
+    constructor(eventEmitter: EventEmitter<T>) {
+        super(eventEmitter)
+    }
+
+    public override publish(event: T): void {
+        // immediately send if Chat UI is ready
+        if (this.isUiReady) {
+            super.publish(event)
+            return
+        }
+
+        this.buffer.push(event)
+    }
+
+    /**
+     * Indicate the Q Chat UI is ready to recieve messages.
+     */
+    public setUiReady() {
+        this.isUiReady = true
+        this.flush()
+    }
+
+    /**
+     * Publishes all blocked messages
+     */
+    private flush() {
+        for (const msg of this.buffer) {
+            super.publish(msg)
+        }
+        this.buffer = []
+    }
+}

--- a/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
+++ b/packages/core/src/amazonq/webview/messages/messageDispatcher.ts
@@ -13,6 +13,7 @@ import { telemetry } from '../../../shared/telemetry'
 import { AmazonQChatMessageDuration } from '../../messages/chatMessageDuration'
 import { globals, openUrl } from '../../../shared'
 import { isClickTelemetry, isOpenAgentTelemetry } from '../ui/telemetry/actions'
+import { DefaultAmazonQAppInitContext } from '../../apps/initContext'
 
 export function dispatchWebViewMessagesToApps(
     webview: Webview,
@@ -21,12 +22,12 @@ export function dispatchWebViewMessagesToApps(
     webview.onDidReceiveMessage((msg) => {
         switch (msg.command) {
             case 'ui-is-ready': {
+                DefaultAmazonQAppInitContext.instance.getAppsToWebViewMessagePublisher().setUiReady()
                 /**
                  * ui-is-ready isn't associated to any tab so just record the telemetry event and continue.
                  * This would be equivalent of the duration between "user clicked open q" and "ui has become available"
                  * NOTE: Amazon Q UI is only loaded ONCE. The state is saved between each hide/show of the webview.
                  */
-
                 telemetry.webview_load.emit({
                     webviewName: 'amazonq',
                     duration: performance.measure(amazonqMark.uiReady, amazonqMark.open).duration,

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 
-export type LogTopic = 'crashMonitoring' | 'dev/beta' | 'notifications' | 'test' | 'childProcess' | 'unknown'
+export type LogTopic = 'crashMonitoring' | 'dev/beta' | 'notifications' | 'test' | 'childProcess' | 'unknown' | 'chat'
 
 class ErrorLog {
     constructor(


### PR DESCRIPTION
## Problem:

When a user starts up VSC, hasn't opened Q chat yet, then highlights text and does a right click option like "send to prompt" THEN the whole prompt fails to make it to chat.

This is because there is a race condition between the message being sent to the webview, and the webview completed loading and ready to recieve messages.

## Solution:

In the appToMessage publisher, verify that the chat is ready to recieve messages based on if the webview sent the chat ui ready message. Otherwise wait until we get it, and then send the message.

### Demo

#### Before

https://github.com/user-attachments/assets/baf86737-4a5a-4f80-86fb-9abca2c56827

#### After 

https://github.com/user-attachments/assets/c3361403-5dae-49df-a878-94722eb4fc62

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
