### PR TITLE
deps(amazonq): Update amazon q language server to 3.x.x

### DIFF
--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -17,7 +17,7 @@ import {
 import path from 'path'
 
 const manifestURL = 'https://aws-toolkit-language-servers.amazonaws.com/codewhisperer/0/manifest.json'
-export const supportedLspServerVersions = '^2.3.0'
+export const supportedLspServerVersions = '^3.1.1'
 
 export class AmazonQLSPResolver implements LspResolver {
     async resolve(): Promise<LspResolution> {


### PR DESCRIPTION
## Problem
Amazon q currently uses the 2.3.2 version of the language server which doesn't appear to be working

## Solution
Update to the 3.x.x series for now

Independently i'm going to follow up with teams to understand how this happened. Had we released this feature to prod amazon q inline would have been completely broken


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
