### PR TITLE
fix(amazonq): auto-review removes existing issues

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-c8a60497-e42c-4141-bcfe-2c44188bc98b.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-c8a60497-e42c-4141-bcfe-2c44188bc98b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/review: Auto-review should not remove issues from manual reviews"
+}

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -614,7 +614,6 @@ function toggleIssuesVisibility(visibleCondition: (issue: CodeScanIssue, filePat
         ...group,
         issues: group.issues.map((issue) => ({ ...issue, visible: visibleCondition(issue, group.filePath) })),
     }))
-    securityScanRender.securityDiagnosticCollection?.clear()
     for (const issue of updatedIssues) {
         updateSecurityDiagnosticCollection(issue)
     }

--- a/packages/core/src/shared/utilities/commentUtils.ts
+++ b/packages/core/src/shared/utilities/commentUtils.ts
@@ -90,13 +90,16 @@ export function insertCommentAboveLine(document: vscode.TextDocument, line: numb
     }
 
     const edit = new vscode.WorkspaceEdit()
-    const position = new vscode.Position(line, 0)
+    const previousLine = Math.max(0, line - 1)
+    const previousLineLength = previousLine > 0 ? document.lineAt(previousLine).text.length : 0
+    const position = new vscode.Position(previousLine, previousLineLength)
     const indent = ' '.repeat(Math.max(0, document.lineAt(line).firstNonWhitespaceCharacterIndex))
+    const commentPrefix = line === 0 ? '' : '\n'
     const commentText = lineComment
-        ? `${indent}${lineComment} ${comment}\n`
+        ? `${commentPrefix}${indent}${lineComment} ${comment}`
         : blockComment?.[0] && blockComment[1]
-          ? `${indent}${blockComment[0]} ${comment} ${blockComment[1]}\n`
-          : `${indent}${defaultCommentConfig.lineComment} ${comment}\n`
+          ? `${commentPrefix}${indent}${blockComment[0]} ${comment} ${blockComment[1]}`
+          : `${commentPrefix}${indent}${defaultCommentConfig.lineComment} ${comment}`
     edit.insert(document.uri, position, commentText)
     void vscode.workspace.applyEdit(edit)
 }

--- a/packages/core/src/test/shared/utilities/commentUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/commentUtils.test.ts
@@ -77,7 +77,7 @@ describe('CommentUtils', function () {
 
             const document = createMockDocument('foo = 1\nbar = 2', 'foo.py', 'python')
             insertCommentAboveLine(document, 1, 'some-comment')
-            assert.ok(insertMock.calledOnceWith(document.uri, new vscode.Position(1, 0), '# some-comment\n'))
+            assert.ok(insertMock.calledOnceWith(document.uri, new vscode.Position(0, 0), '\n# some-comment'))
         })
 
         it('should indent the comment by the same amount as the current line', function () {
@@ -86,7 +86,7 @@ describe('CommentUtils', function () {
 
             const document = createMockDocument('    foo = 1\n    bar = 2', 'foo.py', 'python')
             insertCommentAboveLine(document, 1, 'some-comment')
-            assert.ok(insertMock.calledOnceWith(document.uri, new vscode.Position(1, 0), '    # some-comment\n'))
+            assert.ok(insertMock.calledOnceWith(document.uri, new vscode.Position(0, 0), '\n    # some-comment'))
         })
 
         it('should fallback to block comment if line comment is undefined', function () {
@@ -95,7 +95,7 @@ describe('CommentUtils', function () {
 
             const document = createMockDocument('<aaa>\n  <bbb></bbb>\n</aaa>', 'foo.xml', 'xml')
             insertCommentAboveLine(document, 1, 'some-comment')
-            assert.ok(insertMock.calledOnceWith(document.uri, new vscode.Position(1, 0), '  <!-- some-comment -->\n'))
+            assert.ok(insertMock.calledOnceWith(document.uri, new vscode.Position(0, 0), '\n  <!-- some-comment -->'))
         })
     })
 })


### PR DESCRIPTION
## Problem

Auto-reviews often produce less code issues than manual reviews, but the current behavior is to remove all the issues in the file when processing the new ones. This means that issues discovered by manual reviews but not auto-reviews will silently disappear if auto-reviews is enabled.


## Solution

- Auto-reviews should not clear the previous issues, but instead merge in the new results to the existing group.
- Fixed a related issue with the `ignoreIssue` command being flaky


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
