### PR TITLE
fix(amazonq): language server fails to start in non-debug mode

### DIFF
--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -36,8 +36,11 @@ export function createServerOptions({
     execArgv: string[]
 }) {
     return async () => {
-        const debugArgs = isDebugInstance() ? '--inspect=6080' : ''
-        const lspProcess = new ChildProcess(executable, [debugArgs, serverModule, ...execArgv])
+        const args = [serverModule, ...execArgv]
+        if (isDebugInstance()) {
+            args.unshift('--inspect=6080')
+        }
+        const lspProcess = new ChildProcess(executable, args)
 
         // this is a long running process, awaiting it will never resolve
         void lspProcess.run()


### PR DESCRIPTION
## Problem
The leading `''` when not in debug mode made the process start but not accept any events

## Solution
Only prepend the `inspect` args when required


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
