### PR TITLE
feat(amazonq): Support pre-release LSP versions

### DIFF
--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -4,7 +4,6 @@
  */
 
 import * as vscode from 'vscode'
-import { Range } from 'semver'
 import {
     ManifestResolver,
     LanguageServerResolver,
@@ -15,9 +14,12 @@ import {
     cleanLspDownloads,
 } from 'aws-core-vscode/shared'
 import path from 'path'
+import { Range } from 'semver'
 
-const manifestURL = 'https://aws-toolkit-language-servers.amazonaws.com/codewhisperer/0/manifest.json'
-export const supportedLspServerVersions = '^3.1.1'
+export const manifestURL = 'https://aws-toolkit-language-servers.amazonaws.com/codewhisperer/0/manifest.json'
+export const supportedLspServerVersions = new Range('^3.1.1', {
+    includePrerelease: true,
+})
 
 export class AmazonQLSPResolver implements LspResolver {
     async resolve(): Promise<LspResolution> {
@@ -41,7 +43,7 @@ export class AmazonQLSPResolver implements LspResolver {
         const installationResult = await new LanguageServerResolver(
             manifest,
             name,
-            new Range(supportedLspServerVersions)
+            supportedLspServerVersions
         ).resolve()
 
         const nodePath = path.join(installationResult.assetDirectory, `servers/${getNodeExecutableName()}`)

--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -345,7 +345,11 @@ export class LanguageServerResolver {
             return false
         }
 
-        return semver.satisfies(version.serverVersion, this.versionRange) && !version.isDelisted
+        return (
+            semver.satisfies(version.serverVersion, this.versionRange, {
+                includePrerelease: true,
+            }) && !version.isDelisted
+        )
     }
 
     /**


### PR DESCRIPTION
## Problem
We can't consume prerelease versions from the gamma manifest

## Solution
Support pre release lsp versions + test

## Notes
- I'll have another PR soon that pulls out the configuration so we can switch manifest urls for testing pretty easily
- E2E tests won't work until https://github.com/aws/aws-toolkit-vscode/pull/6538 is merged


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
