### PR TITLE
test(amazonq): add skipped test report generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
         "clean": "npm run clean -w packages/ -w plugins/",
         "reset": "npm run clean && ts-node ./scripts/clean.ts node_modules && npm install",
         "generateNonCodeFiles": "npm run generateNonCodeFiles -w packages/ --if-present",
-        "mergeReports": "ts-node ./scripts/mergeReports.ts"
+        "mergeReports": "ts-node ./scripts/mergeReports.ts",
+        "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
         "@aws-toolkits/telemetry": "^1.0.295",

--- a/scripts/skippedTestReport.ts
+++ b/scripts/skippedTestReport.ts
@@ -1,0 +1,113 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Scans test files for skipped Mocha tests.
+ *
+ * It uses a regex instead of mocha's loader, because mocha's
+ * loader can't resolve vscode by default
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+interface SkippedTest {
+    file: string
+    testName: string
+    lineNumber: number
+}
+
+function findSkippedTests(directoryPath: string): SkippedTest[] {
+    const skippedTests: SkippedTest[] = []
+
+    const skipPatterns = [/\b(describe|it)\.skip\(['"`](.*?)['"`]/g]
+
+    function searchInFile(filePath: string): void {
+        try {
+            const content = fs.readFileSync(filePath, 'utf8')
+            const lines = content.split('\n')
+
+            lines.forEach((line, index) => {
+                for (const pattern of skipPatterns) {
+                    const matches = line.matchAll(pattern)
+                    for (const match of matches) {
+                        skippedTests.push({
+                            file: filePath,
+                            testName: match[2],
+                            lineNumber: index + 1,
+                        })
+                    }
+                }
+            })
+        } catch (error) {
+            console.error(`Error reading file ${filePath}:`, error)
+        }
+    }
+
+    function visitDirectory(currentPath: string): void {
+        const files = fs.readdirSync(currentPath)
+
+        files.forEach((file) => {
+            const fullPath = path.join(currentPath, file)
+            const stat = fs.statSync(fullPath)
+
+            if (stat.isDirectory()) {
+                // Skip hidden directories
+                if (!file.startsWith('.')) {
+                    visitDirectory(fullPath)
+                }
+            } else if (stat.isFile() && file.endsWith('.ts')) {
+                searchInFile(fullPath)
+            }
+        })
+    }
+
+    visitDirectory(directoryPath)
+    return skippedTests
+}
+
+function main() {
+    const targetDirectory = process.argv[2] || '.'
+
+    try {
+        const skippedTests = findSkippedTests(targetDirectory)
+
+        if (skippedTests.length === 0) {
+            console.log('No skipped tests found.')
+            return
+        }
+
+        const testsByFile = skippedTests.reduce(
+            (acc, test) => {
+                const file = test.file
+                if (!acc[file]) {
+                    acc[file] = []
+                }
+                acc[file].push(test)
+                return acc
+            },
+            {} as Record<string, SkippedTest[]>
+        )
+
+        console.log('\nSkipped Tests Report')
+        console.log(`Total skipped tests: ${skippedTests.length}`)
+        console.log(`Files affected: ${Object.keys(testsByFile).length}`)
+        console.log('===================\n')
+
+        Object.entries(testsByFile).forEach(([file, tests]) => {
+            console.log(`📁 ${file}`)
+            console.log('     Skipped tests:')
+            tests.forEach((test) => {
+                console.log(`      • ${test.testName} (line ${test.lineNumber})`)
+            })
+            console.log('')
+        })
+    } catch (error) {
+        console.error('Error:', error)
+        process.exit(1)
+    }
+}
+
+main()


### PR DESCRIPTION
## Problem
This scripts creates a report of skipped tests in the amazon q folder

## Solution
Run: `npm run skippedTestReport`

```
Skipped Tests Report
Total skipped tests: 5
Files affected: 4
===================

📁 packages/amazonq/test/e2e/amazonq/featureDev.test.ts
     Skipped tests:
      • /dev {msg} entry (line 165)
      • file-level accepts (line 220)

📁 packages/amazonq/test/e2e/amazonq/template.test.ts
     Skipped tests:
      • Amazon Q Test Template (line 16)

📁 packages/amazonq/test/e2e/amazonq/testGen.test.ts
     Skipped tests:
      • ${language} file (line 168)

📁 packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
     Skipped tests:
      • Running a Java upgrade from start to finish (line 345)
```



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
