### PR TITLE
config(inline): show next session if only both sessino ids are the same

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/service/inlineCompletionService.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/inlineCompletionService.test.ts
@@ -49,6 +49,7 @@ describe('inlineCompletionService', function () {
             const session = CodeWhispererSessionState.instance.getSession()
             const mockEditor = createMockTextEditor()
             sinon.stub(RecommendationHandler.instance, 'getRecommendations').resolves({
+                sessionId: 'foo',
                 result: 'Succeeded',
                 errorMessage: undefined,
                 recommendationCount: 1,

--- a/packages/core/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/packages/core/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -154,6 +154,9 @@ async function promoteNextSessionIfAvailable(acceptanceEntry: OnRecommendationAc
         CodeWhispererSessionState.instance.setSession(nextSession)
 
         if (nextSession.recommendations.length && acceptanceEntry.sessionId === nextSession.sessionId) {
+            getLogger().debug(
+                `next session id ${nextSession.sessionId} mismatched previous session id ${acceptanceEntry.sessionId}, aborting promoteNextSession`
+            )
             await RecommendationHandler.instance.tryShowRecommendation()
         }
     }

--- a/packages/core/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/packages/core/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -152,7 +152,8 @@ async function promoteNextSessionIfAvailable(acceptanceEntry: OnRecommendationAc
         const nextSession = CodeWhispererSessionState.instance.getNextSession()
         nextSession.startPos = acceptanceEntry.editor.selection.active
         CodeWhispererSessionState.instance.setSession(nextSession)
-        if (nextSession.recommendations.length) {
+
+        if (nextSession.recommendations.length && acceptanceEntry.sessionId === nextSession.sessionId) {
             await RecommendationHandler.instance.tryShowRecommendation()
         }
     }

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -81,6 +81,7 @@ export interface CodeWhispererSupplementalContextItem {
 
 // This response struct can contain more info as needed
 export interface GetRecommendationsResponse {
+    readonly sessionId: string
     readonly result: 'Succeeded' | 'Failed'
     readonly recommendationCount: number
     readonly errorMessage: string | undefined

--- a/packages/core/src/codewhisperer/service/inlineCompletionService.ts
+++ b/packages/core/src/codewhisperer/service/inlineCompletionService.ts
@@ -85,6 +85,7 @@ export class InlineCompletionService {
     ): Promise<GetRecommendationsResponse> {
         if (vsCodeState.isCodeWhispererEditing || RecommendationHandler.instance.isSuggestionVisible()) {
             return {
+                sessionId: '',
                 result: 'Failed',
                 errorMessage: 'Amazon Q is already running',
                 recommendationCount: 0,
@@ -104,6 +105,7 @@ export class InlineCompletionService {
         if (AuthUtil.instance.isConnectionExpired()) {
             await AuthUtil.instance.notifyReauthenticate(isAutoTrigger)
             return {
+                sessionId: '',
                 result: 'Failed',
                 errorMessage: 'auth',
                 recommendationCount: 0,
@@ -115,6 +117,7 @@ export class InlineCompletionService {
         RecommendationHandler.instance.checkAndResetCancellationTokens()
         RecommendationHandler.instance.documentUri = editor.document.uri
         let response: GetRecommendationsResponse = {
+            sessionId: '',
             result: 'Failed',
             errorMessage: undefined,
             recommendationCount: 0,
@@ -140,6 +143,7 @@ export class InlineCompletionService {
                         void showTimedMessage(response.errorMessage ? response.errorMessage : noSuggestions, 2000)
                     }
                     return {
+                        sessionId: '',
                         result: 'Failed',
                         errorMessage: 'cancelled',
                         recommendationCount: 0,
@@ -160,6 +164,7 @@ export class InlineCompletionService {
         TelemetryHelper.instance.tryRecordClientComponentLatency()
 
         return {
+            sessionId: response.sessionId,
             result: 'Succeeded',
             errorMessage: undefined,
             recommendationCount: session.recommendations.length,

--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -288,6 +288,8 @@ export class RecommendationHandler {
             requestId = resp?.$response && resp?.$response?.requestId
             nextToken = resp?.nextToken ? resp?.nextToken : ''
             sessionId = resp?.$response?.httpResponse?.headers['x-amzn-sessionid']
+            getLogger().debug(`${isNextSession ? 'current' : 'next'} session id: ${sessionId}`)
+
             TelemetryHelper.instance.setFirstResponseRequestId(requestId)
             if (page === 0) {
                 currentSession.setTimeToFirstRecommendation(performance.now())
@@ -743,6 +745,9 @@ export class RecommendationHandler {
 
         const nextSessionId = nextResp.sessionId
         if (nextSessionId.length === 0 || nextSessionId !== session.sessionId) {
+            getLogger().debug(
+                `next session id ${nextSessionId} mismatch previous session id ${session.sessionId}, resetting next session`
+            )
             CodeWhispererSessionState.instance.getNextSession().reset()
         }
     }


### PR DESCRIPTION
## Problem

Followup of #6419 

Team decides to only show a subset of prefetched session instead of all as it's too intrusive experience.


## Solution

Only display prefetched sessions when the session ids are identical to the very first one.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
