### PR TITLE
telemetry(auth): debounce `aws_loadCredentials` more aggressively and remove debugging. 

### DIFF
--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -39,11 +39,4 @@ describe('tech debt', function () {
         // This is relevant for the use of `fs.cpSync` in the copyFiles scripts.
         assert.ok(semver.lt(minNodejs, '18.0.0'), 'with node18+, we can remove the dependency on @types/node@18')
     })
-
-    it('remove debugging telemetry', async function () {
-        fixByDate(
-            '2025-02-11',
-            'Remove debugging telemetry in `packages/core/src/auth/providers/credentialsProviderManager.ts`. Should only need to remove the `emit: true` in the decorator.'
-        )
-    })
 })


### PR DESCRIPTION
## Problem
Alternative solution to https://github.com/aws/aws-toolkit-vscode/pull/6541

## Solution
- debounce very aggressively (once per day).
- remove debugging `function_call`. 

## Notes 
debounce ignores args, so regardless of the telemetry metadata, it will only be emitted once per day. That is, regardless of the value of `credentialsSourceId`, it is emitted once per day. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
