### PR TITLE
fix(amazonq): Q infers source file from active test file for UTG.

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-cd65fb78-14de-4214-baac-2e998c4fb143.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-cd65fb78-14de-4214-baac-2e998c4fb143.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /test: Q identify active test file and infer source file for test generation."
+}

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -494,7 +494,7 @@ export class TestController {
                  * Get Diff from exportResultArchive API
                  */
                 ChatSessionManager.Instance.setIsInProgress(true)
-                await startTestGenerationProcess(fileName, filePath, message.prompt, tabID, true, selectionRange)
+                await startTestGenerationProcess(filePath, message.prompt, tabID, true, selectionRange)
             }
         } catch (err: any) {
             // TODO: refactor error handling to be more robust
@@ -549,12 +549,15 @@ export class TestController {
         testGenerationJobGroupName: string
         testGenerationJobId: string
         type: ChatItemType
-        fileName: string
+        filePath: string
     }) {
         this.messenger.sendShortSummary({
             type: 'answer',
             tabID: message.tabID,
-            message: testGenSummaryMessage(message.fileName, message.shortAnswer?.planSummary?.replaceAll('```', '')),
+            message: testGenSummaryMessage(
+                path.basename(message.shortAnswer?.sourceFilePath ?? message.filePath),
+                message.shortAnswer?.planSummary?.replaceAll('```', '')
+            ),
             canBeVoted: true,
             filePath: message.shortAnswer?.testFilePath,
         })
@@ -1117,13 +1120,7 @@ export class TestController {
                 canBeVoted: false,
                 messageId: TestNamedMessages.TEST_GENERATION_BUILD_STATUS_MESSAGE,
             })
-            await startTestGenerationProcess(
-                path.basename(session.sourceFilePath),
-                session.sourceFilePath,
-                '',
-                data.tabID,
-                false
-            )
+            await startTestGenerationProcess(session.sourceFilePath, '', data.tabID, false)
         }
         // TODO: Skip this if startTestGenerationProcess timeouts
         if (session.generatedFilePath) {

--- a/packages/core/src/codewhisperer/commands/startTestGeneration.ts
+++ b/packages/core/src/codewhisperer/commands/startTestGeneration.ts
@@ -28,7 +28,6 @@ import { Range } from '../client/codewhispereruserclient'
 let spawnResult: ChildProcess | null = null
 let isCancelled = false
 export async function startTestGenerationProcess(
-    fileName: string,
     filePath: string,
     userInputPrompt: string,
     tabID: string,
@@ -116,7 +115,7 @@ export async function startTestGenerationProcess(
         const jobStatus = await pollTestJobStatus(
             testJob.testGenerationJob.testGenerationJobId,
             testJob.testGenerationJob.testGenerationJobGroupName,
-            fileName,
+            filePath,
             initialExecution
         )
         // TODO: Send status to test summary

--- a/packages/core/src/codewhisperer/service/testGenHandler.ts
+++ b/packages/core/src/codewhisperer/service/testGenHandler.ts
@@ -129,7 +129,7 @@ export async function createTestJob(
 export async function pollTestJobStatus(
     jobId: string,
     jobGroupName: string,
-    fileName: string,
+    filePath: string,
     initialExecution: boolean
 ) {
     const session = ChatSessionManager.Instance.getSession()
@@ -187,7 +187,7 @@ export async function pollTestJobStatus(
                             shortAnswer,
                             testGenerationJobGroupName: resp.testGenerationJob?.testGenerationJobGroupName,
                             testGenerationJobId: resp.testGenerationJob?.testGenerationJobId,
-                            fileName,
+                            filePath,
                         })
                     }
                 }


### PR DESCRIPTION
## Problem
-  If user tries to run `/test` on the test file, Q considers test file as source file and starts the test generation on the test file.

## Solution
- If user tries to run `/test` on the test file, Q infers the context from the original source file and generate tests accordingly.
- No change in functionality, minor change in UX filename.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
