### PR TITLE
test(amazonq): wait for non-empty suggestion state

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/service/telemetry.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/telemetry.test.ts
@@ -23,7 +23,6 @@ import {
     ConfigurationEntry,
     RecommendationHandler,
     session,
-    vsCodeCursorUpdateDelay,
     AuthUtil,
 } from 'aws-core-vscode/codewhisperer'
 import { env, CodewhispererUserTriggerDecision } from 'aws-core-vscode/shared'

--- a/packages/amazonq/test/unit/codewhisperer/testUtil.ts
+++ b/packages/amazonq/test/unit/codewhisperer/testUtil.ts
@@ -5,13 +5,12 @@
 
 import assert from 'assert'
 import vscode from 'vscode'
-import { CodeWhispererSessionState, vsCodeCursorUpdateDelay } from 'aws-core-vscode/codewhisperer'
+import { session, vsCodeCursorUpdateDelay } from 'aws-core-vscode/codewhisperer'
 import { sleep, waitUntil } from 'aws-core-vscode/shared'
 import { assertTextEditorContains } from 'aws-core-vscode/test'
 
 // Note: RecommendationHandler.isSuggestionVisible seems not to work well, hence not using it
 export async function waitUntilSuggestionSeen(index: number = 0) {
-    const session = CodeWhispererSessionState.instance.getSession()
     const ok = await waitUntil(
         async () => {
             console.log('Suggestion state: %O', session.getSuggestionState(index))

--- a/packages/amazonq/test/unit/codewhisperer/testUtil.ts
+++ b/packages/amazonq/test/unit/codewhisperer/testUtil.ts
@@ -1,0 +1,93 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import vscode from 'vscode'
+import { CodeWhispererSessionState, vsCodeCursorUpdateDelay } from 'aws-core-vscode/codewhisperer'
+import { sleep, waitUntil } from 'aws-core-vscode/shared'
+import { assertTextEditorContains } from 'aws-core-vscode/test'
+
+// Note: RecommendationHandler.isSuggestionVisible seems not to work well, hence not using it
+export async function waitUntilSuggestionSeen(index: number = 0) {
+    const session = CodeWhispererSessionState.instance.getSession()
+    const ok = await waitUntil(
+        async () => {
+            console.log('Suggestion state: %O', session.getSuggestionState(index))
+            return session.getSuggestionState(index) === 'Showed'
+        },
+        {
+            interval: 500,
+            timeout: 5000,
+        }
+    )
+
+    assert.ok(ok === true)
+}
+
+export async function acceptByTab() {
+    const editor = vscode.window.activeTextEditor
+    if (!editor) {
+        throw new Error('no active editor')
+    }
+    const originalContent = editor.document.getText()
+    console.log('original content: %O', originalContent)
+
+    // we have to wait until the inline suggestion is shown in the editor however we don't have an useable API for that so hacky wait to know if the accept is taking effect
+    await waitUntil(
+        async () => {
+            await vscode.commands.executeCommand('editor.action.inlineSuggest.commit')
+            return vscode.window.activeTextEditor?.document.getText() !== originalContent
+        },
+        {
+            interval: 50,
+            timeout: 5000,
+        }
+    )
+
+    // required because oninlineAcceptance has sleep(vsCodeCursorUpdateDelay), otherwise assertion will be executed "before" onAcceptance hook
+    await sleep(vsCodeCursorUpdateDelay + 200)
+}
+
+export async function rejectByEsc() {
+    return vscode.commands.executeCommand('aws.amazonq.rejectCodeSuggestion')
+}
+
+export async function navigateNext() {
+    return vscode.commands.executeCommand('editor.action.inlineSuggest.showNext')
+}
+
+export async function navigatePrev() {
+    return vscode.commands.executeCommand('editor.action.inlineSuggest.showPrevious')
+}
+
+export async function closeActiveEditor() {
+    return vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+}
+
+export async function typing(editor: vscode.TextEditor, s: string) {
+    const initialContent = editor.document.getText()
+    const positionBefore = editor.document.offsetAt(editor.selection.active)
+
+    await editor.edit((edit) => {
+        edit.insert(editor.selection.active, s)
+    })
+
+    await assertTextEditorContains(initialContent + s)
+    await waitUntil(
+        async () => {
+            const positionPendingUpdate = editor.document.offsetAt(editor.selection.active)
+            if (positionPendingUpdate === positionBefore + s.length) {
+                return true
+            }
+        },
+        { interval: 50 }
+    )
+    const positionAfter = editor.document.offsetAt(editor.selection.active)
+    assert.strictEqual(positionAfter, positionBefore + s.length)
+}
+
+export async function backspace(editor: vscode.TextEditor) {
+    return vscode.commands.executeCommand('deleteLeft')
+}

--- a/packages/core/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/packages/core/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* eslint-disable aws-toolkits/no-console-log */
+
 import * as vscode from 'vscode'
 import * as CodeWhispererConstants from '../models/constants'
 import { vsCodeState, OnRecommendationAcceptanceEntry } from '../models/model'
@@ -53,6 +55,8 @@ export const acceptSuggestion = Commands.declare(
                 traceId: TelemetryHelper.instance.traceId,
             })
 
+            console.log('accepted completion')
+
             RecommendationService.instance.incrementAcceptedCount()
             const editor = vscode.window.activeTextEditor
             await Container.instance.lineAnnotationController.refresh(editor, 'codewhisperer')
@@ -76,10 +80,13 @@ export const acceptSuggestion = Commands.declare(
  * This function is called when user accepts a intelliSense suggestion or an inline suggestion
  */
 export async function onInlineAcceptance(acceptanceEntry: OnRecommendationAcceptanceEntry) {
+    console.log('accepted inline completion')
     RecommendationHandler.instance.cancelPaginatedRequest()
     RecommendationHandler.instance.disposeInlineCompletion()
+    console.log('accepted editor is: %O', acceptanceEntry.editor)
 
     if (acceptanceEntry.editor) {
+        console.log('editor was accepted')
         await sleep(CodeWhispererConstants.vsCodeCursorUpdateDelay)
         const languageContext = runtimeLanguageContext.getLanguageContext(
             acceptanceEntry.editor.document.languageId,
@@ -105,6 +112,7 @@ export async function onInlineAcceptance(acceptanceEntry: OnRecommendationAccept
         } catch (error) {
             getLogger().error(`${error} in handling extra brackets or imports`)
         } finally {
+            console.log('finished editing after acceptance')
             vsCodeState.isCodeWhispererEditing = false
         }
 

--- a/packages/core/src/shared/telemetry/telemetryLogger.ts
+++ b/packages/core/src/shared/telemetry/telemetryLogger.ts
@@ -125,4 +125,8 @@ export class TelemetryLogger {
     public queryRegex(re: RegExp | string): MetricDatum[] {
         return this._metrics.filter((m) => m.Metadata?.some((md) => md.Value?.match(re) || md.Key?.match(re)))
     }
+
+    public list() {
+        return this._metrics
+    }
 }


### PR DESCRIPTION
## Problem
- In some cases codewhisperer can emit an "Empty" suggestion state before emitting another telemetry event with "Reject"/"Accept". This introduced a couple e2e test failures/flakiness

## Solution
- Wait until we get a non "Empty" suggestion state in telemetry
- emit more debugging information if a test fails
- only test the last suggestion states value, since that's the one that actually corresponds to the users action

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
