### PR TITLE
telemetry(inline): fix inline completion pre-process timestamp set incorrectly

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-37204218-92a1-49d7-92c0-222624b2cccb.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-37204218-92a1-49d7-92c0-222624b2cccb.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix inline completion preprocess timestamp set incorrectly"
+}

--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -239,7 +239,9 @@ export class RecommendationHandler {
             )
         }
         const request = currentSession.requestContext.request
-        TelemetryHelper.instance.setPreprocessEndTime()
+        if (!isNextSession) {
+            TelemetryHelper.instance.setPreprocessEndTime()
+        }
 
         // set start pos for non pagination call or first pagination call
         if (!pagination || (pagination && page === 0)) {


### PR DESCRIPTION
## Problem

Logs
```
2025-02-11 09:53:56.382 [debug] pre-fetching next recommendation for model routing
2025-02-11 09:53:56.382 [warning] inline completion preprocessEndTime has been set and not reset correctly
2025-02-11 09:53:56.513 [debug] codewhisperer: request-id: 8fc42ac3-b49e-4ae0-884d-39ddf9245200,
    timestamp(epoch): 1739296436511,
    timezone: America/Los_Angeles,
```

bug introduced since #6419 

No functional impact, it's only impacting Q inline preprocess time metrics thus it's incorrectly recorded to the service.

Flow of prefetching

1. users trigger "first" inline request manually / automatically
2. plugins received the response and is ready to render
3. before rendering the current "first" session, plugins also pre-fetch next session and assume users will accept the first suggestion (which is used as part of file context sent to service)
4. render the first session to users
5. if users accept the first suggestion of first session, render 2nd session to users

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
