### PR TITLE
refactor(appbuilder): reduce number of ListRemoteTestEvent calls by remote invoke

### DIFF
--- a/packages/core/src/lambda/vue/remoteInvoke/remoteInvoke.vue
+++ b/packages/core/src/lambda/vue/remoteInvoke/remoteInvoke.vue
@@ -67,6 +67,7 @@
                                 value="savedEvents"
                                 v-model="payload"
                                 name="payload_request"
+                                @change="$emit('loadRemoteTestEvents')"
                             />
                             <label class="label-selector" for="savedEvents"> Remote saved events</label>
                         </div>

--- a/packages/core/src/lambda/vue/remoteInvoke/remoteInvokeFrontend.ts
+++ b/packages/core/src/lambda/vue/remoteInvoke/remoteInvokeFrontend.ts
@@ -132,6 +132,21 @@ export default defineComponent({
                 }
             )
         },
+
+        async loadRemoteTestEvents() {
+            const shouldLoadEvents =
+                this.payload === 'savedEvents' &&
+                this.initialData.FunctionArn &&
+                this.initialData.FunctionRegion &&
+                !this.initialData.TestEvents
+
+            if (shouldLoadEvents) {
+                this.initialData.TestEvents = await client.listRemoteTestEvents(
+                    this.initialData.FunctionArn,
+                    this.initialData.FunctionRegion
+                )
+            }
+        },
     },
     mixins: [saveData],
 })


### PR DESCRIPTION
## Problem
Today Remote Invoke call ListRemoteTestEvent every instances the webview is spun up. This pr introduces condition for which this api calls can be made thereby reducing the spike in number failures we see in our dashboard.

Note: we currently don't have test for frontend logic, however extensive testing was conducted.
<img width="1728" alt="Screenshot 2025-02-11 at 10 04 58 AM" src="https://github.com/user-attachments/assets/2e35be6d-6e18-4bb9-8df9-3eb80e51a58f" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
