### PR TITLE
fix(amazonq): let chat update after entering jdk path

### DIFF
--- a/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
@@ -13,6 +13,7 @@ import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/cod
 import { ToolkitError } from '../../../shared/errors'
 import { setMaven, writeLogs } from './transformFileHandler'
 import { throwIfCancelled } from './transformApiHandler'
+import { sleep } from '../../../shared/utilities/timeoutUtils'
 
 // run 'install' with either 'mvnw.cmd', './mvnw', or 'mvn' (if wrapper exists, we use that, otherwise we use regular 'mvn')
 function installProjectDependencies(dependenciesFolder: FolderInfo, modulePath: string) {
@@ -110,6 +111,8 @@ function copyProjectDependencies(dependenciesFolder: FolderInfo, modulePath: str
 export async function prepareProjectDependencies(dependenciesFolder: FolderInfo, rootPomPath: string) {
     await setMaven()
     getLogger().info('CodeTransformation: running Maven copy-dependencies')
+    // pause to give chat time to update
+    await sleep(100)
     try {
         copyProjectDependencies(dependenciesFolder, rootPomPath)
     } catch (err) {


### PR DESCRIPTION
## Problem

After entering JDK path, chat is sometimes frozen until the local build completes.


## Solution

Pause after user enters JDK path, to give chat time to update before starting the local build.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
