### PR TITLE
test(core): Use a fake global state for integ/e2e tests

### DIFF
--- a/packages/core/src/testInteg/globalSetup.test.ts
+++ b/packages/core/src/testInteg/globalSetup.test.ts
@@ -17,7 +17,7 @@ import * as testUtil from '../test/testUtil'
 import { DeviceFlowAuthorization } from '../auth/sso/ssoAccessTokenProvider'
 import { globals } from '../shared'
 import { GlobalState } from '../shared/globalState'
-import { FakeExtensionContext, FakeMemento } from '../test/fakeExtensionContext'
+import { FakeExtensionContext } from '../test/fakeExtensionContext'
 
 // ASSUMPTION: Tests are not run concurrently
 

--- a/packages/core/src/testInteg/globalSetup.test.ts
+++ b/packages/core/src/testInteg/globalSetup.test.ts
@@ -16,6 +16,8 @@ import * as tokenProvider from '../auth/sso/ssoAccessTokenProvider'
 import * as testUtil from '../test/testUtil'
 import { DeviceFlowAuthorization } from '../auth/sso/ssoAccessTokenProvider'
 import { globals } from '../shared'
+import { GlobalState } from '../shared/globalState'
+import { FakeExtensionContext, FakeMemento } from '../test/fakeExtensionContext'
 
 // ASSUMPTION: Tests are not run concurrently
 
@@ -48,6 +50,15 @@ export async function mochaGlobalSetup(extensionId: string) {
         if (getLogger() instanceof ToolkitLogger) {
             ;(getLogger() as ToolkitLogger).logToConsole()
         }
+
+        const fakeContext = await FakeExtensionContext.create()
+        const testFolder = await testUtil.TestFolder.create()
+        fakeContext.globalStorageUri = vscode.Uri.parse(testFolder.pathFrom('.'))
+        fakeContext.extensionPath = globals.context.extensionPath
+        Object.assign(globals, {
+            // eslint-disable-next-line aws-toolkits/no-banned-usages
+            globalState: new GlobalState(fakeContext.globalState),
+        })
     }
 }
 
@@ -58,9 +69,12 @@ export async function mochaGlobalTeardown(this: Mocha.Context) {
 }
 
 export const mochaHooks = {
-    beforeEach(this: Mocha.Context) {
+    async beforeEach(this: Mocha.Context) {
         globals.telemetry.clearRecords()
         globals.telemetry.logger.clear()
+
+        // mochaGlobalSetup() set this to a fake, so it's safe to clear it here.
+        await globals.globalState.clear()
     },
     afterEach(this: Mocha.Context) {
         patchWindow()


### PR DESCRIPTION
## Problem
Features that depend on global state can cause test failures locally because the tests will use your current global state settings instead of a fake state for integ/e2e tests

## Solution
integ/e2e tests should use a fake global state instead that automatically gets reset after each test

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
