### PR TITLE
fix(amazonq): Prevent adding same file twice for /doc and /dev

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-037e19bd-95f5-4cdf-8408-6eb273ff7ebd.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-037e19bd-95f5-4cdf-8408-6eb273ff7ebd.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Stuck on `Uploading code...` for /dev and /doc in some multi-root workspaces"
+	"description": "/dev and /doc: Multi-root workspace with duplicate files causes infinite 'Uploading code...' loop"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-037e19bd-95f5-4cdf-8408-6eb273ff7ebd.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-037e19bd-95f5-4cdf-8408-6eb273ff7ebd.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Stuck on `Uploading code...` for /dev and /doc in some multi-root workspaces"
+}

--- a/packages/core/src/amazonq/util/files.ts
+++ b/packages/core/src/amazonq/util/files.ts
@@ -48,8 +48,14 @@ export async function prepareRepoData(
 
         let totalBytes = 0
         const ignoredExtensionMap = new Map<string, number>()
+        const addedFilePaths = new Set()
 
         for (const file of files) {
+            if (addedFilePaths.has(file.zipFilePath)) {
+                continue
+            }
+            addedFilePaths.add(file.zipFilePath)
+
             let fileSize
             try {
                 fileSize = (await fs.stat(file.fileUri)).size


### PR DESCRIPTION
## Problem
Stuck on "Uploading code..." for /dev and /doc in a multi-root workspace with the same file paths in it multiple times.

## Solution
Add a check to prevent same file from being added to archive twice

Fixes issue https://github.com/aws/aws-toolkit-vscode/issues/6566

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
