### PR TITLE
fix(amazonq): make sure target JDK version is defined

### DIFF
--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -104,8 +104,9 @@ export async function processSQLConversionTransformFormInput(pathToProject: stri
     transformByQState.setProjectName(path.basename(pathToProject))
     transformByQState.setProjectPath(pathToProject)
     transformByQState.setSchema(schema)
-    transformByQState.setSourceJDKVersion(JDKVersion.JDK8) // use dummy value of JDK8 so that startJob API can be called
-    // targetJDKVersion defaults to JDK17, the only supported version, which is fine
+    // use dummy values of JDK8 & JDK17 so that startJob API can be called
+    transformByQState.setSourceJDKVersion(JDKVersion.JDK8)
+    transformByQState.setTargetJDKVersion(JDKVersion.JDK17)
 }
 
 async function validateJavaHome(): Promise<boolean> {


### PR DESCRIPTION
## Problem

Due to Java 21 support coming out, the target JDK version was no longer hardcoded as JDK17. So for SQL conversions, the target JDK was `undefined` and the `startJob` API was failing.


## Solution

Hardcode JDK17 as a dummy target JDK so that we don't encounter an invalid request exception.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
