### PR TITLE
feat(amazonq): user cancellable lsp download

### DIFF
--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -16,6 +16,7 @@ import { CodeWhispererStreamingServiceException } from '@amzn/codewhisperer-stre
 import { driveLetterRegex } from './utilities/pathUtils'
 import { getLogger } from './logger/logger'
 import { crashMonitoringDirName } from './constants'
+import { RequestCancelledError } from './request'
 
 let _username = 'unknown-user'
 let _isAutomation = false
@@ -618,7 +619,11 @@ function hasTime(error: Error): error is typeof error & { time: Date } {
 }
 
 export function isUserCancelledError(error: unknown): boolean {
-    return CancellationError.isUserCancelled(error) || (error instanceof ToolkitError && error.cancelled)
+    return (
+        CancellationError.isUserCancelled(error) ||
+        (error instanceof ToolkitError && error.cancelled) ||
+        error instanceof RequestCancelledError
+    )
 }
 
 /**

--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -226,7 +226,7 @@ export class LanguageServerResolver {
                 res: await new HttpResourceFetcher(content.url, {
                     showUrl: true,
                     timeout: timeout,
-                    swallowError: false,
+                    throwOnError: true,
                 }).get(),
                 hash: content.hashes[0],
                 filename: content.filename,

--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -17,6 +17,9 @@ import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
 import { showMessageWithCancel } from '../../shared/utilities/messages'
 import { Timeout } from '../utilities/timeoutUtils'
 
+// max timeout for downloading remote LSP assets progress, the lowest possible is 3000, bounded by httpResourceFetcher's waitUntil
+const remoteDownloadTimeout = 5000
+
 export class LanguageServerResolver {
     constructor(
         private readonly manifest: Manifest,
@@ -89,10 +92,7 @@ export class LanguageServerResolver {
      * Returns a timeout to be passed down into httpFetcher to handle user cancellation
      */
     private async showDownloadProgress() {
-        const timeout = new Timeout(5000)
-        timeout?.token.onCancellationRequested((event) => {
-            logger.info('Remote download cancelled by user')
-        })
+        const timeout = new Timeout(remoteDownloadTimeout)
         await showMessageWithCancel(`Downloading '${this.lsName}' language server`, timeout)
         return timeout
     }

--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -15,8 +15,7 @@ import { createHash } from '../crypto'
 import { lspSetupStage, StageResolver, tryStageResolvers } from './utils/setupStage'
 import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
 import { showMessageWithCancel } from '../../shared/utilities/messages'
-import { CancellationError, Timeout } from '../utilities/timeoutUtils'
-import { RequestCancelledError } from '../request'
+import { Timeout } from '../utilities/timeoutUtils'
 
 // max timeout for downloading remote LSP assets progress, the lowest possible is 3000, bounded by httpResourceFetcher's waitUntil
 const remoteDownloadTimeout = 5000
@@ -114,11 +113,6 @@ export class LanguageServerResolver {
             } else {
                 throw new ToolkitError('Failed to download server from remote', { code: 'RemoteDownloadFailed' })
             }
-        } catch (err) {
-            if (err instanceof RequestCancelledError) {
-                throw new CancellationError('user')
-            }
-            throw err
         } finally {
             timeout.dispose()
         }

--- a/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -7,7 +7,8 @@ import { VSCODE_EXTENSION_ID } from '../extensions'
 import { getLogger, Logger } from '../logger/logger'
 import { ResourceFetcher } from './resourcefetcher'
 import { Timeout, CancelEvent, waitUntil } from '../utilities/timeoutUtils'
-import request, { RequestCancelledError, RequestError } from '../request'
+import request, { RequestError } from '../request'
+import { isUserCancelledError } from '../errors'
 
 type RequestHeaders = { eTag?: string; gZip?: boolean }
 
@@ -120,8 +121,8 @@ export class HttpResourceFetcher implements ResourceFetcher<Response> {
                 interval: 100,
                 backoff: 2,
                 retryOnFail: (error: Error) => {
-                    // retry unless we got an user cancellation error
-                    return !(error instanceof RequestCancelledError)
+                    // Retry unless the user intentionally canceled the operation.
+                    return !isUserCancelledError(error)
                 },
             }
         )

--- a/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -22,7 +22,7 @@ export class HttpResourceFetcher implements ResourceFetcher<Response> {
      * @param {string} params.friendlyName If URL is not shown, replaces the URL with this text.
      * @param {Timeout} params.timeout Timeout token to abort/cancel the request. Similar to `AbortSignal`.
      * @param {number} params.retries The number of retries a get request should make if one fails
-     * @param {boolean} params.swallowError True if we want to swallow the request error, false if we want the error to keep bubbling up
+     * @param {boolean} params.throwOnError True if we want to throw if there's request error, defaul to false
      */
     public constructor(
         private readonly url: string,
@@ -30,10 +30,10 @@ export class HttpResourceFetcher implements ResourceFetcher<Response> {
             showUrl: boolean
             friendlyName?: string
             timeout?: Timeout
-            swallowError?: boolean
+            throwOnError?: boolean
         }
     ) {
-        this.params.swallowError = this.params.swallowError ?? true
+        this.params.throwOnError = this.params.throwOnError ?? false
     }
 
     /**
@@ -86,10 +86,10 @@ export class HttpResourceFetcher implements ResourceFetcher<Response> {
                 `Error downloading ${this.logText()}: %s`,
                 error.message ?? error.code ?? error.response.statusText ?? error.response.status
             )
-            if (this.params.swallowError) {
-                return undefined
+            if (this.params.throwOnError) {
+                throw error
             }
-            throw error
+            return undefined
         }
     }
 

--- a/packages/core/src/shared/utilities/timeoutUtils.ts
+++ b/packages/core/src/shared/utilities/timeoutUtils.ts
@@ -223,7 +223,7 @@ interface WaitUntilOptions {
     readonly backoff?: number
     /**
      * Only retries when an error is thrown, otherwise returning the immediate result.
-     * Can also be a callback for furthur error processing
+     * Can also be a callback for conditional retry based on errors
      * - 'truthy' arg is ignored
      * - If the timeout is reached it throws the last error
      * - default: false


### PR DESCRIPTION
## Problem
the cancellation button on notification doesn't actually stop the LSP download

## Solution
Route the notification timeout into `httpResourceFetcher` call, so that the user cancellation event stops the download as well.

Demo: non-cancelled and cancelled downloads:

https://github.com/user-attachments/assets/4f3d4ed0-635a-4f88-aef7-ee62e87bfc83



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
