### PR TITLE
fix(amazonq): fix view summary button

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-eac82ab9-bdab-47c4-834d-600cb1a0b6a2.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-eac82ab9-bdab-47c4-834d-600cb1a0b6a2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/transform: allow View Summary button to work even after accepting diff"
+}

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -343,7 +343,10 @@ export class ProposedTransformationExplorer {
             }
 
             diffModel.clearChanges()
-            transformByQState.setSummaryFilePath('')
+            // update summary path to where it is locally after user accepts changes, so that View Summary button works
+            transformByQState.setSummaryFilePath(
+                path.join(transformByQState.getProjectPath(), ExportResultArchiveStructure.PathToSummary)
+            )
             transformByQState.setProjectCopyFilePath('')
             transformByQState.setResultArchiveFilePath('')
             transformDataProvider.refresh()


### PR DESCRIPTION
## Problem

View Summary button wasn't working after users accept changes, since we save the `summary.md` to where their project is locally.


## Solution

Update summary file path.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
