### PR TITLE
test(amazonq): Set UI ready before executing amazonq e2e tests

### DIFF
--- a/packages/amazonq/test/e2e/amazonq/framework/framework.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/framework.ts
@@ -80,6 +80,10 @@ export class qTestingFramework {
             })
         )
 
+        /**
+         * We need to manually indicate that the UI is ready since we are using a custom mynah UI event routing
+         * implementation instead of routing events through the real webview
+         **/
         DefaultAmazonQAppInitContext.instance.getAppsToWebViewMessagePublisher().setUiReady()
     }
 

--- a/packages/amazonq/test/e2e/amazonq/framework/framework.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/framework.ts
@@ -79,6 +79,8 @@ export class qTestingFramework {
                 await ui.messageReceiver(event)
             })
         )
+
+        DefaultAmazonQAppInitContext.instance.getAppsToWebViewMessagePublisher().setUiReady()
     }
 
     /**

--- a/packages/amazonq/test/e2e/amazonq/framework/framework.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/framework.ts
@@ -79,8 +79,6 @@ export class qTestingFramework {
                 await ui.messageReceiver(event)
             })
         )
-
-        DefaultAmazonQAppInitContext.instance.getAppsToWebViewMessagePublisher().setUiReady()
     }
 
     /**

--- a/packages/amazonq/test/e2e/amazonq/framework/messenger.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/messenger.ts
@@ -190,9 +190,9 @@ export class Messenger {
          * Wait until the chat has finished loading. This happens when a backend request
          * has finished and responded in the chat
          */
-        await waitUntil(
-            () => {
-                return Promise.resolve(event())
+        const ok = await waitUntil(
+            async () => {
+                return event()
             },
             {
                 interval: waitOverrides ? waitOverrides.waitIntervalInMs : this.waitIntervalInMs,
@@ -202,7 +202,7 @@ export class Messenger {
         )
 
         // Do another check just in case the waitUntil time'd out
-        if (!event()) {
+        if (!ok) {
             assert.fail(
                 `Event has not finished loading in: ${waitOverrides ? waitOverrides.waitTimeoutInMs : this.waitTimeoutInMs} ms`
             )


### PR DESCRIPTION
## Problem
- after https://github.com/aws/aws-toolkit-vscode/commit/19d0346db98d45480f9909629b50daf31cba1186 the listener adds messages in a buffer until the ui is ready. It looks like some messages get caught in the buffer during tests since the mynah ui activation is slightly different there
- The waitUntil was waiting until an event evaluated to true and then afterwords checks to see if that same event is still true. This was causing an issue where if the event originally evaluated to true and then instantly evaluated to false, your tests would fail

## Solution
- manually set the ui ready after we've created the mynah ui instance in tests

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
