### PR TITLE
feat(lambda): Autoload debug config when the local invoke view is opened

### DIFF
--- a/packages/core/src/lambda/vue/configEditor/samInvokeBackend.ts
+++ b/packages/core/src/lambda/vue/configEditor/samInvokeBackend.ts
@@ -13,6 +13,7 @@ import {
     AwsSamDebuggerConfiguration,
     isCodeTargetProperties,
     isTemplateTargetProperties,
+    TemplateTargetProperties,
 } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
 import {
     DefaultAwsSamDebugConfigurationValidator,
@@ -433,15 +434,19 @@ export async function registerSamDebugInvokeVueCommand(
     context: vscode.ExtensionContext,
     params: { resource: ResourceNode }
 ) {
-    const launchConfig: AwsSamDebuggerConfiguration | undefined = undefined
     const resource = params?.resource.resource
     const source = 'AppBuilderLocalInvoke'
+    const launchConfigs = await new LaunchConfiguration(resource.location).getSamDebugConfigurations()
+    const launchConfig = launchConfigs.find(
+        (config) => (config.invokeTarget as TemplateTargetProperties).logicalId === resource.resource.Id
+    )
+
     const webview = new WebviewPanel(context, launchConfig, {
         logicalId: resource.resource.Id ?? '',
         region: resource.region ?? '',
         location: resource.location.fsPath,
         handler: resource.resource.Handler!,
-        runtime: resource.resource.Runtime!,
+        runtime: launchConfig?.lambda?.runtime ?? resource.resource.Runtime!,
         arn: resource.functionArn ?? '',
         stackName: resource.stackName ?? '',
         environment: resource.resource.Environment,

--- a/packages/toolkit/.changes/next-release/Feature-d85ac3b3-0e30-41fd-9dc1-1d214275189a.json
+++ b/packages/toolkit/.changes/next-release/Feature-d85ac3b3-0e30-41fd-9dc1-1d214275189a.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "lambda: autoload debug config when Local invoke webview is opened"
+	"description": "App Builder: Autoload debug configuration for local invoke webview"
 }

--- a/packages/toolkit/.changes/next-release/Feature-d85ac3b3-0e30-41fd-9dc1-1d214275189a.json
+++ b/packages/toolkit/.changes/next-release/Feature-d85ac3b3-0e30-41fd-9dc1-1d214275189a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "lambda: autoload debug config when Local invoke webview is opened"
+}


### PR DESCRIPTION
## Problem

Users have to re-select a debug config every time when open the Invoke and Debug webview
## Solution

Automatically load the first matching debug configuration when the local invoke view is opened

Note: No UI tests. https://github.com/aws/aws-toolkit-vscode/blob/master/docs/TESTPLAN.md#testing-gaps

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
