### PR TITLE
test(auth): avoid deprecated InputBox usage that caused flakiness. 

### DIFF
--- a/packages/core/src/auth/credentials/utils.ts
+++ b/packages/core/src/auth/credentials/utils.ts
@@ -14,8 +14,9 @@ import { messages, showMessageWithCancel, showViewLogsMessage } from '../../shar
 import { Timeout, waitTimeout } from '../../shared/utilities/timeoutUtils'
 import { fromExtensionManifest } from '../../shared/settings'
 import { Profile } from './sharedCredentials'
-import { createInputBox, promptUser } from '../../shared/ui/input'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
+import { createInputBox } from '../../shared/ui/inputPrompter'
+import { isValidResponse } from '../../shared/wizards/wizard'
 
 const credentialsTimeout = 300000 // 5 minutes
 const credentialsProgressDelay = 1000
@@ -113,18 +114,16 @@ const errorMessageUserCancelled = localize('AWS.error.mfa.userCancelled', 'User 
  */
 export async function getMfaTokenFromUser(mfaSerial: string, profileName: string): Promise<string> {
     const inputBox = createInputBox({
-        options: {
-            ignoreFocusOut: true,
-            placeHolder: localize('AWS.prompt.mfa.enterCode.placeholder', 'Enter Authentication Code Here'),
-            title: localize('AWS.prompt.mfa.enterCode.title', 'MFA Challenge for {0}', profileName),
-            prompt: localize('AWS.prompt.mfa.enterCode.prompt', 'Enter code for MFA device {0}', mfaSerial),
-        },
+        ignoreFocusOut: true,
+        placeholder: localize('AWS.prompt.mfa.enterCode.placeholder', 'Enter Authentication Code Here'),
+        title: localize('AWS.prompt.mfa.enterCode.title', 'MFA Challenge for {0}', profileName),
+        prompt: localize('AWS.prompt.mfa.enterCode.prompt', 'Enter code for MFA device {0}', mfaSerial),
     })
 
-    const token = await promptUser({ inputBox: inputBox })
+    const token = await inputBox.prompt()
 
     // Distinguish user cancel vs code entry issues with the error message
-    if (!token) {
+    if (!isValidResponse(token)) {
         throw new Error(errorMessageUserCancelled)
     }
 

--- a/packages/core/src/test/credentials/provider/sharedCredentialsProvider.test.ts
+++ b/packages/core/src/test/credentials/provider/sharedCredentialsProvider.test.ts
@@ -497,7 +497,7 @@ describe('SharedCredentialsProvider', async function () {
         })
 
         for (const _ of Array.from({ length: 1000 })) {
-            it.only('assumes role with mfa token', async function () {
+            it('assumes role with mfa token', async function () {
                 const sections = await createTestSections(`
                     ${defaultSection}
                     [profile assume]

--- a/packages/core/src/test/credentials/provider/sharedCredentialsProvider.test.ts
+++ b/packages/core/src/test/credentials/provider/sharedCredentialsProvider.test.ts
@@ -498,12 +498,12 @@ describe('SharedCredentialsProvider', async function () {
 
         it('assumes role with mfa token', async function () {
             const sections = await createTestSections(`
-                    ${defaultSection}
-                    [profile assume]
-                    source_profile = default
-                    role_arn = testarn
-                    mfa_serial= mfaSerialToken
-                    `)
+                ${defaultSection}
+                [profile assume]
+                source_profile = default
+                role_arn = testarn
+                mfa_serial= mfaSerialToken
+                `)
             const sut = new SharedCredentialsProvider('assume', sections)
 
             getTestWindow().onDidShowInputBox((inputBox) => {

--- a/packages/core/src/test/credentials/provider/sharedCredentialsProvider.test.ts
+++ b/packages/core/src/test/credentials/provider/sharedCredentialsProvider.test.ts
@@ -496,27 +496,25 @@ describe('SharedCredentialsProvider', async function () {
             assert.strictEqual(creds.sessionToken, 'token')
         })
 
-        for (const _ of Array.from({ length: 1000 })) {
-            it('assumes role with mfa token', async function () {
-                const sections = await createTestSections(`
+        it('assumes role with mfa token', async function () {
+            const sections = await createTestSections(`
                     ${defaultSection}
                     [profile assume]
                     source_profile = default
                     role_arn = testarn
                     mfa_serial= mfaSerialToken
                     `)
-                const sut = new SharedCredentialsProvider('assume', sections)
+            const sut = new SharedCredentialsProvider('assume', sections)
 
-                getTestWindow().onDidShowInputBox((inputBox) => {
-                    inputBox.acceptValue('mfaToken')
-                })
-
-                const creds = await sut.getCredentials()
-                assert.strictEqual(creds.accessKeyId, 'id')
-                assert.strictEqual(creds.secretAccessKey, 'secret')
-                assert.strictEqual(creds.sessionToken, 'token')
+            getTestWindow().onDidShowInputBox((inputBox) => {
+                inputBox.acceptValue('mfaToken')
             })
-        }
+
+            const creds = await sut.getCredentials()
+            assert.strictEqual(creds.accessKeyId, 'id')
+            assert.strictEqual(creds.secretAccessKey, 'secret')
+            assert.strictEqual(creds.sessionToken, 'token')
+        })
 
         it('does not assume role when no roleArn is present', async function () {
             const sut = new SharedCredentialsProvider('default', await createTestSections(defaultSection))

--- a/packages/core/src/test/credentials/provider/sharedCredentialsProvider.test.ts
+++ b/packages/core/src/test/credentials/provider/sharedCredentialsProvider.test.ts
@@ -496,25 +496,27 @@ describe('SharedCredentialsProvider', async function () {
             assert.strictEqual(creds.sessionToken, 'token')
         })
 
-        it('assumes role with mfa token', async function () {
-            const sections = await createTestSections(`
-                ${defaultSection}
-                [profile assume]
-                source_profile = default
-                role_arn = testarn
-                mfa_serial= mfaSerialToken
-                `)
-            const sut = new SharedCredentialsProvider('assume', sections)
+        for (const _ of Array.from({ length: 1000 })) {
+            it.only('assumes role with mfa token', async function () {
+                const sections = await createTestSections(`
+                    ${defaultSection}
+                    [profile assume]
+                    source_profile = default
+                    role_arn = testarn
+                    mfa_serial= mfaSerialToken
+                    `)
+                const sut = new SharedCredentialsProvider('assume', sections)
 
-            getTestWindow().onDidShowInputBox((inputBox) => {
-                inputBox.acceptValue('mfaToken')
+                getTestWindow().onDidShowInputBox((inputBox) => {
+                    inputBox.acceptValue('mfaToken')
+                })
+
+                const creds = await sut.getCredentials()
+                assert.strictEqual(creds.accessKeyId, 'id')
+                assert.strictEqual(creds.secretAccessKey, 'secret')
+                assert.strictEqual(creds.sessionToken, 'token')
             })
-
-            const creds = await sut.getCredentials()
-            assert.strictEqual(creds.accessKeyId, 'id')
-            assert.strictEqual(creds.secretAccessKey, 'secret')
-            assert.strictEqual(creds.sessionToken, 'token')
-        })
+        }
 
         it('does not assume role when no roleArn is present', async function () {
             const sut = new SharedCredentialsProvider('default', await createTestSections(defaultSection))


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/issues/6594

The `getMfaCodeFromUser` currently uses a deprecated version of `createInputBox` and the following `promptUser` function: 
https://github.com/aws/aws-toolkit-vscode/blob/0fa1b5b47ab642458df934192832a4ffcb6c9d1e/packages/core/src/shared/ui/input.ts#L72-L135

Based on the stack trace, there is a race condition here that can lead to a type error, but unsure how?
Stack trace: 
```
TypeError: inputBox.hide is not a function
      at promptUser (/Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/packages/core/src/shared/ui/input.ts:133:18)
      at async getMfaTokenFromUser (/Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/packages/core/src/auth/credentials/utils.ts:124:19)
      at async /Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/packages/core/src/auth/providers/sharedCredentialsProvider.ts:422:38
```
### Investigation Notes:
- The error only happens when running the test suite as a whole. 
- The error only happens in CI (unable to reproduce locally). 

## Solution
- avoid use of deprecated `createInputBox` [function](https://github.com/aws/aws-toolkit-vscode/blob/0fa1b5b47ab642458df934192832a4ffcb6c9d1e/packages/core/src/shared/ui/input.ts#L31-L58), prefer new version instead.  
- Ran the tests 4x with 1000x on the test, and did not see a failure. 

## Future Work 
- Migrate existing cases away from this deprecated `createInputBox` if there is evidence it leads to flaky tests or unreliable behavior. 
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
