### PR TITLE
fix(appbuilder): pass in the negative version of --use-container when using build quickpick

### DIFF
--- a/packages/core/src/shared/sam/build.ts
+++ b/packages/core/src/shared/sam/build.ts
@@ -284,7 +284,7 @@ function resolveBuildArgConflict(boundArgs: string[]): string[] {
     return Array.from(boundArgsSet)
 }
 export async function resolveBuildFlags(buildFlags: string[], samCliVersion: SemVer | null): Promise<string[]> {
-    // const samCliVersion = (await getSamCliPathAndVersion()).parsedVersion
+    // --no-use-container was not added until v1.133.0
     if (samCliVersion?.compare('1.133.0') ?? -1 < 0) {
         return buildFlags
     }

--- a/packages/core/src/shared/sam/build.ts
+++ b/packages/core/src/shared/sam/build.ts
@@ -29,6 +29,7 @@ import {
 } from './utils'
 import { getConfigFileUri, validateSamBuildConfig } from './config'
 import { runInTerminal } from './processTerminal'
+import { getLogger } from '../logger'
 
 const buildMementoRootKey = 'samcli.build.params'
 export interface BuildParams {
@@ -213,7 +214,7 @@ export async function runBuild(arg?: TreeNode): Promise<SamBuildResult> {
     // refactor
     const buildFlags: string[] =
         params.paramsSource === ParamsSource.Specify && params.buildFlags
-            ? JSON.parse(params.buildFlags)
+            ? resolveBuildFlags(JSON.parse(params.buildFlags))
             : await getBuildFlags(params.paramsSource, projectRoot, defaultFlags)
 
     // todo remove
@@ -280,4 +281,10 @@ function resolveBuildArgConflict(boundArgs: string[]): string[] {
     //     boundArgsSet.add('--no-beta-features')
     // }
     return Array.from(boundArgsSet)
+}
+export function resolveBuildFlags(buildFlags: string[]): string[] {
+    if (!buildFlags.includes('--use-container')) {
+        buildFlags.push('--no-use-container')
+    }
+    return buildFlags
 }

--- a/packages/core/src/test/shared/sam/build.test.ts
+++ b/packages/core/src/test/shared/sam/build.test.ts
@@ -16,6 +16,7 @@ import {
     createParamsSourcePrompter,
     getBuildFlags,
     ParamsSource,
+    resolveBuildFlags,
     runBuild,
 } from '../../../shared/sam/build'
 import { TreeNode } from '../../../shared/treeview/resourceTreeDataProvider'
@@ -227,6 +228,14 @@ describe('SAM build helper functions', () => {
             assert.strictEqual(quickPick.placeholder, 'Select configuration options for sam build')
             assert.strictEqual(quickPick.items.length, 2)
             assert.deepStrictEqual(quickPick.items, expectedItems)
+        })
+    })
+
+    describe('resolveBuildFlags', () => {
+        it('should add --no-use-container if the buildFlags array does not contain --use-container', () => {
+            const buildFlags: string[] = ['--cached', '--debug', '--parallel']
+            const resolvedBuildFlags = ['--cached', '--debug', '--parallel', '--no-use-container']
+            assert.deepStrictEqual(resolvedBuildFlags, resolveBuildFlags(buildFlags))
         })
     })
 })

--- a/packages/toolkit/.changes/next-release/Bug Fix-f7a3ecad-06a7-48cd-896b-2285ea95bd84.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-f7a3ecad-06a7-48cd-896b-2285ea95bd84.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "appBuilder: pass '--no-use-container' when '--use-container' is not selected in quickpick"
+}


### PR DESCRIPTION

## Problem
When users use appbuilder to build their lambda functions, they choose between using their samconfig file or manually selecting the build parameters/flags. The problem is that when the user selects build flags and intentionally doesn't select the ```--use-container``` flag, the command will still be run with --use-container if the samconfig file has ```use_container``` is set to true.

## Solution
Whenever the user manually selects the build flags and doesn't select ```--use-container```, we add the negative version of ```--use-container```, which is ```--no-use-container```. This serves as an override if the samconfig file has ```--use-container``` set to true.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
