### PR TITLE
feat(amazonq): manifest deprecation message with optional don't show

### DIFF
--- a/packages/core/src/dev/activation.ts
+++ b/packages/core/src/dev/activation.ts
@@ -26,7 +26,6 @@ import { DevNotificationsState } from '../notifications/types'
 import { QuickPickItem } from 'vscode'
 import { ChildProcess } from '../shared/utilities/processUtils'
 import { WorkspaceLSPResolver } from '../amazonq/lsp/workspaceInstaller'
-import * as ManifestResolver from '../shared/lsp/manifestResolver'
 
 interface MenuOption {
     readonly label: string

--- a/packages/core/src/dev/activation.ts
+++ b/packages/core/src/dev/activation.ts
@@ -26,6 +26,7 @@ import { DevNotificationsState } from '../notifications/types'
 import { QuickPickItem } from 'vscode'
 import { ChildProcess } from '../shared/utilities/processUtils'
 import { WorkspaceLSPResolver } from '../amazonq/lsp/workspaceInstaller'
+import * as ManifestResolver from '../shared/lsp/manifestResolver'
 
 interface MenuOption {
     readonly label: string
@@ -453,9 +454,15 @@ const resettableFeatures: readonly ResettableFeature[] = [
     },
     {
         name: 'workspace lsp',
-        label: 'Lsp',
+        label: 'Lsp Download',
         detail: 'Resets workspace LSP',
         executor: resetWorkspaceLspDownload,
+    },
+    {
+        name: 'lsp global state',
+        label: 'Lsp State',
+        detail: 'Resets LSP manifest global state',
+        executor: resetLSPGlobalState,
     },
 ] as const
 
@@ -547,6 +554,10 @@ async function resetNotificationsState() {
 
 async function resetWorkspaceLspDownload() {
     await new WorkspaceLSPResolver().resolve()
+}
+
+async function resetLSPGlobalState() {
+    await ManifestResolver.resetManifestState()
 }
 
 async function editNotifications() {

--- a/packages/core/src/dev/activation.ts
+++ b/packages/core/src/dev/activation.ts
@@ -454,7 +454,7 @@ const resettableFeatures: readonly ResettableFeature[] = [
     },
     {
         name: 'workspace lsp',
-        label: 'Lsp Download',
+        label: 'Download Lsp ',
         detail: 'Resets workspace LSP',
         executor: resetWorkspaceLspDownload,
     },

--- a/packages/core/src/dev/activation.ts
+++ b/packages/core/src/dev/activation.ts
@@ -458,12 +458,6 @@ const resettableFeatures: readonly ResettableFeature[] = [
         detail: 'Resets workspace LSP',
         executor: resetWorkspaceLspDownload,
     },
-    {
-        name: 'lsp global state',
-        label: 'Lsp State',
-        detail: 'Resets LSP manifest global state',
-        executor: resetLSPGlobalState,
-    },
 ] as const
 
 // TODO this is *somewhat* similar to `openStorageFromInput`. If we need another
@@ -554,10 +548,6 @@ async function resetNotificationsState() {
 
 async function resetWorkspaceLspDownload() {
     await new WorkspaceLSPResolver().resolve()
-}
-
-async function resetLSPGlobalState() {
-    await ManifestResolver.resetManifestState()
 }
 
 async function editNotifications() {

--- a/packages/core/src/shared/lsp/manifestResolver.ts
+++ b/packages/core/src/shared/lsp/manifestResolver.ts
@@ -111,14 +111,14 @@ export class ManifestResolver {
         const prompts = AmazonQPromptSettings.instance
         const lspId = `${this.lsName}LspManifestMessage`
 
-        // sanity check, if the lsName is changed then we also need to update the prompt keys in settings-amazonq.gen
+        // Sanity check, if the lsName is changed then we also need to update the prompt keys in settings-amazonq.gen
         if (!(lspId in amazonQPrompts)) {
             logger.error(`LSP ID "${lspId}" not found in amazonQPrompts.`)
             return
         }
 
         if (!manifest.isManifestDeprecated) {
-            // in case we got an new url, make sure the prompt is re-enabled for active manifests
+            // In case we got an new url, make sure the prompt is re-enabled for active manifests
             await prompts.enablePrompt(lspId as keyof typeof amazonQPrompts)
             return
         }

--- a/packages/core/src/shared/lsp/manifestResolver.ts
+++ b/packages/core/src/shared/lsp/manifestResolver.ts
@@ -132,10 +132,7 @@ export class ManifestResolver {
     private async saveManifest(etag: string, content: string): Promise<void> {
         const storage = this.getStorage()
 
-        // Only true when incoming manifest is deprecated & existing muteDeprecation is true (set by user)
-        const muteDeprecation =
-            (storage[this.lsName] ? storage[this.lsName].muteDeprecation : false) &&
-            this.parseManifest(content).isManifestDeprecated
+        const muteDeprecation = storage[this.lsName]?.muteDeprecation ?? false
 
         globals.globalState.tryUpdate(manifestStorageKey, {
             ...storage,

--- a/packages/core/src/shared/lsp/manifestResolver.ts
+++ b/packages/core/src/shared/lsp/manifestResolver.ts
@@ -109,7 +109,7 @@ export class ManifestResolver {
      */
     private async checkDeprecation(manifest: Manifest): Promise<void> {
         const prompts = AmazonQPromptSettings.instance
-        const lspId = `${this.lsName}LspManifestMessage`
+        const lspId = `${this.lsName}LspManifestMessage` as keyof typeof amazonQPrompts
 
         // Sanity check, if the lsName is changed then we also need to update the prompt keys in settings-amazonq.gen
         if (!(lspId in amazonQPrompts)) {
@@ -119,19 +119,19 @@ export class ManifestResolver {
 
         if (!manifest.isManifestDeprecated) {
             // In case we got an new url, make sure the prompt is re-enabled for active manifests
-            await prompts.enablePrompt(lspId as keyof typeof amazonQPrompts)
+            await prompts.enablePrompt(lspId)
             return
         }
 
         const deprecationMessage = `"${this.lsName}" manifest is deprecated. No future updates will be available.`
         logger.info(deprecationMessage)
 
-        if (prompts.isPromptEnabled(lspId as keyof typeof amazonQPrompts)) {
+        if (prompts.isPromptEnabled(lspId)) {
             void vscode.window
                 .showInformationMessage(deprecationMessage, localizedText.ok, localizedText.dontShow)
                 .then(async (button) => {
                     if (button === localizedText.dontShow) {
-                        await prompts.disablePrompt(lspId as keyof typeof amazonQPrompts)
+                        await prompts.disablePrompt(lspId)
                     }
                 })
         }

--- a/packages/core/src/shared/lsp/manifestResolver.ts
+++ b/packages/core/src/shared/lsp/manifestResolver.ts
@@ -12,23 +12,19 @@ import { Manifest } from './types'
 import { StageResolver, tryStageResolvers } from './utils/setupStage'
 import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
 import * as localizedText from '../localizedText'
+import { AmazonQPromptSettings, amazonQPrompts } from '../settings'
 
 const logger = getLogger('lsp')
 
 interface StorageManifest {
     etag: string
     content: string
-    dontShow: boolean
 }
 
 type ManifestStorage = Record<string, StorageManifest>
 
 export const manifestStorageKey = 'aws.toolkit.lsp.manifest'
 const manifestTimeoutMs = 15000
-
-export async function resetManifestState() {
-    await globals.globalState.update(manifestStorageKey, {})
-}
 
 export class ManifestResolver {
     constructor(
@@ -74,7 +70,7 @@ export class ManifestResolver {
 
         const manifest = this.parseManifest(resp.content)
         await this.saveManifest(resp.eTag, resp.content)
-        this.checkDeprecation(manifest)
+        await this.checkDeprecation(manifest)
         manifest.location = 'remote'
         return manifest
     }
@@ -89,7 +85,7 @@ export class ManifestResolver {
         }
 
         const manifest = this.parseManifest(manifestData.content)
-        this.checkDeprecation(manifest)
+        await this.checkDeprecation(manifest)
         manifest.location = 'cache'
         return manifest
     }
@@ -108,22 +104,34 @@ export class ManifestResolver {
      * Check if the current manifest is deprecated.
      * If yes and user hasn't muted this notification, shows a toast message with two buttons:
      * - OK: close and do nothing
-     * - Don't Show Again: Update global state (dontShow) so the deprecation message is never shown for this manifest.
+     * - Don't Show Again: Update suppressed prompt setting so the deprecation message is never shown for this manifest.
      * @param manifest
      */
-    private checkDeprecation(manifest: Manifest): void {
+    private async checkDeprecation(manifest: Manifest): Promise<void> {
+        const prompts = AmazonQPromptSettings.instance
+        const lspId = `${this.lsName}LspManifestMessage`
+
+        // sanity check, if the lsName is changed then we also need to update the prompt keys in settings-amazonq.gen
+        if (!(lspId in amazonQPrompts)) {
+            logger.error(`LSP ID "${lspId}" not found in amazonQPrompts.`)
+            return
+        }
+
         if (!manifest.isManifestDeprecated) {
+            // in case we got an new url, make sure the prompt is re-enabled for active manifests
+            await prompts.enablePrompt(lspId as keyof typeof amazonQPrompts)
             return
         }
 
         const deprecationMessage = `"${this.lsName}" manifest is deprecated. No future updates will be available.`
         logger.info(deprecationMessage)
-        if (!this.getStorage()[this.lsName].dontShow) {
+
+        if (prompts.isPromptEnabled(lspId as keyof typeof amazonQPrompts)) {
             void vscode.window
                 .showInformationMessage(deprecationMessage, localizedText.ok, localizedText.dontShow)
-                .then((button) => {
+                .then(async (button) => {
                     if (button === localizedText.dontShow) {
-                        this.getStorage()[this.lsName].dontShow = true
+                        await prompts.disablePrompt(lspId as keyof typeof amazonQPrompts)
                     }
                 })
         }
@@ -132,14 +140,11 @@ export class ManifestResolver {
     private async saveManifest(etag: string, content: string): Promise<void> {
         const storage = this.getStorage()
 
-        const dontShow = storage[this.lsName]?.dontShow ?? false
-
         globals.globalState.tryUpdate(manifestStorageKey, {
             ...storage,
             [this.lsName]: {
                 etag,
                 content,
-                dontShow,
             },
         })
     }

--- a/packages/core/src/shared/lsp/manifestResolver.ts
+++ b/packages/core/src/shared/lsp/manifestResolver.ts
@@ -112,18 +112,20 @@ export class ManifestResolver {
      * @param manifest
      */
     private checkDeprecation(manifest: Manifest): void {
+        if (!manifest.isManifestDeprecated) {
+            return
+        }
+
         const deprecationMessage = `${this.lsName} manifest is deprecated. No future updates will be available.`
-        if (manifest.isManifestDeprecated) {
-            logger.info(deprecationMessage)
-            if (!this.getStorage()[this.lsName].muteDeprecation) {
-                void vscode.window
-                    .showInformationMessage(deprecationMessage, localizedText.ok, localizedText.dontShow)
-                    .then((button) => {
-                        if (button === localizedText.dontShow) {
-                            this.getStorage()[this.lsName].muteDeprecation = true
-                        }
-                    })
-            }
+        logger.info(deprecationMessage)
+        if (!this.getStorage()[this.lsName].muteDeprecation) {
+            void vscode.window
+                .showInformationMessage(deprecationMessage, localizedText.ok, localizedText.dontShow)
+                .then((button) => {
+                    if (button === localizedText.dontShow) {
+                        this.getStorage()[this.lsName].muteDeprecation = true
+                    }
+                })
         }
     }
 
@@ -133,7 +135,7 @@ export class ManifestResolver {
         // Only true when incoming manifest is deprecated & existing muteDeprecation is true (set by user)
         const muteDeprecation =
             (storage[this.lsName] ? storage[this.lsName].muteDeprecation : false) &&
-            (JSON.parse(content) as Manifest).isManifestDeprecated
+            this.parseManifest(content).isManifestDeprecated
 
         globals.globalState.tryUpdate(manifestStorageKey, {
             ...storage,

--- a/packages/core/src/shared/lsp/manifestResolver.ts
+++ b/packages/core/src/shared/lsp/manifestResolver.ts
@@ -108,21 +108,22 @@ export class ManifestResolver {
      * Check if the current manifest is deprecated.
      * If yes and user hasn't muted this notification, shows a toast message with two buttons:
      * - OK: close and do nothing
-     * - Don't Show Again: Update global state (muteDecprecation) so the deprecation message is never shown for this manifest.
+     * - Don't Show Again: Update global state (muteDeprecation) so the deprecation message is never shown for this manifest.
      * @param manifest
      */
     private checkDeprecation(manifest: Manifest): void {
-        if (manifest.isManifestDeprecated && !this.getStorage()[this.lsName].muteDeprecation) {
-            const deprecationMessage = `${this.lsName} manifest is deprecated. No future updates will be available.`
+        const deprecationMessage = `${this.lsName} manifest is deprecated. No future updates will be available.`
+        if (manifest.isManifestDeprecated) {
             logger.info(deprecationMessage)
-
-            void vscode.window
-                .showInformationMessage(deprecationMessage, localizedText.ok, localizedText.dontShow)
-                .then((button) => {
-                    if (button === localizedText.dontShow) {
-                        this.getStorage()[this.lsName].muteDeprecation = true
-                    }
-                })
+            if (!this.getStorage()[this.lsName].muteDeprecation) {
+                void vscode.window
+                    .showInformationMessage(deprecationMessage, localizedText.ok, localizedText.dontShow)
+                    .then((button) => {
+                        if (button === localizedText.dontShow) {
+                            this.getStorage()[this.lsName].muteDeprecation = true
+                        }
+                    })
+            }
         }
     }
 

--- a/packages/core/src/shared/settings-amazonq.gen.ts
+++ b/packages/core/src/shared/settings-amazonq.gen.ts
@@ -18,7 +18,9 @@ export const amazonqSettings = {
         "amazonQWelcomePage": {},
         "amazonQSessionConfigurationMessage": {},
         "minIdeVersion": {},
-        "ssoCacheError": {}
+        "ssoCacheError": {},
+        "AmazonQLspManifestMessage": {},
+        "AmazonQ-WorkspaceLspManifestMessage":{}
     },
     "amazonQ.showInlineCodeSuggestionsWithCodeReferences": {},
     "amazonQ.allowFeatureDevelopmentToRunCodeAndTests": {},

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -671,6 +671,12 @@ export class AmazonQPromptSettings
         }
     }
 
+    public async enablePrompt(promptName: amazonQPromptName): Promise<void> {
+        if (!this.isPromptEnabled(promptName)) {
+            await this.update(promptName, false)
+        }
+    }
+
     public async disablePrompt(promptName: amazonQPromptName): Promise<void> {
         if (this.isPromptEnabled(promptName)) {
             await this.update(promptName, true)


### PR DESCRIPTION
## Problem
If the language server manifest is deprecated we just show it in the logs. However, users may not be explicitly aware that they will need to upgrade the extension to get a different manifest.

Also according to the design specsheet, user should have the option to mute the message for good once seen.

## Solution

- Added a message window with `don't show` and `ok` buttons for deprecated LSP manifest.
- Use AmazonQ suppressed prompts for `don't show` tracking
- Added a re-enable feature so that we can re-enable that setting if manifest gets updated. 

## Note

Also added language server name in logs, helpful to track different instances

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
