### PR TITLE
ci: add post-release notification buildspec

### DIFF
--- a/buildspec/release/80notify.yml
+++ b/buildspec/release/80notify.yml
@@ -1,0 +1,28 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            nodejs: 20
+
+    pre_build:
+        commands:
+            # Check for implicit env vars passed from the release pipeline.
+            - test -n "${NOTIFY_URL}"
+            - test -n "${TARGET_EXTENSION}"
+
+    build:
+        commands:
+            - echo "TARGET_EXTENSION=${TARGET_EXTENSION}"
+            - EXTENSION_NAME=$([ "$TARGET_EXTENSION" = "amazonq" ] && echo "Amazon Q" || echo "AWS Toolkit")
+            - VERSION=$(node -e "console.log(require('./packages/${TARGET_EXTENSION}/package.json').version);")
+            - CHANGELOG=$(cat packages/${TARGET_EXTENSION}/CHANGELOG.md | perl -ne 'BEGIN{$/="\n\n"} print if $. == 2')
+            - MESSAGE=$(envsubst < "$GITHUB_WORKSPACE/buildspec/release/notify.txt")
+            - DATA="{'Content':'${MESSAGE}'}"
+            - |
+                # TODO: Enable for prod only after testing
+                if [ "$STAGE" = "prod" ]; then
+                  echo "SKIPPED (stage=${STAGE}): 'curl -v POST \"[SLACK_URL]\" -H \"Content-Type:application/json\" --data $DATA'"
+                  exit 0
+                fi
+                curl -v POST "${NOTIFY_URL}" -H "Content-Type:application/json" --data $DATA

--- a/buildspec/release/notify.txt
+++ b/buildspec/release/notify.txt
@@ -1,0 +1,6 @@
+Released ${EXTENSION_NAME} v${VERSION} for VSCode
+
+${CHANGELOG}
+
+Changelog: https://github.com/aws/aws-toolkit-vscode/blob/master/packages/${TARGET_EXTENSION}/CHANGELOG.md
+Release Arifact: https://github.com/aws/aws-toolkit-vscode/releases/tag/${TARGET_EXTENSION}/v${VERSION}


### PR DESCRIPTION
Will enable for prod once I confirm it outputs the proper messages.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
