### PR TITLE
ci: fix and enable post-release notification

### DIFF
--- a/buildspec/release/80notify.yml
+++ b/buildspec/release/80notify.yml
@@ -14,15 +14,13 @@ phases:
     build:
         commands:
             - echo "TARGET_EXTENSION=${TARGET_EXTENSION}"
-            - EXTENSION_NAME=$([ "$TARGET_EXTENSION" = "amazonq" ] && echo "Amazon Q" || echo "AWS Toolkit")
-            - VERSION=$(node -e "console.log(require('./packages/${TARGET_EXTENSION}/package.json').version);")
-            - CHANGELOG=$(cat packages/${TARGET_EXTENSION}/CHANGELOG.md | perl -ne 'BEGIN{$/="\n\n"} print if $. == 2')
-            - MESSAGE=$(envsubst < "$GITHUB_WORKSPACE/buildspec/release/notify.txt")
-            - DATA="{'Content':'${MESSAGE}'}"
+            - export EXTENSION_NAME=$([ "$TARGET_EXTENSION" = "amazonq" ] && echo "Amazon Q" || echo "AWS Toolkit")
+            - export VERSION=$(node -e "console.log(require('./packages/${TARGET_EXTENSION}/package.json').version);")
+            - export CHANGELOG=$(cat packages/${TARGET_EXTENSION}/CHANGELOG.md | perl -ne 'BEGIN{$/="\n\n"} print if $. == 2')
+            - MESSAGE=$(envsubst < ./buildspec/release/notify.txt)
             - |
-                # TODO: Enable for prod only after testing
-                if [ "$STAGE" = "prod" ]; then
-                  echo "SKIPPED (stage=${STAGE}): 'curl -v POST \"[SLACK_URL]\" -H \"Content-Type:application/json\" --data $DATA'"
+                if [ "$STAGE" != "prod" ]; then
+                  echo "SKIPPED (stage=${STAGE}): 'curl -v POST \"[NOTIFY_URL]\" -H \"Content-Type:application/json\" --data \"{\"Content\":\"${MESSAGE}\"}\"'"
                   exit 0
                 fi
-                curl -v POST "${NOTIFY_URL}" -H "Content-Type:application/json" --data $DATA
+                curl -v POST "${NOTIFY_URL}" -H "Content-Type:application/json" --data "{\"Content\":\"${MESSAGE}\"}"


### PR DESCRIPTION
- Enable for prod runs
- Fix script slightly because the way codebuild runs bash and the way my local runs bash seems to not be the same.
- Tested on dev release pipeline

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
