### PR TITLE
fix(amazonq): Adding target source file to the zip before traversing the repository

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-951be4f5-ae4f-4ce7-82be-81de2c34d0d3.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-951be4f5-ae4f-4ce7-82be-81de2c34d0d3.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /test: Add the target source file to the zip archive before including files from the rest of the repository."
+}

--- a/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/zipUtil.test.ts
@@ -159,7 +159,7 @@ describe('zipUtil', function () {
         it('should generate zip for test generation successfully', async function () {
             const mkdirSpy = sinon.spy(fs, 'mkdir')
 
-            const result = await zipUtil.generateZipTestGen(appRoot, false)
+            const result = await zipUtil.generateZipTestGen(appRoot, appCodePath, false)
 
             assert.ok(mkdirSpy.calledWith(path.join(testTempDirPath, 'utgRequiredArtifactsDir')))
             assert.ok(
@@ -184,7 +184,10 @@ describe('zipUtil', function () {
             }))
             sinon.stub(fs, 'mkdir').rejects(new Error('Directory creation failed'))
 
-            await assert.rejects(() => zipUtil.generateZipTestGen(appRoot, false), /Directory creation failed/)
+            await assert.rejects(
+                () => zipUtil.generateZipTestGen(appRoot, appCodePath, false),
+                /Directory creation failed/
+            )
         })
 
         it('Should handle zip project errors', async function () {
@@ -193,7 +196,7 @@ describe('zipUtil', function () {
             }))
             sinon.stub(zipUtil, 'zipProject' as keyof ZipUtil).rejects(new Error('Zip failed'))
 
-            await assert.rejects(() => zipUtil.generateZipTestGen(appRoot, false), /Zip failed/)
+            await assert.rejects(() => zipUtil.generateZipTestGen(appRoot, appCodePath, false), /Zip failed/)
         })
     })
 })

--- a/packages/core/src/codewhisperer/commands/startTestGeneration.ts
+++ b/packages/core/src/codewhisperer/commands/startTestGeneration.ts
@@ -58,7 +58,7 @@ export async function startTestGenerationProcess(
             session.projectRootPath = projectPath
             session.listOfTestGenerationJobId = []
         }
-        const zipMetadata = await zipUtil.generateZipTestGen(session.projectRootPath, initialExecution)
+        const zipMetadata = await zipUtil.generateZipTestGen(session.projectRootPath, filePath, initialExecution)
         session.srcPayloadSize = zipMetadata.buildPayloadSizeInBytes
         session.srcZipFileSize = zipMetadata.zipFileSizeInBytes
 


### PR DESCRIPTION
## Problem
- In `/test`, sometimes target source file is not being collected as part of zip and this is causing the backend to fail.

## Solution

- Adding target source file to the zip before traversing the repository.
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
