### PR TITLE
fix(ec2): increase robustness of checking ssm agent ping status. 

### DIFF
--- a/packages/core/src/test/awsService/ec2/model.test.ts
+++ b/packages/core/src/test/awsService/ec2/model.test.ts
@@ -125,6 +125,17 @@ describe('Ec2ConnectClient', function () {
             }
         })
 
+        it('retries if agent status is not online', async function () {
+            const instanceAgentStatus = sinon.stub(SsmClient.prototype, 'getInstanceAgentPingStatus')
+            instanceAgentStatus.onFirstCall().resolves('Offline')
+            instanceAgentStatus.onSecondCall().resolves('Online')
+            try {
+                await client.checkForInstanceSsmError(instanceSelection, { interval: 10, timeout: 100 })
+            } catch (err) {
+                assert.ok(false, `checkForInstanceSsmError failed with error '${err}'`)
+            }
+        })
+
         it('does not throw an error if all checks pass', async function () {
             sinon.stub(Ec2Connecter.prototype, 'isInstanceRunning').resolves(true)
             sinon.stub(Ec2Connecter.prototype, 'getAttachedIamRole').resolves({ Arn: 'testRole' } as IAM.Role)


### PR DESCRIPTION
## Problem
As part of the EC2 Connect process, we check if the SSM agent is pingable on the target instance. This is done here: https://github.com/aws/aws-toolkit-vscode/blob/b9af56c3097242fb796995479f864d95098bf713/packages/core/src/awsService/ec2/model.ts#L153-L162

This check can fail, and is currently does fail a decent amount of the time in telemetry.

## Solution
- wrap the check in a `waitUntil`, retrying every half second up to 10 times. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
