### PR TITLE
refactor(ec2): improve error information in telemetry. 

### DIFF
--- a/packages/core/src/awsService/ec2/model.ts
+++ b/packages/core/src/awsService/ec2/model.ts
@@ -215,8 +215,7 @@ export class Ec2Connecter implements vscode.Disposable {
                 remoteUser.name
             )
         } catch (err) {
-            const message =
-                err instanceof SshError ? `Testing SSM connection to instance failed: ${err.message}` : ''
+            const message = err instanceof SshError ? `Testing SSM connection to instance failed: ${err.message}` : ''
             this.throwConnectionError(message, selection, { ...(err as Error), code: 'EC2SSMTestConnect' })
         } finally {
             await this.ssmClient.terminateSession(testSession)

--- a/packages/core/src/awsService/ec2/model.ts
+++ b/packages/core/src/awsService/ec2/model.ts
@@ -26,7 +26,7 @@ import {
     SshError,
     startSshAgent,
     startVscodeRemote,
-    testSsmConnection,
+    testSshConnection,
 } from '../../shared/extensions/ssh'
 import { getLogger } from '../../shared/logger/logger'
 import { CancellationError, Timeout } from '../../shared/utilities/timeoutUtils'
@@ -200,7 +200,7 @@ export class Ec2Connecter implements vscode.Disposable {
         const remoteEnv = await this.prepareEc2RemoteEnvWithProgress(selection, remoteUser)
         const testSession = await this.ssmClient.startSession(selection.instanceId, 'AWS-StartSSHSession')
         try {
-            await testSsmConnection(
+            await testSshConnection(
                 remoteEnv.SessionProcess,
                 remoteEnv.hostname,
                 remoteEnv.sshPath,
@@ -215,7 +215,8 @@ export class Ec2Connecter implements vscode.Disposable {
                 remoteUser.name
             )
         } catch (err) {
-            const message = err instanceof SshError ? 'Testing SSH connection to instance failed' : ''
+            const message =
+                err instanceof SshError ? `Testing SSM connection to instance failed with error: ${err.message}` : ''
             this.throwConnectionError(message, selection, { ...(err as Error), code: 'EC2SSMTestConnect' })
         } finally {
             await this.ssmClient.terminateSession(testSession)

--- a/packages/core/src/awsService/ec2/model.ts
+++ b/packages/core/src/awsService/ec2/model.ts
@@ -216,7 +216,7 @@ export class Ec2Connecter implements vscode.Disposable {
             )
         } catch (err) {
             const message =
-                err instanceof SshError ? `Testing SSM connection to instance failed with error: ${err.message}` : ''
+                err instanceof SshError ? `Testing SSM connection to instance failed: ${err.message}` : ''
             this.throwConnectionError(message, selection, { ...(err as Error), code: 'EC2SSMTestConnect' })
         } finally {
             await this.ssmClient.terminateSession(testSession)

--- a/packages/core/src/shared/extensions/ssh.ts
+++ b/packages/core/src/shared/extensions/ssh.ts
@@ -130,7 +130,7 @@ export class RemoteSshSettings extends Settings.define('remote.SSH', remoteSshTy
     }
 }
 
-export async function testSshConnection(
+export async function testSsmConnection(
     ProcessClass: typeof ChildProcess,
     hostname: string,
     sshPath: string,
@@ -150,7 +150,7 @@ export async function testSshConnection(
         })
         return result
     } catch (error) {
-        throw new SshError('SSH connection test failed', { cause: error as Error })
+        throw new SshError('SSH connection test failed', { cause: error as Error, code: 'SSMTestConnectionFailed' })
     }
 }
 

--- a/packages/core/src/shared/extensions/ssh.ts
+++ b/packages/core/src/shared/extensions/ssh.ts
@@ -130,6 +130,15 @@ export class RemoteSshSettings extends Settings.define('remote.SSH', remoteSshTy
     }
 }
 
+/**
+ * Test a SSH connection over SSM.
+ * @param ProcessClass given process to test the connection within.
+ * @param hostname
+ * @param sshPath
+ * @param user
+ * @param session SSM session credentials. These cannot be reused, so it may be required to create a seperate session for the test connection.
+ * @returns
+ */
 export async function testSshConnection(
     ProcessClass: typeof ChildProcess,
     hostname: string,
@@ -146,8 +155,9 @@ export async function testSshConnection(
             },
         })
     } catch (error) {
-        const errorMessage = [process.result()?.stderr ?? ''].join('\n')
-        throw new SshError(errorMessage, { cause: error as Error })
+        throw new SshError(process.result()?.stderr ?? 'An unknown error occurred when testing the connection', {
+            cause: error as Error,
+        })
     }
 }
 

--- a/packages/core/src/shared/extensions/ssh.ts
+++ b/packages/core/src/shared/extensions/ssh.ts
@@ -137,20 +137,16 @@ export async function testSsmConnection(
     user: string,
     session: SSM.StartSessionResponse
 ): Promise<ChildProcessResult | never> {
+    const env = { SESSION_ID: session.SessionId, STREAM_URL: session.StreamUrl, TOKEN: session.TokenValue }
+    const process = new ProcessClass(sshPath, ['-T', `${user}@${hostname}`, 'echo "test connection succeeded" && exit'])
     try {
-        const env = { SESSION_ID: session.SessionId, STREAM_URL: session.StreamUrl, TOKEN: session.TokenValue }
-        const result = await new ProcessClass(sshPath, [
-            '-T',
-            `${user}@${hostname}`,
-            'echo "test connection succeeded" && exit',
-        ]).run({
+        return await process.run({
             spawnOptions: {
                 env,
             },
         })
-        return result
     } catch (error) {
-        throw new SshError('SSH connection test failed', { cause: error as Error, code: 'SSMTestConnectionFailed' })
+        throw new SshError('SSH connection test failed', { cause: error as Error })
     }
 }
 

--- a/packages/core/src/shared/extensions/ssh.ts
+++ b/packages/core/src/shared/extensions/ssh.ts
@@ -130,7 +130,7 @@ export class RemoteSshSettings extends Settings.define('remote.SSH', remoteSshTy
     }
 }
 
-export async function testSsmConnection(
+export async function testSshConnection(
     ProcessClass: typeof ChildProcess,
     hostname: string,
     sshPath: string,
@@ -146,7 +146,8 @@ export async function testSsmConnection(
             },
         })
     } catch (error) {
-        throw new SshError('SSH connection test failed', { cause: error as Error })
+        const errorMessage = [process.result()?.stderr ?? ''].join('\n')
+        throw new SshError(errorMessage, { cause: error as Error })
     }
 }
 

--- a/packages/core/src/test/shared/extensions/ssh.test.ts
+++ b/packages/core/src/test/shared/extensions/ssh.test.ts
@@ -4,7 +4,7 @@
  */
 import * as assert from 'assert'
 import { ChildProcess } from '../../../shared/utilities/processUtils'
-import { startSshAgent, testSsmConnection } from '../../../shared/extensions/ssh'
+import { startSshAgent, testSshConnection } from '../../../shared/extensions/ssh'
 import { createBoundProcess } from '../../../shared/remoteSession'
 import { createExecutableFile, createTestWorkspaceFolder } from '../../testUtil'
 import { WorkspaceFolder } from 'vscode'
@@ -74,7 +74,7 @@ describe('testSshConnection', function () {
         } as SSM.StartSessionResponse
 
         await createExecutableFile(sshPath, echoEnvVarsCmd(['MY_VAR']))
-        const r = await testSsmConnection(process, 'localhost', sshPath, 'test-user', session)
+        const r = await testSshConnection(process, 'localhost', sshPath, 'test-user', session)
         assertOutputContains(r.stdout, 'yes')
     })
 
@@ -97,7 +97,7 @@ describe('testSshConnection', function () {
         const process = createBoundProcess(envProvider)
 
         await createExecutableFile(sshPath, echoEnvVarsCmd(['SESSION_ID', 'STREAM_URL', 'TOKEN']))
-        const r = await testSsmConnection(process, 'localhost', sshPath, 'test-user', newSession)
+        const r = await testSshConnection(process, 'localhost', sshPath, 'test-user', newSession)
         assertOutputContains(r.stdout, `${newSession.SessionId} ${newSession.StreamUrl} ${newSession.TokenValue}`)
     })
 
@@ -105,7 +105,7 @@ describe('testSshConnection', function () {
         const executableFileContent = isWin() ? `echo "%1 %2"` : `echo "$1 $2"`
         const process = createBoundProcess(async () => ({}))
         await createExecutableFile(sshPath, executableFileContent)
-        const r = await testSsmConnection(process, 'localhost', sshPath, 'test-user', {} as SSM.StartSessionResponse)
+        const r = await testSshConnection(process, 'localhost', sshPath, 'test-user', {} as SSM.StartSessionResponse)
         assertOutputContains(r.stdout, '-T')
         assertOutputContains(r.stdout, 'test-user@localhost')
     })

--- a/packages/core/src/test/shared/extensions/ssh.test.ts
+++ b/packages/core/src/test/shared/extensions/ssh.test.ts
@@ -4,7 +4,7 @@
  */
 import * as assert from 'assert'
 import { ChildProcess } from '../../../shared/utilities/processUtils'
-import { startSshAgent, testSshConnection } from '../../../shared/extensions/ssh'
+import { startSshAgent, testSsmConnection } from '../../../shared/extensions/ssh'
 import { createBoundProcess } from '../../../shared/remoteSession'
 import { createExecutableFile, createTestWorkspaceFolder } from '../../testUtil'
 import { WorkspaceFolder } from 'vscode'
@@ -74,7 +74,7 @@ describe('testSshConnection', function () {
         } as SSM.StartSessionResponse
 
         await createExecutableFile(sshPath, echoEnvVarsCmd(['MY_VAR']))
-        const r = await testSshConnection(process, 'localhost', sshPath, 'test-user', session)
+        const r = await testSsmConnection(process, 'localhost', sshPath, 'test-user', session)
         assertOutputContains(r.stdout, 'yes')
     })
 
@@ -97,7 +97,7 @@ describe('testSshConnection', function () {
         const process = createBoundProcess(envProvider)
 
         await createExecutableFile(sshPath, echoEnvVarsCmd(['SESSION_ID', 'STREAM_URL', 'TOKEN']))
-        const r = await testSshConnection(process, 'localhost', sshPath, 'test-user', newSession)
+        const r = await testSsmConnection(process, 'localhost', sshPath, 'test-user', newSession)
         assertOutputContains(r.stdout, `${newSession.SessionId} ${newSession.StreamUrl} ${newSession.TokenValue}`)
     })
 
@@ -105,7 +105,7 @@ describe('testSshConnection', function () {
         const executableFileContent = isWin() ? `echo "%1 %2"` : `echo "$1 $2"`
         const process = createBoundProcess(async () => ({}))
         await createExecutableFile(sshPath, executableFileContent)
-        const r = await testSshConnection(process, 'localhost', sshPath, 'test-user', {} as SSM.StartSessionResponse)
+        const r = await testSsmConnection(process, 'localhost', sshPath, 'test-user', {} as SSM.StartSessionResponse)
         assertOutputContains(r.stdout, '-T')
         assertOutputContains(r.stdout, 'test-user@localhost')
     })


### PR DESCRIPTION
## Problem
Within telemetry, there are a large group of fatal errors within EC2 Connect being grouped together under the same general error code. Additionally, there is very little information in the error message to determine the source of this error. Specifically, it appears the the test SSM connection done before attempting to pass the connection to VS Code, implemented [here](https://github.com/aws/aws-toolkit-vscode/blob/b9af56c3097242fb796995479f864d95098bf713/packages/core/src/shared/extensions/ssh.ts#L133-L155), can fail, and gives us a general error code with little information about its root cause.

## Solution
- Add a specific error code for this connection type. (reused an old unused one)
- Pipe the error from the child process into the error message so that we get it in telemetry. 
- Add a docstring to test connect function, since its not obvious whats happening as it involves both ssh and ssm. 

Example Error:
<img width="465" alt="image" src="https://github.com/user-attachments/assets/8b27746d-9291-48a4-a125-dcea761a2c13" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
