### PR TITLE
fix(amazonq): Updating logic for getWorkspaceRelativePath in shared src for /test

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-ee447a9f-6a92-47c5-8e94-069c1aee46ab.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-ee447a9f-6a92-47c5-8e94-069c1aee46ab.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /test: Fixing the issue of target file does not exist."
+}

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -410,9 +410,14 @@ export class ZipUtil {
             return
         }
 
-        const sourceFiles = await collectFiles(projectPaths, vscode.workspace.workspaceFolders as CurrentWsFolders, {
-            maxSizeBytes: this.getProjectScanPayloadSizeLimitInBytes(),
-        })
+        const sourceFiles = await collectFiles(
+            projectPaths,
+            vscode.workspace.workspaceFolders as CurrentWsFolders,
+            {
+                maxSizeBytes: this.getProjectScanPayloadSizeLimitInBytes(),
+            },
+            useCase
+        )
         for (const file of sourceFiles) {
             const projectName = path.basename(file.workspaceFolder.uri.fsPath)
             const zipEntryPath = this.getZipEntryPath(projectName, file.relativeFilePath)


### PR DESCRIPTION
## Problem
- This will fix `Target file doesn't exist or is a directory.` issue in unit test generation.
- If user opens project in workspace mode and try `/test` then in shared workspaceUtils: https://github.com/aws/aws-toolkit-vscode/blob/35502be238b1bf7c3ff73e44df8d077a6d32aa85/packages/core/src/shared/utilities/workspaceUtils.ts#L220-L236 returns the files starting from src but UTG does need values from child level.
## Solution
Given above function with workspaceFolders as 
```
[
  {
    uri: {
      scheme: "file",
      authority: "",
      path: "/Users/Q/Downloads/TestingUTG/Sample/src",
      query: "",
      fragment: "",
      _formatted: "file:///Users/Q/Downloads/TestingUTG/Sample/src",
      _fsPath: "/Users/Q/Downloads/TestingUTG/Sample/src",
    },
    name: "src",
    index: 0,
  },
  {
    uri: {
      scheme: "file",
      authority: "",
      path: "/Users/laileni/Downloads/TestingUTG/Sample/src/Sample",
      query: "",
      fragment: "",
      _formatted: "file:///Users/Q/Downloads/TestingUTG/Sample/src/Sample",
      _fsPath: "/Users/Q/Downloads/TestingUTG/Sample/src/Sample",
    },
    name: "📦 Sample",
    index: 1,
  },
]
```

User requires the project/folder with path: "/Users/Q/Downloads/TestingUTG/Sample/src/Sample" but right now this gives the path from  "/Users/Q/Downloads/TestingUTG/Sample/src" which incorrectly collects the files and this is causing failures in Unit test generation.

Example:
Expected Payload is 
```
Sample 
    - File A
    - Folder B 
    etc...
 ```
 but actual payload is 
 ```
 Sample 
    - src
       -- Sample
           --- File A
           --- Folder B 
 ```
    

-  Sort workspace folders by path length (descending) to prioritize deeper paths
### TODO: 
- Need to enable this for entire Q

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
