### PR TITLE
config(amazonq-chat): disable and remove implicit workspace context experiment

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -645,21 +645,6 @@ export class ChatController {
                     this.messenger.sendOpenSettingsMessage(triggerID, tabID)
                     return
                 }
-            } else if (
-                !LspController.instance.isIndexingInProgress() &&
-                CodeWhispererSettings.instance.isLocalIndexEnabled()
-            ) {
-                const start = performance.now()
-                triggerPayload.relevantTextDocuments = await waitUntil(
-                    async function () {
-                        if (triggerPayload.message) {
-                            return await LspController.instance.query(triggerPayload.message)
-                        }
-                        return []
-                    },
-                    { timeout: 500, interval: 200, truthy: false }
-                )
-                triggerPayload.projectContextQueryLatencyMs = performance.now() - start
             }
         }
 

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -54,7 +54,6 @@ import { isSsoConnection } from '../../../auth/connection'
 import { inspect } from '../../../shared/utilities/collectionUtils'
 import { DefaultAmazonQAppInitContext } from '../../../amazonq/apps/initContext'
 import globals from '../../../shared/extensionGlobals'
-import { waitUntil } from '../../../shared/utilities/timeoutUtils'
 
 export interface ChatControllerMessagePublishers {
     readonly processPromptChatMessage: MessagePublisher<PromptMessage>


### PR DESCRIPTION
## Problem
Remove as experiment has been disable from the service side, no need to collect workspace context if service doesn't actually utilize it.

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
