### PR TITLE
refactor(util): generalize expected pattern to allow for positive and negative pattern. 

### DIFF
--- a/packages/core/src/awsService/ec2/sshKeyPair.ts
+++ b/packages/core/src/awsService/ec2/sshKeyPair.ts
@@ -79,10 +79,16 @@ export class SshKeyPair {
         const overrideKeys = async (_t: string, proc: RunParameterContext) => {
             await proc.send('yes')
         }
-        return !(await tryRun('ssh-keygen', ['-t', keyType, '-N', '', '-q', '-f', keyPath], 'yes', 'unknown key type', {
-            onStdout: overrideKeys,
-            timeout: new Timeout(5000),
-        }))
+        return await tryRun(
+            'ssh-keygen',
+            ['-t', keyType, '-N', '', '-q', '-f', keyPath],
+            'yes',
+            { negative: 'unknown key type' },
+            {
+                onStdout: overrideKeys,
+                timeout: new Timeout(5000),
+            }
+        )
     }
 
     public static async tryKeyTypes(keyPath: string, keyTypes: sshKeyType[]): Promise<boolean> {

--- a/packages/core/src/shared/sam/cli/samCliLocator.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocator.ts
@@ -24,7 +24,7 @@ export class SamCliLocationProvider {
 
     /** Checks that the given `sam` actually works by invoking `sam --version`. */
     private static async isValidSamLocation(samPath: string) {
-        const isValid = await tryRun(samPath, ['--version'], 'no', 'SAM CLI')
+        const isValid = await tryRun(samPath, ['--version'], 'no', { positive: 'SAM CLI' })
         this.samLocationValid = isValid
         return isValid
     }

--- a/packages/core/src/shared/utilities/textUtilities.ts
+++ b/packages/core/src/shared/utilities/textUtilities.ts
@@ -273,3 +273,15 @@ export function extractFileAndCodeSelectionFromMessage(message: any) {
     const selection = message?.context?.focusAreaContext?.selectionInsideExtendedCodeBlock as vscode.Selection
     return { filePath, selection }
 }
+
+export type AcceptPattern = Partial<{
+    positive: string
+    negative: string
+}>
+
+export function matchesPattern(text: string, pattern: AcceptPattern): boolean {
+    const { positive, negative } = pattern
+    const matchesPositive = !positive || text.includes(positive)
+    const matchesNegative = !negative || !text.includes(negative)
+    return matchesPositive && matchesNegative
+}

--- a/packages/core/src/test/shared/utilities/textUtilities.test.ts
+++ b/packages/core/src/test/shared/utilities/textUtilities.test.ts
@@ -13,6 +13,7 @@ import {
     sanitizeFilename,
     toSnakeCase,
     undefinedIfEmpty,
+    matchesPattern,
 } from '../../../shared/utilities/textUtilities'
 
 describe('textUtilities', async function () {
@@ -69,6 +70,21 @@ describe('textUtilities', async function () {
         assert.deepStrictEqual(indent('abc\n 123\n', 2, true), '  abc\n  123\n')
         assert.deepStrictEqual(indent('   abc\n\n  \n123\nfoo\n', 4, false), '       abc\n\n      \n    123\n    foo\n')
         assert.deepStrictEqual(indent('   abc\n\n    \n123\nfoo\n', 4, true), '    abc\n\n    \n    123\n    foo\n')
+    })
+
+    it('matchesPattern', function () {
+        assert.ok(matchesPattern('abc', { positive: 'ab', negative: 'cd' }))
+        assert.ok(matchesPattern('abc', { positive: 'ab' }))
+        assert.ok(matchesPattern('abc', { negative: 'cd' }))
+        assert.ok(matchesPattern('abc', { negative: 'abcd' }))
+        assert.ok(matchesPattern('abc', { positive: 'abc' }))
+        assert.ok(matchesPattern('abc', {}))
+
+        assert.ok(!matchesPattern('abc', { positive: 'abcd' }))
+        assert.ok(!matchesPattern('abc', { positive: 'abc', negative: 'a' }))
+        assert.ok(!matchesPattern('abcde', { negative: 'ab' }))
+        assert.ok(!matchesPattern('abc', { negative: 'ab' }))
+        assert.ok(!matchesPattern('a a a a', { negative: 'a' }))
     })
 })
 


### PR DESCRIPTION
## Problem
Attempting to generate the ssh keys via tryRun can log a failure, when there is no failure. Looking at https://github.com/aws/aws-toolkit-vscode/blob/35502be238b1bf7c3ff73e44df8d077a6d32aa85/packages/core/src/awsService/ec2/sshKeyPair.ts#L78-L86 

We use `tryRun` to detect if the output contains "unknown key type". This allows us to detect when a certain key type such as RSA or ed25519 is not supported on the local machine. Detecting if the key generated successfully is a harder problem, as the output did not contain a consistent message. 

However, it results in `tryRun` logging a failure to find "unknown key type" in the output, which means failed to find the expected text in the output, but still generated the key. This is then logged as a failure, but is functionally a success. This is very confusing behavior. 

The root of this problem is we are trying to use `tryRun` in a way it doesn't naturally support. Rather than use it awkwardly, we can extend it. 

## Solution
TODO: simplify solution by just passing a regex. 
- generalize the pattern accepted by `tryRun` to allow for both positive and negative accept strings. 

## Alternative Solution 
- turn logging off for this run of `tryRun`. However, the logs can be helpful here, and there may be other cases of `tryRun` usage in the future where detecting the negative is an easier problem. 
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
