### PR TITLE
fix(amazonq): skip empty plan tables

### DIFF
--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -506,6 +506,11 @@ export function addTableMarkdown(plan: string, stepId: string, tableMapping: { [
         return plan
     }
     const table = JSON.parse(tableObj)
+    if (table.rows.length === 0) {
+        // empty table
+        plan += `\n\nThere are no ${table.name.toLowerCase()} to display.\n\n`
+        return plan
+    }
     plan += `\n\n\n${table.name}\n|`
     const columns = table.columnNames
     // eslint-disable-next-line unicorn/no-array-for-each


### PR DESCRIPTION
## Problem

When a plan table is empty, the table header shows.


## Solution

Don't show the table header when the table is empty.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
