### PR TITLE
refactor(util): allow tryRun to take a regex. 

### DIFF
--- a/packages/core/src/awsService/ec2/sshKeyPair.ts
+++ b/packages/core/src/awsService/ec2/sshKeyPair.ts
@@ -79,10 +79,16 @@ export class SshKeyPair {
         const overrideKeys = async (_t: string, proc: RunParameterContext) => {
             await proc.send('yes')
         }
-        return !(await tryRun('ssh-keygen', ['-t', keyType, '-N', '', '-q', '-f', keyPath], 'yes', 'unknown key type', {
-            onStdout: overrideKeys,
-            timeout: new Timeout(5000),
-        }))
+        return await tryRun(
+            'ssh-keygen',
+            ['-t', keyType, '-N', '', '-q', '-f', keyPath],
+            'yes',
+            /^(?!.*Unknown key type).*/i,
+            {
+                onStdout: overrideKeys,
+                timeout: new Timeout(5000),
+            }
+        )
     }
 
     public static async tryKeyTypes(keyPath: string, keyTypes: sshKeyType[]): Promise<boolean> {

--- a/packages/core/src/shared/utilities/pathFind.ts
+++ b/packages/core/src/shared/utilities/pathFind.ts
@@ -11,6 +11,7 @@ import { GitExtension } from '../extensions/git'
 import { Settings } from '../settings'
 import { getLogger } from '../logger/logger'
 import { mergeResolvedShellPath } from '../env/resolveEnv'
+import { matchesPattern } from './textUtilities'
 
 /** Full path to VSCode CLI. */
 let vscPath: string
@@ -32,7 +33,7 @@ export async function tryRun(
     p: string,
     args: string[],
     logging: 'yes' | 'no' | 'noresult' = 'yes',
-    expected?: string,
+    expected?: string | RegExp,
     opt?: ChildProcessOptions
 ): Promise<boolean> {
     const proc = new ChildProcess(p, args, { logging: 'no' })
@@ -40,7 +41,7 @@ export async function tryRun(
         ...opt,
         spawnOptions: { env: await mergeResolvedShellPath(opt?.spawnOptions?.env ?? process.env) },
     })
-    const ok = r.exitCode === 0 && (expected === undefined || r.stdout.includes(expected))
+    const ok = r.exitCode === 0 && (expected === undefined || matchesPattern(r.stdout, expected))
     if (logging === 'noresult') {
         getLogger().info('tryRun: %s: %s', ok ? 'ok' : 'failed', proc)
     } else if (logging !== 'no') {

--- a/packages/core/src/shared/utilities/textUtilities.ts
+++ b/packages/core/src/shared/utilities/textUtilities.ts
@@ -273,3 +273,10 @@ export function extractFileAndCodeSelectionFromMessage(message: any) {
     const selection = message?.context?.focusAreaContext?.selectionInsideExtendedCodeBlock as vscode.Selection
     return { filePath, selection }
 }
+
+export function matchesPattern(source: string, target: string | RegExp) {
+    if (typeof target === 'string') {
+        return source.includes(target)
+    }
+    return target.test(source)
+}

--- a/packages/core/src/test/shared/utilities/pathFind.test.ts
+++ b/packages/core/src/test/shared/utilities/pathFind.test.ts
@@ -42,6 +42,24 @@ describe('pathFind', function () {
         assert.ok(regex.test(vscPath), `expected regex ${regex} to match: "${vscPath}"`)
     })
 
+    describe('tryRun', function () {
+        it('returns true if output matches expected', async function () {
+            const posResult = await tryRun('echo', ['hello'], 'no', 'hello')
+            assert.ok(posResult)
+
+            const negResult = await tryRun('echo', ['hi'], 'no', 'hello')
+            assert.ok(!negResult)
+        })
+
+        it('supports regex on output match', async function () {
+            const posResult = await tryRun('echo', ['hello'], 'no', /hel*o/)
+            assert.ok(posResult)
+
+            const negResult = await tryRun('echo', ['hi'], 'no', /^(?!(hi)).*$/)
+            assert.ok(!negResult)
+        })
+    })
+
     describe('findSshPath', function () {
         let previousPath: string | undefined
 


### PR DESCRIPTION
## Problem
This is aimed at fixing the following ec2 bug.

Attempting to generate the ssh keys via tryRun can log a failure, when there is no failure. Looking at https://github.com/aws/aws-toolkit-vscode/blob/35502be238b1bf7c3ff73e44df8d077a6d32aa85/packages/core/src/awsService/ec2/sshKeyPair.ts#L78-L86 

We use `tryRun` to detect if the output contains "unknown key type". This allows us to detect when a certain key type such as RSA or ed25519 is not supported on the local machine. Detecting if the key generated successfully is a harder problem, as the output did not contain a consistent message. 

However, it results in `tryRun` logging a failure to find "unknown key type" in the output, which means failed to find the expected text in the output, but still generated the key. This is then logged as a failure, but is functionally a success. This is very confusing behavior. 

The root of this problem is we are trying to use `tryRun` in a way it doesn't naturally support. Rather than use it awkwardly, we can extend it. 

## Solution
- add support for regex in tryRun

New logs:

```
2025-02-20 12:07:01.624 [info] tryRun: ok: PID 22605: [ssh-keygen -t ed25519 -N  -q -f /Users/hkobew/Library/Application Support/Code/User/globalStorage/amazonwebservices.aws-toolkit-vscode/aws-ec2-key] {
  exitCode: 0,
  stdout: '/Users/hkobew/Library/Application Support/Code/User/globalStorage/amazonwebservices.aws-toolkit-vscode/aws-ec2-key already exists.\n' +
    'Overwrite (y/n)?',
  stderr: '',
  error: undefined,
  signal: undefined
}
```

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
