### PR TITLE
fix(amazonq): update capability card text for /test

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-e587b325-81f7-4ad0-8945-7c162dceffcd.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-e587b325-81f7-4ad0-8945-7c162dceffcd.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/test: update capability card text"
+}

--- a/packages/core/src/amazonqTest/chat/views/connector/connector.ts
+++ b/packages/core/src/amazonqTest/chat/views/connector/connector.ts
@@ -141,16 +141,16 @@ export class CapabilityCardMessage extends ChatMessage {
                 message: '',
                 messageType: 'answer',
                 informationCard: {
-                    title: '/test',
-                    description: 'Included in your Q Developer Agent subscription',
+                    title: '/test -  Unit test generation',
+                    description: 'Generate unit tests for selected code',
                     content: {
-                        body: `I can generate unit tests for your active file.
+                        body: `I can generate unit tests for the active file or open project in your IDE.
 
-After you select the functions or methods I should focus on, I will:
-1. Generate unit tests
-2. Place them into relevant test file
+I can do things like:
+- Add unit tests for highlighted functions
+- Generate tests for null and empty inputs 
 
-To learn more, check out our [User Guide](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/q-in-IDE.html).`,
+To learn more, visit the [Amazon Q Developer User Guide](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/test-generation.html).`,
                     },
                     icon: 'check-list' as MynahIcons,
                 },


### PR DESCRIPTION
## Problem
- Capability card text should be updated

## Solution
- Update capability card with correct text
 
![vsc](https://github.com/user-attachments/assets/b5a1aca0-25c4-4f75-a4ff-c43ea79f9614)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
