### PR TITLE
fix(amazonq): fix uploading file method error handling for /doc

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-6b8cf110-2050-4ac1-8a3b-637ed54980cf.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-6b8cf110-2050-4ac1-8a3b-637ed54980cf.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /doc: Fix uploading file method throwing incorrect workspace too large error message"
+}

--- a/packages/core/src/amazonq/util/files.ts
+++ b/packages/core/src/amazonq/util/files.ts
@@ -13,6 +13,7 @@ import {
 } from '../../shared/utilities/workspaceUtils'
 
 import { ContentLengthError, PrepareRepoFailedError } from '../../amazonqFeatureDev/errors'
+import { ContentLengthError as DocContentLengthError } from '../../amazonqDoc/errors'
 import { getLogger } from '../../shared/logger/logger'
 import { maxFileSizeBytes } from '../../amazonqFeatureDev/limits'
 import { CurrentWsFolders, DeletedFileInfo, NewFileInfo, NewFileZipContents } from '../../amazonqDoc/types'
@@ -48,6 +49,7 @@ export type PrepareRepoDataOptions = {
     telemetry?: TelemetryHelper
     zip?: ZipStream
     isIncludeInfraDiagram?: boolean
+    featureName?: 'featureDev' | 'docGeneration'
 }
 
 /**
@@ -186,6 +188,9 @@ export async function prepareRepoData(
     } catch (error) {
         getLogger().debug(`featureDev: Failed to prepare repo: ${error}`)
         if (error instanceof ToolkitError && error.code === 'ContentLengthError') {
+            if (options?.featureName === 'docGeneration') {
+                throw new DocContentLengthError()
+            }
             throw new ContentLengthError()
         }
         throw new PrepareRepoFailedError()

--- a/packages/core/src/amazonqDoc/session/sessionState.ts
+++ b/packages/core/src/amazonqDoc/session/sessionState.ts
@@ -144,6 +144,7 @@ export class DocPrepareCodeGenState extends BasePrepareCodeGenState {
         return await prepareRepoData(workspaceRoots, workspaceFolders, span, {
             ...options,
             isIncludeInfraDiagram: true,
+            featureName: 'docGeneration',
         })
     }
 }


### PR DESCRIPTION
## Problem
File upload method threw incorrect error message when workspace too large for /doc

## Solution

Fix uploading file method error handling for /doc
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
