### PR TITLE
refactor(sdkv3): switch to using built-in sdkv3 pagination. 

### DIFF
--- a/packages/core/src/shared/clients/clientWrapper.ts
+++ b/packages/core/src/shared/clients/clientWrapper.ts
@@ -50,7 +50,8 @@ export abstract class ClientWrapper<C extends AwsClient> implements vscode.Dispo
         for await (const page of p) {
             results.push(extractPage(page))
         }
-        return results.flat().filter((result) => result !== undefined)
+        const filteredResult = results.flat().filter((result) => result !== undefined) as Output[]
+        return filteredResult
     }
 
     public dispose() {


### PR DESCRIPTION
## Problem
The AWS SDK now supports built-in pagination: [https://aws.amazon.com/blogs/developer/pagination-using-async-iterators-in-modular-aws-sdk-for-javascript/ ](https://aws.amazon.com/blogs/developer/pagination-using-async-iterators-in-modular-aws-sdk-for-javascript/)
Currently, have our own logic build on top of calls to do this logic for us. However, the SDK paginators are likely more reliable, and avoids reimplementing logic. They are also part of the SDK making them easier to integrate with (specifically for types).

Doing this early in the migration process has the potential to reduce a lot of unnecessary code.

## Solution
- Migrate existing use cases of sdkv3 to use these paginators.
- Create general support for them in the Wrapper class.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
