### PR TITLE
fix(amazonq): skip tests locally

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-8e53fbd9-35d8-40f0-95be-5c7ac2478353.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-8e53fbd9-35d8-40f0-95be-5c7ac2478353.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/transform: skip running tests locally when user chooses to do so"
+}

--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -162,6 +162,7 @@ describe('Amazon Q Code Transformation', function () {
             const tmpDir = (await TestFolder.create()).path
 
             transformByQState.setSummaryFilePath(path.join(tmpDir, 'summary.md'))
+            transformByQState.setToPartiallySucceeded()
 
             transformByQState
                 .getChatMessenger()

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -125,12 +125,12 @@ export class Messenger {
             mandatory: true,
             options: [
                 {
-                    value: CodeWhispererConstants.runUnitTestsMessage,
-                    label: CodeWhispererConstants.runUnitTestsMessage,
-                },
-                {
                     value: CodeWhispererConstants.skipUnitTestsMessage,
                     label: CodeWhispererConstants.skipUnitTestsMessage,
+                },
+                {
+                    value: CodeWhispererConstants.runUnitTestsMessage,
+                    label: CodeWhispererConstants.runUnitTestsMessage,
                 },
             ],
         })
@@ -533,7 +533,7 @@ export class Messenger {
             })
         }
 
-        if (transformByQState.getSummaryFilePath()) {
+        if (transformByQState.isPartiallySucceeded() || transformByQState.isSucceeded()) {
             buttons.push({
                 keepCardAfterClick: true,
                 text: CodeWhispererConstants.viewSummaryButtonText,

--- a/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
@@ -27,6 +27,11 @@ function installProjectDependencies(dependenciesFolder: FolderInfo, modulePath: 
 
         // Note: IntelliJ runs 'clean' separately from 'install'. Evaluate benefits (if any) of this.
         const args = [`-Dmaven.repo.local=${dependenciesFolder.path}`, 'clean', 'install', '-q']
+
+        if (transformByQState.getCustomBuildCommand() === CodeWhispererConstants.skipUnitTestsBuildCommand) {
+            args.push('-DskipTests')
+        }
+
         let environment = process.env
 
         if (transformByQState.getJavaHome() !== undefined) {


### PR DESCRIPTION
## Problem

When users choose to skip tests, we were skipping them on our server by passing in their choice to our backend, but we weren't also skipping them locally.


## Solution

Tell Maven to use `-DskipTests`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
