### PR TITLE
fix(amazonq):  ignored lines should not show up in /review scan issues

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b183d3cf-e277-4465-a28d-53a0bdf7f424.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b183d3cf-e277-4465-a28d-53a0bdf7f424.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/review: ignored lines should not show up in scan issues"
+}

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -22,10 +22,8 @@ import sinon from 'sinon'
 import * as vscode from 'vscode'
 import path from 'path'
 
-const buildRawCodeScanIssue = (fromProject: boolean = true, params?: Partial<RawCodeScanIssue>): RawCodeScanIssue => ({
-    filePath: fromProject
-        ? 'workspaceFolder/python3.7-plain-sam-app/hello_world/app.py'
-        : path.join(getWorkspaceFolder().substring(1), '/python3.7-plain-sam-app/hello_world/app.py'),
+const buildRawCodeScanIssue = (params?: Partial<RawCodeScanIssue>): RawCodeScanIssue => ({
+    filePath: 'workspaceFolder/python3.7-plain-sam-app/hello_world/app.py',
     startLine: 1,
     endLine: 1,
     title: 'title',
@@ -99,21 +97,21 @@ describe('securityScanHandler', function () {
                 .onFirstCall()
                 .resolves(
                     buildMockListCodeScanFindingsResponse(
-                        JSON.stringify([buildRawCodeScanIssue(true, { title: 'title1' })]),
+                        JSON.stringify([buildRawCodeScanIssue({ title: 'title1' })]),
                         true
                     )
                 )
                 .onSecondCall()
                 .resolves(
                     buildMockListCodeScanFindingsResponse(
-                        JSON.stringify([buildRawCodeScanIssue(true, { title: 'title2' })]),
+                        JSON.stringify([buildRawCodeScanIssue({ title: 'title2' })]),
                         true
                     )
                 )
                 .onThirdCall()
                 .resolves(
                     buildMockListCodeScanFindingsResponse(
-                        JSON.stringify([buildRawCodeScanIssue(true, { title: 'title3' })]),
+                        JSON.stringify([buildRawCodeScanIssue({ title: 'title3' })]),
                         false
                     )
                 )
@@ -154,22 +152,6 @@ describe('securityScanHandler', function () {
                     )
                 )
             }
-        })
-        it('should include ListCodeScanFindings from opened file that is not from project', async function () {
-            mockClient.listCodeScanFindings.resolves(
-                buildMockListCodeScanFindingsResponse(JSON.stringify([buildRawCodeScanIssue(false)]))
-            )
-
-            const aggregatedCodeScanIssueList = await listScanResults(
-                mockClient,
-                'jobId',
-                'codeScanFindingsSchema',
-                [],
-                CodeAnalysisScope.PROJECT,
-                undefined
-            )
-            assert.equal(aggregatedCodeScanIssueList.length, 1)
-            assert.equal(aggregatedCodeScanIssueList[0].issues.length, 1)
         })
     })
 

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -20,7 +20,6 @@ import { timeoutUtils } from 'aws-core-vscode/shared'
 import assert from 'assert'
 import sinon from 'sinon'
 import * as vscode from 'vscode'
-// import fs from 'fs' // eslint-disable-line no-restricted-imports
 import path from 'path'
 
 const buildRawCodeScanIssue = (fromProject: boolean = true, params?: Partial<RawCodeScanIssue>): RawCodeScanIssue => ({

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -66,6 +66,9 @@ const buildMockListCodeScanFindingsResponse = (
 })
 
 function getWorkspaceFolder(): string {
+    if (vscode.workspace.workspaceFolders !== undefined && vscode.workspace.workspaceFolders.length > 0) {
+        return vscode.workspace.workspaceFolders[0].uri.toString().split('file://')[1]
+    }
     return path.join(__dirname, '../../../../../../core/src/testFixtures/workspaceFolder')
 }
 

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -66,7 +66,10 @@ const buildMockListCodeScanFindingsResponse = (
 })
 
 function getWorkspaceFolder(): string {
-    return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? path.join(__dirname, '../../../../../../core/src/testFixtures/workspaceFolder')
+    return (
+        vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ??
+        path.join(__dirname, '../../../../../../core/src/testFixtures/workspaceFolder')
+    )
 }
 
 describe('securityScanHandler', function () {

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -66,10 +66,7 @@ const buildMockListCodeScanFindingsResponse = (
 })
 
 function getWorkspaceFolder(): string {
-    if (vscode.workspace.workspaceFolders !== undefined && vscode.workspace.workspaceFolders.length > 0) {
-        return vscode.workspace.workspaceFolders[0].uri.toString().split('file://')[1]
-    }
-    return path.join(__dirname, '../../../../../../core/src/testFixtures/workspaceFolder')
+    return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? path.join(__dirname, '../../../../../../core/src/testFixtures/workspaceFolder')
 }
 
 describe('securityScanHandler', function () {

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -66,7 +66,7 @@ const buildMockListCodeScanFindingsResponse = (
 })
 
 function getWorkspaceFolder(): string {
-    return path.join(__dirname, '../../../../../../core/dist/src/testFixtures/workspaceFolder')
+    return path.join(__dirname, '../../../../../../core/src/testFixtures/workspaceFolder')
 }
 
 describe('securityScanHandler', function () {

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -85,7 +85,7 @@ export async function listScanResults(
                 const document = await vscode.workspace.openTextDocument(filePath)
                 const aggregatedCodeScanIssue: AggregatedCodeScanIssue = {
                     filePath: filePath,
-                    issues: issues.map((issue) => mapRawToCodeScanIssue(issue, jobId, scope, document)),
+                    issues: issues.map((issue) => mapRawToCodeScanIssue(issue, document, jobId, scope)),
                 }
                 aggregatedCodeScanIssueList.push(aggregatedCodeScanIssue)
             }
@@ -95,7 +95,7 @@ export async function listScanResults(
             const document = await vscode.workspace.openTextDocument(maybeAbsolutePath)
             const aggregatedCodeScanIssue: AggregatedCodeScanIssue = {
                 filePath: maybeAbsolutePath,
-                issues: issues.map((issue) => mapRawToCodeScanIssue(issue, jobId, scope, document)),
+                issues: issues.map((issue) => mapRawToCodeScanIssue(issue, document, jobId, scope)),
             }
             aggregatedCodeScanIssueList.push(aggregatedCodeScanIssue)
         }
@@ -105,9 +105,9 @@ export async function listScanResults(
 
 function mapRawToCodeScanIssue(
     issue: RawCodeScanIssue,
+    document: vscode.TextDocument,
     jobId: string,
-    scope: CodeWhispererConstants.CodeAnalysisScope,
-    document: vscode.TextDocument
+    scope: CodeWhispererConstants.CodeAnalysisScope
 ): CodeScanIssue {
     const isIssueTitleIgnored = CodeWhispererSettings.instance.getIgnoredSecurityIssues().includes(issue.title)
     const isSingleIssueIgnored = detectCommentAboveLine(

--- a/packages/core/src/test/codewhisperer/securityScanHandler.test.ts
+++ b/packages/core/src/test/codewhisperer/securityScanHandler.test.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PromiseResult } from 'aws-sdk/lib/request'
-import { Stub, stub } from 'aws-core-vscode/test'
+import { PromiseResult, Request } from 'aws-sdk/lib/request'
+import { createMockDocument } from './testUtil'
+import { Stub, stub } from '../utilities/stubber'
 import { AWSError, HttpResponse } from 'aws-sdk'
 import {
     CodeAnalysisScope,
@@ -15,12 +16,13 @@ import {
     ListCodeScanFindingsResponse,
     pollScanJobStatus,
     SecurityScanTimedOutError,
-} from 'aws-core-vscode/codewhisperer'
-import { timeoutUtils } from 'aws-core-vscode/shared'
+} from '../../codewhisperer'
+import { timeoutUtils } from '../../shared'
 import assert from 'assert'
-import sinon from 'sinon'
+import * as sinon from 'sinon'
 import * as vscode from 'vscode'
 import fs from 'fs' // eslint-disable-line no-restricted-imports
+import { GetCodeScanResponse } from '../../codewhisperer/client/codewhispererclient'
 
 const buildRawCodeScanIssue = (params?: Partial<RawCodeScanIssue>): RawCodeScanIssue => ({
     filePath: 'workspaceFolder/python3.7-plain-sam-app/hello_world/app.py',
@@ -72,6 +74,8 @@ describe('securityScanHandler', function () {
             mockClient = stub(DefaultCodeWhispererClient)
             sinon.stub(fs, 'existsSync').returns(true)
             sinon.stub(fs, 'statSync').returns({ isFile: () => true } as fs.Stats)
+            const textDocumentMock = createMockDocument('first line\n second line\n fourth line')
+            sinon.stub(vscode.workspace, 'openTextDocument').resolves(textDocumentMock)
         })
 
         afterEach(function () {
@@ -290,16 +294,64 @@ describe('securityScanHandler', function () {
         it('should return status when scan completes successfully', async function () {
             mockClient.getCodeScan
                 .onFirstCall()
-                .resolves({ status: 'Pending', $response: { requestId: 'req1' } })
+                .resolves({
+                    status: 'Pending',
+                    $response: {
+                        requestId: 'req1',
+                        hasNextPage: function (): boolean {
+                            throw new Error('Function not implemented.')
+                        },
+                        nextPage: function (): Request<GetCodeScanResponse, AWSError> | null {
+                            throw new Error('Function not implemented.')
+                        },
+                        data: undefined,
+                        error: undefined,
+                        redirectCount: 0,
+                        retryCount: 0,
+                        httpResponse: new HttpResponse(),
+                    },
+                })
                 .onSecondCall()
-                .resolves({ status: 'Completed', $response: { requestId: 'req2' } })
+                .resolves({
+                    status: 'Completed',
+                    $response: {
+                        requestId: 'req2',
+                        hasNextPage: function (): boolean {
+                            throw new Error('Function not implemented.')
+                        },
+                        nextPage: function (): Request<GetCodeScanResponse, AWSError> | null {
+                            throw new Error('Function not implemented.')
+                        },
+                        data: undefined,
+                        error: undefined,
+                        redirectCount: 0,
+                        retryCount: 0,
+                        httpResponse: new HttpResponse(),
+                    },
+                })
 
             const result = await pollScanJobStatus(mockClient, mockJobId, CodeAnalysisScope.FILE_AUTO, mockStartTime)
             assert.strictEqual(result, 'Completed')
         })
 
         it('should throw SecurityScanTimedOutError when polling exceeds timeout for express scans', async function () {
-            mockClient.getCodeScan.resolves({ status: 'Pending', $response: { requestId: 'req1' } })
+            mockClient.getCodeScan.resolves({
+                status: 'Pending',
+                $response: {
+                    requestId: 'req1',
+                    hasNextPage: function (): boolean {
+                        throw new Error('Function not implemented.')
+                    },
+                    nextPage: function (): Request<GetCodeScanResponse, AWSError> | null {
+                        throw new Error('Function not implemented.')
+                    },
+                    data: undefined,
+                    error: undefined,
+                    redirectCount: 0,
+                    retryCount: 0,
+                    httpResponse: new HttpResponse(),
+                },
+            })
 
             const pollPromise = pollScanJobStatus(mockClient, mockJobId, CodeAnalysisScope.FILE_AUTO, mockStartTime)
 
@@ -310,7 +362,23 @@ describe('securityScanHandler', function () {
         })
 
         it('should throw SecurityScanTimedOutError when polling exceeds timeout for standard scans', async function () {
-            mockClient.getCodeScan.resolves({ status: 'Pending', $response: { requestId: 'req1' } })
+            mockClient.getCodeScan.resolves({
+                status: 'Pending',
+                $response: {
+                    requestId: 'req1',
+                    hasNextPage: function (): boolean {
+                        throw new Error('Function not implemented.')
+                    },
+                    nextPage: function (): Request<GetCodeScanResponse, AWSError> | null {
+                        throw new Error('Function not implemented.')
+                    },
+                    data: undefined,
+                    error: undefined,
+                    redirectCount: 0,
+                    retryCount: 0,
+                    httpResponse: new HttpResponse(),
+                },
+            })
 
             const pollPromise = pollScanJobStatus(mockClient, mockJobId, CodeAnalysisScope.PROJECT, mockStartTime)
 


### PR DESCRIPTION
## Problem
When running a new `/review` scan, Q fails to respect previously added ignore line, causing ignored issues to reappear in subsequent reviews.

## Solution
Fixed incorrect filter logic on ignoring single line issue
Old unit tests for `listScanResults` will not work after this change. So in addition, I improved all of `securityScanHandler`'s unit tests to not use any file stubs to better simulate real environment. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
