### PR TITLE
feat(sdkv3): enable persistent connections by forcing keep alive header. 

### DIFF
--- a/packages/core/src/shared/awsClientBuilderV3.ts
+++ b/packages/core/src/shared/awsClientBuilderV3.ts
@@ -213,6 +213,13 @@ export function overwriteEndpoint(
     return next(args)
 }
 
+/**
+ * Overwrite agents behavior and add the keepAliveHeader. This is needed due to
+ * https://github.com/microsoft/vscode/issues/173861.
+ * @param next
+ * @param args
+ * @returns
+ */
 export function addKeepAliveHeader(next: BuildHandler<any, any>, args: any) {
     const request = args.request
     if (HttpRequest.isInstance(request)) {

--- a/packages/core/src/shared/awsClientBuilderV3.ts
+++ b/packages/core/src/shared/awsClientBuilderV3.ts
@@ -5,7 +5,7 @@
 
 import { CredentialsShim } from '../auth/deprecated/loginManager'
 import { AwsContext } from './awsContext'
-import { AwsCredentialIdentityProvider, RetryStrategyV2 } from '@smithy/types'
+import { AwsCredentialIdentityProvider, Logger, RetryStrategyV2 } from '@smithy/types'
 import { getUserAgent } from './telemetry/util'
 import { DevSettings } from './settings'
 import {
@@ -64,6 +64,7 @@ interface AwsClientOptions {
     apiVersion: string
     endpoint: string
     retryStrategy: RetryStrategy | RetryStrategyV2
+    logger: Logger
 }
 
 export class AWSClientBuilderV3 {

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -17,6 +17,16 @@ describe('tech debt', function () {
         assert.ok(now <= cutoffDate, msg)
     }
 
+    it('vscode minimum version', async function () {
+        const minVscode = env.getMinVscodeVersion()
+        assert.ok(semver.lt(minVscode, '1.84.0'))
+
+        assert.ok(
+            semver.lt(minVscode, '1.110.0'),
+            'Check to see if https://github.com/microsoft/vscode/issues/173861 is resolved. Allows us to remove work done by https://github.com/aws/aws-toolkit-vscode-staging/pull/1214 and part of https://github.com/aws/aws-toolkit-vscode/pull/6664'
+        )
+    })
+
     it('nodejs minimum version', async function () {
         const minNodejs = env.getMinNodejsVersion()
 

--- a/packages/core/src/test/techdebt.test.ts
+++ b/packages/core/src/test/techdebt.test.ts
@@ -17,17 +17,6 @@ describe('tech debt', function () {
         assert.ok(now <= cutoffDate, msg)
     }
 
-    it('vscode minimum version', async function () {
-        const minVscode = env.getMinVscodeVersion()
-        assert.ok(semver.lt(minVscode, '1.84.0'))
-
-        // see https://github.com/microsoft/vscode/issues/173861
-        assert.ok(
-            semver.lt(minVscode, '1.93.0'),
-            'keepAlive works properly in vscode 1.93+. Remove src/codewhisperer/client/agent.ts and other code related to https://github.com/aws/aws-toolkit-vscode-staging/pull/1214'
-        )
-    })
-
     it('nodejs minimum version', async function () {
         const minNodejs = env.getMinNodejsVersion()
 

--- a/packages/core/src/testE2E/shared/awsClientBuilderV3.test.ts
+++ b/packages/core/src/testE2E/shared/awsClientBuilderV3.test.ts
@@ -46,14 +46,11 @@ describe('SDKv3 Client Behavior', function () {
         const httpHandler = new NodeHttpHandler({
             httpAgent: new http.Agent({ keepAlive: true }),
         })
-        const client = await globals.sdkClientBuilderV3.createAwsService({
-            serviceClient: SSMClient,
-            clientOptions: {
-                region: 'us-east-1',
-                endpoint: `http://localhost:${port}`,
-                requestHandler: httpHandler,
-                logger: testLogger,
-            },
+        const client = await globals.sdkClientBuilderV3.createAwsService(SSMClient, {
+            region: 'us-east-1',
+            endpoint: `http://localhost:${port}`,
+            requestHandler: httpHandler,
+            logger: testLogger,
         })
         await client.send(new DescribeSessionsCommand({ State: 'Active' }))
         await client.send(new DescribeSessionsCommand({ State: 'Active' }))

--- a/packages/core/src/testE2E/shared/awsClientBuilderV3.test.ts
+++ b/packages/core/src/testE2E/shared/awsClientBuilderV3.test.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import http from 'http'
+import assert from 'assert'
+import { SSMClient, DescribeSessionsCommand } from '@aws-sdk/client-ssm'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
+import { Logger } from '@aws-sdk/types'
+import { globals } from '../../shared'
+
+describe('SDKv3 Client Behavior', function () {
+    const port = 4576
+    let server: http.Server
+    let testLogger: Logger
+    let requests: http.IncomingMessage[]
+
+    before(function () {
+        server = http.createServer({ keepAlive: true }, (req, rsp) => {
+            rsp.writeHead(200, { 'Content-Type': 'application/json' })
+            rsp.end(JSON.stringify({ message: 'success' }))
+        })
+        const defaultLog = (m: object) => console.log(JSON.stringify(m, undefined, 3))
+        testLogger = {
+            debug: defaultLog,
+            warn: defaultLog,
+            error: defaultLog,
+            info: defaultLog,
+        }
+        server.listen(port, () => {})
+        server.on('request', (req) => {
+            requests.push(req)
+        })
+    })
+
+    beforeEach(function () {
+        requests = []
+    })
+
+    after(function () {
+        server.close()
+    })
+
+    it('reuses connections', async function () {
+        const httpHandler = new NodeHttpHandler({
+            httpAgent: new http.Agent({ keepAlive: true }),
+        })
+        const client = await globals.sdkClientBuilderV3.createAwsService({
+            serviceClient: SSMClient,
+            clientOptions: {
+                region: 'us-east-1',
+                endpoint: `http://localhost:${port}`,
+                requestHandler: httpHandler,
+                logger: testLogger,
+            },
+        })
+        await client.send(new DescribeSessionsCommand({ State: 'Active' }))
+        await client.send(new DescribeSessionsCommand({ State: 'Active' }))
+
+        assert.strictEqual(requests[0].headers.connection, 'keep-alive')
+        assert.strictEqual(requests[1].headers.connection, 'keep-alive')
+    })
+})


### PR DESCRIPTION
## Problem
Inspecting the logs, and http requests themselves, it appears that the sdkv3 clients are somehow adding a `connection: close` header to the http requests. This is not done by the SDK (according to SDK team), and inspecting the headers throughout the SDK packages at the recommended points suggests this is being overwritten somewhere else. 

Creating a new vscode extension with this code snippet also fails, but a new project without vscode succeeds. This suggests its VS Code. 

I believe this is caused by https://github.com/microsoft/vscode/issues/173861, which was resolved, but is now reopened. The comments and techdebt tests suggested this is no longer an issue, but it now is again due to fix being reverted. 

## Solution
- Remove outdated notes/test that suggest this is fixed in newer versions of VS Code. 
- add e2e test verifying expected `keepAlive` behavior. 
- Add custom "build" step middleware that adds the keepAlive to the HTTP request, unless explicitly told not to. 
- Improve some typing in the middleware by making use of type assertions. 

### Notes
Related work done to completely overwrite the proxyAgent in vscode to fix this done here: https://github.com/aws/aws-toolkit-vscode-staging/pull/1214. However, this code is outdated and doesn't work anymore (its also unused). There is a functioning implementation of this logic at https://github.com/sourcegraph/cody/blob/62d73f78c432036d1f99bc9631ed534cc2ed846b/vscode/src/net/net.patch.ts. 

However, adding the `keepAlive` header manually appears to be working based on the e2e test. My understanding is that if the client was closing the connection in between each request, it must send a FIN message to the server to let it know according to TCP. The server would then close its side of the connection as well, but we know from the e2e test this isn't happening since it maintains the same connection across two requests. Therefore, the client must also be keeping its connection open, making use of persistent connections on both sides. 

### Experimental Results
Redoing the experiment of timing repeated requests when caching, not-caching, and caching with the change in this PR (connection persistence):
<img width="485" alt="image" src="https://github.com/user-attachments/assets/786130ea-6e6c-4029-8e1d-df5cc89edb66" />
Note: experiment separate into 3 trails of 10 requests to limit the effect of throttling.

Therefore, this change is saving almost 40 ms per request!

## Future Work
Delete the dead code at https://github.com/aws/aws-toolkit-vscode-staging/pull/1214. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
