### PR TITLE
refactor(cw): Rename the mergedTextDocument field. 

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -25,7 +25,7 @@ import { ChatMessage, ErrorMessage, FollowUp, Suggestion } from '../../../view/c
 import { ChatSession } from '../../../clients/chat/v0/chat'
 import { ChatException } from './model'
 import { CWCTelemetryHelper } from '../telemetryHelper'
-import { ChatPromptCommandType, MergedRelevantDocument, TriggerPayload } from '../model'
+import { ChatPromptCommandType, DocumentReference, TriggerPayload } from '../model'
 import { getHttpStatusCode, getRequestId, ToolkitError } from '../../../../shared/errors'
 import { keys } from '../../../../shared/utilities/tsUtils'
 import { getLogger } from '../../../../shared/logger/logger'
@@ -69,7 +69,7 @@ export class Messenger {
     public sendInitalStream(
         tabID: string,
         triggerID: string,
-        mergedRelevantDocuments: MergedRelevantDocument[] | undefined
+        mergedRelevantDocuments: DocumentReference[] | undefined
     ) {
         this.dispatcher.sendChatMessage(
             new ChatMessage(

--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -189,7 +189,9 @@ export interface TriggerPayload {
     readonly context?: string[] | QuickActionCommand[]
     relevantTextDocuments?: RelevantTextDocumentAddition[]
     additionalContents?: AdditionalContentEntry[]
-    mergedRelevantDocuments?: MergedRelevantDocument[]
+    // a reference to all documents used in chat payload
+    // for providing better context transparency
+    documentReferences?: DocumentReference[]
     useRelevantDocuments?: boolean
     traceId?: string
 }
@@ -197,7 +199,7 @@ export interface TriggerPayload {
 // TODO move this to API definition (or just use this across the codebase)
 export type RelevantTextDocumentAddition = RelevantTextDocument & { startLine: number; endLine: number }
 
-export interface MergedRelevantDocument {
+export interface DocumentReference {
     readonly relativeFilePath: string
     readonly lineRanges: Array<{ first: number; second: number }>
 }

--- a/packages/core/src/codewhispererChat/view/connector/connector.ts
+++ b/packages/core/src/codewhispererChat/view/connector/connector.ts
@@ -8,7 +8,7 @@ import { MessagePublisher } from '../../../amazonq/messages/messagePublisher'
 import { EditorContextCommandType } from '../../commands/registerCommands'
 import { AuthFollowUpType } from '../../../amazonq/auth/model'
 import { ChatItemButton, ChatItemFormItem, MynahUIDataModel, QuickActionCommand } from '@aws/mynah-ui'
-import { MergedRelevantDocument } from '../../controllers/chat/model'
+import { DocumentReference } from '../../controllers/chat/model'
 
 class UiMessage {
     readonly time: number = Date.now()
@@ -207,7 +207,7 @@ export interface ChatMessageProps {
     readonly messageID: string
     readonly userIntent: string | undefined
     readonly codeBlockLanguage: string | undefined
-    readonly contextList: MergedRelevantDocument[] | undefined
+    readonly contextList: DocumentReference[] | undefined
 }
 
 export class ChatMessage extends UiMessage {
@@ -222,7 +222,7 @@ export class ChatMessage extends UiMessage {
     readonly messageID: string | undefined
     readonly userIntent: string | undefined
     readonly codeBlockLanguage: string | undefined
-    readonly contextList: MergedRelevantDocument[] | undefined
+    readonly contextList: DocumentReference[] | undefined
     override type = 'chatMessage'
 
     constructor(props: ChatMessageProps, tabID: string) {


### PR DESCRIPTION
## Problem
The mergedRelevantTextDocument should have a better name. It is actually the documents that are referenced.

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
