### PR TITLE
fix(amazonq): adjust feature config customization arn override logic

### DIFF
--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -128,7 +128,7 @@ export const setSelectedCustomization = async (customization: Customization, isO
         return
     }
     if (isOverride) {
-        const previousOverride = globals.globalState.tryGet<string>('aws.amazonq.customization.override', String)
+        const previousOverride = globals.globalState.tryGet<string>('aws.amazonq.customization.overrideV2', String)
         if (customization.arn === previousOverride) {
             return
         }
@@ -143,7 +143,7 @@ export const setSelectedCustomization = async (customization: Customization, isO
 
     await globals.globalState.update('CODEWHISPERER_SELECTED_CUSTOMIZATION', selectedCustomizationObj)
     if (isOverride) {
-        await globals.globalState.update('aws.amazonq.customization.override', customization.arn)
+        await globals.globalState.update('aws.amazonq.customization.overrideV2', customization.arn)
     }
     vsCodeState.isFreeTierLimitReached = false
     await Commands.tryExecute('aws.amazonq.refreshStatusBar')

--- a/packages/core/src/shared/featureConfig.ts
+++ b/packages/core/src/shared/featureConfig.ts
@@ -33,7 +33,7 @@ export class FeatureContext {
     ) {}
 }
 
-const featureConfigPollIntervalInMs = 30 * 60 * 1000 // 30 mins
+const featureConfigPollIntervalInMs = 180 * 60 * 1000 // 180 mins
 
 export const Features = {
     customizationArnOverride: 'customizationArnOverride',
@@ -144,7 +144,8 @@ export class FeatureConfigProvider {
 
             const customizationArnOverride = this.featureConfigs.get(Features.customizationArnOverride)?.value
                 ?.stringValue
-            if (customizationArnOverride !== undefined) {
+            const previousOverride = globals.globalState.tryGet<string>('aws.amazonq.customization.overrideV2', String)
+            if (customizationArnOverride !== undefined && customizationArnOverride != previousOverride) {
                 // Double check if server-side wrongly returns a customizationArn to BID users
                 if (isBuilderIdConnection(AuthUtil.instance.conn)) {
                     this.featureConfigs.delete(Features.customizationArnOverride)

--- a/packages/core/src/shared/featureConfig.ts
+++ b/packages/core/src/shared/featureConfig.ts
@@ -145,7 +145,7 @@ export class FeatureConfigProvider {
             const customizationArnOverride = this.featureConfigs.get(Features.customizationArnOverride)?.value
                 ?.stringValue
             const previousOverride = globals.globalState.tryGet<string>('aws.amazonq.customization.overrideV2', String)
-            if (customizationArnOverride !== undefined && customizationArnOverride != previousOverride) {
+            if (customizationArnOverride !== undefined && customizationArnOverride !== previousOverride) {
                 // Double check if server-side wrongly returns a customizationArn to BID users
                 if (isBuilderIdConnection(AuthUtil.instance.conn)) {
                     this.featureConfigs.delete(Features.customizationArnOverride)

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -45,7 +45,6 @@ export type globalKey =
     | 'aws.toolkit.amazonq.dismissed'
     | 'aws.toolkit.amazonqInstall.dismissed'
     | 'aws.amazonq.workspaceIndexToggleOn'
-    | 'aws.amazonq.customization.override'
     | 'aws.amazonq.customization.overrideV2'
     // Deprecated/legacy names. New keys should start with "aws.".
     | '#sessionCreationDates' // Legacy name from `ssoAccessTokenProvider.ts`.

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -46,6 +46,7 @@ export type globalKey =
     | 'aws.toolkit.amazonqInstall.dismissed'
     | 'aws.amazonq.workspaceIndexToggleOn'
     | 'aws.amazonq.customization.override'
+    | 'aws.amazonq.customization.overrideV2'
     // Deprecated/legacy names. New keys should start with "aws.".
     | '#sessionCreationDates' // Legacy name from `ssoAccessTokenProvider.ts`.
     | 'CODECATALYST_RECONNECT'


### PR DESCRIPTION
1. change poll interval from 30mins to 180 mins
2. Only call listAvailableCustomizations for new customization override for update
3. Use a new field customizationArnOverrideV2 for a clean override plan

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
