### PR TITLE
fix(amazonq): Test generation shows incorrect view diff view

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-21c570d4-388e-460f-88e1-7034ed7e17d4.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-21c570d4-388e-460f-88e1-7034ed7e17d4.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q /test: Unit test generation displays an inaccurate diff view for non-primary packages in the workspace."
+}

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -678,12 +678,7 @@ export class TestController {
     private async openDiff(message: OpenDiffMessage) {
         const session = this.sessionStorage.getSession()
         const filePath = session.generatedFilePath
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
-        if (!workspaceFolder) {
-            throw new Error('No workspace folder found')
-        }
-        const projectPath = workspaceFolder.uri.fsPath
-        const absolutePath = path.join(projectPath, filePath)
+        const absolutePath = path.join(session.projectRootPath, filePath)
         const fileExists = await fs.existsFile(absolutePath)
         const leftUri = fileExists ? vscode.Uri.file(absolutePath) : vscode.Uri.from({ scheme: 'untitled' })
         const rightUri = vscode.Uri.file(path.join(this.tempResultDirPath, 'resultArtifacts', filePath))


### PR DESCRIPTION


## Problem
- When users attempt to generate unit test cases using the /test command for packages other than the primary one in the workspace, they encounter a diff view suggesting the absence of an existing file. However, this is incorrect as there is already an existing test file in the package.


## Solution
- Fixed this issue by getting the project path from the target file.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
