### PR TITLE
fix(amazonq): Set context limit to 40k characters

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -997,11 +997,11 @@ export class ChatController {
             if (CodeWhispererSettings.instance.isLocalIndexEnabled()) {
                 const start = performance.now()
                 let remainingContextLength = contextMaxLength
-                triggerPayload.additionalContents?.forEach((i) => {
-                    if (i.innerContext) {
-                        remainingContextLength -= i.innerContext.length
+                for (const additionalContent of triggerPayload.additionalContents || []) {
+                    if (additionalContent.innerContext) {
+                        remainingContextLength -= additionalContent.innerContext.length
                     }
-                })
+                }
                 triggerPayload.relevantTextDocuments = []
                 const relevantTextDocuments = await LspController.instance.query(triggerPayload.message)
                 for (const relevantDocument of relevantTextDocuments) {


### PR DESCRIPTION
## Problem
This is a band-aid to temporarily set the size of `relevantTextDocuments` and `additionalContentEntry[]` combined to be lower than 40k characters, due to limitations on the service side. This PR will fix the issue when the API returns validation exception.

## Solution

1. Truncation is performed at chunk level. 
2. Prioritize `additionalContentEntry[]` over `relevantTextDocuments`
3. Added TODO for a total character count indicator.



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
