### PR TITLE
feat(toolkit): Expand data source and output options for Distributed Map in ASL language schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8073,8 +8073,9 @@
             "link": true
         },
         "node_modules/amazon-states-language-service": {
-            "version": "1.15.0",
-            "license": "MIT",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.16.1.tgz",
+            "integrity": "sha512-52010w3M+Lvu3PZ3TiIhPRx9On7OpBEPyrhQonf4Luz5+uqCVuY2YLXTawvMURm//6k7g9CZrtEffAPopPY/+w==",
             "dependencies": {
                 "js-yaml": "^4.1.0",
                 "jsonata": "2.0.5",
@@ -18934,7 +18935,7 @@
                 "@vscode/debugprotocol": "^1.57.0",
                 "@zip.js/zip.js": "^2.7.41",
                 "adm-zip": "^0.5.10",
-                "amazon-states-language-service": "^1.15.0",
+                "amazon-states-language-service": "^1.16.1",
                 "async-lock": "^1.4.0",
                 "aws-sdk": "^2.1692.0",
                 "aws-ssm-document-language-service": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -521,7 +521,7 @@
         "@vscode/debugprotocol": "^1.57.0",
         "@zip.js/zip.js": "^2.7.41",
         "adm-zip": "^0.5.10",
-        "amazon-states-language-service": "^1.15.0",
+        "amazon-states-language-service": "^1.16.1",
         "async-lock": "^1.4.0",
         "aws-sdk": "^2.1692.0",
         "aws-ssm-document-language-service": "^1.0.0",

--- a/packages/toolkit/.changes/next-release/Feature-43784260-ff60-4419-8fe3-a886a2b37fc6.json
+++ b/packages/toolkit/.changes/next-release/Feature-43784260-ff60-4419-8fe3-a886a2b37fc6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Step Functions: Expand data source and output options for Distributed Map in ASL language schema"
+}


### PR DESCRIPTION

## Problem


## Solution
Upgrade `amazon-states-language-service` to 1.16.1.
The new version expands data source and output options for Distributed Map in ASL. 

Feature release post: https://aws.amazon.com/about-aws/whats-new/2025/02/aws-step-functions-data-source-output-option-distributed-map/

---
![Screenshot 2025-02-25 at 12 28 22 PM](https://github.com/user-attachments/assets/8d70d111-558b-4973-b206-2601929d0e9e)


- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
