### PR TITLE
fix(amazonq): /test file collection usecase adds more patterns to filtering.

### DIFF
--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -896,3 +896,21 @@ export enum SecurityScanStep {
 }
 
 export const amazonqCodeIssueDetailsTabTitle = 'Code Issue Details'
+
+export const testGenExcludePatterns = [
+    '**/annotation-generated-src/*',
+    '**/annotation-generated-tst/*',
+    '**/build/*',
+    '**/env/*',
+    '**/release-info/*',
+    '**/*.jar',
+    '**/*.exe',
+    '**/*.a',
+    '**/*.map',
+    '**/*.graph',
+    '**/*.so',
+    '**/*.csv',
+    '**/*.dylib',
+    '**/*.parquet',
+    '**/*.xlsx',
+]

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -913,4 +913,11 @@ export const testGenExcludePatterns = [
     '**/*.dylib',
     '**/*.parquet',
     '**/*.xlsx',
+    '**/*.tar.gz',
+    '**/*.tar',
+    '**/*.pack',
+    '**/*.pkg',
+    '**/*.pkl',
+    '**/*.deb',
+    '**/*.model',
 ]

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -412,7 +412,9 @@ export class ZipUtil {
 
         const sourceFiles = await collectFiles(
             projectPaths,
-            vscode.workspace.workspaceFolders as CurrentWsFolders,
+            [...(vscode.workspace.workspaceFolders ?? [])].sort(
+                (a, b) => b.uri.fsPath.length - a.uri.fsPath.length
+            ) as CurrentWsFolders,
             {
                 maxSizeBytes: this.getProjectScanPayloadSizeLimitInBytes(),
             },

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -412,9 +412,11 @@ export class ZipUtil {
 
         const sourceFiles = await collectFiles(
             projectPaths,
-            [...(vscode.workspace.workspaceFolders ?? [])].sort(
-                (a, b) => b.uri.fsPath.length - a.uri.fsPath.length
-            ) as CurrentWsFolders,
+            (useCase === FeatureUseCase.TEST_GENERATION
+                ? [...(vscode.workspace.workspaceFolders ?? [])].sort(
+                      (a, b) => b.uri.fsPath.length - a.uri.fsPath.length
+                  )
+                : vscode.workspace.workspaceFolders) as CurrentWsFolders,
             {
                 maxSizeBytes: this.getProjectScanPayloadSizeLimitInBytes(),
             },

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -13,7 +13,7 @@ import { fs } from '../../shared/fs/fs'
 import { getLoggerForScope } from '../service/securityScanHandler'
 import { runtimeLanguageContext } from './runtimeLanguageContext'
 import { CodewhispererLanguage } from '../../shared/telemetry/telemetry.gen'
-import { CurrentWsFolders, collectFiles } from '../../shared/utilities/workspaceUtils'
+import { CurrentWsFolders, collectFiles, defaultExcludePatterns } from '../../shared/utilities/workspaceUtils'
 import {
     FileSizeExceededError,
     NoActiveFileError,
@@ -419,8 +419,11 @@ export class ZipUtil {
                 : vscode.workspace.workspaceFolders) as CurrentWsFolders,
             {
                 maxSizeBytes: this.getProjectScanPayloadSizeLimitInBytes(),
-            },
-            useCase
+                excludePatterns:
+                    useCase === 'TEST_GENERATION'
+                        ? [...CodeWhispererConstants.testGenExcludePatterns, ...defaultExcludePatterns]
+                        : defaultExcludePatterns,
+            }
         )
         for (const file of sourceFiles) {
             const projectName = path.basename(file.workspaceFolder.uri.fsPath)

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -420,7 +420,7 @@ export class ZipUtil {
             {
                 maxSizeBytes: this.getProjectScanPayloadSizeLimitInBytes(),
                 excludePatterns:
-                    useCase === 'TEST_GENERATION'
+                    useCase === FeatureUseCase.TEST_GENERATION
                         ? [...CodeWhispererConstants.testGenExcludePatterns, ...defaultExcludePatterns]
                         : defaultExcludePatterns,
             }

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -224,18 +224,12 @@ export function getWorkspaceRelativePath(
         workspaceFolders?: readonly vscode.WorkspaceFolder[]
     } = {
         workspaceFolders: vscode.workspace.workspaceFolders,
-    },
-    useCase?: FeatureUseCase
+    }
 ): { relativePath: string; workspaceFolder: vscode.WorkspaceFolder } | undefined {
     if (!override.workspaceFolders) {
         return
     }
     let folders = override.workspaceFolders
-    if (useCase && useCase === FeatureUseCase.TEST_GENERATION) {
-        // Sort workspace folders by path length (descending) to prioritize deeper paths
-        // TODO: Need to enable this for entire Q
-        folders = [...override.workspaceFolders].sort((a, b) => b.uri.fsPath.length - a.uri.fsPath.length)
-    }
 
     for (const folder of folders) {
         if (isInDirectory(folder.uri.fsPath, childPath)) {
@@ -410,10 +404,10 @@ export async function collectFiles(
             excludePatternFilter
         )
 
-        const files = excludeByGitIgnore ? await filterOutGitignoredFiles(rootPath, allFiles, false) : allFiles
+        const files = excludeByGitIgnore ? await filterOutGitignoredFiles(rootPath, allFiles, false, useCase) : allFiles
 
         for (const file of files) {
-            const relativePath = getWorkspaceRelativePath(file.fsPath, { workspaceFolders }, useCase)
+            const relativePath = getWorkspaceRelativePath(file.fsPath, { workspaceFolders })
             if (!relativePath) {
                 continue
             }

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -229,7 +229,7 @@ export function getWorkspaceRelativePath(
     if (!override.workspaceFolders) {
         return
     }
-    let folders = override.workspaceFolders
+    const folders = override.workspaceFolders
 
     for (const folder of folders) {
         if (isInDirectory(folder.uri.fsPath, childPath)) {
@@ -301,7 +301,7 @@ export function getExcludePattern(useDefaults: boolean = true, useCase?: Feature
         allPatterns.push(...defaultExcludePatterns)
     }
 
-    if (useCase == FeatureUseCase.TEST_GENERATION) {
+    if (useCase === FeatureUseCase.TEST_GENERATION) {
         allPatterns.push(...testGenExcludePatterns)
     }
 

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -20,7 +20,6 @@ import fs from '../fs/fs'
 import { ChildProcess } from './processUtils'
 import { isWin } from '../vscode/env'
 import { maxRepoSizeBytes } from '../../amazonqFeatureDev/constants'
-import { FeatureUseCase, testGenExcludePatterns } from '../../codewhisperer/models/constants'
 
 type GitIgnoreRelativeAcceptor = {
     folderPath: string

--- a/packages/core/src/shared/utilities/workspaceUtils.ts
+++ b/packages/core/src/shared/utilities/workspaceUtils.ts
@@ -355,8 +355,7 @@ export async function collectFiles(
         excludeByGitIgnore?: boolean // default true
         excludePatterns?: string[] // default defaultExcludePatterns
         filterFn?: CollectFilesFilter
-    },
-    useCase?: FeatureUseCase
+    }
 ): Promise<CollectFilesResultItem[]> {
     const storage: Awaited<CollectFilesResultItem[]> = []
 
@@ -387,10 +386,7 @@ export async function collectFiles(
     const inputExcludePatterns = options?.excludePatterns ?? defaultExcludePatterns
     const maxSizeBytes = options?.maxSizeBytes ?? maxRepoSizeBytes
 
-    const excludePatterns = [
-        ...getGlobalExcludePatterns(),
-        ...(useCase === FeatureUseCase.TEST_GENERATION ? [...testGenExcludePatterns, ...defaultExcludePatterns] : []),
-    ]
+    const excludePatterns = [...getGlobalExcludePatterns()]
     if (inputExcludePatterns.length) {
         excludePatterns.push(...inputExcludePatterns)
     }


### PR DESCRIPTION
## Problem
/test has been seeing quite a lot of failures due to file paylaod limit exceeded errors in past weeks in both IDEs but in last week there has been huge rise in these errors for /test on VSCode.

## Solution
We have noticed a change that ignores to use default patterns in file filtering was introduced in PR #6561 . We have also collected data from internal customers by adding payload manifest in JetBrains for these errors and compiled a list of extensions which are causing this issue. We have decided to add these patterns to ignore list on VSCode as well.
- For Test Generation useCase, we have added back default pattern ignore list
- we have created testGenIgnorePattern list and added these patterns to Filtering methods for Test Generation UseCase.
- Fixed the workspace folders sorting for Test Generation useCase in ziputils and removed it from workspaceUtils

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
