### PR TITLE
docs(amazonq): Add instructions on how to start Amazon Q inline debugging

### DIFF
--- a/docs/lsp-debugging.md
+++ b/docs/lsp-debugging.md
@@ -24,4 +24,4 @@
 
 ## Amazon Q Inline Activation
 
--   In order to get inline completion working you must open a supported file type defined in CodewhispererInlineCompletionLanguages in `packages/amazonq/src/app/inline/completion.ts` before breakpoints can be hit in the language server
+-   In order to get inline completion working you must open a supported file type defined in CodewhispererInlineCompletionLanguages in `packages/amazonq/src/app/inline/completion.ts`

--- a/docs/lsp-debugging.md
+++ b/docs/lsp-debugging.md
@@ -21,3 +21,7 @@
     to get the project setup
 3. Uncomment the `AWS_LANGUAGE_SERVER_OVERRIDE` variable in `amazonq/.vscode/launch.json` Extension configuration
 4. Use the `Launch LSP with Debugging` configuration and set breakpoints in VSCode or the language server
+
+## Amazon Q Inline Activation
+
+-   In order to get inline completion working you must open a supported file type defined in CodewhispererInlineCompletionLanguages in `packages/amazonq/src/app/inline/completion.ts` before breakpoints can be hit in the language server


### PR DESCRIPTION
## Problem
- Multiple people have gotten confused on how to get the language server activated for inline

## Solution
- Add that to the language server debugging documentation

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
