### PR TITLE
fix(amazonq): Fix edge cases of context command updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4935,9 +4935,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.23.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.23.0-beta.7.tgz",
-            "integrity": "sha512-qRwy8bP8inhbTb94xv9tJvqrmvv+PDcGyOKuPE9vx4+cwymNtf8HVp5IcIjJ/oTWV5bWA7M3o0mm9qEFFYdB6w==",
+            "version": "4.23.0-beta.11",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.23.0-beta.11.tgz",
+            "integrity": "sha512-3ZwOSM7UZ1aNO/SyGRhBdrr7Fj2MOcqmT5zzbTCRKrfNmQXMJBCm+lFh54bc2B0S4OskzE2vcvrI16+dBm7WGg==",
             "hasInstallScript": true,
             "dependencies": {
                 "escape-html": "^1.0.3",
@@ -18925,7 +18925,7 @@
                 "@aws-sdk/property-provider": "<3.696.0",
                 "@aws-sdk/smithy-client": "<3.696.0",
                 "@aws-sdk/util-arn-parser": "<3.696.0",
-                "@aws/mynah-ui": "^4.23.0-beta.7",
+                "@aws/mynah-ui": "^4.23.0-beta.11",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -510,7 +510,7 @@
         "@aws-sdk/property-provider": "<3.696.0",
         "@aws-sdk/smithy-client": "<3.696.0",
         "@aws-sdk/util-arn-parser": "<3.696.0",
-        "@aws/mynah-ui": "^4.23.0-beta.7",
+        "@aws/mynah-ui": "^4.23.0-beta.11",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^3.0.0",

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -375,7 +375,7 @@ export const createMynahUI = (
                         fileTreeTitle: '',
                         filePaths: item.contextList.map((file) => file.relativeFilePath),
                         rootFolderTitle: 'Context',
-                        collapsedByDefault: true,
+                        collapsed: true,
                         hideFileCount: true,
                         details: Object.fromEntries(
                             item.contextList.map((file) => [


### PR DESCRIPTION
## Problem
1. If user create a file using the File>New File buttons, the onCreateFile listener does not capture it.
2. Renaming file or folders is not listened and updated.

## Solution
1. Listen to new files created by File>New File buttons
2. Listen to renaming file or folders 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
