### PR TITLE
fix(amazonq): update lsp artifact to 0.1.42

### DIFF
--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -62,7 +62,7 @@ export interface Manifest {
 }
 const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
-const supportedLspServerVersions = ['0.1.40']
+const supportedLspServerVersions = ['0.1.42']
 
 const nodeBinName = process.platform === 'win32' ? 'node.exe' : 'node'
 


### PR DESCRIPTION
## Problem
In certain rare cases, when the changed file has no dot in filename, this file was misread as folders in the older LSP. Now this bug is fixed in 0.1.42 lsp.

## Solution
update lsp artifact to 0.1.42

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
