### PR TITLE
telemetry(amazonq): add telemetry for falcon features

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -194,6 +194,15 @@ export interface TriggerPayload {
     documentReferences?: DocumentReference[]
     useRelevantDocuments?: boolean
     traceId?: string
+    additionalContextLengths?: AdditionalContextLengths
+    truncatedAdditionalContextLengths?: AdditionalContextLengths
+    workspaceRulesCount?: number
+}
+
+export type AdditionalContextLengths = {
+    fileContextLength: number
+    promptContextLength: number
+    ruleContextLength: number
 }
 
 // TODO move this to API definition (or just use this across the codebase)

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -27,6 +27,7 @@ import {
     ResponseBodyLinkClickMessage,
     SourceLinkClickMessage,
     TriggerPayload,
+    AdditionalContextLengths,
 } from './model'
 import { TriggerEvent, TriggerEventsStorage } from '../../storages/triggerEvents'
 import globals from '../../../shared/extensionGlobals'
@@ -38,6 +39,8 @@ import { supportedLanguagesList } from '../chat/chatRequest/converter'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { getSelectedCustomization } from '../../../codewhisperer/util/customizationUtil'
 import { undefinedIfEmpty } from '../../../shared/utilities/textUtilities'
+import { AdditionalContextPrompt } from '../../../amazonq/lsp/types'
+import { getUserPromptsDirectory } from './controller'
 
 export function logSendTelemetryEventFailure(error: any) {
     let requestId: string | undefined
@@ -140,6 +143,39 @@ export class CWCTelemetryHelper {
 
     public recordExitFocusChat() {
         telemetry.amazonq_exitFocusChat.emit({ result: 'Succeeded', passive: true })
+    }
+
+    public getContextType(prompt: AdditionalContextPrompt): string {
+        if (prompt.relativePath.startsWith('.amazonq/rules')) {
+            return 'rule'
+        } else if (prompt.filePath.startsWith(getUserPromptsDirectory())) {
+            return 'prompt'
+        } else {
+            return 'file'
+        }
+    }
+
+    public getContextLengths(prompts: AdditionalContextPrompt[]): AdditionalContextLengths {
+        let fileContextLength = 0
+        let promptContextLength = 0
+        let ruleContextLength = 0
+
+        for (const prompt of prompts) {
+            const type = this.getContextType(prompt)
+            switch (type) {
+                case 'rule':
+                    ruleContextLength += prompt.content.length
+                    break
+                case 'file':
+                    fileContextLength += prompt.content.length
+                    break
+                case 'prompt':
+                    promptContextLength += prompt.content.length
+                    break
+            }
+        }
+
+        return { fileContextLength, promptContextLength, ruleContextLength }
     }
 
     public async recordFeedback(message: ChatItemFeedbackMessage) {
@@ -420,6 +456,30 @@ export class CWCTelemetryHelper {
         })
     }
 
+    private getAdditionalContextCounts(triggerPayload: TriggerPayload) {
+        const counts = {
+            fileContextCount: 0,
+            folderContextCount: 0,
+            promptContextCount: 0,
+        }
+
+        if (triggerPayload.context) {
+            for (const context of triggerPayload.context) {
+                if (typeof context !== 'string') {
+                    if (context.id === 'file') {
+                        counts.fileContextCount++
+                    } else if (context.id === 'folder') {
+                        counts.folderContextCount++
+                    } else if (context.id === 'prompt') {
+                        counts.promptContextCount++
+                    }
+                }
+            }
+        }
+
+        return counts
+    }
+
     public emitAddMessage(tabID: string, fullDisplayLatency: number, traceId: string, startTime?: number) {
         const payload = this.messageStorage.get(tabID)
         if (!payload) {
@@ -433,6 +493,9 @@ export class CWCTelemetryHelper {
             triggerPayload.relevantTextDocuments &&
             triggerPayload.relevantTextDocuments.length > 0 &&
             triggerPayload.useRelevantDocuments === true
+
+        const contextCounts = this.getAdditionalContextCounts(triggerPayload)
+
         const event: AmazonqAddMessage = {
             result: 'Succeeded',
             cwsprChatConversationId: this.getConversationId(message.tabID) ?? '',
@@ -464,6 +527,20 @@ export class CWCTelemetryHelper {
             credentialStartUrl: AuthUtil.instance.startUrl,
             codewhispererCustomizationArn: triggerPayload.customization.arn,
             cwsprChatHasProjectContext: hasProjectLevelContext,
+            cwsprChatHasContextList: triggerPayload.documentReferences && triggerPayload.documentReferences?.length > 0,
+            cwsprChatFolderContextCount: contextCounts.folderContextCount,
+            cwsprChatFileContextCount: contextCounts.fileContextCount,
+            cwsprChatFileContextLength: triggerPayload.additionalContextLengths?.fileContextLength ?? 0,
+            cwsprChatFileContextTruncatedLength:
+                triggerPayload.truncatedAdditionalContextLengths?.fileContextLength ?? 0,
+            cwsprChatRuleContextCount: triggerPayload.workspaceRulesCount,
+            cwsprChatRuleContextLength: triggerPayload.additionalContextLengths?.ruleContextLength ?? 0,
+            cwsprChatRuleContextTruncatedLength:
+                triggerPayload.truncatedAdditionalContextLengths?.ruleContextLength ?? 0,
+            cwsprChatPromptContextCount: contextCounts.promptContextCount,
+            cwsprChatPromptContextLength: triggerPayload.additionalContextLengths?.promptContextLength ?? 0,
+            cwsprChatPromptContextTruncatedLength:
+                triggerPayload.truncatedAdditionalContextLengths?.promptContextLength ?? 0,
             traceId,
         }
 

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -84,6 +84,61 @@
             "description": "Query latency in ms for local project context"
         },
         {
+            "name": "cwsprChatFolderContextCount",
+            "type": "int",
+            "description": "# of folders manually added to context"
+        },
+        {
+            "name": "cwsprChatFileContextCount",
+            "type": "int",
+            "description": "# of files manually added to context"
+        },
+        {
+            "name": "cwsprChatFileContextLength",
+            "type": "int",
+            "description": "Total length of files added to context"
+        },
+        {
+            "name": "cwsprChatFileContextTruncatedLength",
+            "type": "int",
+            "description": "Truncated length of files added to context"
+        },
+        {
+            "name": "cwsprChatPromptContextCount",
+            "type": "int",
+            "description": "# of saved prompts manually added to context"
+        },
+        {
+            "name": "cwsprChatPromptContextLength",
+            "type": "int",
+            "description": "Total length of saved prompts added to context"
+        },
+        {
+            "name": "cwsprChatPromptContextTruncatedLength",
+            "type": "int",
+            "description": "Truncated length of saved prompts added to context"
+        },
+        {
+            "name": "cwsprChatRuleContextCount",
+            "type": "int",
+            "description": "# of workspace rules automatically added to context"
+        },
+        {
+            "name": "cwsprChatRuleContextLength",
+            "type": "int",
+            "description": "Total length of workspace rules added to context"
+        },
+        {
+            "name": "cwsprChatRuleContextTruncatedLength",
+            "type": "int",
+            "description": "Truncated length of workspace rules added to context"
+        },
+        {
+            "name": "cwsprChatHasContextList",
+            "type": "boolean",
+            "description": "true if context list is displayed to user"
+        },
+        {
             "name": "amazonqIndexFileSizeInMB",
             "type": "int",
             "description": "The sum of file sizes that were indexed in MB"
@@ -639,6 +694,10 @@
             "description": "When chat panel is closed"
         },
         {
+            "name": "amazonq_createSavedPrompt",
+            "description": "When a saved user prompt is created"
+        },
+        {
             "name": "amazonq_startConversation",
             "description": "When user starts a new conversation",
             "metadata": [
@@ -803,6 +862,50 @@
                 },
                 {
                     "type": "codewhispererCustomizationArn",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatHasContextList",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatFolderContextCount",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatFileContextCount",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatFileContextLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatFileContextTruncatedLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatPromptContextCount",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatPromptContextLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatRuleContextTruncatedLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatRuleContextCount",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatRuleContextLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatPromptContextTruncatedLength",
                     "required": false
                 }
             ]


### PR DESCRIPTION
This PR adds the following telemetry for falcon features:

**New metric**: `amazonq_createSavedPrompt` - tracks when user creates a saved prompt using UX

**Additing to existing metric**: `amazonq_addMessage`:

- `cwsprChatHasContextList` - true if context list is displayed to user
- `cwsprChatPromptContextCount` - # of saved prompts manually added to context
- `cwsprChatPromptContextLength` - Total length of saved prompts added to context
- `cwsprChatPromptContextTruncatedLength` - Truncated length of saved prompts added to context
- `cwsprChatRuleContextCount` - # of workspace rules automatically added to context
- `cwsprChatRuleContextLength` - Total length of workspace rules added to context
- `cwsprChatRuleContextTruncatedLength` - Truncated length of workspace rules added to context
- `cwsprChatFileContextCount` - # of files manually added to context
- `cwsprChatFileContextLength` - Total length of files added to context
- `cwsprChatFileContextTruncatedLength` - Truncated length of files added to context
- `cwsprChatFolderContextCount` - # of folders manually added to context



Telemetry doc: https://quip-amazon.com/XRRfA9b8Ux24/Falcon-Telemetry-Toolkits-telemetry




---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
