### PR TITLE
fix(stepfunctions): Prevent opening Workflow Studio for invalid JSON/YAML; add save and deploy message handler

### DIFF
--- a/packages/core/src/stepFunctions/commands/publishStateMachine.ts
+++ b/packages/core/src/stepFunctions/commands/publishStateMachine.ts
@@ -18,7 +18,7 @@ const localize = nls.loadMessageBundle()
 export async function publishStateMachine(
     awsContext: AwsContext,
     outputChannel: vscode.OutputChannel,
-    region: string | undefined
+    region?: string
 ) {
     const logger: Logger = getLogger()
 

--- a/packages/core/src/stepFunctions/workflowStudio/types.ts
+++ b/packages/core/src/stepFunctions/workflowStudio/types.ts
@@ -35,6 +35,7 @@ export enum MessageType {
 export enum Command {
     INIT = 'INIT',
     SAVE_FILE = 'SAVE_FILE',
+    SAVE_FILE_AND_DEPLOY = 'SAVE_FILE_AND_DEPLOY',
     AUTO_SYNC_FILE = 'AUTO_SYNC_FILE',
     FILE_CHANGED = 'FILE_CHANGED',
     LOAD_STAGE = 'LOAD_STAGE',


### PR DESCRIPTION
## Problem
1. Deploy state machine workflow is not very visible to the customers
2. Currently when user is opening WFS with custom action in the side panel and has invalid JSON/YAML, the side panel opens and immediately closes (since WFS does not support invalid JSON/YAML). This experience does not look smooth.

## Solution
1. With Workflow Studio integration, we'll add `Save & Deploy` button to the UI which will save file, close WFS editor and start the deployment flow. Adding a message handler for this action
2. Adding a check for invalid JSON/YAML before attempting to open WFS in the side panel. If file is invalid, the panel will not be opened and the user will see a notification
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
