### PR TITLE
fix(amazonq): file list flicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4935,9 +4935,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.23.0-beta.12",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.23.0-beta.12.tgz",
-            "integrity": "sha512-/koL2JR31dccP1NgWbbHCBK3RwlC84+PbasEW6hSbjLOi5K3h9N5kcqLCn8vSIljMORS5XDnqErg7ZCcDkjXDg==",
+            "version": "4.23.0-beta.14",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.23.0-beta.14.tgz",
+            "integrity": "sha512-agmqB6ilxhgFi2eToEWYbmfzvUBOQcYUYdVtJ0/q1kjQj2UoJcRsLjulnsHd7Ml1pJlvSSh/LmxyNKVhiBwVQg==",
             "hasInstallScript": true,
             "dependencies": {
                 "escape-html": "^1.0.3",
@@ -18925,7 +18925,7 @@
                 "@aws-sdk/property-provider": "<3.696.0",
                 "@aws-sdk/smithy-client": "<3.696.0",
                 "@aws-sdk/util-arn-parser": "<3.696.0",
-                "@aws/mynah-ui": "^4.23.0-beta.12",
+                "@aws/mynah-ui": "^4.23.0-beta.14",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/middleware-retry": "^3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -510,7 +510,7 @@
         "@aws-sdk/property-provider": "<3.696.0",
         "@aws-sdk/smithy-client": "<3.696.0",
         "@aws-sdk/util-arn-parser": "<3.696.0",
-        "@aws/mynah-ui": "^4.23.0-beta.12",
+        "@aws/mynah-ui": "^4.23.0-beta.14",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/middleware-retry": "^3.0.0",

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -351,7 +351,7 @@ export const createMynahUI = (
                     ...(item.relatedContent !== undefined ? { relatedContent: item.relatedContent } : {}),
                     ...(item.followUp !== undefined ? { followUp: item.followUp } : {}),
                     ...(item.fileList !== undefined ? { fileList: item.fileList } : {}),
-                    ...(item.header !== undefined ? { header: item.header } : {}),
+                    ...(item.header !== undefined ? { header: item.header } : { header: undefined }),
                 })
                 if (
                     item.messageId !== undefined &&


### PR DESCRIPTION
## Problem
File list in header flickers as message is rendering (see screen recording)

https://github.com/user-attachments/assets/485c665f-cde1-4ed6-a316-8cea2ac63a49


## Solution
Update to latest mynah beta. Pass `undefined` to `header` in subsequent messages (as instructed by Mynah UI team)


Note: no fix in changelog needed since feature hasnt yet been released

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
