### PR TITLE
fix(amazonq): allow subsequent reviews in review tab

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-c2494a35-1254-4920-abec-2fb44a15ac1d.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-c2494a35-1254-4920-abec-2fb44a15ac1d.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix a bug where subsequent /review did not work after reviewing once"
+	"description": "/review: subsequent reviews weren't possible"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-c2494a35-1254-4920-abec-2fb44a15ac1d.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-c2494a35-1254-4920-abec-2fb44a15ac1d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix a bug where subsequent /review did not work after reviewing once"
+}

--- a/packages/amazonq/src/app/amazonqScan/app.ts
+++ b/packages/amazonq/src/app/amazonqScan/app.ts
@@ -25,6 +25,7 @@ export function init(appContext: AmazonQAppInitContext) {
         authClicked: new vscode.EventEmitter<any>(),
         tabOpened: new vscode.EventEmitter<any>(),
         tabClosed: new vscode.EventEmitter<any>(),
+        runScan: new vscode.EventEmitter<any>(),
         formActionClicked: new vscode.EventEmitter<any>(),
         errorThrown: new vscode.EventEmitter<any>(),
         showSecurityScan: new vscode.EventEmitter<any>(),

--- a/packages/amazonq/src/app/amazonqScan/chat/controller/controller.ts
+++ b/packages/amazonq/src/app/amazonqScan/chat/controller/controller.ts
@@ -49,7 +49,7 @@ export class ScanController {
         this.authController = new AuthController()
 
         this.chatControllerMessageListeners.tabOpened.event((data) => {
-            return this.tabOpened(data).then(() => this.scanInitiated(data))
+            return this.tabOpened(data)
         })
 
         this.chatControllerMessageListeners.tabClosed.event((data) => {
@@ -58,6 +58,10 @@ export class ScanController {
 
         this.chatControllerMessageListeners.authClicked.event((data) => {
             this.authClicked(data)
+        })
+
+        this.chatControllerMessageListeners.runScan.event((data) => {
+            return this.scanInitiated(data)
         })
 
         this.chatControllerMessageListeners.formActionClicked.event((data) => {

--- a/packages/amazonq/src/app/amazonqScan/chat/views/actions/uiMessageListener.ts
+++ b/packages/amazonq/src/app/amazonqScan/chat/views/actions/uiMessageListener.ts
@@ -40,6 +40,9 @@ export class UIMessageListener {
             case 'auth-follow-up-was-clicked':
                 this.authClicked(msg)
                 break
+            case 'review':
+                this.scan(msg)
+                break
             case 'form-action-click':
                 this.formActionClicked(msg)
                 break
@@ -56,6 +59,12 @@ export class UIMessageListener {
                 this.chatItemVoted(msg)
                 break
         }
+    }
+
+    private scan(msg: UIMessage) {
+        this.scanControllerEventsEmitters?.runScan.fire({
+            tabID: msg.tabID,
+        })
     }
 
     private formActionClicked(msg: UIMessage) {

--- a/packages/core/src/amazonq/webview/ui/apps/amazonqCommonsConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/amazonqCommonsConnector.ts
@@ -71,7 +71,8 @@ export class Connector {
             this.onNewTab('agentWalkthrough')
             return
         } else if (messageData.command === 'review') {
-            this.onNewTab('review')
+            // tabID does not exist when calling from QuickAction Menu bar
+            this.handleCommand({ command: '/review' }, '')
             return
         }
     }

--- a/packages/core/src/amazonqScan/controller.ts
+++ b/packages/core/src/amazonqScan/controller.ts
@@ -20,6 +20,7 @@ export interface ScanChatControllerEventEmitters {
     readonly tabOpened: vscode.EventEmitter<any>
     readonly tabClosed: vscode.EventEmitter<any>
     readonly authClicked: vscode.EventEmitter<any>
+    readonly runScan: vscode.EventEmitter<any>
     readonly formActionClicked: vscode.EventEmitter<any>
     readonly errorThrown: vscode.EventEmitter<any>
     readonly showSecurityScan: vscode.EventEmitter<any>


### PR DESCRIPTION
## Problem

Subsequent reviews (`/review`) were not possible after running a review. 

## Solution

- subsequent reviews are now allowed
- Fix were made to not impact the previous bug fix where review causes two "run code review" chat messages
- Fix were made not to impact previous bug fix to auto-trigger `/review` from Quick Actions Menu
- Reverts https://github.com/aws/aws-toolkit-vscode/pull/6550

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
