### PR TITLE
telemetry(amazonq): deprecate `codewhisperer_userDecision` metric

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/commands/onAcceptance.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/commands/onAcceptance.test.ts
@@ -6,16 +6,8 @@
 import assert from 'assert'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
-import {
-    onAcceptance,
-    AcceptedSuggestionEntry,
-    session,
-    CodeWhispererTracker,
-    RecommendationHandler,
-    AuthUtil,
-} from 'aws-core-vscode/codewhisperer'
+import { onAcceptance, AcceptedSuggestionEntry, session, CodeWhispererTracker } from 'aws-core-vscode/codewhisperer'
 import { resetCodeWhispererGlobalVariables, createMockTextEditor } from 'aws-core-vscode/test'
-import { assertTelemetryCurried } from 'aws-core-vscode/test'
 
 describe('onAcceptance', function () {
     describe('onAcceptance', function () {
@@ -67,47 +59,6 @@ describe('onAcceptance', function () {
             assert.deepStrictEqual(actualArg.startPosition, new vscode.Position(1, 0))
             assert.deepStrictEqual(actualArg.endPosition, new vscode.Position(1, 26))
             assert.strictEqual(actualArg.index, 0)
-        })
-
-        it('Should report telemetry that records this user decision event', async function () {
-            const testStartUrl = 'testStartUrl'
-            sinon.stub(AuthUtil.instance, 'startUrl').value(testStartUrl)
-            const mockEditor = createMockTextEditor()
-            session.requestIdList = ['test']
-            RecommendationHandler.instance.requestId = 'test'
-            session.sessionId = 'test'
-            session.startPos = new vscode.Position(1, 0)
-            mockEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0))
-            session.recommendations = [{ content: "print('Hello World!')" }]
-            session.setSuggestionState(0, 'Showed')
-            session.triggerType = 'OnDemand'
-            session.setCompletionType(0, session.recommendations[0])
-            const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
-            await onAcceptance({
-                editor: mockEditor,
-                range: new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 21)),
-                effectiveRange: new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 26)),
-                acceptIndex: 0,
-                recommendation: "print('Hello World!')",
-                requestId: '',
-                sessionId: '',
-                triggerType: 'OnDemand',
-                completionType: 'Line',
-                language: 'python',
-                references: undefined,
-            })
-            assertTelemetry({
-                codewhispererRequestId: 'test',
-                codewhispererSessionId: 'test',
-                codewhispererPaginationProgress: 1,
-                codewhispererTriggerType: 'OnDemand',
-                codewhispererSuggestionIndex: 0,
-                codewhispererSuggestionState: 'Accept',
-                codewhispererSuggestionReferenceCount: 0,
-                codewhispererCompletionType: 'Line',
-                codewhispererLanguage: 'python',
-                credentialStartUrl: testStartUrl,
-            })
         })
     })
 })

--- a/packages/amazonq/test/unit/codewhisperer/commands/onInlineAcceptance.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/commands/onInlineAcceptance.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import { resetCodeWhispererGlobalVariables, createMockTextEditor } from 'aws-core-vscode/test'
-import { onInlineAcceptance, RecommendationHandler, AuthUtil, session } from 'aws-core-vscode/codewhisperer'
+import { onInlineAcceptance, RecommendationHandler, session } from 'aws-core-vscode/codewhisperer'
 
 describe('onInlineAcceptance', function () {
     describe('onInlineAcceptance', function () {

--- a/packages/amazonq/test/unit/codewhisperer/commands/onInlineAcceptance.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/commands/onInlineAcceptance.test.ts
@@ -7,10 +7,7 @@ import assert from 'assert'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import { resetCodeWhispererGlobalVariables, createMockTextEditor } from 'aws-core-vscode/test'
-import { assertTelemetryCurried } from 'aws-core-vscode/test'
 import { onInlineAcceptance, RecommendationHandler, AuthUtil, session } from 'aws-core-vscode/codewhisperer'
-import { globals } from 'aws-core-vscode/shared'
-import { extensionVersion } from 'aws-core-vscode/shared'
 
 describe('onInlineAcceptance', function () {
     describe('onInlineAcceptance', function () {
@@ -41,52 +38,6 @@ describe('onInlineAcceptance', function () {
                 references: undefined,
             })
             assert.ok(spy.calledWith())
-        })
-
-        it('Should report telemetry that records this user decision event', async function () {
-            await globals.globalState.update('CODEWHISPERER_USER_GROUP', {
-                version: extensionVersion,
-            })
-
-            const testStartUrl = 'testStartUrl'
-            sinon.stub(AuthUtil.instance, 'startUrl').value(testStartUrl)
-            const mockEditor = createMockTextEditor()
-            session.requestIdList = ['test']
-            RecommendationHandler.instance.requestId = 'test'
-            session.requestIdList = ['test']
-            session.sessionId = 'test'
-            session.startPos = new vscode.Position(1, 0)
-            mockEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0))
-            session.recommendations = [{ content: "print('Hello World!')" }]
-            session.setSuggestionState(0, 'Showed')
-            session.triggerType = 'OnDemand'
-            session.setCompletionType(0, session.recommendations[0])
-            const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
-            await onInlineAcceptance({
-                editor: mockEditor,
-                range: new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 21)),
-                effectiveRange: new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 21)),
-                acceptIndex: 0,
-                recommendation: "print('Hello World!')",
-                requestId: '',
-                sessionId: '',
-                triggerType: 'OnDemand',
-                completionType: 'Line',
-                language: 'python',
-                references: undefined,
-            })
-            assertTelemetry({
-                codewhispererRequestId: 'test',
-                codewhispererSessionId: 'test',
-                codewhispererPaginationProgress: 1,
-                codewhispererTriggerType: 'OnDemand',
-                codewhispererSuggestionIndex: 0,
-                codewhispererSuggestionState: 'Accept',
-                codewhispererSuggestionReferenceCount: 0,
-                codewhispererCompletionType: 'Line',
-                codewhispererLanguage: 'python',
-                credentialStartUrl: testStartUrl,
-            })
         })
     })
 })

--- a/packages/amazonq/test/unit/codewhisperer/service/recommendationHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/recommendationHandler.test.ts
@@ -150,41 +150,6 @@ describe('recommendationHandler', function () {
                 codewhispererSupplementalContextLength: 100,
             })
         })
-
-        it('should call telemetry function that records a Empty userDecision event', async function () {
-            const mockServerResult = {
-                recommendations: [],
-                nextToken: '',
-                $response: {
-                    requestId: 'test_request_empty',
-                    httpResponse: {
-                        headers: {
-                            'x-amzn-sessionid': 'test_request_empty',
-                        },
-                    },
-                },
-            }
-            const handler = new RecommendationHandler()
-            sinon.stub(handler, 'getServerResponse').resolves(mockServerResult)
-            sinon.stub(performance, 'now').returns(0.0)
-            session.startPos = new vscode.Position(1, 0)
-            session.requestIdList = ['test_request_empty']
-            session.startCursorOffset = 2
-            await handler.getRecommendations(mockClient, mockEditor, 'AutoTrigger', config, 'Enter')
-            const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
-            assertTelemetry({
-                codewhispererRequestId: 'test_request_empty',
-                codewhispererSessionId: 'test_request_empty',
-                codewhispererPaginationProgress: 0,
-                codewhispererTriggerType: 'AutoTrigger',
-                codewhispererSuggestionIndex: -1,
-                codewhispererSuggestionState: 'Empty',
-                codewhispererSuggestionReferenceCount: 0,
-                codewhispererCompletionType: 'Line',
-                codewhispererLanguage: 'python',
-                credentialStartUrl: testStartUrl,
-            })
-        })
     })
 
     describe('isValidResponse', function () {

--- a/packages/amazonq/test/unit/codewhisperer/util/telemetryHelper.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/telemetryHelper.test.ts
@@ -282,41 +282,4 @@ describe('telemetryHelper', function () {
             assert.strictEqual(actual, 'Empty')
         })
     })
-
-    describe('recordUserDecisionTelemetry', function () {
-        beforeEach(async function () {
-            await resetCodeWhispererGlobalVariables()
-        })
-
-        it('Should call telemetry record for each recommendations with proper arguments', async function () {
-            const telemetryHelper = new TelemetryHelper()
-            const response = [{ content: "print('Hello')" }]
-            const requestIdList = ['test_x', 'test_x', 'test_y']
-            const sessionId = 'test_x'
-            session.triggerType = 'AutoTrigger'
-            const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
-            const suggestionState = new Map<number, string>([[0, 'Showed']])
-            const completionTypes = new Map<number, CodewhispererCompletionType>([[0, 'Line']])
-            telemetryHelper.recordUserDecisionTelemetry(
-                requestIdList,
-                sessionId,
-                response,
-                0,
-                0,
-                completionTypes,
-                suggestionState
-            )
-            assertTelemetry({
-                codewhispererRequestId: 'test_x',
-                codewhispererSessionId: 'test_x',
-                codewhispererPaginationProgress: 0,
-                codewhispererTriggerType: 'AutoTrigger',
-                codewhispererSuggestionIndex: 0,
-                codewhispererSuggestionState: 'Accept',
-                codewhispererSuggestionReferenceCount: 0,
-                codewhispererCompletionType: 'Line',
-                codewhispererLanguage: 'python',
-            })
-        })
-    })
 })

--- a/packages/core/src/codewhisperer/util/telemetryHelper.ts
+++ b/packages/core/src/codewhisperer/util/telemetryHelper.ts
@@ -158,25 +158,6 @@ export class TelemetryHelper {
     ) {
         const selectedCustomization = getSelectedCustomization()
 
-        telemetry.codewhisperer_userDecision.emit({
-            codewhispererCompletionType: 'Line',
-            codewhispererGettingStartedTask: session.taskType,
-            codewhispererLanguage: language,
-            codewhispererPaginationProgress: paginationIndex,
-            codewhispererRequestId: requestIdList[0],
-            codewhispererSessionId: sessionId ? sessionId : undefined,
-            codewhispererSuggestionIndex: -1,
-            codewhispererSuggestionState: 'Empty',
-            codewhispererSuggestionReferenceCount: 0,
-            codewhispererSuggestionReferences: undefined,
-            codewhispererSupplementalContextIsUtg: supplementalContextMetadata?.isUtg,
-            codewhispererSupplementalContextLength: supplementalContextMetadata?.contentsLength,
-            codewhispererSupplementalContextTimeout: supplementalContextMetadata?.isProcessTimeout,
-            codewhispererTriggerType: session.triggerType,
-            credentialStartUrl: AuthUtil.instance.startUrl,
-            traceId: this.traceId,
-        })
-
         telemetry.codewhisperer_userTriggerDecision.emit({
             codewhispererAutomatedTriggerType: session.autoTriggerType,
             codewhispererClassifierResult: this.classifierResult,
@@ -297,7 +278,6 @@ export class TelemetryHelper {
                 credentialStartUrl: AuthUtil.instance.startUrl,
                 traceId: this.traceId,
             }
-            telemetry.codewhisperer_userDecision.emit(event)
             events.push(event)
         }
 

--- a/packages/core/src/shared/telemetry/exemptMetrics.ts
+++ b/packages/core/src/shared/telemetry/exemptMetrics.ts
@@ -25,7 +25,6 @@ const validationExemptMetrics: Set<string> = new Set([
     'codeTransform_jobStatusChanged',
     'codeTransform_logApiError',
     'codeTransform_logApiLatency',
-    'codewhisperer_userDecision',
     'codewhisperer_codeScanIssueHover',
     'codewhisperer_codePercentage',
     'codewhisperer_userModification',


### PR DESCRIPTION
## Problem
the `codewhisperer_userDecision ` metric isn't used by the codewhisperer/Q team. And it is very noisy (5x more emits than second most frequent metric, 20x more emits than the third).

## Solution
Stop emitting this metric from vsCode

## Note
The user decision [events](https://github.com/aws/aws-toolkit-vscode/blob/ebb932698ff32c8d65504c702065a18cc2d325b0/packages/core/src/codewhisperer/util/telemetryHelper.ts#L261C19-L261C24) are still kept since they are used to calculate `userTriggerDecision`. De-noising it would be the next TODO

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
