### PR TITLE
fix(amazonq): context fixes for multiroot workspace setup

### DIFF
--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -329,6 +329,7 @@ export class LspController {
             getLogger().info(`LspController: Skipping building index. No projects found in workspace`)
             return
         }
+        projPaths.sort()
         try {
             this._isIndexingInProgress = true
             const projRoot = projPaths[0]

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -329,7 +329,6 @@ export class LspController {
             getLogger().info(`LspController: Skipping building index. No projects found in workspace`)
             return
         }
-        projPaths.sort()
         try {
             this._isIndexingInProgress = true
             const projRoot = projPaths[0]

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -14,8 +14,10 @@ import { UserWrittenCodeTracker } from '../../../../codewhisperer/tracker/userWr
 export class ChatSession {
     private sessionId?: string
 
-    contexts: Map<number, Map<string, { first: number; second: number }[]>> = new Map()
-    currentContextId: number = 0
+    contexts: Map<string, { first: number; second: number }[]> = new Map()
+    // TODO: doesn't handle the edge case when two files share the same relativePath string but from different root
+    // e.g. root_a/file1 vs root_b/file1
+    relativePathToWorkspaceRoot: Map<string, string> = new Map()
     public get sessionIdentifier(): string | undefined {
         return this.sessionId
     }

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -582,7 +582,6 @@ export class ChatController {
     }
     private async processFileClickMessage(message: FileClick) {
         const session = this.sessionStorage.getSession(message.tabID)
-        // TODO remove currentContextId but use messageID to track context for each answer message
         const lineRanges = session.contexts.get(message.filePath)
 
         if (!lineRanges) {

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -917,14 +917,14 @@ export class ChatController {
         if (contextCommands.length === 0) {
             return []
         }
-        let workspaceFolders = (vscode.workspace.workspaceFolders ?? []).map((folder) => folder.uri.fsPath)
+        const workspaceFolders = (vscode.workspace.workspaceFolders ?? []).map((folder) => folder.uri.fsPath)
         if (!workspaceFolders) {
             return []
         }
         workspaceFolders.sort()
-        let workspaceFolder = workspaceFolders[0]
+        const workspaceFolder = workspaceFolders[0]
         for (const contextCommand of contextCommands) {
-            let relativePath = path.relative(
+            const relativePath = path.relative(
                 workspaceFolder,
                 path.join(contextCommand.workspaceFolder, contextCommand.relativePath)
             )

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -917,10 +917,12 @@ export class ChatController {
         if (contextCommands.length === 0) {
             return []
         }
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri?.fsPath
-        if (!workspaceFolder) {
+        let workspaceFolders = (vscode.workspace.workspaceFolders ?? []).map((folder) => folder.uri.fsPath)
+        if (!workspaceFolders) {
             return []
         }
+        workspaceFolders.sort()
+        let workspaceFolder = workspaceFolders[0]
         for (const contextCommand of contextCommands) {
             let relativePath = path.relative(
                 workspaceFolder,


### PR DESCRIPTION
## Problem
In multiroot workspace setup, the contextList UI displays files that are deduped for the same files and doesn't resolve relative paths correctly.

1. In a multi-root workspace, the index is built on the root of the 1st project after sorting workspaceFolders, thus the chunk response also contains relativePath to the 1st project root after sorting. In order to get the same relativePath from explicit @file, we also need to use the root of the 1st project after sorting workspaceFolders.
2. Use a relativePath to projectRoot map to store the project root for each relativePath so that on clicking the file(which only returns relativePath in the event) we correctly construct the absolute path of the file to open in the editor.

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
