### PR TITLE
telemetry(amazonq): emit metrics per finding

### DIFF
--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -263,6 +263,19 @@ export async function startSecurityScan(
             scope,
             editor
         )
+        for (const issue of securityRecommendationCollection
+            .flatMap(({ issues }) => issues)
+            .filter(({ visible, autoDetected }) => visible && !autoDetected)) {
+            telemetry.codewhisperer_codeScanIssueDetected.emit({
+                autoDetected: issue.autoDetected,
+                codewhispererCodeScanJobId: issue.scanJobId,
+                detectorId: issue.detectorId,
+                findingId: issue.findingId,
+                includesFix: issue.suggestedFixes.length > 0,
+                ruleId: issue.ruleId,
+                result: 'Succeeded',
+            })
+        }
         const { total, withFixes } = securityRecommendationCollection.reduce(
             (accumulator, current) => ({
                 total: accumulator.total + current.issues.length,

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1325,6 +1325,34 @@
         {
             "name": "docdb_addRegion",
             "description": "User clicked on add region command"
+        },
+        {
+            "name": "codewhisperer_codeScanIssueDetected",
+            "description": "Called when a code scan issue is returned from the service",
+            "metadata": [
+                {
+                    "type": "autoDetected",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererCodeScanJobId",
+                    "required": false
+                },
+                {
+                    "type": "detectorId"
+                },
+                {
+                    "type": "findingId"
+                },
+                {
+                    "type": "includesFix",
+                    "required": false
+                },
+                {
+                    "type": "ruleId",
+                    "required": false
+                }
+            ]
         }
     ]
 }

--- a/packages/core/src/test/codewhisperer/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/startSecurityScan.test.ts
@@ -232,6 +232,11 @@ describe('startSecurityScan', function () {
             codewhispererCodeScanScope: 'PROJECT',
             passive: false,
         })
+        assertTelemetry('codewhisperer_codeScanIssueDetected', {
+            autoDetected: false,
+            detectorId: 'detectorId',
+            findingId: 'findingId',
+        })
     })
 
     it('Should cancel a scan if a newer one has started', async function () {


### PR DESCRIPTION
## Problem

Events about findings are always tied to hover, apply fix, etc. Not able to understand the number of findings which never get acted on.


## Solution

Emit metrics about findings at the time of scan results.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
