### PR TITLE
telemetry(amazonq): add metrics to `amazonq_interactWithMessage`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.296",
+                "@aws-toolkits/telemetry": "^1.0.301",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -4913,9 +4913,10 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.297",
+            "version": "1.0.301",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.301.tgz",
+            "integrity": "sha512-w5xvR5CQVvYE7PlkIx7Hf91aIjauduub0xvIB/Bvw0wpQvZu+CbITh3tFTbG3QNZf3cUmYMaiCtbKWd8Skx7YQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^6.12.6",
                 "cross-spawn": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.296",
+        "@aws-toolkits/telemetry": "^1.0.301",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",

--- a/packages/amazonq/.changes/next-release/Feature-f0e30c17-67f5-4538-a109-e7acf203a76c.json
+++ b/packages/amazonq/.changes/next-release/Feature-f0e30c17-67f5-4538-a109-e7acf203a76c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q chat: Add support for `.md` file rules in workspace-level `.amazonq/rules` directory"
+}

--- a/packages/core/src/amazonq/webview/ui/texts/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/texts/constants.ts
@@ -44,6 +44,8 @@ export const helpMessage = `I'm Amazon Q, a generative AI assistant. Learn more 
 \n\n- Answer questions about AWS
 \n\n- Answer questions about general programming concepts
 \n\n- Answer questions about your workspace with @workspace
+\n\n- Answer questions about your code with @Files and @Folders
+\n\n- Create and use saved prompts with @Prompts
 \n\n- Explain what a line of code or code function does
 \n\n- Write unit tests and code
 \n\n- Debug and fix code

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -588,8 +588,9 @@ export class ChatController {
             return
         }
 
-        // TODO: Fix for multiple workspace setup
-        const projectRoot = session.relativePathToWorkspaceRoot.get(message.filePath)
+        // Check if clicked file is in a different workspace root
+        const projectRoot =
+            session.relativePathToWorkspaceRoot.get(message.filePath) || workspace.workspaceFolders?.[0]?.uri.fsPath
         if (!projectRoot) {
             return
         }

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -893,7 +893,7 @@ export class ChatController {
             const folderExists = await fs.exists(rulesPath)
 
             if (folderExists) {
-                const entries = await vscode.workspace.fs.readDirectory(rulesPath)
+                const entries = await fs.readdir(rulesPath)
 
                 for (const [name, type] of entries) {
                     if (type === vscode.FileType.File && name.endsWith(promptFileExtension)) {
@@ -961,6 +961,7 @@ export class ChatController {
         try {
             prompts = await LspClient.instance.getContextCommandPrompt(contextCommands)
         } catch (e) {
+            // todo: handle @workspace used before indexing is ready
             getLogger().verbose(`Could not get context command prompts: ${e}`)
         }
 

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -582,7 +582,7 @@ export class ChatController {
     }
     private async processFileClickMessage(message: FileClick) {
         const session = this.sessionStorage.getSession(message.tabID)
-        const lineRanges = session.contexts.get(session.currentContextId)?.get(message.filePath)
+        const lineRanges = session.contexts.get(message.filePath)
 
         if (!lineRanges) {
             return

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -928,7 +928,7 @@ export class ChatController {
             )
             session.relativePathToWorkspaceRoot.set(relativePath, contextCommand.workspaceFolder)
         }
-        let prompts = []
+        let prompts: AdditionalContextPrompt[] = []
         try {
             prompts = await LspClient.instance.getContextCommandPrompt(contextCommands)
         } catch (e) {

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -137,7 +137,7 @@ export class Messenger {
         }
         this.telemetryHelper.setResponseStreamStartTime(tabID)
 
-        let cwsprChatHasProjectContext
+        let cwsprChatHasProjectContext = false
         if (
             triggerPayload.relevantTextDocuments &&
             triggerPayload.relevantTextDocuments.length > 0 &&

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -136,13 +136,24 @@ export class Messenger {
             )
         }
         this.telemetryHelper.setResponseStreamStartTime(tabID)
+
+        let cwsprChatHasProjectContext
         if (
             triggerPayload.relevantTextDocuments &&
             triggerPayload.relevantTextDocuments.length > 0 &&
             triggerPayload.useRelevantDocuments === true
         ) {
-            this.telemetryHelper.setResponseFromProjectContext(messageID)
+            cwsprChatHasProjectContext = true
         }
+        const additionalCounts = this.telemetryHelper.getAdditionalContextCounts(triggerPayload)
+
+        this.telemetryHelper.setResponseFromAdditionalContext(messageID, {
+            cwsprChatHasProjectContext,
+            cwsprChatRuleContextCount: triggerPayload.workspaceRulesCount,
+            cwsprChatFileContextCount: additionalCounts.fileContextCount,
+            cwsprChatFolderContextCount: additionalCounts.folderContextCount,
+            cwsprChatPromptContextCount: additionalCounts.promptContextCount,
+        })
 
         const eventCounts = new Map<string, number>()
         waitUntil(

--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -205,6 +205,14 @@ export type AdditionalContextLengths = {
     ruleContextLength: number
 }
 
+export type AdditionalContextInfo = {
+    cwsprChatFileContextCount?: number
+    cwsprChatFolderContextCount?: number
+    cwsprChatPromptContextCount?: number
+    cwsprChatRuleContextCount?: number
+    cwsprChatHasProjectContext?: boolean
+}
+
 // TODO move this to API definition (or just use this across the codebase)
 export type RelevantTextDocumentAddition = RelevantTextDocument & { startLine: number; endLine: number }
 


### PR DESCRIPTION
- Send metrics on additional context to the `amazonq_interactWithMessage` event. This enables measuring success metrics as they relate to the new context features. 
- Improve error handling when collecting context items & metrics.
- Add new features to /help message
- Improve efficiency by switching from vscode.workspace.findFiles to fs.readDirectory



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
