### PR TITLE
telemetry(amazonq): createUpload metric for scans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4913,7 +4913,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.297",
+            "version": "1.0.303",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.303.tgz",
+            "integrity": "sha512-HftSS0X6yDEzYh0xa8Q2AqZGs/GGu7KHPND/8WDNW8q8glPI7XK9/VLIjZue2G+dLjBCnsIlRMkidUQN1DCl+A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -6602,6 +6604,8 @@
         },
         "node_modules/@ts-morph/common": {
             "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.24.0.tgz",
+            "integrity": "sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6613,6 +6617,8 @@
         },
         "node_modules/@ts-morph/common/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6621,6 +6627,8 @@
         },
         "node_modules/@ts-morph/common/node_modules/minimatch": {
             "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6635,6 +6643,8 @@
         },
         "node_modules/@ts-morph/common/node_modules/mkdirp": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+            "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -9276,6 +9286,8 @@
         },
         "node_modules/code-block-writer": {
             "version": "13.0.3",
+            "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+            "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
             "dev": true,
             "license": "MIT"
         },
@@ -11462,6 +11474,8 @@
         },
         "node_modules/fs-extra": {
             "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13061,6 +13075,8 @@
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17225,6 +17241,8 @@
         },
         "node_modules/ts-morph": {
             "version": "23.0.0",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-23.0.0.tgz",
+            "integrity": "sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17488,6 +17506,8 @@
         },
         "node_modules/universalify": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4913,9 +4913,7 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.303",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.303.tgz",
-            "integrity": "sha512-HftSS0X6yDEzYh0xa8Q2AqZGs/GGu7KHPND/8WDNW8q8glPI7XK9/VLIjZue2G+dLjBCnsIlRMkidUQN1DCl+A==",
+            "version": "1.0.297",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -6604,8 +6602,6 @@
         },
         "node_modules/@ts-morph/common": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.24.0.tgz",
-            "integrity": "sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6617,8 +6613,6 @@
         },
         "node_modules/@ts-morph/common/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6627,8 +6621,6 @@
         },
         "node_modules/@ts-morph/common/node_modules/minimatch": {
             "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6643,8 +6635,6 @@
         },
         "node_modules/@ts-morph/common/node_modules/mkdirp": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-            "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -9286,8 +9276,6 @@
         },
         "node_modules/code-block-writer": {
             "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
-            "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
             "dev": true,
             "license": "MIT"
         },
@@ -11474,8 +11462,6 @@
         },
         "node_modules/fs-extra": {
             "version": "11.3.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13075,8 +13061,6 @@
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17241,8 +17225,6 @@
         },
         "node_modules/ts-morph": {
             "version": "23.0.0",
-            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-23.0.0.tgz",
-            "integrity": "sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17506,8 +17488,6 @@
         },
         "node_modules/universalify": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -22,14 +22,9 @@ import { RawCodeScanIssue } from '../models/model'
 import * as crypto from 'crypto'
 import path = require('path')
 import { pageableToCollection } from '../../shared/utilities/collectionUtils'
-import {
-    ArtifactMap,
-    CreateUploadUrlRequest,
-    CreateUploadUrlResponse,
-    UploadIntent,
-} from '../client/codewhispereruserclient'
+import { ArtifactMap, CreateUploadUrlRequest, CreateUploadUrlResponse } from '../client/codewhispereruserclient'
 import { TelemetryHelper } from '../util/telemetryHelper'
-import request from '../../shared/request'
+import request, { RequestError } from '../../shared/request'
 import { ZipMetadata } from '../util/zipUtil'
 import { getNullLogger } from '../../shared/logger/logger'
 import {
@@ -49,6 +44,8 @@ import { ChatSessionManager } from '../../amazonqTest/chat/storages/chatSession'
 import { getStringHash } from '../../shared/utilities/textUtilities'
 import { getClientId } from '../../shared/telemetry/util'
 import globals from '../../shared/extensionGlobals'
+import { AmazonqCreateUpload, Span, telemetry } from '../../shared/telemetry/telemetry'
+import { AuthUtil } from '../util/authUtil'
 
 export async function listScanResults(
     client: DefaultCodeWhispererClient,
@@ -276,45 +273,55 @@ export async function getPresignedUrlAndUpload(
     scope: CodeWhispererConstants.CodeAnalysisScope,
     scanName: string
 ) {
-    const logger = getLoggerForScope(scope)
-    if (zipMetadata.zipFilePath === '') {
-        getLogger().error('Failed to create valid source zip')
-        throw new InvalidSourceZipError()
-    }
-    const srcReq: CreateUploadUrlRequest = {
-        contentMd5: getMd5(zipMetadata.zipFilePath),
-        artifactType: 'SourceCode',
-        uploadIntent: getUploadIntent(scope),
-        uploadContext: {
-            codeAnalysisUploadContext: {
-                codeScanName: scanName,
+    const artifactMap = await telemetry.amazonq_createUpload.run(async (span) => {
+        const logger = getLoggerForScope(scope)
+        if (zipMetadata.zipFilePath === '') {
+            getLogger().error('Failed to create valid source zip')
+            throw new InvalidSourceZipError()
+        }
+        const uploadIntent = getUploadIntent(scope)
+        span.record({
+            amazonqUploadIntent: uploadIntent,
+            amazonqRepositorySize: zipMetadata.srcPayloadSizeInBytes,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+        const srcReq: CreateUploadUrlRequest = {
+            contentMd5: getMd5(zipMetadata.zipFilePath),
+            artifactType: 'SourceCode',
+            uploadIntent: uploadIntent,
+            uploadContext: {
+                codeAnalysisUploadContext: {
+                    codeScanName: scanName,
+                },
             },
-        },
-    }
-    logger.verbose(`Prepare for uploading src context...`)
-    const srcResp = await client.createUploadUrl(srcReq).catch((err) => {
-        getLogger().error(`Failed getting presigned url for uploading src context. Request id: ${err.requestId}`)
-        throw new CreateUploadUrlError(err)
+        }
+        logger.verbose(`Prepare for uploading src context...`)
+        const srcResp = await client.createUploadUrl(srcReq).catch((err) => {
+            getLogger().error(`Failed getting presigned url for uploading src context. Request id: ${err.requestId}`)
+            span.record({ requestId: err.requestId })
+            throw new CreateUploadUrlError(err.message)
+        })
+        logger.verbose(`CreateUploadUrlRequest request id: ${srcResp.$response.requestId}`)
+        logger.verbose(`Complete Getting presigned Url for uploading src context.`)
+        logger.verbose(`Uploading src context...`)
+        await uploadArtifactToS3(zipMetadata.zipFilePath, srcResp, FeatureUseCase.CODE_SCAN, scope, span)
+        logger.verbose(`Complete uploading src context.`)
+        const artifactMap: ArtifactMap = {
+            SourceCode: srcResp.uploadId,
+        }
+        return artifactMap
     })
-    logger.verbose(`CreateUploadUrlRequest request id: ${srcResp.$response.requestId}`)
-    logger.verbose(`Complete Getting presigned Url for uploading src context.`)
-    logger.verbose(`Uploading src context...`)
-    await uploadArtifactToS3(zipMetadata.zipFilePath, srcResp, FeatureUseCase.CODE_SCAN, scope)
-    logger.verbose(`Complete uploading src context.`)
-    const artifactMap: ArtifactMap = {
-        SourceCode: srcResp.uploadId,
-    }
     return artifactMap
 }
 
-function getUploadIntent(scope: CodeWhispererConstants.CodeAnalysisScope): UploadIntent {
+function getUploadIntent(scope: CodeWhispererConstants.CodeAnalysisScope) {
     if (
-        scope === CodeWhispererConstants.CodeAnalysisScope.FILE_AUTO ||
+        scope === CodeWhispererConstants.CodeAnalysisScope.PROJECT ||
         scope === CodeWhispererConstants.CodeAnalysisScope.FILE_ON_DEMAND
     ) {
-        return CodeWhispererConstants.fileScanUploadIntent
-    } else {
         return CodeWhispererConstants.projectScanUploadIntent
+    } else {
+        return CodeWhispererConstants.fileScanUploadIntent
     }
 }
 
@@ -356,7 +363,8 @@ export async function uploadArtifactToS3(
     fileName: string,
     resp: CreateUploadUrlResponse,
     featureUseCase: FeatureUseCase,
-    scope?: CodeWhispererConstants.CodeAnalysisScope
+    scope?: CodeWhispererConstants.CodeAnalysisScope,
+    span?: Span<AmazonqCreateUpload>
 ) {
     const logger = getLoggerForScope(scope)
     const encryptionContext = `{"uploadId":"${resp.uploadId}"}`
@@ -378,6 +386,14 @@ export async function uploadArtifactToS3(
         }).response
         logger.debug(`StatusCode: ${response.status}, Text: ${response.statusText}`)
     } catch (error) {
+        if (span && error instanceof RequestError) {
+            const requestId = error.response.headers.get('x-amz-request-id') ?? undefined
+            span.record({
+                requestId: requestId,
+                requestServiceType: 's3',
+                httpStatusCode: error.code.toString(),
+            })
+        }
         let errorMessage = ''
         const isCodeScan = featureUseCase === FeatureUseCase.CODE_SCAN
         const featureType = isCodeScan ? 'security scans' : 'unit test generation'

--- a/packages/core/src/shared/telemetry/spans.ts
+++ b/packages/core/src/shared/telemetry/spans.ts
@@ -219,8 +219,8 @@ export class TelemetrySpan<T extends MetricBase = MetricBase> implements Span<T>
                 result: getTelemetryResult(err),
                 reason: getTelemetryReason(err),
                 reasonDesc: getTelemetryReasonDesc(err),
-                requestId: getRequestId(err),
-                httpStatusCode: getHttpStatusCode(err),
+                ...(!this.state.requestId ? { requestId: getRequestId(err) } : {}),
+                ...(!this.state.httpStatusCode ? { httpStatusCode: getHttpStatusCode(err) } : {}),
             } as Partial<T>)
         }
 

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -410,6 +410,17 @@
             "name": "executedCount",
             "type": "int",
             "description": "The number of executed operations"
+        },
+        {
+            "name": "amazonqUploadIntent",
+            "type": "string",
+            "description": "The intent of the upload",
+            "allowedValues": [
+                "TRANSFORMATION",
+                "TASK_ASSIST_PLANNING",
+                "AUTOMATIC_FILE_SECURITY_SCAN",
+                "FULL_PROJECT_SECURITY_SCAN"
+            ]
         }
     ],
     "metrics": [
@@ -1167,7 +1178,31 @@
                     "required": false
                 },
                 {
+                    "type": "amazonqUploadIntent",
+                    "required": false
+                },
+                {
                     "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "duration",
+                    "required": false
+                },
+                {
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "requestId",
+                    "required": false
+                },
+                {
+                    "type": "requestServiceType",
+                    "required": false
+                },
+                {
+                    "type": "result",
                     "required": false
                 }
             ]

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1184,26 +1184,6 @@
                 {
                     "type": "credentialStartUrl",
                     "required": false
-                },
-                {
-                    "type": "duration",
-                    "required": false
-                },
-                {
-                    "type": "reason",
-                    "required": false
-                },
-                {
-                    "type": "requestId",
-                    "required": false
-                },
-                {
-                    "type": "requestServiceType",
-                    "required": false
-                },
-                {
-                    "type": "result",
-                    "required": false
                 }
             ]
         },


### PR DESCRIPTION
## Problem

Some users are reporting S3 upload failures but we don't have the requestIds to investigate further.


## Solution

Emit `amazonq_createUpload` metric with requestIds


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
