### PR TITLE
telemetry(amazonq): add vectorIndexEnabled boolean to workspace index telemetry

### DIFF
--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -357,6 +357,7 @@ export class LspController {
                     amazonqIndexMemoryUsageInMB: usage ? usage.memoryUsage / (1024 * 1024) : undefined,
                     amazonqIndexCpuUsagePercentage: usage ? usage.cpuUsage : undefined,
                     amazonqIndexFileSizeInMB: totalSizeBytes / (1024 * 1024),
+                    amazonqVectorIndexEnabled: buildIndexConfig.isVectorIndexEnabled,
                     credentialStartUrl: buildIndexConfig.startUrl,
                 })
             } else {
@@ -366,6 +367,7 @@ export class LspController {
                     result: 'Failed',
                     amazonqIndexFileCount: 0,
                     amazonqIndexFileSizeInMB: 0,
+                    amazonqVectorIndexEnabled: buildIndexConfig.isVectorIndexEnabled,
                     reason: `Unknown`,
                 })
             }
@@ -377,6 +379,7 @@ export class LspController {
                 result: 'Failed',
                 amazonqIndexFileCount: 0,
                 amazonqIndexFileSizeInMB: 0,
+                amazonqVectorIndexEnabled: buildIndexConfig.isVectorIndexEnabled,
                 reason: `${error instanceof Error ? error.name : 'Unknown'}`,
                 reasonDesc: `Error when building index. ${error instanceof Error ? error.message : error}`,
             })

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -149,6 +149,11 @@
             "description": "The sum of file sizes that were indexed in MB"
         },
         {
+            "name": "amazonqVectorIndexEnabled",
+            "type": "boolean",
+            "description": "True if vector index is enabled"
+        },
+        {
             "name": "amazonqIndexFileCount",
             "type": "int",
             "description": "Number of files indexed"
@@ -804,6 +809,10 @@
                 },
                 {
                     "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "amazonqVectorIndexEnabled",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem
We do not know the % of users who has vector index enabled.

## Solution

Add a boolean flag for whether  vector index is enabled.
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
