### PR TITLE
fix(amazonq): path resolution incorrectness in windows for .amazonq/rules

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -881,15 +881,15 @@ export class ChatController {
     /**
      * @returns A Uri array of prompt files in each workspace root's .amazonq/rules directory
      */
-    private async collectWorkspaceRules(): Promise<vscode.Uri[]> {
-        const rulesFiles: vscode.Uri[] = []
+    private async collectWorkspaceRules(): Promise<string[]> {
+        const rulesFiles: string[] = []
 
         if (!vscode.workspace.workspaceFolders) {
             return rulesFiles
         }
 
         for (const folder of vscode.workspace.workspaceFolders) {
-            const rulesPath = vscode.Uri.joinPath(folder.uri, '.amazonq', 'rules')
+            const rulesPath = path.join(folder.uri.fsPath, '.amazonq', 'rules')
             const folderExists = await fs.exists(rulesPath)
 
             if (folderExists) {
@@ -897,7 +897,7 @@ export class ChatController {
 
                 for (const [name, type] of entries) {
                     if (type === vscode.FileType.File && name.endsWith(promptFileExtension)) {
-                        rulesFiles.push(vscode.Uri.joinPath(rulesPath, name))
+                        rulesFiles.push(path.join(rulesPath, name))
                     }
                 }
             }
@@ -918,11 +918,12 @@ export class ChatController {
         if (workspaceRules.length > 0) {
             contextCommands.push(
                 ...workspaceRules.map((rule) => {
-                    const workspaceFolderPath = vscode.workspace.getWorkspaceFolder(rule)?.uri?.path || ''
+                    const workspaceFolderPath =
+                        vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(rule))?.uri?.path || ''
                     return {
                         workspaceFolder: workspaceFolderPath,
                         type: 'file' as ContextCommandItemType,
-                        relativePath: path.relative(workspaceFolderPath, rule.path),
+                        relativePath: path.relative(workspaceFolderPath, rule),
                     }
                 })
             )

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as path from 'path'
 import { UserIntent } from '@amzn/codewhisperer-streaming'
 import {
     AmazonqAddMessage,
@@ -147,7 +148,7 @@ export class CWCTelemetryHelper {
     }
 
     public getContextType(prompt: AdditionalContextPrompt): string {
-        if (prompt.relativePath.startsWith('.amazonq/rules')) {
+        if (prompt.relativePath.startsWith(path.join('.amazonq', 'rules'))) {
             return 'rule'
         } else if (prompt.filePath.startsWith(getUserPromptsDirectory())) {
             return 'prompt'


### PR DESCRIPTION
## Problem
In Windows, the rules under .amazonq/rules were not send in the chat prompt because of path resolution failure.

## Solution
![Screenshot 2025-03-04 at 3 34 34 PM](https://github.com/user-attachments/assets/649c4f40-365e-4b67-9bff-48a2a8a6c450)
Use path.join instead of vscode.Uri.joinPath

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
