### PR TITLE
feat(lambda): Update SAM CLI to accept a runtime parameter in local invokes

### DIFF
--- a/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -220,7 +220,7 @@ export interface SamCliLocalInvokeInvocationArguments {
     name?: string
     /** AWS region */
     region?: string
-    /** Runtime to use for testing. Can be different from the one specified in the template. */
+    /** Overrides the template-specified runtime. */
     runtime?: Runtime
 }
 

--- a/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/packages/core/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -217,6 +217,8 @@ export interface SamCliLocalInvokeInvocationArguments {
     name?: string
     /** AWS region */
     region?: string
+    /** Runtime to use for testing. Can be different from the one specified in the template. */
+    runtime?: string
 }
 
 /**
@@ -265,6 +267,7 @@ export class SamCliLocalInvokeInvocation {
             ...(this.args.parameterOverrides ?? [])
         )
         invokeArgs.push(...(this.args.extraArgs ?? []))
+        pushIf(invokeArgs, !!this.args.runtime, '--runtime', this.args.runtime)
 
         return await this.args.invoker.invoke({
             options: {

--- a/packages/core/src/shared/sam/localLambdaRunner.ts
+++ b/packages/core/src/shared/sam/localLambdaRunner.ts
@@ -247,6 +247,7 @@ async function invokeLambdaHandler(
             parameterOverrides: config.parameterOverrides,
             name: config.name,
             region: config.region,
+            runtime: config.lambda?.runtime,
         }
 
         // sam local invoke ...

--- a/packages/core/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/packages/core/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -8,6 +8,7 @@ import * as path from 'path'
 import { makeTemporaryToolkitFolder } from '../../../../shared/filesystemUtilities'
 import {
     SamCliLocalInvokeInvocation,
+    SamCliLocalInvokeInvocationArguments,
     SamLocalInvokeCommand,
     SamLocalInvokeCommandArgs,
 } from '../../../../shared/sam/cli/samCliLocalInvoke'
@@ -35,6 +36,10 @@ describe('SamCliLocalInvokeInvocation', async function () {
     let placeholderEventFile: string
     const nonRelevantArg = 'arg is not of interest to this test'
     let mockGetSamCliVersion: sinon.SinonStub
+    const validRuntime = 'python3.10'
+    const invalidRuntime = 'python2.7'
+    const validCliVersion = new SemVer('1.135.0')
+    const invalidCliVersion = new SemVer('1.134.0')
     let sandbox: sinon.SinonSandbox
 
     before(async function () {
@@ -60,10 +65,32 @@ describe('SamCliLocalInvokeInvocation', async function () {
         await fs.delete(tempFolder, { recursive: true })
     })
 
+    function createTaskInvoker(onInvoke: (invokeArgs: SamLocalInvokeCommandArgs) => void): SamLocalInvokeCommand {
+        return new TestSamLocalInvokeCommand(onInvoke)
+    }
+
+    async function executeInvocation(
+        options: Partial<SamCliLocalInvokeInvocationArguments>
+    ): Promise<SamLocalInvokeCommandArgs> {
+        let invokeArgs: SamLocalInvokeCommandArgs = {} as SamLocalInvokeCommandArgs
+        const invocation = new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: createTaskInvoker((args: SamLocalInvokeCommandArgs) => {
+                invokeArgs = args
+            }),
+            ...options,
+        })
+        await invocation.execute()
+        return invokeArgs
+    }
+
     it('invokes `sam local` with args', async function () {
         mockGetSamCliVersion = sandbox
             .stub(SamUtilsModule, 'getSamCliPathAndVersion')
-            .callsFake(sandbox.stub().resolves({ parsedVersion: new SemVer('1.135.0') }))
+            .callsFake(sandbox.stub().resolves({ parsedVersion: validCliVersion }))
 
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
@@ -76,7 +103,6 @@ describe('SamCliLocalInvokeInvocation', async function () {
                 assert.strictEqual(invokeArgs.args[4], '--template')
                 assert.strictEqual(invokeArgs.args[6], '--event')
                 assert.strictEqual(invokeArgs.args[8], '--env-vars')
-
                 // `extraArgs` are appended to the end.
                 assert.strictEqual(invokeArgs.args[10], '--build-dir')
                 assert.strictEqual(invokeArgs.args[11], 'my/build/dir/')
@@ -94,230 +120,78 @@ describe('SamCliLocalInvokeInvocation', async function () {
             environmentVariablePath: nonRelevantArg,
             invoker: taskInvoker,
             extraArgs: ['--build-dir', 'my/build/dir/'],
-            runtime: 'python3.10',
+            runtime: validRuntime,
         }).execute()
     })
 
     it('Passes template resource name to sam cli', async function () {
         const expectedResourceName = 'HelloWorldResource'
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgIsPresent(invokeArgs.args, expectedResourceName)
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: expectedResourceName,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-        }).execute()
+        const invokeArgs = await executeInvocation({ templateResourceName: expectedResourceName })
+        assertArgIsPresent(invokeArgs.args, expectedResourceName)
     })
 
     it('Passes template path to sam cli', async function () {
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgsContainArgument(invokeArgs.args, '--template', placeholderTemplateFile)
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-        }).execute()
+        const invokeArgs = await executeInvocation({})
+        assertArgsContainArgument(invokeArgs.args, '--template', placeholderTemplateFile)
     })
 
     it('Passes event path to sam cli', async function () {
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgsContainArgument(invokeArgs.args, '--event', placeholderEventFile)
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-        }).execute()
+        const invokeArgs = await executeInvocation({})
+        assertArgsContainArgument(invokeArgs.args, '--event', placeholderEventFile)
     })
 
     it('Passes env-vars path to sam cli', async function () {
         const expectedEnvVarsPath = 'envvars.json'
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgsContainArgument(invokeArgs.args, '--env-vars', expectedEnvVarsPath)
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: expectedEnvVarsPath,
-            invoker: taskInvoker,
-        }).execute()
+        const invokeArgs = await executeInvocation({ environmentVariablePath: expectedEnvVarsPath })
+        assertArgsContainArgument(invokeArgs.args, '--env-vars', expectedEnvVarsPath)
     })
 
     it('Passes debug port to sam cli', async function () {
         const expectedDebugPort = '1234'
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgsContainArgument(invokeArgs.args, '-d', expectedDebugPort)
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            debugPort: expectedDebugPort,
-            invoker: taskInvoker,
-        }).execute()
+        const invokeArgs = await executeInvocation({ debugPort: expectedDebugPort })
+        assertArgsContainArgument(invokeArgs.args, '-d', expectedDebugPort)
     })
 
     it('undefined debug port does not pass to sam cli', async function () {
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgNotPresent(invokeArgs.args, '-d')
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            debugPort: undefined,
-            invoker: taskInvoker,
-        }).execute()
+        const invokeArgs = await executeInvocation({ debugPort: undefined })
+        assertArgNotPresent(invokeArgs.args, '-d')
     })
 
     it('Passes docker network to sam cli', async function () {
         const expectedDockerNetwork = 'hello-world'
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgsContainArgument(invokeArgs.args, '--docker-network', expectedDockerNetwork)
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            dockerNetwork: expectedDockerNetwork,
-        }).execute()
+        const invokeArgs = await executeInvocation({ dockerNetwork: expectedDockerNetwork })
+        assertArgsContainArgument(invokeArgs.args, '--docker-network', expectedDockerNetwork)
     })
 
     it('Does not pass docker network to sam cli when undefined', async function () {
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgNotPresent(invokeArgs.args, '--docker-network')
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            dockerNetwork: undefined,
-        }).execute()
+        const invokeArgs = await executeInvocation({ dockerNetwork: undefined })
+        assertArgNotPresent(invokeArgs.args, '--docker-network')
     })
 
     it('passes --skip-pull-image to sam cli if skipPullImage is true', async function () {
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgIsPresent(invokeArgs.args, '--skip-pull-image')
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            skipPullImage: true,
-        }).execute()
+        const invokeArgs = await executeInvocation({ skipPullImage: true })
+        assertArgIsPresent(invokeArgs.args, '--skip-pull-image')
     })
 
     it('does not pass --skip-pull-image to sam cli if skipPullImage is false', async function () {
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgNotPresent(invokeArgs.args, '--skip-pull-image')
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            skipPullImage: false,
-        }).execute()
+        const invokeArgs = await executeInvocation({ skipPullImage: false })
+        assertArgNotPresent(invokeArgs.args, '--skip-pull-image')
     })
 
     it('does not pass --skip-pull-image to sam cli if skipPullImage is undefined', async function () {
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgNotPresent(invokeArgs.args, '--skip-pull-image')
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            skipPullImage: undefined,
-        }).execute()
+        const invokeArgs = await executeInvocation({ skipPullImage: undefined })
+        assertArgNotPresent(invokeArgs.args, '--skip-pull-image')
     })
 
     it('Passes debuggerPath to sam cli', async function () {
         const expectedDebuggerPath = path.join('foo', 'bar')
-
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgsContainArgument(invokeArgs.args, '--debugger-path', expectedDebuggerPath)
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            debuggerPath: expectedDebuggerPath,
-        }).execute()
+        const invokeArgs = await executeInvocation({ debuggerPath: expectedDebuggerPath })
+        assertArgsContainArgument(invokeArgs.args, '--debugger-path', expectedDebuggerPath)
     })
 
     it('Does not pass debuggerPath to sam cli when undefined', async function () {
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assertArgNotPresent(invokeArgs.args, '--debugger-path')
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-        }).execute()
+        const invokeArgs = await executeInvocation({})
+        assertArgNotPresent(invokeArgs.args, '--debugger-path')
     })
 
     it('Passes runtime to sam cli', async function () {
@@ -325,66 +199,25 @@ describe('SamCliLocalInvokeInvocation', async function () {
             .stub(SamUtilsModule, 'getSamCliPathAndVersion')
             .callsFake(sandbox.stub().resolves({ parsedVersion: new SemVer('1.135.0') }))
 
-        const runtime = 'python3.10'
-
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assert(mockGetSamCliVersion.calledOnce)
-                assertArgsContainArgument(invokeArgs.args, '--runtime', runtime)
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            runtime: runtime,
-        }).execute()
+        const invokeArgs = await executeInvocation({ runtime: validRuntime })
+        assertArgsContainArgument(invokeArgs.args, '--runtime', validRuntime)
     })
 
     it('Does not pass runtime to sam cli when version < 1.135.0', async function () {
         mockGetSamCliVersion = sandbox
             .stub(SamUtilsModule, 'getSamCliPathAndVersion')
-            .callsFake(sandbox.stub().resolves({ parsedVersion: new SemVer('1.134.0') }))
+            .callsFake(sandbox.stub().resolves({ parsedVersion: invalidCliVersion }))
 
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assert(mockGetSamCliVersion.calledOnce)
-                assertArgNotPresent(invokeArgs.args, '--runtime')
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            runtime: 'python3.10',
-        }).execute()
+        const invokeArgs = await executeInvocation({ runtime: validRuntime })
+        assertArgNotPresent(invokeArgs.args, '--runtime')
     })
 
     it('Does not pass runtime to sam cli when runtime is deprecated', async function () {
         mockGetSamCliVersion = sandbox
             .stub(SamUtilsModule, 'getSamCliPathAndVersion')
-            .callsFake(sandbox.stub().resolves({ parsedVersion: new SemVer('1.135.0') }))
+            .callsFake(sandbox.stub().resolves({ parsedVersion: validCliVersion }))
 
-        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
-            (invokeArgs: SamLocalInvokeCommandArgs) => {
-                assert(mockGetSamCliVersion.calledOnce)
-                assertArgNotPresent(invokeArgs.args, '--runtime')
-            }
-        )
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            runtime: 'python2.7',
-        }).execute()
+        const invokeArgs = await executeInvocation({ runtime: invalidRuntime })
+        assertArgNotPresent(invokeArgs.args, '--runtime')
     })
 })

--- a/packages/core/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/packages/core/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -68,6 +68,10 @@ describe('SamCliLocalInvokeInvocation', async function () {
                 // `extraArgs` are appended to the end.
                 assert.strictEqual(invokeArgs.args[10], '--build-dir')
                 assert.strictEqual(invokeArgs.args[11], 'my/build/dir/')
+
+                // 'runtime' is the last argument.
+                assert.strictEqual(invokeArgs.args[invokeArgs.args.length - 2], '--runtime')
+                assert.strictEqual(invokeArgs.args[invokeArgs.args.length - 1], 'python3.10')
             }
         )
 
@@ -78,6 +82,7 @@ describe('SamCliLocalInvokeInvocation', async function () {
             environmentVariablePath: nonRelevantArg,
             invoker: taskInvoker,
             extraArgs: ['--build-dir', 'my/build/dir/'],
+            runtime: 'python3.10',
         }).execute()
     })
 
@@ -291,6 +296,41 @@ describe('SamCliLocalInvokeInvocation', async function () {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assertArgNotPresent(invokeArgs.args, '--debugger-path')
+            }
+        )
+
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker,
+        }).execute()
+    })
+
+    it('Passes runtime to sam cli', async function () {
+        const runtime = 'python3.10'
+
+        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
+            (invokeArgs: SamLocalInvokeCommandArgs) => {
+                assertArgsContainArgument(invokeArgs.args, '--runtime', runtime)
+            }
+        )
+
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker,
+            runtime: runtime,
+        }).execute()
+    })
+
+    it('Does not pass runtime to sam cli when undefined', async function () {
+        const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
+            (invokeArgs: SamLocalInvokeCommandArgs) => {
+                assertArgNotPresent(invokeArgs.args, '--runtime')
             }
         )
 

--- a/packages/toolkit/.changes/next-release/Feature-c5435979-4c37-4dce-8ebb-dd14b77d3b87.json
+++ b/packages/toolkit/.changes/next-release/Feature-c5435979-4c37-4dce-8ebb-dd14b77d3b87.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Allow customers to local invoke with the runtime selected in the local invoke webview"
+	"description": "AppBuilder: selecting a runtime in the local invoke view can override the runtime specified in template.yaml"
 }

--- a/packages/toolkit/.changes/next-release/Feature-c5435979-4c37-4dce-8ebb-dd14b77d3b87.json
+++ b/packages/toolkit/.changes/next-release/Feature-c5435979-4c37-4dce-8ebb-dd14b77d3b87.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Allow customers to local invoke with the runtime selected in the local invoke webview"
+}


### PR DESCRIPTION
## Problem
Customers are not able to local invoke with the runtime selected in the webview UI. Currently the runtime used is the one specified on the template. The feature was already added to SAMCLI https://github.com/aws/aws-sam-cli/pull/7885.

## Solution
Allows customers to change runtimes when locally invoking in the local invoke webview, without having to change it in their template and rebuilding. Under the hood, the newly added ```--runtime``` option will be appended to the ```samcli``` command.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
