### PR TITLE
fix(amazonq): highlightCommand missing `@` prefix

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1069,7 +1069,7 @@ export class ChatController {
         if (
             commandName &&
             triggerPayload.message &&
-            triggerPayload.context?.find((context) => typeof context !== 'string' && context.command === commandName)
+            triggerPayload.context?.some((context) => typeof context !== 'string' && context.command === commandName)
         ) {
             const truncatedCommand = commandName.startsWith('@') ? commandName.slice(1) : commandName
             triggerPayload.message = triggerPayload.message.replace(truncatedCommand, commandName)


### PR DESCRIPTION
## Problem
The recent mynah-ui upgrade removes the `@` prefix from context commands. This breaks the functionality of the highlightCommand

## Solution
Append a `@` to the highlightCommand in the payload message.
mynah-ui will push a fix to their library this week, so for next release we will upgrade mynah and remove this temporary fix.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
