### PR TITLE
revert(amazonq): generate scanName from workspace config #6679

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-90704e88-3ab3-4030-8bc6-fdde95aa3923.json
+++ b/packages/amazonq/.changes/next-release/Feature-90704e88-3ab3-4030-8bc6-fdde95aa3923.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "/review: Code reviews are now created with additional workspace context to enable grouping of related scans in the backend"
-}

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -15,9 +15,8 @@ import {
     ListCodeScanFindingsResponse,
     pollScanJobStatus,
     SecurityScanTimedOutError,
-    generateScanName,
 } from 'aws-core-vscode/codewhisperer'
-import { getStringHash, timeoutUtils } from 'aws-core-vscode/shared'
+import { timeoutUtils } from 'aws-core-vscode/shared'
 import assert from 'assert'
 import sinon from 'sinon'
 import * as vscode from 'vscode'
@@ -319,39 +318,6 @@ describe('securityScanHandler', function () {
             clock.tick(expectedTimeoutMs + 1000)
 
             await assert.rejects(() => pollPromise, SecurityScanTimedOutError)
-        })
-    })
-
-    describe('generateScanName', function () {
-        const clientId = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
-
-        it('generates scan name for FILE_AUTO scope', function () {
-            const result = generateScanName(['/some/root/path'], CodeAnalysisScope.FILE_AUTO, '/path/to/some/file')
-            assert.strictEqual(result, getStringHash(`${clientId}::/path/to/some/file::FILE_AUTO`))
-        })
-
-        it('generates scan name for FILE_ON_DEMAND scope', function () {
-            const result = generateScanName(['/some/root/path'], CodeAnalysisScope.FILE_ON_DEMAND, '/path/to/some/file')
-            assert.strictEqual(result, getStringHash(`${clientId}::/path/to/some/file::FILE_ON_DEMAND`))
-        })
-
-        it('generates scan name for PROJECT scope with a single project root', function () {
-            const result = generateScanName(['/some/root/path'], CodeAnalysisScope.PROJECT)
-            assert.strictEqual(result, getStringHash(`${clientId}::/some/root/path::PROJECT`))
-        })
-
-        it('generates scan name for PROJECT scope with multiple project roots', function () {
-            const result = generateScanName(['/some/root/pathB', '/some/root/pathA'], CodeAnalysisScope.PROJECT)
-            assert.strictEqual(result, getStringHash(`${clientId}::/some/root/pathA,/some/root/pathB::PROJECT`))
-        })
-
-        it('does not exceed 126 characters', function () {
-            let reallyDeepFilePath = ''
-            for (let i = 0; i < 100; i++) {
-                reallyDeepFilePath += '/some/deep/path'
-            }
-            const result = generateScanName(['/some/root/path'], CodeAnalysisScope.FILE_ON_DEMAND, reallyDeepFilePath)
-            assert.ok(result.length <= 126)
         })
     })
 })

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -18,7 +18,6 @@ import {
     listScanResults,
     throwIfCancelled,
     getLoggerForScope,
-    generateScanName,
 } from '../service/securityScanHandler'
 import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
 import {
@@ -39,6 +38,7 @@ import path from 'path'
 import { ZipMetadata, ZipUtil } from '../util/zipUtil'
 import { debounce } from 'lodash'
 import { once } from '../../shared/utilities/functionUtils'
+import { randomUUID } from '../../shared/crypto'
 import { CodeAnalysisScope, ProjectSizeExceededErrorMessage, SecurityScanStep } from '../models/constants'
 import {
     CodeScanJobFailedError,
@@ -185,7 +185,7 @@ export async function startSecurityScan(
         }
         let artifactMap: ArtifactMap = {}
         const uploadStartTime = performance.now()
-        const scanName = generateScanName(projectPaths, scope, fileName)
+        const scanName = randomUUID()
         try {
             artifactMap = await getPresignedUrlAndUpload(client, zipMetadata, scope, scanName)
         } finally {

--- a/packages/core/src/codewhisperer/index.ts
+++ b/packages/core/src/codewhisperer/index.ts
@@ -72,12 +72,7 @@ export { DocumentChangedSource, KeyStrokeHandler, DefaultDocumentChangedType } f
 export { ReferenceLogViewProvider } from './service/referenceLogViewProvider'
 export { LicenseUtil } from './util/licenseUtil'
 export { SecurityIssueProvider } from './service/securityIssueProvider'
-export {
-    listScanResults,
-    mapToAggregatedList,
-    pollScanJobStatus,
-    generateScanName,
-} from './service/securityScanHandler'
+export { listScanResults, mapToAggregatedList, pollScanJobStatus } from './service/securityScanHandler'
 export { CodeWhispererCodeCoverageTracker } from './tracker/codewhispererCodeCoverageTracker'
 export { TelemetryHelper } from './util/telemetryHelper'
 export { LineSelection, LineTracker } from './tracker/lineTracker'

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -41,9 +41,6 @@ import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
 import { FeatureUseCase } from '../models/constants'
 import { UploadTestArtifactToS3Error } from '../../amazonqTest/error'
 import { ChatSessionManager } from '../../amazonqTest/chat/storages/chatSession'
-import { getStringHash } from '../../shared/utilities/textUtilities'
-import { getClientId } from '../../shared/telemetry/util'
-import globals from '../../shared/extensionGlobals'
 import { AmazonqCreateUpload, Span, telemetry } from '../../shared/telemetry/telemetry'
 import { AuthUtil } from '../util/authUtil'
 
@@ -435,22 +432,4 @@ function getPollingTimeoutMsForScope(scope: CodeWhispererConstants.CodeAnalysisS
     return scope === CodeWhispererConstants.CodeAnalysisScope.FILE_AUTO
         ? CodeWhispererConstants.expressScanTimeoutMs
         : CodeWhispererConstants.standardScanTimeoutMs
-}
-
-/**
- * Generates a scanName that unique identifies a user's workspace configuration for a Q code review.
- *
- * @param projectPaths List of project root paths
- * @param scope {@link CodeWhispererConstants.CodeAnalysisScope} Scope of files included in the code review
- * @param fileName File name of the file being reviewed, or pass undefined for workspace review
- * @returns A string hash that uniquely identifies the workspace configuration
- */
-export function generateScanName(
-    projectPaths: string[],
-    scope: CodeWhispererConstants.CodeAnalysisScope,
-    fileName?: string
-) {
-    const clientId = getClientId(globals.globalState)
-    const projectId = fileName ?? projectPaths.sort((a, b) => a.localeCompare(b)).join(',')
-    return getStringHash(`${clientId}::${projectId}::${scope}`)
 }

--- a/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
+++ b/packages/core/src/testE2E/codewhisperer/securityScan.test.ts
@@ -18,11 +18,11 @@ import {
     createScanJob,
     pollScanJobStatus,
     listScanResults,
-    generateScanName,
 } from '../../codewhisperer/service/securityScanHandler'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
 import fs from '../../shared/fs/fs'
 import { ZipUtil } from '../../codewhisperer/util/zipUtil'
+import { randomUUID } from '../../shared/crypto'
 
 const filePromptWithSecurityIssues = `from flask import app
 
@@ -95,7 +95,7 @@ describe('CodeWhisperer security scan', async function () {
         const projectPaths = zipUtil.getProjectPaths()
         const scope = CodeWhispererConstants.CodeAnalysisScope.PROJECT
         const zipMetadata = await zipUtil.generateZip(uri, scope)
-        const codeScanName = generateScanName(projectPaths, scope)
+        const codeScanName = randomUUID()
 
         let artifactMap
         try {


### PR DESCRIPTION
This reverts commit 62d3ec19969c5eef6ee22f7ed155a0c32452ebcf.

## Problem

Scan name change is causing unexpected behavior from the service.


## Solution

Temporarily revert this change

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
