### PR TITLE
refactor(codecatalyst): migrate cc client to sdkv3 (WIP)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1187,6 +1187,3301 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/client-codecatalyst": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-codecatalyst/-/client-codecatalyst-3.693.0.tgz",
+            "integrity": "sha512-ZgNERu+3FnE72GJwCMe/Y1TeSlJms8PC1x+mSW4IEMFjBd9T5bv+9ywTZbPfF6thQ1X3H0fvi9KoWLWru8ulAQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/middleware-host-header": "3.693.0",
+                "@aws-sdk/middleware-logger": "3.693.0",
+                "@aws-sdk/middleware-recursion-detection": "3.693.0",
+                "@aws-sdk/middleware-user-agent": "3.693.0",
+                "@aws-sdk/region-config-resolver": "3.693.0",
+                "@aws-sdk/token-providers": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@aws-sdk/util-endpoints": "3.693.0",
+                "@aws-sdk/util-user-agent-browser": "3.693.0",
+                "@aws-sdk/util-user-agent-node": "3.693.0",
+                "@smithy/config-resolver": "^3.0.11",
+                "@smithy/core": "^2.5.2",
+                "@smithy/fetch-http-handler": "^4.1.0",
+                "@smithy/hash-node": "^3.0.9",
+                "@smithy/invalid-dependency": "^3.0.9",
+                "@smithy/middleware-content-length": "^3.0.11",
+                "@smithy/middleware-endpoint": "^3.2.2",
+                "@smithy/middleware-retry": "^3.0.26",
+                "@smithy/middleware-serde": "^3.0.9",
+                "@smithy/middleware-stack": "^3.0.9",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/node-http-handler": "^3.3.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/smithy-client": "^3.4.3",
+                "@smithy/types": "^3.7.0",
+                "@smithy/url-parser": "^3.0.9",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.26",
+                "@smithy/util-defaults-mode-node": "^3.0.26",
+                "@smithy/util-endpoints": "^2.1.5",
+                "@smithy/util-middleware": "^3.0.9",
+                "@smithy/util-retry": "^3.0.9",
+                "@smithy/util-utf8": "^3.0.0",
+                "@types/uuid": "^9.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.758.0.tgz",
+            "integrity": "sha512-BoGO6IIWrLyLxQG6txJw6RT2urmbtlwfggapNCrNPyYjlXpzTSJhBYjndg7TpDATFd0SXL0zm8y/tXsUXNkdYQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/middleware-host-header": "3.734.0",
+                "@aws-sdk/middleware-logger": "3.734.0",
+                "@aws-sdk/middleware-recursion-detection": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.758.0",
+                "@aws-sdk/region-config-resolver": "3.734.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@aws-sdk/util-user-agent-browser": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.758.0",
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/core": "^3.1.5",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/hash-node": "^4.0.1",
+                "@smithy/invalid-dependency": "^4.0.1",
+                "@smithy/middleware-content-length": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-retry": "^4.0.7",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/node-http-handler": "^4.0.3",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.7",
+                "@smithy/util-defaults-mode-node": "^4.0.7",
+                "@smithy/util-endpoints": "^3.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.758.0.tgz",
+            "integrity": "sha512-iU3s2aXAnxwSjtXE88eMugab5F673cx7osHpDu4ZFxiRQyZcK5xYaSeISZaRdUcSnNjX99T5lB++8fOoNS+C5Q==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/credential-provider-node": "3.758.0",
+                "@aws-sdk/middleware-host-header": "3.734.0",
+                "@aws-sdk/middleware-logger": "3.734.0",
+                "@aws-sdk/middleware-recursion-detection": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.758.0",
+                "@aws-sdk/region-config-resolver": "3.734.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@aws-sdk/util-user-agent-browser": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.758.0",
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/core": "^3.1.5",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/hash-node": "^4.0.1",
+                "@smithy/invalid-dependency": "^4.0.1",
+                "@smithy/middleware-content-length": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-retry": "^4.0.7",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/node-http-handler": "^4.0.3",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.7",
+                "@smithy/util-defaults-mode-node": "^4.0.7",
+                "@smithy/util-endpoints": "^3.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/core": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
+            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
+            "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
+            "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
+            "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
+            "integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
+            "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.743.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
+            "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-endpoints": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
+            "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
+            "integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/config-resolver": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+            "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/core": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
+            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/hash-node": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+            "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+            "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+            "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-retry": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
+            "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
+            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/smithy-client": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
+            "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
+            "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-endpoints": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+            "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-retry": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+            "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/core": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
+            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
+            "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
+            "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
+            "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
+            "integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
+            "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.743.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
+            "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-endpoints": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
+            "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
+            "integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/config-resolver": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+            "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/core": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
+            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/hash-node": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+            "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+            "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+            "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-retry": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
+            "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
+            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/smithy-client": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
+            "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
+            "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-endpoints": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+            "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-retry": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+            "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/core": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.693.0.tgz",
+            "integrity": "sha512-v6Z/kWmLFqRLDPEwl9hJGhtTgIFHjZugSfF1Yqffdxf4n1AWgtHS7qSegakuMyN5pP4K2tvUD8qHJ+gGe2Bw2A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/core": "^2.5.2",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/property-provider": "^3.1.9",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/signature-v4": "^4.2.2",
+                "@smithy/smithy-client": "^3.4.3",
+                "@smithy/types": "^3.7.0",
+                "@smithy/util-middleware": "^3.0.9",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.758.0.tgz",
+            "integrity": "sha512-N27eFoRrO6MeUNumtNHDW9WOiwfd59LPXPqDrIa3kWL/s+fOKFHb9xIcF++bAwtcZnAxKkgpDCUP+INNZskE+w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/core": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
+            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/core": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
+            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/smithy-client": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.758.0.tgz",
+            "integrity": "sha512-Xt9/U8qUCiw1hihztWkNeIR+arg6P+yda10OuCHX6kFVx3auTlU7+hCqs3UxqniGU4dguHuftf3mRpi5/GJ33Q==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.3",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/core": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
+            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/core": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
+            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
+            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/smithy-client": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.758.0.tgz",
+            "integrity": "sha512-+DaMv63wiq7pJrhIQzZYMn4hSarKiizDoJRvyR7WGhnn0oQ/getX9Z0VNCV3i7lIFoLNTb7WMmQ9k7+z/uD5EQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.758.0",
+                "@aws-sdk/credential-provider-http": "3.758.0",
+                "@aws-sdk/credential-provider-ini": "3.758.0",
+                "@aws-sdk/credential-provider-process": "3.758.0",
+                "@aws-sdk/credential-provider-sso": "3.758.0",
+                "@aws-sdk/credential-provider-web-identity": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.758.0.tgz",
+            "integrity": "sha512-AzcY74QTPqcbXWVgjpPZ3HOmxQZYPROIBz2YINF0OQk0MhezDWV/O7Xec+K1+MPGQO3qS6EDrUUlnPLjsqieHA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/core": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
+            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/core": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
+            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/smithy-client": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.758.0.tgz",
+            "integrity": "sha512-x0FYJqcOLUCv8GLLFDYMXRAQKGjoM+L0BG4BiHYZRDf24yQWFCAZsCQAYKo6XZYh2qznbsW6f//qpyJ5b0QVKQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.758.0",
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/token-providers": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/core": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
+            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.758.0.tgz",
+            "integrity": "sha512-ckptN1tNrIfQUaGWm/ayW1ddG+imbKN7HHhjFdS4VfItsP0QQOB0+Ov+tpgb4MoNR4JaUghMIVStjIeHN2ks1w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/nested-clients": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/core": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
+            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/smithy-client": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.693.0.tgz",
+            "integrity": "sha512-BCki6sAZ5jYwIN/t3ElCiwerHad69ipHwPsDCxJQyeiOnJ8HG+lEpnVIfrnI8A0fLQNSF3Gtx6ahfBpKiv1Oug==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.693.0.tgz",
+            "integrity": "sha512-dXnXDPr+wIiJ1TLADACI1g9pkSB21KkMIko2u4CJ2JCBoxi5IqeTnVoa6YcC8GdFNVRl+PorZ3Zqfmf1EOTC6w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.693.0.tgz",
+            "integrity": "sha512-0LDmM+VxXp0u3rG0xQRWD/q6Ubi7G8I44tBPahevD5CaiDZTkmNTrVUf0VEJgVe0iCKBppACMBDkLB0/ETqkFw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.693.0.tgz",
+            "integrity": "sha512-/KUq/KEpFFbQmNmpp7SpAtFAdViquDfD2W0QcG07zYBfz9MwE2ig48ALynXm5sMpRmnG7sJXjdvPtTsSVPfkiw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@aws-sdk/util-endpoints": "3.693.0",
+                "@smithy/core": "^2.5.2",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.693.0.tgz",
+            "integrity": "sha512-YLUkMsUY0GLW/nfwlZ69cy1u07EZRmsv8Z9m0qW317/EZaVx59hcvmcvb+W4bFqj5E8YImTjoGfE4cZ0F9mkyw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/types": "^3.7.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.9",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/token-providers": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.693.0.tgz",
+            "integrity": "sha512-nDBTJMk1l/YmFULGfRbToOA2wjf+FkQT4dMgYCv+V9uSYsMzQj8A7Tha2dz9yv4vnQgYaEiErQ8d7HVyXcVEoA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/property-provider": "^3.1.9",
+                "@smithy/shared-ini-file-loader": "^3.1.10",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sso-oidc": "^3.693.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.693.0.tgz",
+            "integrity": "sha512-eo4F6DRQ/kxS3gxJpLRv+aDNy76DxQJL5B3DPzpr9Vkq0ygVoi4GT5oIZLVaAVIJmi6k5qq9dLsYZfWLUxJJSg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/types": "^3.7.0",
+                "@smithy/util-endpoints": "^2.1.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.693.0.tgz",
+            "integrity": "sha512-6EUfuKOujtddy18OLJUaXfKBgs+UcbZ6N/3QV4iOkubCUdeM1maIqs++B9bhCbWeaeF5ORizJw5FTwnyNjE/mw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/types": "^3.7.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.693.0.tgz",
+            "integrity": "sha512-td0OVX8m5ZKiXtecIDuzY3Y3UZIzvxEr57Hp21NOwieqKCG2UeyQWWeGPv0FQaU7dpTkvFmVNI+tx9iB8V/Nhg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/abort-controller": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
+            "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+            "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/service-error-classification": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
+            "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/service-error-classification/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
+            "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.3",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
+            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-utf8/node_modules/@smithy/is-array-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+            "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-cognito-identity": {
             "version": "3.637.0",
             "license": "Apache-2.0",
@@ -3380,6 +6675,955 @@
                 "tslib": "^2.6.2"
             }
         },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.758.0.tgz",
+            "integrity": "sha512-cymSKMcP5d+OsgetoIZ5QCe1wnp2Q/tq+uIxVdh9MbfdBBEnl9Ecq6dH6VlYS89sp4QKuxHxkWXVnbXU3Q19Aw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/credential-provider-env": "3.758.0",
+                "@aws-sdk/credential-provider-http": "3.758.0",
+                "@aws-sdk/credential-provider-process": "3.758.0",
+                "@aws-sdk/credential-provider-sso": "3.758.0",
+                "@aws-sdk/credential-provider-web-identity": "3.758.0",
+                "@aws-sdk/nested-clients": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/client-sso": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.758.0.tgz",
+            "integrity": "sha512-BoGO6IIWrLyLxQG6txJw6RT2urmbtlwfggapNCrNPyYjlXpzTSJhBYjndg7TpDATFd0SXL0zm8y/tXsUXNkdYQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/middleware-host-header": "3.734.0",
+                "@aws-sdk/middleware-logger": "3.734.0",
+                "@aws-sdk/middleware-recursion-detection": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.758.0",
+                "@aws-sdk/region-config-resolver": "3.734.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@aws-sdk/util-user-agent-browser": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.758.0",
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/core": "^3.1.5",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/hash-node": "^4.0.1",
+                "@smithy/invalid-dependency": "^4.0.1",
+                "@smithy/middleware-content-length": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-retry": "^4.0.7",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/node-http-handler": "^4.0.3",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.7",
+                "@smithy/util-defaults-mode-node": "^4.0.7",
+                "@smithy/util-endpoints": "^3.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/core": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
+            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.758.0.tgz",
+            "integrity": "sha512-N27eFoRrO6MeUNumtNHDW9WOiwfd59LPXPqDrIa3kWL/s+fOKFHb9xIcF++bAwtcZnAxKkgpDCUP+INNZskE+w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.758.0.tgz",
+            "integrity": "sha512-Xt9/U8qUCiw1hihztWkNeIR+arg6P+yda10OuCHX6kFVx3auTlU7+hCqs3UxqniGU4dguHuftf3mRpi5/GJ33Q==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.3",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.758.0.tgz",
+            "integrity": "sha512-AzcY74QTPqcbXWVgjpPZ3HOmxQZYPROIBz2YINF0OQk0MhezDWV/O7Xec+K1+MPGQO3qS6EDrUUlnPLjsqieHA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.758.0.tgz",
+            "integrity": "sha512-x0FYJqcOLUCv8GLLFDYMXRAQKGjoM+L0BG4BiHYZRDf24yQWFCAZsCQAYKo6XZYh2qznbsW6f//qpyJ5b0QVKQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.758.0",
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/token-providers": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
+            "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
+            "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
+            "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
+            "integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
+            "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/token-providers": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.758.0.tgz",
+            "integrity": "sha512-ckptN1tNrIfQUaGWm/ayW1ddG+imbKN7HHhjFdS4VfItsP0QQOB0+Ov+tpgb4MoNR4JaUghMIVStjIeHN2ks1w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/nested-clients": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.743.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
+            "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-endpoints": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
+            "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
+            "integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/abort-controller": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/config-resolver": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+            "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/core": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
+            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/credential-provider-imds": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
+            "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/hash-node": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+            "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+            "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+            "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-retry": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
+            "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
+            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/querystring-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+            "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/service-error-classification": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
+            "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/smithy-client": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
+            "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
+            "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-endpoints": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+            "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-retry": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+            "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-stream": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
+            "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.3",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@aws-sdk/credential-provider-node": {
             "version": "3.637.0",
             "license": "Apache-2.0",
@@ -3540,6 +7784,460 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.758.0.tgz",
+            "integrity": "sha512-XGguXhBqiCXMXRxcfCAVPlMbm3VyJTou79r/3mxWddHWF0XbhaQiBIbUz6vobVTD25YQRbWSmSch7VA8kI5Lrw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/nested-clients": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/core": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
+            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/abort-controller": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/core": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
+            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
+            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/querystring-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+            "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/smithy-client": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-stream": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
+            "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.3",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.620.0",
             "license": "Apache-2.0",
@@ -3663,6 +8361,835 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.758.0.tgz",
+            "integrity": "sha512-YZ5s7PSvyF3Mt2h1EQulCG93uybprNGbBkPmVuy/HMMfbFTt4iL3SbKjxqvOZelm86epFfj7pvK7FliI2WOEcg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/middleware-host-header": "3.734.0",
+                "@aws-sdk/middleware-logger": "3.734.0",
+                "@aws-sdk/middleware-recursion-detection": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.758.0",
+                "@aws-sdk/region-config-resolver": "3.734.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@aws-sdk/util-user-agent-browser": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.758.0",
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/core": "^3.1.5",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/hash-node": "^4.0.1",
+                "@smithy/invalid-dependency": "^4.0.1",
+                "@smithy/middleware-content-length": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-retry": "^4.0.7",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/node-http-handler": "^4.0.3",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.7",
+                "@smithy/util-defaults-mode-node": "^4.0.7",
+                "@smithy/util-endpoints": "^3.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
+            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
+            "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
+            "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
+            "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
+            "integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@smithy/core": "^3.1.5",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
+            "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.743.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
+            "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-endpoints": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
+            "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
+            "integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.758.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/config-resolver": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+            "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/core": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
+            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/credential-provider-imds": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
+            "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/hash-node": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+            "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+            "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+            "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-retry": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
+            "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
+            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+            "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/service-error-classification": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
+            "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/smithy-client": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
+            "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
+            "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.6",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-endpoints": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+            "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-retry": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+            "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-stream": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
+            "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.3",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/property-provider": {
@@ -17648,6 +23175,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../src.gen/@amzn/codewhisperer-streaming",
                 "@aws-sdk/client-cloudformation": "<3.696.0",
                 "@aws-sdk/client-cloudwatch-logs": "<3.696.0",
+                "@aws-sdk/client-codecatalyst": "<3.696.0",
                 "@aws-sdk/client-cognito-identity": "<3.696.0",
                 "@aws-sdk/client-docdb": "<3.696.0",
                 "@aws-sdk/client-docdb-elastic": "<3.696.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -514,6 +514,7 @@
         "@aws-sdk/protocol-http": "<3.696.0",
         "@aws-sdk/smithy-client": "<3.696.0",
         "@aws-sdk/util-arn-parser": "<3.696.0",
+        "@aws-sdk/client-codecatalyst": "<3.696.0",
         "@aws/mynah-ui": "^4.23.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",

--- a/packages/core/src/shared/awsClientBuilderV3.ts
+++ b/packages/core/src/shared/awsClientBuilderV3.ts
@@ -61,10 +61,6 @@ export interface AwsCommand<InputType extends object, OutputType extends object>
     resolveMiddleware: (stack: any, configuration: any, options: any) => Handler<any, any>
 }
 
-export interface AwsCommandOutput {
-    $metadata: object
-}
-
 export interface AwsClientOptions {
     credentials: AwsCredentialIdentityProvider
     region: string | Provider<string>

--- a/packages/core/src/shared/awsClientBuilderV3.ts
+++ b/packages/core/src/shared/awsClientBuilderV3.ts
@@ -51,14 +51,18 @@ export interface AwsClient {
     middlewareStack: {
         add: MiddlewareStack<any, MetadataBearer>['add']
     }
-    send: (command: AwsCommand, options?: any) => Promise<any>
+    send: (command: AwsCommand<object, object>, options?: any) => Promise<any>
     destroy: () => void
 }
 
-export interface AwsCommand {
-    input: object
+export interface AwsCommand<InputType extends object, OutputType extends object> {
+    input: InputType
     middlewareStack: any
     resolveMiddleware: (stack: any, configuration: any, options: any) => Handler<any, any>
+}
+
+export interface AwsCommandOutput {
+    $metadata: object
 }
 
 export interface AwsClientOptions {

--- a/packages/core/src/shared/awsClientBuilderV3.ts
+++ b/packages/core/src/shared/awsClientBuilderV3.ts
@@ -5,7 +5,13 @@
 
 import { CredentialsShim } from '../auth/deprecated/loginManager'
 import { AwsContext } from './awsContext'
-import { AwsCredentialIdentityProvider, Logger, RetryStrategyV2 } from '@smithy/types'
+import {
+    AwsCredentialIdentityProvider,
+    Logger,
+    RetryStrategyV2,
+    TokenIdentity,
+    TokenIdentityProvider,
+} from '@smithy/types'
 import { getUserAgent } from './telemetry/util'
 import { DevSettings } from './settings'
 import {
@@ -68,6 +74,7 @@ export interface AwsClientOptions {
     endpoint: string
     retryStrategy: RetryStrategy | RetryStrategyV2
     logger: Logger
+    token: TokenIdentity | TokenIdentityProvider
 }
 
 interface AwsServiceOptions<C extends AwsClient> {

--- a/packages/core/src/shared/clients/clientWrapper.ts
+++ b/packages/core/src/shared/clients/clientWrapper.ts
@@ -28,10 +28,12 @@ export abstract class ClientWrapper<C extends AwsClient> implements vscode.Dispo
             : globals.sdkClientBuilderV3.getAwsService(args)
     }
 
-    protected async makeRequest<CommandInput extends object, CommandOutput extends object, Command extends AwsCommand>(
-        command: new (o: CommandInput) => Command,
-        commandOptions: CommandInput
-    ): Promise<CommandOutput> {
+    protected async makeRequest<
+        CommandInput extends object,
+        CommandOutput extends object,
+        CommandOptions extends CommandInput,
+        Command extends AwsCommand<CommandInput, CommandOutput>,
+    >(command: new (o: CommandInput) => Command, commandOptions: CommandOptions): Promise<CommandOutput> {
         return await this.getClient().send(new command(commandOptions))
     }
 

--- a/packages/core/src/shared/clients/codecatalystClient.ts
+++ b/packages/core/src/shared/clients/codecatalystClient.ts
@@ -127,24 +127,16 @@ function toBranch(
     }
 }
 
-interface RetryOptions {
-    retryDelayOptions?: RetryDelayOptions
-    maxRetries?: number
-}
-
 async function createCodeCatalystClient(
     connection: SsoConnection,
     regionCode: string,
-    endpoint: string | AWS.Endpoint,
-    retryOptions: RetryOptions
+    endpoint: string
 ): Promise<CodeCatalyst> {
     const c = await globals.sdkClientBuilder.createAwsService(CodeCatalyst, {
         region: regionCode,
         correctClockSkew: true,
         endpoint: endpoint,
         token: new TokenProvider(connection),
-        retryDelayOptions: retryOptions.retryDelayOptions,
-        maxRetries: retryOptions.maxRetries,
     } as ServiceConfigurationOptions)
 
     return c
@@ -178,10 +170,9 @@ export async function createClient(
     connection: SsoConnection,
     regionCode = getCodeCatalystConfig().region,
     endpoint = getCodeCatalystConfig().endpoint,
-    retryOptions: RetryOptions = {},
     authOptions: AuthOptions = {}
 ): Promise<CodeCatalystClient> {
-    const sdkClient = await createCodeCatalystClient(connection, regionCode, endpoint, retryOptions)
+    const sdkClient = await createCodeCatalystClient(connection, regionCode, endpoint)
     const c = new CodeCatalystClientInternal(connection, sdkClient)
     try {
         await c.verifySession()


### PR DESCRIPTION
## Problem


## Solution
- refactor `call` wrapper to work with commands, rather than requests. 
- Support passing `token` into clients. 
- `correctClockskew` is enabled by default so it can be dropped: https://github.com/aws/aws-sdk-js-v3/blob/eae65cded5e703306346bdbd1b5de9d23050054a/UPGRADING.md


## Future Work 
- Look into adding the performance logging in the original `call` function to the default middleware stack. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
