### PR TITLE
telemetry: computeEnv reports "wsl" for all remote envs

### DIFF
--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -257,33 +257,39 @@ export function getUserAgent(
 }
 
 /**
- * All the types of ENVs the extension can run in.
+ * Kinds of machines/environments the extension can run in.
  *
  * NOTES:
- * - append `-amzn` for any environment internal to Amazon
+ * - Append `-amzn` for any environment internal to Amazon.
+ * - Append `-web` for web browser (*without* compute).
  */
 export type EnvType =
     | 'cloud9'
+    | 'cloud9-web'
     | 'cloudDesktop-amzn'
     | 'codecatalyst'
-    | 'local'
     | 'ec2'
     | 'ec2-amzn' // ec2 but with an internal Amazon OS
+    | 'local'
     | 'sagemaker'
+    | 'sagemaker-web'
     | 'test'
-    | 'wsl'
     | 'unknown'
+    | 'remote' // Generic (unknown) remote env.
+    | 'web' // Generic (unknown) web env.
+    | 'wsl'
 
 /**
  * Returns the identifier for the environment that the extension is running in.
  */
 export async function getComputeEnvType(): Promise<EnvType> {
+    const web = isWeb()
     if (isCloud9()) {
-        return 'cloud9'
+        return web ? 'cloud9-web' : 'cloud9'
     } else if (isInDevEnv()) {
         return 'codecatalyst'
     } else if (isSageMaker()) {
-        return 'sagemaker'
+        return web ? 'sagemaker-web' : 'sagemaker'
     } else if (isRemoteWorkspace()) {
         if (isAmazonInternalOs()) {
             if (await isCloudDesktop()) {
@@ -292,12 +298,16 @@ export async function getComputeEnvType(): Promise<EnvType> {
             return 'ec2-amzn'
         }
         return 'ec2'
-    } else if (env.remoteName) {
+    } else if (env.remoteName === 'wsl') {
         return 'wsl'
     } else if (isAutomation()) {
         return 'test'
     } else if (!env.remoteName) {
         return 'local'
+    } else if (web) {
+        return 'web'
+    } else if (env.remoteName) {
+        return 'remote'
     } else {
         return 'unknown'
     }

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -302,14 +302,12 @@ export async function getComputeEnvType(): Promise<EnvType> {
         return 'wsl'
     } else if (isAutomation()) {
         return 'test'
-    } else if (!env.remoteName) {
-        return 'local'
     } else if (web) {
         return 'web'
     } else if (env.remoteName) {
         return 'remote'
     } else {
-        return 'unknown'
+        return 'local'
     }
 }
 

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -274,7 +274,6 @@ export type EnvType =
     | 'sagemaker'
     | 'sagemaker-web'
     | 'test'
-    | 'unknown'
     | 'remote' // Generic (unknown) remote env.
     | 'web' // Generic (unknown) web env.
     | 'wsl'
@@ -305,9 +304,9 @@ export async function getComputeEnvType(): Promise<EnvType> {
     } else if (web) {
         return 'web'
     } else if (env.remoteName) {
-        return 'remote'
+        return 'remote' // Generic (unknown) remote env.
     } else {
-        return 'local'
+        return 'local' // Generic (unknown) local env.
     }
 }
 


### PR DESCRIPTION
## Problem
1. `computeEnv` reports "wsl" for all remote envs.
2. `computeEnv` does not report "web" envs.

## Solution
1. Only report "wsl" for WSL envs.
2. Report "remote" for other remote envs.
3. Report "web" for unknown web envs.







---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
