### PR TITLE
ci(jscpd): add back hint message on detection of clones

### DIFF
--- a/.github/workflows/filterDuplicates.js
+++ b/.github/workflows/filterDuplicates.js
@@ -111,6 +111,9 @@ async function run() {
     console.log('%s duplicates found', filteredDuplicates.length)
     if (filteredDuplicates.length > 0) {
         console.log(formatDuplicates(filteredDuplicates, commitHash, repoName))
+        console.log(
+            '* Hint: if these duplicates appear unrelated to the changes, rebase onto or merge in the latest target branch.'
+        )
         process.exit(1)
     }
 }


### PR DESCRIPTION
## Problem
There appears to be cases where the fix pushed here fails: https://github.com/aws/aws-toolkit-vscode/pull/6572. 

## Solution
- re-add the hint message for the case described here: https://github.com/aws/aws-toolkit-vscode/pull/6564

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
