### PR TITLE
fix(amazonq): Keyboard navigation does not work on create prompt overlay

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-917c4c75-6019-4d7d-a246-0248cf2be55d.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-917c4c75-6019-4d7d-a246-0248cf2be55d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q chat: Create a new prompt form does not autofocus or submit with Enter press"
+}

--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -160,6 +160,29 @@ export class Connector extends BaseConnector {
         )
     }
 
+    onFormTextualItemKeyPress = (
+        tabId: string,
+        event: KeyboardEvent,
+        formData: Record<string, string>,
+        itemId: string,
+        eventId?: string
+    ) => {
+        if (itemId === 'prompt-name' && event.key === 'Enter') {
+            event.preventDefault()
+            this.sendMessageToExtension({
+                command: 'form-action-click',
+                action: {
+                    id: 'submit-create-prompt',
+                    formItemValues: formData,
+                },
+                tabType: this.getTabType(),
+                tabID: tabId,
+            })
+            return true
+        }
+        return false
+    }
+
     handleMessageReceive = async (messageData: any): Promise<void> => {
         if (messageData.type === 'chatMessage') {
             await this.processChatMessage(messageData)

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -670,6 +670,20 @@ export class Connector {
         }
     }
 
+    onFormTextualItemKeyPress = (
+        event: KeyboardEvent,
+        formData: Record<string, string>,
+        itemId: string,
+        tabId: string,
+        eventId?: string
+    ) => {
+        switch (this.tabsStorage.getTab(tabId)?.type) {
+            case 'cwc':
+                return this.cwChatConnector.onFormTextualItemKeyPress(tabId, event, formData, itemId, eventId)
+        }
+        return false
+    }
+
     onCustomFormAction = (
         tabId: string,
         messageId: string | undefined,

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -777,6 +777,15 @@ export const createMynahUI = (
         onCustomFormAction: (tabId, action, eventId) => {
             connector.onCustomFormAction(tabId, undefined, action, eventId)
         },
+        onFormTextualItemKeyPress: (
+            event: KeyboardEvent,
+            formData: Record<string, string>,
+            itemId: string,
+            tabId: string,
+            eventId?: string
+        ) => {
+            return connector.onFormTextualItemKeyPress(event, formData, itemId, tabId, eventId)
+        },
         onChatPromptProgressActionButtonClicked: (tabID, action) => {
             connector.onCustomFormAction(tabID, undefined, action)
         },

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -539,6 +539,7 @@ export class ChatController {
                     id: 'prompt-name',
                     type: 'textinput',
                     mandatory: true,
+                    autoFocus: true,
                     title: i18n('AWS.amazonq.savedPrompts.title'),
                     placeholder: i18n('AWS.amazonq.savedPrompts.placeholder'),
                     description: i18n('AWS.amazonq.savedPrompts.description'),


### PR DESCRIPTION
## Problem
When a user selects "Create a new prompt", a mouse is required to 1) select the prompt name input field and 2) click the Enter button. This flow should be able to be completed with just the keyboard

## Solution
Autofocus prompt input field, and allow submit on Enter key press.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
