### PR TITLE
fix(amazonq): incorrect path for diff on windows

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-f80cc751-cb9d-45b6-a03a-3aec945a4565.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-f80cc751-cb9d-45b6-a03a-3aec945a4565.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/review: Invalid file path characters caused some detections to be skipped on Windows"
+}

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -24,6 +24,7 @@ import { FeatureUseCase } from '../models/constants'
 import { ChildProcess, ChildProcessOptions } from '../../shared/utilities/processUtils'
 import { ProjectZipError } from '../../amazonqTest/error'
 import { removeAnsi } from '../../shared/utilities/textUtilities'
+import { normalize } from '../../shared/utilities/pathUtils'
 
 export interface ZipMetadata {
     rootDir: string
@@ -122,7 +123,7 @@ export class ZipUtil {
             zip.addFile(zipEntryPath, Buffer.from(content, 'utf-8'))
 
             if (scope === CodeWhispererConstants.CodeAnalysisScope.FILE_ON_DEMAND) {
-                const gitDiffContent = `+++ b/${path.normalize(zipEntryPath).replaceAll(path.win32.sep, path.posix.sep)}` // Sending file path in payload for LLM code review
+                const gitDiffContent = `+++ b/${normalize(zipEntryPath)}` // Sending file path in payload for LLM code review
                 zip.addFile(ZipConstants.codeDiffFilePath, Buffer.from(gitDiffContent, 'utf-8'))
             }
         } else {

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -122,7 +122,7 @@ export class ZipUtil {
             zip.addFile(zipEntryPath, Buffer.from(content, 'utf-8'))
 
             if (scope === CodeWhispererConstants.CodeAnalysisScope.FILE_ON_DEMAND) {
-                const gitDiffContent = `+++ b/${path.normalize(zipEntryPath)}` // Sending file path in payload for LLM code review
+                const gitDiffContent = `+++ b/${path.normalize(zipEntryPath).replaceAll(path.win32.sep, path.posix.sep)}` // Sending file path in payload for LLM code review
                 zip.addFile(ZipConstants.codeDiffFilePath, Buffer.from(gitDiffContent, 'utf-8'))
             }
         } else {


### PR DESCRIPTION
## Problem

Diff path is incorrect when running a scan from windows. The code scan service expects diff paths in UNIX format.


## Solution

Replace all `\` with `/`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
