### PR TITLE
fix(amazonq): incorrect zip entry path for file scans

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b89574ec-9f50-4b4c-b548-30bfce5d0999.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b89574ec-9f50-4b4c-b548-30bfce5d0999.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/review: Zip files are created with the wrong file path for file scans in multifolder workspaces."
+}

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -117,7 +117,8 @@ export class ZipUtil {
             // Note: workspaceFolder.name is not the same as the file system folder name,
             // use the fsPath value instead
             const projectName = path.basename(workspaceFolder.uri.fsPath)
-            const relativePath = vscode.workspace.asRelativePath(uri)
+            // Set includeWorkspaceFolder to false because we are already manually prepending the projectName
+            const relativePath = vscode.workspace.asRelativePath(uri, false)
             const zipEntryPath = this.getZipEntryPath(projectName, relativePath)
             zip.addFile(zipEntryPath, Buffer.from(content, 'utf-8'))
 


### PR DESCRIPTION
## Problem

Reproduce steps:
1. Open a window with multiple workspace folders, for example `workspaceFolders: [folder1, folder2]`
2. Open any file and run a code review on the active file, for example `folder1/sample.py`
3. The zip entry will be created with the workspaceFolder duplicated, for example `folder1/folder1/sample.py`

## Solution
Explicitly set `includeWorkspaceFolder` to false when getting the relative path of the file.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
