### PR TITLE
feat(amazonq): show code diff instead of only code fix for fix preview

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-a7de0f94-cd21-4adc-8fcf-3082aa862528.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-a7de0f94-cd21-4adc-8fcf-3082aa862528.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/review: show code diff for fix preview"
+}

--- a/packages/amazonq/.changes/next-release/Feature-6192cfc5-c6cb-4302-bfcf-ec90cac95b72.json
+++ b/packages/amazonq/.changes/next-release/Feature-6192cfc5-c6cb-4302-bfcf-ec90cac95b72.json
@@ -1,4 +1,4 @@
 {
-	"type": "Bug Fix",
+	"type": "Feature",
 	"description": "/review: show code diff for fix preview"
 }

--- a/packages/core/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/packages/core/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -157,7 +157,11 @@ export class SecurityIssueHoverProvider implements vscode.HoverProvider {
      * @returns The markdown string
      */
     private _makeCodeBlock(code: string, language?: string) {
-        const lines = code.replaceAll('\n\\ No newline at end of file', '').split('\n')
+        const lines = code
+            .replaceAll('\n\\ No newline at end of file', '')
+            .replaceAll('--- buggyCode\n', '')
+            .replaceAll('+++ fixCode\n', '')
+            .split('\n')
         const maxLineChars = lines.reduce((acc, curr) => Math.max(acc, curr.length), 0)
         const paddedLines = lines.map((line) => line.padEnd(maxLineChars + 2))
 

--- a/packages/core/src/codewhisperer/views/securityIssue/vue/root.vue
+++ b/packages/core/src/codewhisperer/views/securityIssue/vue/root.vue
@@ -103,7 +103,6 @@ import highSeverity from '../../../../../resources/images/severity-high.svg'
 import criticalSeverity from '../../../../../resources/images/severity-critical.svg'
 import markdownIt from 'markdown-it'
 import hljs from 'highlight.js'
-import { parsePatch } from 'diff'
 import { CodeScanIssue } from '../../../models/model'
 
 const client = WebviewClientFactory.create<SecurityIssueWebview>()
@@ -344,7 +343,6 @@ export default defineComponent({
             if (!this.isFixAvailable) {
                 return
             }
-            const [parsedDiff] = parsePatch(this.suggestedFix)
             return md.render(`
 \`\`\`${this.languageId} 
 ${this.suggestedFix.replaceAll('--- buggyCode\n', '').replaceAll('+++ fixCode\n', '')}

--- a/packages/core/src/codewhisperer/views/securityIssue/vue/root.vue
+++ b/packages/core/src/codewhisperer/views/securityIssue/vue/root.vue
@@ -345,27 +345,11 @@ export default defineComponent({
                 return
             }
             const [parsedDiff] = parsePatch(this.suggestedFix)
-            const { oldStart } = parsedDiff.hunks[0]
-            const [referenceStart, referenceEnd] = this.referenceSpan
-            const htmlString = md.render(`
-\`\`\`${this.languageId} showLineNumbers startFrom=${oldStart} ${
-                referenceStart && referenceEnd
-                    ? `highlightStart=${referenceStart + 1} highlightEnd=${referenceEnd + 1}`
-                    : ''
-            }
-${this.fixedCode}
+            return md.render(`
+\`\`\`${this.languageId} 
+${this.suggestedFix.replaceAll('--- buggyCode\n', '').replaceAll('+++ fixCode\n', '')}
 \`\`\`
       `)
-            const parser = new DOMParser()
-            const doc = parser.parseFromString(htmlString, 'text/html')
-            const referenceTracker = doc.querySelector('.reference-tracker')
-            if (referenceTracker) {
-                const tooltip = doc.createElement('div')
-                tooltip.classList.add('tooltip')
-                tooltip.innerHTML = this.referenceText
-                referenceTracker.appendChild(tooltip)
-            }
-            return doc.body.innerHTML
         },
         scrollTo(refName: string) {
             this.$nextTick(() => this.$refs?.[refName]?.scrollIntoView({ behavior: 'smooth' }))


### PR DESCRIPTION
## Problem

We currently see only code fix for fix preview. We want to see the diff containing both code fix and original code.

## Solution

Remove logic to generate only the code fix. 

Remove logic for line number as it will be different for the diff.

/review: show code diff instead of only code fix for fix preview
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
