### PR TITLE
telemetry(amazonq): Add status field to unit test generation telemetry for tracking user actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.305",
+                "@aws-toolkits/telemetry": "^1.0.307",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -4806,9 +4806,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.305",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.305.tgz",
-            "integrity": "sha512-6OEW2ke7vx3yAv7MYthUZ7RZfJMUMqH3rCH3MtL84WmkylVu9nF+/RrAM4S3uKyS/EBuGPp/vZIEFBLdHbZWYg==",
+            "version": "1.0.307",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.307.tgz",
+            "integrity": "sha512-YYpVM0AI2qTP2OgR3J7DFvj/WLiuFQVB7upZh1i45mflae3EWprTPs0wGV5M9wI3PTFRR4zWnxhfL5Du08p9DQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.305",
+        "@aws-toolkits/telemetry": "^1.0.307",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -286,7 +286,7 @@ export class TestController {
         }
         TelemetryHelper.instance.sendTestGenerationToolkitEvent(
             session,
-            true,
+            session.isSupportedLanguage,
             true,
             isCancel ? 'Cancelled' : 'Failed',
             session.startTestGenerationRequestId,
@@ -295,7 +295,15 @@ export class TestController {
             session.isCodeBlockSelected,
             session.artifactsUploadDuration,
             session.srcPayloadSize,
-            session.srcZipFileSize
+            session.srcZipFileSize,
+            session.charsOfCodeAccepted,
+            session.numberOfTestsGenerated,
+            session.linesOfCodeGenerated,
+            session.charsOfCodeGenerated,
+            session.numberOfTestsGenerated,
+            session.linesOfCodeGenerated,
+            undefined,
+            isCancel ? 'CANCELLED' : 'FAILED'
         )
         if (session.stopIteration) {
             // Error from Science
@@ -502,6 +510,7 @@ export class TestController {
                     unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> I will still generate a suggestion below.`
                 }
                 this.messenger.sendMessage(unsupportedMessage, tabID, 'answer')
+                session.isSupportedLanguage = false
                 await this.onCodeGeneration(
                     session,
                     userPrompt,
@@ -529,6 +538,7 @@ export class TestController {
                     )
                 }
                 session.isCodeBlockSelected = selectionRange !== undefined
+                session.isSupportedLanguage = true
 
                 /**
                  * Zip the project
@@ -792,7 +802,9 @@ export class TestController {
             session.linesOfCodeAccepted,
             session.charsOfCodeGenerated,
             session.numberOfTestsGenerated,
-            session.linesOfCodeGenerated
+            session.linesOfCodeGenerated,
+            undefined,
+            'ACCEPTED'
         )
 
         await this.endSession(message, FollowUpTypes.SkipBuildAndFinish)
@@ -918,7 +930,9 @@ export class TestController {
                 0,
                 session.charsOfCodeGenerated,
                 session.numberOfTestsGenerated,
-                session.linesOfCodeGenerated
+                session.linesOfCodeGenerated,
+                undefined,
+                'REJECTED'
             )
             telemetry.ui_click.emit({ elementId: 'unitTestGeneration_rejectDiff' })
         }

--- a/packages/core/src/amazonqTest/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqTest/chat/controller/messenger/messenger.ts
@@ -296,7 +296,8 @@ export class Messenger {
                         undefined,
                         undefined,
                         undefined,
-                        'TestGenCancelled'
+                        'TestGenCancelled',
+                        'CANCELLED'
                     )
                     this.dispatcher.sendUpdatePromptProgress(
                         new UpdatePromptProgressMessage(tabID, cancellingProgressField)
@@ -310,7 +311,19 @@ export class Messenger {
                         'Succeeded',
                         messageId,
                         performance.now() - session.testGenerationStartTime,
-                        undefined
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        'ACCEPTED'
                     )
                     this.dispatcher.sendUpdatePromptProgress(
                         new UpdatePromptProgressMessage(tabID, testGenCompletedField)

--- a/packages/core/src/amazonqTest/chat/session/session.ts
+++ b/packages/core/src/amazonqTest/chat/session/session.ts
@@ -35,6 +35,7 @@ export class Session {
     public testGenerationJob: TestGenerationJob | undefined
 
     // Start Test generation
+    public isSupportedLanguage: boolean = false
     public conversationState: ConversationState = ConversationState.IDLE
     public shortAnswer: ShortAnswer | undefined
     public sourceFilePath: string = ''

--- a/packages/core/src/codewhisperer/util/telemetryHelper.ts
+++ b/packages/core/src/codewhisperer/util/telemetryHelper.ts
@@ -13,6 +13,7 @@ import {
     CodewhispererPreviousSuggestionState,
     CodewhispererUserDecision,
     CodewhispererUserTriggerDecision,
+    Status,
     telemetry,
 } from '../../shared/telemetry/telemetry'
 import { CodewhispererCompletionType, CodewhispererSuggestionState } from '../../shared/telemetry/telemetry'
@@ -85,12 +86,13 @@ export class TelemetryHelper {
         generatedCharactersCount?: number,
         generatedCount?: number,
         generatedLinesCount?: number,
-        reason?: string
+        reason?: string,
+        status?: Status
     ) {
         telemetry.amazonq_utgGenerateTests.emit({
             cwsprChatProgrammingLanguage: session.fileLanguage ?? 'plaintext',
             hasUserPromptSupplied: session.hasUserPromptSupplied,
-            isSupportedLanguage: isSupportedLanguage,
+            isSupportedLanguage: session.isSupportedLanguage,
             isFileInWorkspace: isFileInWorkspace,
             result: result,
             artifactsUploadDuration: artifactsUploadDuration,
@@ -110,6 +112,7 @@ export class TelemetryHelper {
             requestId: requestId,
             reasonDesc: reasonDesc,
             reason: reason,
+            status: status,
         })
     }
 


### PR DESCRIPTION
## Problem
- The current unit test generation telemetry event lacks a field to distinguish between user actions: acceptance, rejection, failure, or cancellation.

## Solution
- Enhancing the amazonq_utgGenerateTests telemetry event by incorporating a status field to capture user actions in toolkit metrics.
- Bumping telemetry version to `1.0.307`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
