### PR TITLE
feat(amazonq): support SAS findings

### DIFF
--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -673,6 +673,10 @@ export const generateFix = Commands.declare(
             if (!targetIssue) {
                 return
             }
+            if (targetIssue.ruleId === CodeWhispererConstants.sasRuleId) {
+                getLogger().warn('GenerateFix is not available for SAS findings.')
+                return
+            }
             await telemetry.codewhisperer_codeScanIssueGenerateFix.run(async () => {
                 try {
                     await vscode.commands

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -334,9 +334,12 @@ export const securityScanLanguageIds = [
     'sh',
     'shell',
     'shellscript',
+    'brazilPackageConfig',
 ] as const
 
 export type SecurityScanLanguageId = (typeof securityScanLanguageIds)[number]
+
+export const sasRuleId = 'sbom-software-assurance-services'
 
 // wait time for editor to update editor.selection.active (in milliseconds)
 export const vsCodeCursorUpdateDelay = 10

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -75,9 +75,10 @@ export async function listScanResults(
         // Project path example: /Users/username/project
         // Key example: project/src/main/java/com/example/App.java
         for (const projectPath of projectPaths) {
-            // We need to remove the project path from the key to get the absolute path to the file
-            // Do not use .. in between because there could be multiple project paths in the same parent dir.
-            const filePath = path.join(projectPath, key.split('/').slice(1).join('/'))
+            // There could be multiple projectPaths with the same parent dir
+            // In that case, make sure to break out of this loop after a filePath is found
+            // or else it might result in duplicate findings.
+            const filePath = path.join(projectPath, '..', key)
             if (existsSync(filePath) && statSync(filePath).isFile()) {
                 const document = await vscode.workspace.openTextDocument(filePath)
                 const aggregatedCodeScanIssue: AggregatedCodeScanIssue = {
@@ -85,6 +86,7 @@ export async function listScanResults(
                     issues: issues.map((issue) => mapRawToCodeScanIssue(issue, document, jobId, scope)),
                 }
                 aggregatedCodeScanIssueList.push(aggregatedCodeScanIssue)
+                break
             }
         }
         const maybeAbsolutePath = `/${key}`

--- a/packages/core/src/codewhisperer/util/securityScanLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/securityScanLanguageContext.ts
@@ -47,6 +47,7 @@ export class SecurityScanLanguageContext {
             sh: 'shell',
             shell: 'shell',
             shellscript: 'shell',
+            brazilPackageConfig: 'plaintext',
         })
     }
 

--- a/packages/core/src/codewhisperer/views/securityIssue/vue/root.vue
+++ b/packages/core/src/codewhisperer/views/securityIssue/vue/root.vue
@@ -80,12 +80,19 @@
             v-if="!isFixAvailable"
             @click="generateFix"
             class="mr-8 button-theme-primary"
-            :disabled="isGenerateFixLoading"
+            :disabled="isGenerateFixLoading || isGenerateFixDisabled"
         >
             Generate Fix
         </button>
         <button v-if="isFixAvailable" @click="applyFix" class="mr-8 button-theme-primary">Accept Fix</button>
-        <button v-if="isFixAvailable" @click="regenerateFix" class="mr-8 button-theme-secondary">Regenerate Fix</button>
+        <button
+            v-if="isFixAvailable"
+            @click="regenerateFix"
+            class="mr-8 button-theme-secondary"
+            :disabled="isGenerateFixDisabled"
+        >
+            Regenerate Fix
+        </button>
         <button @click="explainWithQ" class="mr-8 button-theme-secondary">Explain</button>
         <button @click="ignoreIssue" class="mr-8 button-theme-secondary">Ignore</button>
         <button @click="ignoreAllIssues" class="mr-8 button-theme-secondary">Ignore All</button>
@@ -105,6 +112,7 @@ import markdownIt from 'markdown-it'
 import hljs from 'highlight.js'
 import { parsePatch } from 'diff'
 import { CodeScanIssue } from '../../../models/model'
+import { sasRuleId } from '../../../models/constants'
 
 const client = WebviewClientFactory.create<SecurityIssueWebview>()
 const severityImages: Record<string, string> = {
@@ -198,6 +206,7 @@ export default defineComponent({
             fixedCode: '',
             referenceText: '',
             referenceSpan: [0, 0],
+            isGenerateFixDisabled: false,
         }
     },
     created() {
@@ -278,6 +287,7 @@ export default defineComponent({
             this.endLine = issue.endLine
             this.isFixAvailable = false
             this.isFixDescriptionAvailable = false
+            this.isGenerateFixDisabled = issue.ruleId === sasRuleId
             if (suggestedFix) {
                 this.isFixAvailable = !!suggestedFix.code && suggestedFix.code?.trim() !== ''
                 this.suggestedFix = suggestedFix.code ?? ''

--- a/packages/core/src/shared/utilities/commentUtils.ts
+++ b/packages/core/src/shared/utilities/commentUtils.ts
@@ -47,6 +47,7 @@ const languageCommentConfig: Record<SecurityScanLanguageId, CommentConfig | unde
     sh: { lineComment: '#', blockComment: [": '", "'"] },
     shell: { lineComment: '#', blockComment: [": '", "'"] },
     shellscript: { lineComment: '#', blockComment: [": '", "'"] },
+    brazilPackageConfig: { lineComment: '#' },
 }
 
 export function getLanguageCommentConfig(languageId: string): CommentConfig {


### PR DESCRIPTION
## Problem

Support SAS findings


## Solution

- Enable hover component for `brazilPackageConfig` languageId
- Disable generateFix for SAS findings
- Fixed a bug that caused findings to be duplicated


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
