### PR TITLE
fix(amazonq): remove duplicates from lsp getContextCommandPrompt

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1103,12 +1103,14 @@ export class ChatController {
             const relativePathsOfMergedRelevantDocuments = triggerPayload.documentReferences.map(
                 (doc) => doc.relativeFilePath
             )
+            const seen: string[] = []
             for (const relativePath of relativePathsOfContextCommandFiles) {
-                if (!relativePathsOfMergedRelevantDocuments.includes(relativePath)) {
+                if (!relativePathsOfMergedRelevantDocuments.includes(relativePath) && !seen.includes(relativePath)) {
                     triggerPayload.documentReferences.push({
                         relativeFilePath: relativePath,
                         lineRanges: [{ first: -1, second: -1 }],
                     })
+                    seen.push(relativePath)
                 }
             }
             if (triggerPayload.documentReferences) {


### PR DESCRIPTION
There are two types of context shown in the context list:
1. the ones by explicit @
2. the ones by @workspace 1) has relativePaths with start/end line being -1, 2) has relativePaths with non -1 start/end lines,
1) is doing dedupe with 2) but 1) also needs to dedupe itself

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
