### PR TITLE
test(amazonq): add retries to flaky e2e tests

### DIFF
--- a/packages/amazonq/test/e2e/amazonq/chat.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/chat.test.ts
@@ -14,6 +14,7 @@ import { loginToIdC } from './utils/setup'
 import { webviewConstants, webviewTabConstants } from 'aws-core-vscode/amazonq'
 
 describe('Amazon Q Chat', function () {
+    this.retries(3)
     let framework: qTestingFramework
     let tab: Messenger
     let store: MynahUIDataModel

--- a/packages/amazonq/test/e2e/inline/inline.test.ts
+++ b/packages/amazonq/test/e2e/inline/inline.test.ts
@@ -19,8 +19,10 @@ import { Commands, globals, sleep, waitUntil, collectionUtil } from 'aws-core-vs
 import { loginToIdC } from '../amazonq/utils/setup'
 
 describe('Amazon Q Inline', async function () {
-    let tempFolder: string
     const retries = 3
+    this.retries(retries)
+
+    let tempFolder: string
     const waitOptions = {
         interval: 500,
         timeout: 10000,


### PR DESCRIPTION
## Problem
- The inline tests are flaky when calling the backend and showing the result
- Chat tests are flaky when doing simple 

It's not entirely clear why the chat tests are flaky. They just started being flaky after https://github.com/aws/aws-toolkit-vscode/commit/098941432b044f8c59d9013ba4c6166d67b2a7e7 was merged, which is completely unrelated

## Solution
- Add upto 3 retries

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
