### PR TITLE
deps(apigateway): migrate client to use v3.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,6 +146,530 @@
                 "tslib": "^2.6.2"
             }
         },
+        "node_modules/@aws-sdk/client-api-gateway": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.693.0.tgz",
+            "integrity": "sha512-6Fz0YF4aQc1mrW5rGYYwXGntUDILsIkWgZvUkTDIVT5Hwyz9CmSeKOJCh8oESucEX6/N0UzVWnpW+Z36pElQUQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.693.0",
+                "@aws-sdk/client-sts": "3.693.0",
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/credential-provider-node": "3.693.0",
+                "@aws-sdk/middleware-host-header": "3.693.0",
+                "@aws-sdk/middleware-logger": "3.693.0",
+                "@aws-sdk/middleware-recursion-detection": "3.693.0",
+                "@aws-sdk/middleware-sdk-api-gateway": "3.693.0",
+                "@aws-sdk/middleware-user-agent": "3.693.0",
+                "@aws-sdk/region-config-resolver": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@aws-sdk/util-endpoints": "3.693.0",
+                "@aws-sdk/util-user-agent-browser": "3.693.0",
+                "@aws-sdk/util-user-agent-node": "3.693.0",
+                "@smithy/config-resolver": "^3.0.11",
+                "@smithy/core": "^2.5.2",
+                "@smithy/fetch-http-handler": "^4.1.0",
+                "@smithy/hash-node": "^3.0.9",
+                "@smithy/invalid-dependency": "^3.0.9",
+                "@smithy/middleware-content-length": "^3.0.11",
+                "@smithy/middleware-endpoint": "^3.2.2",
+                "@smithy/middleware-retry": "^3.0.26",
+                "@smithy/middleware-serde": "^3.0.9",
+                "@smithy/middleware-stack": "^3.0.9",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/node-http-handler": "^3.3.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/smithy-client": "^3.4.3",
+                "@smithy/types": "^3.7.0",
+                "@smithy/url-parser": "^3.0.9",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.26",
+                "@smithy/util-defaults-mode-node": "^3.0.26",
+                "@smithy/util-endpoints": "^2.1.5",
+                "@smithy/util-middleware": "^3.0.9",
+                "@smithy/util-retry": "^3.0.9",
+                "@smithy/util-stream": "^3.3.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/client-sso": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.693.0.tgz",
+            "integrity": "sha512-QEynrBC26x6TG9ZMzApR/kZ3lmt4lEIs2D+cHuDxt6fDGzahBUsQFBwJqhizzsM97JJI5YvmJhmihoYjdSSaXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/middleware-host-header": "3.693.0",
+                "@aws-sdk/middleware-logger": "3.693.0",
+                "@aws-sdk/middleware-recursion-detection": "3.693.0",
+                "@aws-sdk/middleware-user-agent": "3.693.0",
+                "@aws-sdk/region-config-resolver": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@aws-sdk/util-endpoints": "3.693.0",
+                "@aws-sdk/util-user-agent-browser": "3.693.0",
+                "@aws-sdk/util-user-agent-node": "3.693.0",
+                "@smithy/config-resolver": "^3.0.11",
+                "@smithy/core": "^2.5.2",
+                "@smithy/fetch-http-handler": "^4.1.0",
+                "@smithy/hash-node": "^3.0.9",
+                "@smithy/invalid-dependency": "^3.0.9",
+                "@smithy/middleware-content-length": "^3.0.11",
+                "@smithy/middleware-endpoint": "^3.2.2",
+                "@smithy/middleware-retry": "^3.0.26",
+                "@smithy/middleware-serde": "^3.0.9",
+                "@smithy/middleware-stack": "^3.0.9",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/node-http-handler": "^3.3.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/smithy-client": "^3.4.3",
+                "@smithy/types": "^3.7.0",
+                "@smithy/url-parser": "^3.0.9",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.26",
+                "@smithy/util-defaults-mode-node": "^3.0.26",
+                "@smithy/util-endpoints": "^2.1.5",
+                "@smithy/util-middleware": "^3.0.9",
+                "@smithy/util-retry": "^3.0.9",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
+            "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/credential-provider-node": "3.693.0",
+                "@aws-sdk/middleware-host-header": "3.693.0",
+                "@aws-sdk/middleware-logger": "3.693.0",
+                "@aws-sdk/middleware-recursion-detection": "3.693.0",
+                "@aws-sdk/middleware-user-agent": "3.693.0",
+                "@aws-sdk/region-config-resolver": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@aws-sdk/util-endpoints": "3.693.0",
+                "@aws-sdk/util-user-agent-browser": "3.693.0",
+                "@aws-sdk/util-user-agent-node": "3.693.0",
+                "@smithy/config-resolver": "^3.0.11",
+                "@smithy/core": "^2.5.2",
+                "@smithy/fetch-http-handler": "^4.1.0",
+                "@smithy/hash-node": "^3.0.9",
+                "@smithy/invalid-dependency": "^3.0.9",
+                "@smithy/middleware-content-length": "^3.0.11",
+                "@smithy/middleware-endpoint": "^3.2.2",
+                "@smithy/middleware-retry": "^3.0.26",
+                "@smithy/middleware-serde": "^3.0.9",
+                "@smithy/middleware-stack": "^3.0.9",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/node-http-handler": "^3.3.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/smithy-client": "^3.4.3",
+                "@smithy/types": "^3.7.0",
+                "@smithy/url-parser": "^3.0.9",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.26",
+                "@smithy/util-defaults-mode-node": "^3.0.26",
+                "@smithy/util-endpoints": "^2.1.5",
+                "@smithy/util-middleware": "^3.0.9",
+                "@smithy/util-retry": "^3.0.9",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.693.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/client-sts": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
+            "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.693.0",
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/credential-provider-node": "3.693.0",
+                "@aws-sdk/middleware-host-header": "3.693.0",
+                "@aws-sdk/middleware-logger": "3.693.0",
+                "@aws-sdk/middleware-recursion-detection": "3.693.0",
+                "@aws-sdk/middleware-user-agent": "3.693.0",
+                "@aws-sdk/region-config-resolver": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@aws-sdk/util-endpoints": "3.693.0",
+                "@aws-sdk/util-user-agent-browser": "3.693.0",
+                "@aws-sdk/util-user-agent-node": "3.693.0",
+                "@smithy/config-resolver": "^3.0.11",
+                "@smithy/core": "^2.5.2",
+                "@smithy/fetch-http-handler": "^4.1.0",
+                "@smithy/hash-node": "^3.0.9",
+                "@smithy/invalid-dependency": "^3.0.9",
+                "@smithy/middleware-content-length": "^3.0.11",
+                "@smithy/middleware-endpoint": "^3.2.2",
+                "@smithy/middleware-retry": "^3.0.26",
+                "@smithy/middleware-serde": "^3.0.9",
+                "@smithy/middleware-stack": "^3.0.9",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/node-http-handler": "^3.3.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/smithy-client": "^3.4.3",
+                "@smithy/types": "^3.7.0",
+                "@smithy/url-parser": "^3.0.9",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.26",
+                "@smithy/util-defaults-mode-node": "^3.0.26",
+                "@smithy/util-endpoints": "^2.1.5",
+                "@smithy/util-middleware": "^3.0.9",
+                "@smithy/util-retry": "^3.0.9",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/core": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.693.0.tgz",
+            "integrity": "sha512-v6Z/kWmLFqRLDPEwl9hJGhtTgIFHjZugSfF1Yqffdxf4n1AWgtHS7qSegakuMyN5pP4K2tvUD8qHJ+gGe2Bw2A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/core": "^2.5.2",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/property-provider": "^3.1.9",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/signature-v4": "^4.2.2",
+                "@smithy/smithy-client": "^3.4.3",
+                "@smithy/types": "^3.7.0",
+                "@smithy/util-middleware": "^3.0.9",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.693.0.tgz",
+            "integrity": "sha512-sL8MvwNJU7ZpD7/d2VVb3by1GknIJUxzTIgYtVkDVA/ojo+KRQSSHxcj0EWWXF5DTSh2Tm+LrEug3y1ZyKHsDA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/fetch-http-handler": "^4.1.0",
+                "@smithy/node-http-handler": "^3.3.0",
+                "@smithy/property-provider": "^3.1.9",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/smithy-client": "^3.4.3",
+                "@smithy/types": "^3.7.0",
+                "@smithy/util-stream": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.693.0.tgz",
+            "integrity": "sha512-kvaa4mXhCCOuW7UQnBhYqYfgWmwy7WSBSDClutwSLPZvgrhYj2l16SD2lN4IfYdxARYMJJ1lFYp3/jJG/9Yk4Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/credential-provider-env": "3.693.0",
+                "@aws-sdk/credential-provider-http": "3.693.0",
+                "@aws-sdk/credential-provider-process": "3.693.0",
+                "@aws-sdk/credential-provider-sso": "3.693.0",
+                "@aws-sdk/credential-provider-web-identity": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/credential-provider-imds": "^3.2.6",
+                "@smithy/property-provider": "^3.1.9",
+                "@smithy/shared-ini-file-loader": "^3.1.10",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.693.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.693.0.tgz",
+            "integrity": "sha512-42WMsBjTNnjYxYuM3qD/Nq+8b7UdMopUq5OduMDxoM3mFTV6PXMMnfI4Z1TNnR4tYRvPXAnuNltF6xmjKbSJRA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.693.0",
+                "@aws-sdk/credential-provider-http": "3.693.0",
+                "@aws-sdk/credential-provider-ini": "3.693.0",
+                "@aws-sdk/credential-provider-process": "3.693.0",
+                "@aws-sdk/credential-provider-sso": "3.693.0",
+                "@aws-sdk/credential-provider-web-identity": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/credential-provider-imds": "^3.2.6",
+                "@smithy/property-provider": "^3.1.9",
+                "@smithy/shared-ini-file-loader": "^3.1.10",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.693.0.tgz",
+            "integrity": "sha512-479UlJxY+BFjj3pJFYUNC0DCMrykuG7wBAXfsvZqQxKUa83DnH5Q1ID/N2hZLkxjGd4ZW0AC3lTOMxFelGzzpQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.693.0",
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/token-providers": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/property-provider": "^3.1.9",
+                "@smithy/shared-ini-file-loader": "^3.1.10",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.693.0.tgz",
+            "integrity": "sha512-8LB210Pr6VeCiSb2hIra+sAH4KUBLyGaN50axHtIgufVK8jbKIctTZcVY5TO9Se+1107TsruzeXS7VeqVdJfFA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/property-provider": "^3.1.9",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.693.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.693.0.tgz",
+            "integrity": "sha512-BCki6sAZ5jYwIN/t3ElCiwerHad69ipHwPsDCxJQyeiOnJ8HG+lEpnVIfrnI8A0fLQNSF3Gtx6ahfBpKiv1Oug==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.693.0.tgz",
+            "integrity": "sha512-dXnXDPr+wIiJ1TLADACI1g9pkSB21KkMIko2u4CJ2JCBoxi5IqeTnVoa6YcC8GdFNVRl+PorZ3Zqfmf1EOTC6w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.693.0.tgz",
+            "integrity": "sha512-0LDmM+VxXp0u3rG0xQRWD/q6Ubi7G8I44tBPahevD5CaiDZTkmNTrVUf0VEJgVe0iCKBppACMBDkLB0/ETqkFw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.693.0.tgz",
+            "integrity": "sha512-/KUq/KEpFFbQmNmpp7SpAtFAdViquDfD2W0QcG07zYBfz9MwE2ig48ALynXm5sMpRmnG7sJXjdvPtTsSVPfkiw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@aws-sdk/util-endpoints": "3.693.0",
+                "@smithy/core": "^2.5.2",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.693.0.tgz",
+            "integrity": "sha512-YLUkMsUY0GLW/nfwlZ69cy1u07EZRmsv8Z9m0qW317/EZaVx59hcvmcvb+W4bFqj5E8YImTjoGfE4cZ0F9mkyw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/types": "^3.7.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.9",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/token-providers": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.693.0.tgz",
+            "integrity": "sha512-nDBTJMk1l/YmFULGfRbToOA2wjf+FkQT4dMgYCv+V9uSYsMzQj8A7Tha2dz9yv4vnQgYaEiErQ8d7HVyXcVEoA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/property-provider": "^3.1.9",
+                "@smithy/shared-ini-file-loader": "^3.1.10",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sso-oidc": "^3.693.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.693.0.tgz",
+            "integrity": "sha512-eo4F6DRQ/kxS3gxJpLRv+aDNy76DxQJL5B3DPzpr9Vkq0ygVoi4GT5oIZLVaAVIJmi6k5qq9dLsYZfWLUxJJSg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/types": "^3.7.0",
+                "@smithy/util-endpoints": "^2.1.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.693.0.tgz",
+            "integrity": "sha512-6EUfuKOujtddy18OLJUaXfKBgs+UcbZ6N/3QV4iOkubCUdeM1maIqs++B9bhCbWeaeF5ORizJw5FTwnyNjE/mw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/types": "^3.7.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.693.0.tgz",
+            "integrity": "sha512-td0OVX8m5ZKiXtecIDuzY3Y3UZIzvxEr57Hp21NOwieqKCG2UeyQWWeGPv0FQaU7dpTkvFmVNI+tx9iB8V/Nhg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/types": "^3.7.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@smithy/is-array-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+            "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-api-gateway/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-cloudformation": {
             "version": "3.682.0",
             "license": "Apache-2.0",
@@ -4340,6 +4864,21 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-api-gateway": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.693.0.tgz",
+            "integrity": "sha512-SvvrnN1+hC0DmXBA/QA9aEEgf0+YIsGuydX43y3gej0wQGF6jrdMyOoBumKCmOmvnOqbDSrBCW9RhdLVPauQJw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.692.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/types": "^3.7.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -18667,6 +19206,7 @@
             "dependencies": {
                 "@amzn/amazon-q-developer-streaming-client": "file:../../src.gen/@amzn/amazon-q-developer-streaming-client",
                 "@amzn/codewhisperer-streaming": "file:../../src.gen/@amzn/codewhisperer-streaming",
+                "@aws-sdk/client-api-gateway": "<3.696.0",
                 "@aws-sdk/client-cloudformation": "<3.696.0",
                 "@aws-sdk/client-cloudwatch-logs": "<3.696.0",
                 "@aws-sdk/client-cognito-identity": "<3.696.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -504,6 +504,7 @@
         "@aws-sdk/client-ec2": "<3.696.0",
         "@aws-sdk/client-iam": "<3.696.0",
         "@aws-sdk/client-s3": "<3.696.0",
+        "@aws-sdk/client-api-gateway": "<3.696.0",
         "@aws-sdk/lib-storage": "<3.696.0",
         "@aws-sdk/client-lambda": "<3.696.0",
         "@aws-sdk/client-ssm": "<3.696.0",

--- a/packages/core/src/awsService/apigateway/commands/copyUrl.ts
+++ b/packages/core/src/awsService/apigateway/commands/copyUrl.ts
@@ -12,7 +12,7 @@ import * as vscode from 'vscode'
 import { ProgressLocation } from 'vscode'
 
 import { Stage } from 'aws-sdk/clients/apigateway'
-import { DefaultApiGatewayClient } from '../../../shared/clients/apiGatewayClient'
+import { ApiGatewayClient } from '../../../shared/clients/apiGateway'
 import { defaultDnsSuffix, RegionProvider } from '../../../shared/regions/regionProvider'
 import { getLogger } from '../../../shared/logger/logger'
 import { telemetry } from '../../../shared/telemetry/telemetry'
@@ -25,7 +25,7 @@ interface StageInvokeUrlQuickPick extends vscode.QuickPickItem {
 export async function copyUrlCommand(node: RestApiNode, regionProvider: RegionProvider): Promise<void> {
     const region = node.regionCode
     const dnsSuffix = regionProvider.getDnsSuffixForRegion(region) || defaultDnsSuffix
-    const client = new DefaultApiGatewayClient(region)
+    const client = new ApiGatewayClient(region)
 
     let stages: Stage[]
     try {

--- a/packages/core/src/awsService/apigateway/explorer/apiGatewayNodes.ts
+++ b/packages/core/src/awsService/apigateway/explorer/apiGatewayNodes.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode'
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { compareTreeItems, makeChildrenNodes } from '../../../shared/treeview/utils'
-import { DefaultApiGatewayClient } from '../../../shared/clients/apiGatewayClient'
+import { ApiGatewayClient } from '../../../shared/clients/apiGateway'
 import { RestApi } from 'aws-sdk/clients/apigateway'
 import { toArrayAsync, toMap, updateInPlace } from '../../../shared/utilities/collectionUtils'
 import { RestApiNode } from './apiNodes'
@@ -25,7 +25,7 @@ export class ApiGatewayNode extends AWSTreeNodeBase {
     public constructor(
         private readonly partitionId: string,
         public override readonly regionCode: string,
-        private readonly client = new DefaultApiGatewayClient(regionCode)
+        private readonly client = new ApiGatewayClient(regionCode)
     ) {
         super('API Gateway', vscode.TreeItemCollapsibleState.Collapsed)
         this.apiNodes = new Map<string, RestApiNode>()

--- a/packages/core/src/awsService/apigateway/vue/invokeRemoteRestApi.ts
+++ b/packages/core/src/awsService/apigateway/vue/invokeRemoteRestApi.ts
@@ -13,7 +13,7 @@ import { localize } from '../../../shared/utilities/vsCodeUtils'
 import { Result } from '../../../shared/telemetry/telemetry'
 import { VueWebview } from '../../../webviews/main'
 import { ExtContext } from '../../../shared/extensions'
-import { DefaultApiGatewayClient } from '../../../shared/clients/apiGatewayClient'
+import { ApiGatewayClient } from '../../../shared/clients/apiGateway'
 import { telemetry } from '../../../shared/telemetry/telemetry'
 
 interface InvokeApiMessage {
@@ -50,7 +50,7 @@ export class RemoteRestInvokeWebview extends VueWebview {
     public constructor(
         private readonly data: InvokeRemoteRestApiInitialData,
         private readonly channel: vscode.OutputChannel,
-        private readonly client = new DefaultApiGatewayClient(data.Region)
+        private readonly client = new ApiGatewayClient(data.Region)
     ) {
         super(RemoteRestInvokeWebview.sourcePath)
     }
@@ -115,7 +115,7 @@ export async function invokeRemoteRestApi(
     const logger: Logger = getLogger()
 
     try {
-        const client = new DefaultApiGatewayClient(params.apiNode.regionCode)
+        const client = new ApiGatewayClient(params.apiNode.regionCode)
         logger.info(`Loading API Resources for API ${params.apiNode.name} (id: ${params.apiNode.id})`)
         const resources = (await toArrayAsync(client.getResourcesForApi(params.apiNode.id)))
             .sort((a, b) => a.path!.localeCompare(b.path!))

--- a/packages/core/src/shared/clients/apiGateway.ts
+++ b/packages/core/src/shared/clients/apiGateway.ts
@@ -2,19 +2,19 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { APIGateway } from 'aws-sdk'
-import { RestApi, Stages } from 'aws-sdk/clients/apigateway'
 import { ClientWrapper } from './clientWrapper'
 import {
     APIGatewayClient as ApiGatewayClientSDK,
     GetResourcesCommand,
     GetResourcesRequest,
     GetRestApisCommand,
+    GetRestApisRequest,
     GetStagesCommand,
     Resource,
     Resources,
+    RestApi,
     RestApis,
+    Stages,
     TestInvokeMethodCommand,
     TestInvokeMethodRequest,
     TestInvokeMethodResponse,
@@ -48,7 +48,7 @@ export class ApiGatewayClient extends ClientWrapper<ApiGatewayClientSDK> {
     }
 
     public async *listApis(): AsyncIterableIterator<RestApi> {
-        const request: APIGateway.GetRestApisRequest = {}
+        const request: GetRestApisRequest = {}
 
         do {
             const response: RestApis = await this.makeRequest(GetRestApisCommand, request)

--- a/packages/core/src/shared/clients/apiGateway.ts
+++ b/packages/core/src/shared/clients/apiGateway.ts
@@ -6,10 +6,8 @@
 import { APIGateway } from 'aws-sdk'
 import { RestApi, Stages } from 'aws-sdk/clients/apigateway'
 import globals from '../extensionGlobals'
-import { ClassToInterfaceType } from '../utilities/tsUtils'
 
-export type ApiGatewayClient = ClassToInterfaceType<DefaultApiGatewayClient>
-export class DefaultApiGatewayClient {
+export class ApiGatewayClient {
     public constructor(public readonly regionCode: string) {}
 
     public async *getResourcesForApi(apiId: string): AsyncIterableIterator<APIGateway.Resource> {

--- a/packages/core/src/test/awsService/apigateway/explorer/apiGatewayNodes.test.ts
+++ b/packages/core/src/test/awsService/apigateway/explorer/apiGatewayNodes.test.ts
@@ -11,7 +11,7 @@ import {
 import { asyncGenerator } from '../../../../shared/utilities/collectionUtils'
 import { ApiGatewayNode } from '../../../../awsService/apigateway/explorer/apiGatewayNodes'
 import { RestApiNode } from '../../../../awsService/apigateway/explorer/apiNodes'
-import { DefaultApiGatewayClient } from '../../../../shared/clients/apiGatewayClient'
+import { ApiGatewayClient } from '../../../../shared/clients/apiGateway'
 import { stub } from '../../../utilities/stubber'
 
 const fakePartitionId = 'aws'
@@ -37,7 +37,7 @@ describe('ApiGatewayNode', function () {
     let apiNames: { name: string; id: string }[]
 
     function createClient() {
-        const client = stub(DefaultApiGatewayClient, { regionCode: fakeRegionCode })
+        const client = stub(ApiGatewayClient, { regionCode: fakeRegionCode })
         client.listApis.callsFake(() => asyncGenerator(apiNames))
 
         return client


### PR DESCRIPTION
## Problem
client still uses v2.

## Solution
- Very straightforward migration, mostly exchanging types. 

## Verification
- Create a simple APIGateway that redirects to a GET request to this repo's homepage. 
- Use the invoke method from the IDE.
- Copy ARN, name, and URL. 


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
