### PR TITLE
feat(timeout): make retryOnFail as always a function

### DIFF
--- a/packages/amazonq/test/e2e/inline/inline.test.ts
+++ b/packages/amazonq/test/e2e/inline/inline.test.ts
@@ -24,7 +24,7 @@ describe('Amazon Q Inline', async function () {
     const waitOptions = {
         interval: 500,
         timeout: 10000,
-        retryOnFail: false,
+        retryOnFail: () => true,
     }
 
     before(async function () {

--- a/packages/core/src/notifications/controller.ts
+++ b/packages/core/src/notifications/controller.ts
@@ -298,7 +298,7 @@ export class RemoteFetcher implements NotificationFetcher {
             {
                 interval: RemoteFetcher.retryIntervalMs,
                 timeout: RemoteFetcher.retryTimeout,
-                retryOnFail: true,
+                retryOnFail: () => true,
                 // No exponential backoff - necessary?
             }
         )

--- a/packages/core/src/shared/crashMonitoring.ts
+++ b/packages/core/src/shared/crashMonitoring.ts
@@ -492,7 +492,7 @@ export class FileSystemState {
                 timeout: 15_000,
                 interval: 100,
                 backoff: 2,
-                retryOnFail: true,
+                retryOnFail: () => true,
             })
 
             return funcWithRetries
@@ -550,7 +550,7 @@ export class FileSystemState {
             timeout: 15_000,
             interval: 100,
             backoff: 2,
-            retryOnFail: true,
+            retryOnFail: () => true,
         })
         await funcWithRetries
     }
@@ -618,7 +618,12 @@ export class FileSystemState {
                 }
                 const funcWithIgnoreBadFile = () => ignoreBadFileError(loadExtFromDisk)
                 const funcWithRetries = () =>
-                    waitUntil(funcWithIgnoreBadFile, { timeout: 15_000, interval: 100, backoff: 2, retryOnFail: true })
+                    waitUntil(funcWithIgnoreBadFile, {
+                        timeout: 15_000,
+                        interval: 100,
+                        backoff: 2,
+                        retryOnFail: () => true,
+                    })
                 const funcWithCtx = () => withFailCtx('parseRunningExtFile', funcWithRetries)
                 const ext: ExtInstanceHeartbeat | undefined = await funcWithCtx()
 

--- a/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -120,9 +120,9 @@ export class HttpResourceFetcher implements ResourceFetcher<Response> {
                 timeout: 3000,
                 interval: 100,
                 backoff: 2,
-                retryOnFail: (error: Error) => {
-                    // Retry unless the user intentionally canceled the operation.
-                    return !isUserCancelledError(error)
+                retryOnFail: (error: Error | undefined) => {
+                    // Only stops retry when the user intentionally canceled the operation.
+                    return error ? !isUserCancelledError(error) : true
                 },
             }
         )

--- a/packages/core/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/timeoutUtils.test.ts
@@ -400,8 +400,8 @@ export const timeoutUtilsDescribe = describe('timeoutUtils', async function () {
             fn.onCall(2).resolves('success')
 
             const res = waitUntil(fn, {
-                retryOnFail: (error: Error) => {
-                    return error.message === 'Retry error'
+                retryOnFail: (error) => {
+                    return error ? error.message === 'Retry error' : false
                 },
             })
 
@@ -420,8 +420,8 @@ export const timeoutUtilsDescribe = describe('timeoutUtils', async function () {
 
             const res = assert.rejects(
                 waitUntil(fn, {
-                    retryOnFail: (error: Error) => {
-                        return error.message === 'Retry error'
+                    retryOnFail: (error) => {
+                        return error ? error.message === 'Retry error' : true
                     },
                 }),
                 (e) => e instanceof Error && e.message === 'Last error'
@@ -439,7 +439,7 @@ export const timeoutUtilsDescribe = describe('timeoutUtils', async function () {
             fn.onCall(1).throws()
             fn.onCall(2).resolves('success')
 
-            const res = waitUntil(fn, { retryOnFail: true })
+            const res = waitUntil(fn, { retryOnFail: () => true })
 
             await clock.tickAsync(timeoutUtils.waitUntilDefaultInterval)
             assert.strictEqual(fn.callCount, 2)
@@ -450,7 +450,7 @@ export const timeoutUtilsDescribe = describe('timeoutUtils', async function () {
 
         it('retryOnFail ignores truthiness', async function () {
             fn.resolves(false)
-            const res = waitUntil(fn, { retryOnFail: true, truthy: true })
+            const res = waitUntil(fn, { retryOnFail: () => true, truthy: true })
             assert.strictEqual(await res, false)
         })
 
@@ -466,7 +466,7 @@ export const timeoutUtilsDescribe = describe('timeoutUtils', async function () {
             // We must wrap w/ assert.rejects() here instead of at the end, otherwise Mocha raise a
             // `rejected promise not handled within 1 second: Error: last`
             const res = assert.rejects(
-                waitUntil(fn, { retryOnFail: true }),
+                waitUntil(fn, { retryOnFail: () => true }),
                 (e) => e instanceof Error && e.message === 'last'
             )
 
@@ -488,7 +488,7 @@ export const timeoutUtilsDescribe = describe('timeoutUtils', async function () {
 
             // Note 701 instead of 700 for timeout. The 1 millisecond allows the final call to execute
             // since the timeout condition is >= instead of >
-            const res = waitUntil(fn, { timeout: 701, interval: 100, backoff: 2, retryOnFail: true })
+            const res = waitUntil(fn, { timeout: 701, interval: 100, backoff: 2, retryOnFail: () => true })
 
             // Check the call count after each iteration, ensuring the function is called
             // after the correct delay between retries.


### PR DESCRIPTION
## Problem
Follow up from [this change](https://github.com/aws/aws-toolkit-vscode/pull/6573#discussion_r1974238222)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
