### PR TITLE
fix(amazonq): increase scan timeout threshold

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-4f680a31-ba5e-4baa-9984-666e0c1c2b72.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-4f680a31-ba5e-4baa-9984-666e0c1c2b72.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "increase scan timeout to reduce front-end timeout errors"
+}

--- a/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/securityScanHandler.test.ts
@@ -15,6 +15,7 @@ import {
     ListCodeScanFindingsResponse,
     pollScanJobStatus,
     SecurityScanTimedOutError,
+    CodeWhispererConstants,
 } from 'aws-core-vscode/codewhisperer'
 import { timeoutUtils } from 'aws-core-vscode/shared'
 import assert from 'assert'
@@ -303,7 +304,7 @@ describe('securityScanHandler', function () {
 
             const pollPromise = pollScanJobStatus(mockClient, mockJobId, CodeAnalysisScope.FILE_AUTO, mockStartTime)
 
-            const expectedTimeoutMs = 60_000
+            const expectedTimeoutMs = CodeWhispererConstants.expressScanTimeoutMs
             clock.tick(expectedTimeoutMs + 1000)
 
             await assert.rejects(() => pollPromise, SecurityScanTimedOutError)
@@ -314,7 +315,7 @@ describe('securityScanHandler', function () {
 
             const pollPromise = pollScanJobStatus(mockClient, mockJobId, CodeAnalysisScope.PROJECT, mockStartTime)
 
-            const expectedTimeoutMs = 600_000
+            const expectedTimeoutMs = CodeWhispererConstants.standardScanTimeoutMs
             clock.tick(expectedTimeoutMs + 1000)
 
             await assert.rejects(() => pollPromise, SecurityScanTimedOutError)

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -261,7 +261,7 @@ export const codeScanZipExt = '.zip'
 
 export const contextTruncationTimeoutSeconds = 10
 
-export const standardScanTimeoutMs = 600_000 // 10 minutes
+export const standardScanTimeoutMs = 900_000 // 15 minutes
 
 export const expressScanTimeoutMs = 60_000
 


### PR DESCRIPTION
## Problem
- we are getting quite a noteworthy amount of scan timeout errors on the front end. 

## Solution
- increase front-end timeout

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
