### PR TITLE
fix(lambda): making metric change for serverless land

### DIFF
--- a/packages/core/src/awsService/appBuilder/serverlessLand/main.ts
+++ b/packages/core/src/awsService/appBuilder/serverlessLand/main.ts
@@ -57,7 +57,7 @@ export async function createNewServerlessLandProject(extContext: ExtContext): Pr
             true
         )
         telemetry.record({
-            templateName: assetName,
+            templateName: config.pattern,
             runtimeString: config.runtime,
             iac: config.iac,
         })


### PR DESCRIPTION
## Problem
Earlier we recorded the pattern name based on the asset name, which resulted in multiple records for the same template. This occurred because the asset name included the runtime name as well.

## Solution
Modified the metric recording process to capture the pattern name, which remains consistent across runtimes. This approach ensures there is a single entry for each pattern, regardless of the runtime utilized. The runtime information is recorded separately.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
