### PR TITLE
fix(amazonq): Fixed a bug where issues are double counted in the Q chat

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-a24316fe-1ff9-44e4-9d5c-6b78aa7f0d1e.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-a24316fe-1ff9-44e4-9d5c-6b78aa7f0d1e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Code Review: Fixed a bug where issues are double counted in the Q chat"
+}

--- a/packages/core/src/codewhisperer/service/securityScanHandler.ts
+++ b/packages/core/src/codewhisperer/service/securityScanHandler.ts
@@ -74,11 +74,13 @@ export async function listScanResults(
     for (const [key, issues] of codeScanIssueMap.entries()) {
         // Project path example: /Users/username/project
         // Key example: project/src/main/java/com/example/App.java
+        const mappedProjectPaths: Set<string> = new Set()
         for (const projectPath of projectPaths) {
             // We need to remove the project path from the key to get the absolute path to the file
             // Do not use .. in between because there could be multiple project paths in the same parent dir.
             const filePath = path.join(projectPath, key.split('/').slice(1).join('/'))
             if (existsSync(filePath) && statSync(filePath).isFile()) {
+                mappedProjectPaths.add(filePath)
                 const document = await vscode.workspace.openTextDocument(filePath)
                 const aggregatedCodeScanIssue: AggregatedCodeScanIssue = {
                     filePath: filePath,
@@ -88,7 +90,11 @@ export async function listScanResults(
             }
         }
         const maybeAbsolutePath = `/${key}`
-        if (existsSync(maybeAbsolutePath) && statSync(maybeAbsolutePath).isFile()) {
+        if (
+            !mappedProjectPaths.has(maybeAbsolutePath) &&
+            existsSync(maybeAbsolutePath) &&
+            statSync(maybeAbsolutePath).isFile()
+        ) {
             const document = await vscode.workspace.openTextDocument(maybeAbsolutePath)
             const aggregatedCodeScanIssue: AggregatedCodeScanIssue = {
                 filePath: maybeAbsolutePath,


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
