### PR TITLE
feat(amazonq): client-side build support

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-73d53c1b-6a88-448a-a4a3-144e99bd95e6.json
+++ b/packages/amazonq/.changes/next-release/Feature-73d53c1b-6a88-448a-a4a3-144e99bd95e6.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "/transform: run all builds client-side instead of server-side"
-}

--- a/packages/amazonq/.changes/next-release/Feature-73d53c1b-6a88-448a-a4a3-144e99bd95e6.json
+++ b/packages/amazonq/.changes/next-release/Feature-73d53c1b-6a88-448a-a4a3-144e99bd95e6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "/transform: run all builds client-side instead of server-side"
+}

--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -150,6 +150,8 @@ describe('Amazon Q Code Transformation', function () {
                 waitIntervalInMs: 1000,
             })
 
+            // Add this back when custom 1P upgrades support is ready
+            /*
             const customDependencyVersionPrompt = tab.getChatItems().pop()
             assert.strictEqual(
                 customDependencyVersionPrompt?.body?.includes('You can optionally upload a YAML file'),
@@ -162,13 +164,15 @@ describe('Amazon Q Code Transformation', function () {
                 waitTimeoutInMs: 5000,
                 waitIntervalInMs: 1000,
             })
+            */
 
             const sourceJdkPathPrompt = tab.getChatItems().pop()
             assert.strictEqual(sourceJdkPathPrompt?.body?.includes('Enter the path to JDK 8'), true)
 
             tab.addChatMessage({ prompt: '/dummy/path/to/jdk8' })
+
             // 2 additional chat messages get sent after JDK path submitted; wait for both of them
-            await tab.waitForEvent(() => tab.getChatItems().length > 15, {
+            await tab.waitForEvent(() => tab.getChatItems().length > 13, {
                 waitTimeoutInMs: 5000,
                 waitIntervalInMs: 1000,
             })
@@ -190,7 +194,7 @@ describe('Amazon Q Code Transformation', function () {
                 text: 'View summary',
             })
 
-            await tab.waitForEvent(() => tab.getChatItems().length > 16, {
+            await tab.waitForEvent(() => tab.getChatItems().length > 14, {
                 waitTimeoutInMs: 5000,
                 waitIntervalInMs: 1000,
             })

--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -418,7 +418,7 @@ describe('Amazon Q Code Transformation', function () {
 
         it('WHEN transforming a Java 8 project E2E THEN job is successful', async function () {
             transformByQState.setTransformationType(TransformationType.LANGUAGE_UPGRADE)
-            await setMaven()
+            setMaven()
             await startTransformByQ.processLanguageUpgradeTransformFormInput(tempDir, JDKVersion.JDK8, JDKVersion.JDK17)
             await startTransformByQ.startTransformByQ()
             assert.strictEqual(transformByQState.getPolledJobStatus(), 'COMPLETED')

--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -150,7 +150,7 @@ describe('Amazon Q Code Transformation', function () {
                 waitIntervalInMs: 1000,
             })
 
-            // Add this back when custom 1P upgrades support is ready
+            // TO-DO: add this back when releasing CSB
             /*
             const customDependencyVersionPrompt = tab.getChatItems().pop()
             assert.strictEqual(

--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -75,6 +75,9 @@ describe('Amazon Q Code Transformation', function () {
                 },
             ])
 
+            transformByQState.setSourceJDKVersion(JDKVersion.JDK8)
+            transformByQState.setTargetJDKVersion(JDKVersion.JDK17)
+
             tab.addChatMessage({ command: '/transform' })
 
             // wait for /transform to respond with some intro messages and the first user input form
@@ -141,17 +144,31 @@ describe('Amazon Q Code Transformation', function () {
                 formItemValues: oneOrMultipleDiffsFormValues,
             })
 
-            // 2 additional chat messages (including message with 4th form) get sent after 3rd form submitted; wait for both of them
+            // 2 additional chat messages get sent after 3rd form submitted; wait for both of them
             await tab.waitForEvent(() => tab.getChatItems().length > 11, {
                 waitTimeoutInMs: 5000,
                 waitIntervalInMs: 1000,
             })
-            const jdkPathPrompt = tab.getChatItems().pop()
-            assert.strictEqual(jdkPathPrompt?.body?.includes('Enter the path to JDK'), true)
 
-            // 2 additional chat messages get sent after 4th form submitted; wait for both of them
-            tab.addChatMessage({ prompt: '/dummy/path/to/jdk8' })
+            const customDependencyVersionPrompt = tab.getChatItems().pop()
+            assert.strictEqual(
+                customDependencyVersionPrompt?.body?.includes('You can optionally upload a YAML file'),
+                true
+            )
+            tab.clickCustomFormButton({ id: 'gumbyTransformFormContinue' })
+
+            // 2 additional chat messages get sent after Continue button clicked; wait for both of them
             await tab.waitForEvent(() => tab.getChatItems().length > 13, {
+                waitTimeoutInMs: 5000,
+                waitIntervalInMs: 1000,
+            })
+
+            const sourceJdkPathPrompt = tab.getChatItems().pop()
+            assert.strictEqual(sourceJdkPathPrompt?.body?.includes('Enter the path to JDK 8'), true)
+
+            tab.addChatMessage({ prompt: '/dummy/path/to/jdk8' })
+            // 2 additional chat messages get sent after JDK path submitted; wait for both of them
+            await tab.waitForEvent(() => tab.getChatItems().length > 15, {
                 waitTimeoutInMs: 5000,
                 waitIntervalInMs: 1000,
             })
@@ -173,7 +190,7 @@ describe('Amazon Q Code Transformation', function () {
                 text: 'View summary',
             })
 
-            await tab.waitForEvent(() => tab.getChatItems().length > 14, {
+            await tab.waitForEvent(() => tab.getChatItems().length > 16, {
                 waitTimeoutInMs: 5000,
                 waitIntervalInMs: 1000,
             })

--- a/packages/amazonq/test/unit/amazonqGumby/transformApiHandler.test.ts
+++ b/packages/amazonq/test/unit/amazonqGumby/transformApiHandler.test.ts
@@ -6,6 +6,7 @@ import assert from 'assert'
 import {
     TransformationProgressUpdate,
     TransformationStep,
+    findDownloadArtifactProgressUpdate,
     findDownloadArtifactStep,
     getArtifactsFromProgressUpdate,
 } from 'aws-core-vscode/codewhisperer/node'
@@ -92,6 +93,68 @@ describe('Amazon Q Transform - transformApiHandler tests', function () {
             const { transformationStep, progressUpdate } = findDownloadArtifactStep(transformationStepsFixture)
 
             assert.strictEqual(transformationStep, undefined)
+            assert.strictEqual(progressUpdate, undefined)
+        })
+    })
+
+    describe('findDownloadArtifactProgressUpdate', function () {
+        it('will return correct progress update from transformationStep', function () {
+            const transformationStepsFixture: TransformationStep[] = [
+                {
+                    id: 'dummy-id',
+                    name: 'Step name',
+                    description: 'Step description',
+                    status: 'TRANSFORMING',
+                    progressUpdates: [
+                        {
+                            name: 'Progress update name',
+                            status: 'AWAITING_CLIENT_ACTION',
+                            description: 'Client-side build happening now',
+                            startTime: new Date(),
+                            endTime: new Date(),
+                            downloadArtifacts: [
+                                {
+                                    downloadArtifactId: 'some-download-artifact-id',
+                                    downloadArtifactType: 'some-download-artifact-type',
+                                },
+                            ],
+                        },
+                    ],
+                    startTime: new Date(),
+                    endTime: new Date(),
+                },
+            ]
+            const progressUpdate = findDownloadArtifactProgressUpdate(transformationStepsFixture)
+            assert.strictEqual(progressUpdate, transformationStepsFixture[0].progressUpdates?.[0])
+        })
+
+        it('will return undefined if step status is NOT AWAITING_CLIENT_ACTION', function () {
+            const transformationStepsFixture: TransformationStep[] = [
+                {
+                    id: 'dummy-id',
+                    name: 'Step name',
+                    description: 'Step description',
+                    status: 'TRANSFORMING',
+                    progressUpdates: [
+                        {
+                            name: 'Progress update name',
+                            status: 'SOMETHING-BESIDES-AWAITING_CLIENT_ACTION',
+                            description: 'Progress update description',
+                            startTime: new Date(),
+                            endTime: new Date(),
+                            downloadArtifacts: [
+                                {
+                                    downloadArtifactId: 'some-download-artifact-id',
+                                    downloadArtifactType: 'some-download-artifact-type',
+                                },
+                            ],
+                        },
+                    ],
+                    startTime: new Date(),
+                    endTime: new Date(),
+                },
+            ]
+            const progressUpdate = findDownloadArtifactProgressUpdate(transformationStepsFixture)
             assert.strictEqual(progressUpdate, undefined)
         })
     })

--- a/packages/amazonq/test/unit/amazonqGumby/transformApiHandler.test.ts
+++ b/packages/amazonq/test/unit/amazonqGumby/transformApiHandler.test.ts
@@ -131,27 +131,16 @@ describe('Amazon Q Transform - transformApiHandler tests', function () {
         it('will return undefined if step status is NOT AWAITING_CLIENT_ACTION', function () {
             const transformationStepsFixture: TransformationStep[] = [
                 {
-                    id: 'dummy-id',
-                    name: 'Step name',
-                    description: 'Step description',
+                    id: 'random-id',
+                    name: 'not-awaiting-client-action step name',
+                    description: 'not-awaiting-client-action step description',
                     status: 'TRANSFORMING',
                     progressUpdates: [
                         {
-                            name: 'Progress update name',
+                            name: 'some progress update name',
                             status: 'SOMETHING-BESIDES-AWAITING_CLIENT_ACTION',
-                            description: 'Progress update description',
-                            startTime: new Date(),
-                            endTime: new Date(),
-                            downloadArtifacts: [
-                                {
-                                    downloadArtifactId: 'some-download-artifact-id',
-                                    downloadArtifactType: 'some-download-artifact-type',
-                                },
-                            ],
                         },
                     ],
-                    startTime: new Date(),
-                    endTime: new Date(),
                 },
             ]
             const progressUpdate = findDownloadArtifactProgressUpdate(transformationStepsFixture)

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -386,6 +386,7 @@ export class GumbyController {
                 break
             case ButtonActions.CONTINUE_TRANSFORMATION_FORM:
                 this.messenger.sendMessage('Ok, I will continue without this information.', message.tabID, 'ai-prompt')
+                transformByQState.setCustomDependencyVersionFilePath('')
                 this.promptJavaHome('source', message.tabID)
                 break
             case ButtonActions.VIEW_TRANSFORMATION_HUB:
@@ -453,7 +454,7 @@ export class GumbyController {
             })
 
             this.messenger.sendOneOrMultipleDiffsMessage(oneOrMultipleDiffsSelection, message.tabID)
-            this.messenger.sendCustomDependencyVersionSelectionMessage(message.tabID)
+            await this.messenger.sendCustomDependencyVersionMessage(message.tabID)
         })
     }
 

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -387,7 +387,11 @@ export class GumbyController {
                 await this.processCustomDependencyVersionFile(message)
                 break
             case ButtonActions.CONTINUE_TRANSFORMATION_FORM:
-                this.messenger.sendMessage('Ok, I will continue without this information.', message.tabID, 'ai-prompt')
+                this.messenger.sendMessage(
+                    CodeWhispererConstants.continueWithoutYamlMessage,
+                    message.tabID,
+                    'ai-prompt'
+                )
                 transformByQState.setCustomDependencyVersionFilePath('')
                 this.promptJavaHome('source', message.tabID)
                 break
@@ -459,7 +463,9 @@ export class GumbyController {
             })
 
             this.messenger.sendOneOrMultipleDiffsMessage(oneOrMultipleDiffsSelection, message.tabID)
-            await this.messenger.sendCustomDependencyVersionMessage(message.tabID)
+            this.promptJavaHome('source', message.tabID)
+            // When custom 1P upgrades ready, delete line above and uncomment line below
+            // await this.messenger.sendCustomDependencyVersionMessage(message.tabID)
         })
     }
 

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -50,7 +50,7 @@ export type UnrecoverableErrorType =
     | 'job-start-failed'
     | 'unsupported-source-db'
     | 'unsupported-target-db'
-    | 'missing-yaml-key'
+    | 'invalid-custom-versions-file'
     | 'error-parsing-sct-file'
     | 'invalid-zip-no-sct-file'
     | 'invalid-from-to-jdk'
@@ -462,8 +462,8 @@ export class Messenger {
             case 'unsupported-target-db':
                 message = CodeWhispererConstants.invalidMetadataFileUnsupportedTargetDB
                 break
-            case 'missing-yaml-key':
-                message = CodeWhispererConstants.invalidYamlFileMissingKey
+            case 'invalid-custom-versions-file':
+                message = CodeWhispererConstants.invalidCustomVersionsFileMessage
                 break
             case 'error-parsing-sct-file':
                 message = CodeWhispererConstants.invalidMetadataFileErrorParsing
@@ -647,7 +647,7 @@ ${codeSnippet}
         this.sendInProgressMessage(tabID, message)
     }
 
-    public sendInProgressMessage(tabID: string, message: string, messageName?: string) {
+    public sendInProgressMessage(tabID: string, message: string) {
         this.dispatcher.sendAsyncEventProgress(
             new AsyncEventProgressMessage(tabID, { inProgress: true, message: undefined })
         )

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -50,6 +50,7 @@ export type UnrecoverableErrorType =
     | 'job-start-failed'
     | 'unsupported-source-db'
     | 'unsupported-target-db'
+    | 'missing-yaml-key'
     | 'error-parsing-sct-file'
     | 'invalid-zip-no-sct-file'
     | 'invalid-from-to-jdk'
@@ -345,6 +346,35 @@ export class Messenger {
         )
     }
 
+    public sendPermissionToBuildMessage(tabID: string) {
+        const message = CodeWhispererConstants.buildLocallyChatMessage
+
+        const buttons: ChatItemButton[] = []
+        buttons.push({
+            keepCardAfterClick: false,
+            text: 'Agree',
+            id: ButtonActions.AGREE_TO_LOCAL_BUILD,
+            position: 'outside',
+        })
+        buttons.push({
+            keepCardAfterClick: false,
+            text: 'No, stop the transformation',
+            id: ButtonActions.CANCEL_TRANSFORMATION_FORM,
+            position: 'outside',
+        })
+
+        this.dispatcher.sendChatMessage(
+            new ChatMessage(
+                {
+                    message,
+                    messageType: 'ai-prompt',
+                    buttons,
+                },
+                tabID
+            )
+        )
+    }
+
     public sendAsyncEventProgress(
         tabID: string,
         inProgress: boolean,
@@ -460,6 +490,9 @@ export class Messenger {
                 break
             case 'unsupported-target-db':
                 message = CodeWhispererConstants.invalidMetadataFileUnsupportedTargetDB
+                break
+            case 'missing-yaml-key':
+                message = CodeWhispererConstants.invalidYamlFileMissingKey
                 break
             case 'error-parsing-sct-file':
                 message = CodeWhispererConstants.invalidMetadataFileErrorParsing
@@ -786,7 +819,7 @@ dependencyManagement:
       originType: "FIRST_PARTY" # or "THIRD_PARTY"  # Optional
     - identifier: "com.example:library2"
       targetVersion: "3.0.0"
-      origin: "THIRD_PARTY"
+      originType: "THIRD_PARTY"
   plugins:
     - identifier: "com.example.plugin"
       targetVersion: "1.2.0"

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -346,35 +346,6 @@ export class Messenger {
         )
     }
 
-    public sendPermissionToBuildMessage(tabID: string) {
-        const message = CodeWhispererConstants.buildLocallyChatMessage
-
-        const buttons: ChatItemButton[] = []
-        buttons.push({
-            keepCardAfterClick: false,
-            text: 'Agree',
-            id: ButtonActions.AGREE_TO_LOCAL_BUILD,
-            position: 'outside',
-        })
-        buttons.push({
-            keepCardAfterClick: false,
-            text: 'No, stop the transformation',
-            id: ButtonActions.CANCEL_TRANSFORMATION_FORM,
-            position: 'outside',
-        })
-
-        this.dispatcher.sendChatMessage(
-            new ChatMessage(
-                {
-                    message,
-                    messageType: 'ai-prompt',
-                    buttons,
-                },
-                tabID
-            )
-        )
-    }
-
     public sendAsyncEventProgress(
         tabID: string,
         inProgress: boolean,

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -781,7 +781,7 @@ ${codeSnippet}
     }
 
     public async sendCustomDependencyVersionMessage(tabID: string) {
-        const message = 'You can optionally upload a YAML file to specify which dependency versions to upgrade to.'
+        const message = CodeWhispererConstants.chooseYamlMessage
         const buttons: ChatItemButton[] = []
 
         buttons.push({

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -747,7 +747,7 @@ ${codeSnippet}
         )
     }
 
-    public async sendCustomDependencyVersionSelectionMessage(tabID: string) {
+    public async sendCustomDependencyVersionMessage(tabID: string) {
         const message = 'You can optionally upload a YAML file to specify which dependency versions to upgrade to.'
         const buttons: ChatItemButton[] = []
 

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -8,6 +8,7 @@
  * As much as possible, all strings used in the experience should originate here.
  */
 
+import vscode from 'vscode'
 import { AuthFollowUpType, AuthMessageDataMap } from '../../../../amazonq/auth/model'
 import { JDKVersion, TransformationCandidateProject, transformByQState } from '../../../../codewhisperer/models/model'
 import { FeatureAuthState } from '../../../../codewhisperer/util/authUtil'
@@ -416,38 +417,12 @@ export class Messenger {
         this.dispatcher.sendChatMessage(jobSubmittedMessage)
     }
 
-    public sendUserPrompt(prompt: string, tabID: string) {
+    public sendMessage(prompt: string, tabID: string, type: 'prompt' | 'ai-prompt') {
         this.dispatcher.sendChatMessage(
             new ChatMessage(
                 {
                     message: prompt,
-                    messageType: 'prompt',
-                },
-                tabID
-            )
-        )
-    }
-
-    public sendStaticTextResponse(messageType: StaticTextResponseType, tabID: string) {
-        let message = '...'
-
-        switch (messageType) {
-            case 'java-home-not-set':
-                message = MessengerUtils.createJavaHomePrompt()
-                break
-            case 'end-HIL-early':
-                message = 'I will continue transforming your code without upgrading this dependency.'
-                break
-            case 'choose-transformation-objective':
-                message = CodeWhispererConstants.chooseTransformationObjective
-                break
-        }
-
-        this.dispatcher.sendChatMessage(
-            new ChatMessage(
-                {
-                    message,
-                    messageType: 'ai-prompt',
+                    messageType: type,
                 },
                 tabID
             )
@@ -772,7 +747,56 @@ ${codeSnippet}
         )
     }
 
-    public async sendSelectSQLMetadataFileMessage(tabID: string) {
+    public async sendCustomDependencyVersionSelectionMessage(tabID: string) {
+        const message = 'You can optionally upload a YAML file to specify which dependency versions to upgrade to.'
+        const buttons: ChatItemButton[] = []
+
+        buttons.push({
+            keepCardAfterClick: true,
+            text: 'Select .yaml file',
+            id: ButtonActions.SELECT_CUSTOM_DEPENDENCY_VERSION_FILE,
+            disabled: false,
+        })
+
+        buttons.push({
+            keepCardAfterClick: false,
+            text: 'Continue without this',
+            id: ButtonActions.CONTINUE_TRANSFORMATION_FORM,
+            disabled: false,
+        })
+
+        this.dispatcher.sendChatMessage(
+            new ChatMessage(
+                {
+                    message,
+                    messageType: 'ai-prompt',
+                    buttons,
+                },
+                tabID
+            )
+        )
+        const sampleYAML = `name: "custom-dependency-management"
+description: "Custom dependency version management for Java migration from JDK 8/11/17 to JDK 17/21"
+
+dependencyManagement:
+  dependencies:
+    - identifier: "com.example:library1"
+      targetVersion: "2.1.0"
+      versionProperty: "library1.version"  # Optional
+      originType: "FIRST_PARTY" # or "THIRD_PARTY"  # Optional
+    - identifier: "com.example:library2"
+      targetVersion: "3.0.0"
+      origin: "THIRD_PARTY"
+  plugins:
+    - identifier: "com.example.plugin"
+      targetVersion: "1.2.0"
+      versionProperty: "plugin.version"  # Optional`
+
+        const doc = await vscode.workspace.openTextDocument({ content: sampleYAML, language: 'yaml' })
+        await vscode.window.showTextDocument(doc)
+    }
+
+    public sendSelectSQLMetadataFileMessage(tabID: string) {
         const message = CodeWhispererConstants.selectSQLMetadataFileHelpMessage
         const buttons: ChatItemButton[] = []
 

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
@@ -22,7 +22,6 @@ export enum ButtonActions {
     SELECT_SQL_CONVERSION_METADATA_FILE = 'gumbySQLConversionMetadataTransformFormConfirm',
     SELECT_CUSTOM_DEPENDENCY_VERSION_FILE = 'gumbyCustomDependencyVersionTransformFormConfirm',
     CONTINUE_TRANSFORMATION_FORM = 'gumbyTransformFormContinue',
-    AGREE_TO_LOCAL_BUILD = 'gumbyAgreeToLocalBuild',
     CONFIRM_DEPENDENCY_FORM = 'gumbyTransformDependencyFormConfirm',
     CANCEL_DEPENDENCY_FORM = 'gumbyTransformDependencyFormCancel',
     CONFIRM_JAVA_HOME_FORM = 'gumbyJavaHomeFormConfirm',

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
@@ -22,6 +22,7 @@ export enum ButtonActions {
     SELECT_SQL_CONVERSION_METADATA_FILE = 'gumbySQLConversionMetadataTransformFormConfirm',
     SELECT_CUSTOM_DEPENDENCY_VERSION_FILE = 'gumbyCustomDependencyVersionTransformFormConfirm',
     CONTINUE_TRANSFORMATION_FORM = 'gumbyTransformFormContinue',
+    AGREE_TO_LOCAL_BUILD = 'gumbyAgreeToLocalBuild',
     CONFIRM_DEPENDENCY_FORM = 'gumbyTransformDependencyFormConfirm',
     CANCEL_DEPENDENCY_FORM = 'gumbyTransformDependencyFormCancel',
     CONFIRM_JAVA_HOME_FORM = 'gumbyJavaHomeFormConfirm',

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
@@ -5,7 +5,7 @@
  */
 
 import * as os from 'os'
-import { transformByQState, JDKVersion } from '../../../../codewhisperer/models/model'
+import { JDKVersion } from '../../../../codewhisperer/models/model'
 import * as CodeWhispererConstants from '../../../../codewhisperer/models/constants'
 import DependencyVersions from '../../../models/dependencies'
 
@@ -20,6 +20,8 @@ export enum ButtonActions {
     CONFIRM_SKIP_TESTS_FORM = 'gumbyTransformSkipTestsFormConfirm',
     CONFIRM_SELECTIVE_TRANSFORMATION_FORM = 'gumbyTransformOneOrMultipleDiffsFormConfirm',
     SELECT_SQL_CONVERSION_METADATA_FILE = 'gumbySQLConversionMetadataTransformFormConfirm',
+    SELECT_CUSTOM_DEPENDENCY_VERSION_FILE = 'gumbyCustomDependencyVersionTransformFormConfirm',
+    CONTINUE_TRANSFORMATION_FORM = 'gumbyTransformFormContinue',
     CONFIRM_DEPENDENCY_FORM = 'gumbyTransformDependencyFormConfirm',
     CANCEL_DEPENDENCY_FORM = 'gumbyTransformDependencyFormCancel',
     CONFIRM_JAVA_HOME_FORM = 'gumbyJavaHomeFormConfirm',
@@ -35,14 +37,11 @@ export enum GumbyCommands {
 }
 
 export default class MessengerUtils {
-    static createJavaHomePrompt = (): string => {
-        let javaHomePrompt = `${
-            CodeWhispererConstants.enterJavaHomeChatMessage
-        } ${transformByQState.getSourceJDKVersion()}. \n`
+    static createJavaHomePrompt = (jdkVersion: JDKVersion | undefined): string => {
+        let javaHomePrompt = `${CodeWhispererConstants.enterJavaHomeChatMessage} ${jdkVersion}. \n`
         if (os.platform() === 'win32') {
             javaHomePrompt += CodeWhispererConstants.windowsJavaHomeHelpChatMessage
         } else if (os.platform() === 'darwin') {
-            const jdkVersion = transformByQState.getSourceJDKVersion()
             if (jdkVersion === JDKVersion.JDK8) {
                 javaHomePrompt += ` ${CodeWhispererConstants.macJavaVersionHomeHelpChatMessage(1.8)}`
             } else if (jdkVersion === JDKVersion.JDK11) {

--- a/packages/core/src/amazonqGumby/chat/session/session.ts
+++ b/packages/core/src/amazonqGumby/chat/session/session.ts
@@ -7,7 +7,8 @@ import { TransformationCandidateProject } from '../../../codewhisperer/models/mo
 
 export enum ConversationState {
     IDLE,
-    PROMPT_JAVA_HOME,
+    PROMPT_SOURCE_JAVA_HOME,
+    PROMPT_TARGET_JAVA_HOME,
     COMPILING,
     JOB_SUBMITTED,
     WAITING_FOR_HIL_INPUT,

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -117,7 +117,7 @@ export async function compileProject() {
         await prepareProjectDependencies(dependenciesFolder, modulePath)
     } catch (err) {
         // open build-logs.txt file to show user error logs
-        await writeAndShowBuildLogs()
+        await writeAndShowBuildLogs(true)
         throw err
     }
 }

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -753,7 +753,8 @@ export async function postTransformationJob() {
     }
 
     if (transformByQState.getPayloadFilePath() !== '') {
-        fs.rmSync(transformByQState.getPayloadFilePath(), { recursive: true, force: true }) // delete ZIP if it exists
+        // delete original upload ZIP at very end of transformation
+        fs.rmSync(transformByQState.getPayloadFilePath(), { recursive: true, force: true })
     }
 
     // attempt download for user

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -56,7 +56,6 @@ import { submitFeedback } from '../../feedback/vue/submitFeedback'
 import { placeholder } from '../../shared/vscode/commands2'
 import {
     AlternateDependencyVersionsNotFoundError,
-    JavaHomeNotSetError,
     JobStartError,
     ModuleUploadError,
     PollJobError,
@@ -69,8 +68,7 @@ import {
     getJsonValuesFromManifestFile,
     highlightPomIssueInProject,
     parseVersionsListFromPomFile,
-    setMaven,
-    writeLogs,
+    writeAndShowBuildLogs,
 } from '../service/transformByQ/transformFileHandler'
 import { sleep } from '../../shared/utilities/timeoutUtils'
 import DependencyVersions from '../../amazonqGumby/models/dependencies'
@@ -111,37 +109,6 @@ export async function processSQLConversionTransformFormInput(pathToProject: stri
     transformByQState.setTargetJDKVersion(JDKVersion.JDK17)
 }
 
-async function validateJavaHome(): Promise<boolean> {
-    const versionData = await getVersionData()
-    let javaVersionUsedByMaven = versionData[1]
-    if (javaVersionUsedByMaven !== undefined) {
-        javaVersionUsedByMaven = javaVersionUsedByMaven.slice(0, 3)
-        if (javaVersionUsedByMaven === '1.8') {
-            javaVersionUsedByMaven = JDKVersion.JDK8
-        } else if (javaVersionUsedByMaven === '11.') {
-            javaVersionUsedByMaven = JDKVersion.JDK11
-        } else if (javaVersionUsedByMaven === '17.') {
-            javaVersionUsedByMaven = JDKVersion.JDK17
-        } else if (javaVersionUsedByMaven === '21.') {
-            javaVersionUsedByMaven = JDKVersion.JDK21
-        }
-    }
-    if (javaVersionUsedByMaven !== transformByQState.getSourceJDKVersion()) {
-        // means either javaVersionUsedByMaven is undefined or it does not match the project JDK
-        return false
-    }
-
-    return true
-}
-
-export async function validateCanCompileProject() {
-    await setMaven()
-    const javaHomeFound = await validateJavaHome()
-    if (!javaHomeFound) {
-        throw new JavaHomeNotSetError()
-    }
-}
-
 export async function compileProject() {
     try {
         const dependenciesFolder: FolderInfo = getDependenciesFolderInfo()
@@ -150,9 +117,7 @@ export async function compileProject() {
         await prepareProjectDependencies(dependenciesFolder, modulePath)
     } catch (err) {
         // open build-logs.txt file to show user error logs
-        const logFilePath = await writeLogs()
-        const doc = await vscode.workspace.openTextDocument(logFilePath)
-        await vscode.window.showTextDocument(doc)
+        await writeAndShowBuildLogs()
         throw err
     }
 }
@@ -300,7 +265,7 @@ export async function initiateHumanInTheLoopPrompt(jobId: string) {
         const profile = AuthUtil.instance.regionProfileManager.activeRegionProfile
         const humanInTheLoopManager = HumanInTheLoopManager.instance
         // 1) We need to call GetTransformationPlan to get artifactId
-        const transformationSteps = await getTransformationSteps(jobId, false, profile)
+        const transformationSteps = await getTransformationSteps(jobId, profile)
         const { transformationStep, progressUpdate } = findDownloadArtifactStep(transformationSteps)
 
         if (!transformationStep || !progressUpdate) {
@@ -566,7 +531,7 @@ export async function pollTransformationStatusUntilPlanReady(jobId: string, prof
         try {
             const tempToolkitFolder = await makeTemporaryToolkitFolder()
             const tempBuildLogsDir = path.join(tempToolkitFolder, 'q-transformation-build-logs')
-            await downloadAndExtractResultArchive(jobId, undefined, tempBuildLogsDir, 'Logs')
+            await downloadAndExtractResultArchive(jobId, tempBuildLogsDir)
             pathToLog = path.join(tempBuildLogsDir, 'buildCommandOutput.log')
             transformByQState.setPreBuildLogFilePath(pathToLog)
         } catch (e) {

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -663,6 +663,11 @@ export const jobCancelledNotification = 'You cancelled the transformation.'
 
 export const continueWithoutHilMessage = 'I will continue transforming your code without upgrading this dependency.'
 
+export const continueWithoutYamlMessage = 'Ok, I will continue without this information.'
+
+export const chooseYamlMessage =
+    'You can optionally upload a YAML file to specify which dependency versions to upgrade to.'
+
 export const enterJavaHomePlaceholder = 'Enter the path to your Java installation'
 
 export const openNewTabPlaceholder = 'Open a new tab to chat with Q'

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -655,6 +655,12 @@ export const jobCancelledChatMessage =
 
 export const jobCancelledNotification = 'You cancelled the transformation.'
 
+export const continueWithoutHilMessage = 'I will continue transforming your code without upgrading this dependency.'
+
+export const enterJavaHomePlaceholder = 'Enter the path to your Java installation'
+
+export const openNewTabPlaceholder = 'Open a new tab to chat with Q'
+
 export const diffMessage = (multipleDiffs: boolean) => {
     return multipleDiffs
         ? 'You can review the diffs to see my proposed changes and accept or reject them. You will be able to accept changes from one diff at a time. If you reject changes in one diff, you will not be able to view or accept changes in the other diffs.'
@@ -756,7 +762,7 @@ export const cleanInstallErrorChatMessage = `Sorry, I couldn\'t run the Maven cl
 
 export const cleanInstallErrorNotification = `Amazon Q could not run the Maven clean install command to build your project. For more information, see the [Amazon Q documentation](${codeTransformTroubleshootMvnFailure}).`
 
-export const enterJavaHomeChatMessage = 'Enter the path to JDK '
+export const enterJavaHomeChatMessage = 'Enter the path to JDK'
 
 export const projectPromptChatMessage =
     'I can upgrade your Java project. To start the transformation, I need some information from you. Choose the project you want to upgrade and the target code version to upgrade to. Then, choose Confirm.'

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -806,9 +806,8 @@ export const skipUnitTestsFormTitle = 'Choose to skip unit tests'
 
 export const selectiveTransformationFormTitle = 'Choose how to receive proposed changes'
 
-// TO-DO: get text from Allie for this
 export const skipUnitTestsFormMessage =
-    'I will build your project using `mvn clean test` by default. If you would like me to build your project without running unit tests, I will use `mvn clean test-compile`.'
+    'I will build generated code in your local environment, not on the server side. For information on how I scan code to reduce security risks associated with building the code in your local environment, see the [Amazon Q Developer documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/code-transformation.html#java-local-builds).\n\nI will build your project using `mvn clean test` by default. If you would like me to build your project without running unit tests, I will use `mvn clean test-compile`.'
 
 export const runUnitTestsMessage = 'Run unit tests'
 

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -599,8 +599,8 @@ export const invalidMetadataFileUnsupportedSourceDB =
 export const invalidMetadataFileUnsupportedTargetDB =
     'I can only convert SQL for migrations to Aurora PostgreSQL or Amazon RDS for PostgreSQL target databases. The provided .sct file indicates another target database for this migration.'
 
-export const invalidYamlFileMissingKey =
-    'Your YAML file is not formatted correctly. Make sure that the .yaml file you upload follows the format of the sample file provided.'
+export const invalidCustomVersionsFileMessage =
+    'Your .YAML file is not formatted correctly. Make sure that the .YAML file you upload follows the format of the sample file provided.'
 
 export const invalidMetadataFileErrorParsing =
     "It looks like the .sct file you provided isn't valid. Make sure that you've uploaded the .zip file you retrieved from your schema conversion in AWS DMS."

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -807,7 +807,7 @@ export const skipUnitTestsFormTitle = 'Choose to skip unit tests'
 export const selectiveTransformationFormTitle = 'Choose how to receive proposed changes'
 
 export const skipUnitTestsFormMessage =
-    'I will build generated code in your local environment, not on the server side. For information on how I scan code to reduce security risks associated with building the code in your local environment, see the [Amazon Q Developer documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/code-transformation.html#java-local-builds).\n\nI will build your project using `mvn clean test` by default. If you would like me to build your project without running unit tests, I will use `mvn clean test-compile`.'
+    'I will build your project using `mvn clean test` by default. If you would like me to build your project without running unit tests, I will use `mvn clean test-compile`.'
 
 export const runUnitTestsMessage = 'Run unit tests'
 

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -806,6 +806,7 @@ export const skipUnitTestsFormTitle = 'Choose to skip unit tests'
 
 export const selectiveTransformationFormTitle = 'Choose how to receive proposed changes'
 
+// TO-DO: get text from Allie for this
 export const skipUnitTestsFormMessage =
     'I will build your project using `mvn clean test` by default. If you would like me to build your project without running unit tests, I will use `mvn clean test-compile`.'
 

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -587,6 +587,9 @@ export const buildSucceededChatMessage = 'I was able to build your project and w
 export const buildSucceededNotification =
     'Amazon Q was able to build your project and will start transforming your code soon.'
 
+export const buildLocallyChatMessage =
+    'I will build your project on this machine throughout the transformation process.'
+
 export const absolutePathDetectedMessage = (numPaths: number, buildFile: string, listOfPaths: string) =>
     `I detected ${numPaths} potential absolute file path(s) in your ${buildFile} file: **${listOfPaths}**. Absolute file paths might cause issues when I build your code. Any errors will show up in the build log.`
 
@@ -598,6 +601,9 @@ export const invalidMetadataFileUnsupportedSourceDB =
 
 export const invalidMetadataFileUnsupportedTargetDB =
     'I can only convert SQL for migrations to Aurora PostgreSQL or Amazon RDS for PostgreSQL target databases. The provided .sct file indicates another target database for this migration.'
+
+export const invalidYamlFileMissingKey =
+    'Your YAML file is not formatted correctly. Make sure that the .yaml file you upload follows the format of the sample file provided.'
 
 export const invalidMetadataFileErrorParsing =
     "It looks like the .sct file you provided isn't valid. Make sure that you've uploaded the .zip file you retrieved from your schema conversion in AWS DMS."

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -587,9 +587,6 @@ export const buildSucceededChatMessage = 'I was able to build your project and w
 export const buildSucceededNotification =
     'Amazon Q was able to build your project and will start transforming your code soon.'
 
-export const buildLocallyChatMessage =
-    'I will build your project on this machine throughout the transformation process.'
-
 export const absolutePathDetectedMessage = (numPaths: number, buildFile: string, listOfPaths: string) =>
     `I detected ${numPaths} potential absolute file path(s) in your ${buildFile} file: **${listOfPaths}**. Absolute file paths might cause issues when I build your code. Any errors will show up in the build log.`
 

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -684,7 +684,7 @@ export class ZipManifest {
     buildLogs: string = 'build-logs.txt'
     version: string = '1.0'
     hilCapabilities: string[] = ['HIL_1pDependency_VersionUpgrade']
-    transformCapabilities: string[] = ['EXPLAINABILITY_V1']
+    transformCapabilities: string[] = ['EXPLAINABILITY_V1', 'CLIENT_SIDE_BUILD']
     customBuildCommand: string = 'clean test'
     requestedConversions?: {
         sqlConversion?: {
@@ -771,6 +771,8 @@ export class TransformByQState {
 
     private metadataPathSQL: string = ''
 
+    private customVersionPath: string = ''
+
     private linesOfCodeSubmitted: number | undefined = undefined
 
     private planFilePath: string = ''
@@ -790,11 +792,13 @@ export class TransformByQState {
 
     private jobFailureErrorChatMessage: string | undefined = undefined
 
-    private errorLog: string = ''
+    private buildLog: string = ''
 
     private mavenName: string = ''
 
-    private javaHome: string | undefined = undefined
+    private sourceJavaHome: string | undefined = undefined
+
+    private targetJavaHome: string | undefined = undefined
 
     private chatControllers: ChatControllerEventEmitters | undefined = undefined
     private chatMessenger: Messenger | undefined = undefined
@@ -897,6 +901,10 @@ export class TransformByQState {
         return this.metadataPathSQL
     }
 
+    public getCustomDependencyVersionFilePath() {
+        return this.customVersionPath
+    }
+
     public getStatus() {
         return this.transformByQState
     }
@@ -937,16 +945,20 @@ export class TransformByQState {
         return this.jobFailureErrorChatMessage
     }
 
-    public getErrorLog() {
-        return this.errorLog
+    public getBuildLog() {
+        return this.buildLog
     }
 
     public getMavenName() {
         return this.mavenName
     }
 
-    public getJavaHome() {
-        return this.javaHome
+    public getSourceJavaHome() {
+        return this.sourceJavaHome
+    }
+
+    public getTargetJavaHome() {
+        return this.targetJavaHome
     }
 
     public getChatControllers() {
@@ -969,8 +981,12 @@ export class TransformByQState {
         return this.intervalId
     }
 
-    public appendToErrorLog(message: string) {
-        this.errorLog += `${message}\n\n`
+    public appendToBuildLog(message: string) {
+        this.buildLog += `${message}\n\n`
+    }
+
+    public clearBuildLog() {
+        this.buildLog = ''
     }
 
     public setToNotStarted() {
@@ -1061,6 +1077,10 @@ export class TransformByQState {
         this.metadataPathSQL = path
     }
 
+    public setCustomDependencyVersionFilePath(path: string) {
+        this.customVersionPath = path
+    }
+
     public setPlanFilePath(filePath: string) {
         this.planFilePath = filePath
     }
@@ -1101,8 +1121,12 @@ export class TransformByQState {
         this.mavenName = mavenName
     }
 
-    public setJavaHome(javaHome: string) {
-        this.javaHome = javaHome
+    public setSourceJavaHome(javaHome: string) {
+        this.sourceJavaHome = javaHome
+    }
+
+    public setTargetJavaHome(javaHome: string) {
+        this.targetJavaHome = javaHome
     }
 
     public setChatControllers(controllers: ChatControllerEventEmitters) {
@@ -1144,6 +1168,7 @@ export class TransformByQState {
         this.jobFailureMetadata = ''
         this.payloadFilePath = ''
         this.metadataPathSQL = ''
+        this.customVersionPath = ''
         this.sourceJDKVersion = undefined
         this.targetJDKVersion = undefined
         this.sourceDB = undefined
@@ -1151,7 +1176,7 @@ export class TransformByQState {
         this.sourceServerName = ''
         this.schemaOptions.clear()
         this.schema = ''
-        this.errorLog = ''
+        this.buildLog = ''
         this.customBuildCommand = ''
         this.intervalId = undefined
         this.produceMultipleDiffs = false

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -685,7 +685,8 @@ export class ZipManifest {
     buildLogs: string = 'build-logs.txt'
     version: string = '1.0'
     hilCapabilities: string[] = ['HIL_1pDependency_VersionUpgrade']
-    transformCapabilities: string[] = ['EXPLAINABILITY_V1', 'CLIENT_SIDE_BUILD']
+    // TO-DO: add 'CLIENT_SIDE_BUILD' here when releasing
+    transformCapabilities: string[] = ['EXPLAINABILITY_V1']
     customBuildCommand: string = 'clean test'
     requestedConversions?: {
         sqlConversion?: {

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -678,6 +678,7 @@ export enum BuildSystem {
     Unknown = 'Unknown',
 }
 
+// TO-DO: include the custom YAML file path here somewhere?
 export class ZipManifest {
     sourcesRoot: string = 'sources/'
     dependenciesRoot: string = 'dependencies/'

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -858,23 +858,16 @@ export function getArtifactsFromProgressUpdate(progressUpdate: TransformationPro
     }
 }
 
+// used for client-side build
 export function findDownloadArtifactProgressUpdate(transformationSteps: TransformationSteps) {
-    for (let i = 0; i < transformationSteps.length; i++) {
-        const progressUpdates = transformationSteps[i].progressUpdates
-        if (progressUpdates) {
-            for (let j = 0; j < progressUpdates.length; j++) {
-                if (
-                    progressUpdates[j].status === 'AWAITING_CLIENT_ACTION' &&
-                    progressUpdates[j].downloadArtifacts?.[0]?.downloadArtifactId
-                ) {
-                    return progressUpdates[j]
-                }
-            }
-        }
-    }
-    return undefined
+    return transformationSteps
+        .flatMap((step) => step.progressUpdates ?? [])
+        .find(
+            (update) => update.status === 'AWAITING_CLIENT_ACTION' && update.downloadArtifacts?.[0]?.downloadArtifactId
+        )
 }
 
+// used for HIL
 export function findDownloadArtifactStep(transformationSteps: TransformationSteps) {
     for (let i = 0; i < transformationSteps.length; i++) {
         const progressUpdates = transformationSteps[i].progressUpdates

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -41,12 +41,7 @@ import { calculateTotalLatency } from '../../../amazonqGumby/telemetry/codeTrans
 import { MetadataResult } from '../../../shared/telemetry/telemetryClient'
 import request from '../../../shared/request'
 import { JobStoppedError, ZipExceedsSizeLimitError } from '../../../amazonqGumby/errors'
-import {
-    createLocalBuildUploadZip,
-    extractOriginalProjectSources,
-    loadManifestFile,
-    writeAndShowBuildLogs,
-} from './transformFileHandler'
+import { createLocalBuildUploadZip, extractOriginalProjectSources, writeAndShowBuildLogs } from './transformFileHandler'
 import { createCodeWhispererChatStreamingClient } from '../../../shared/clients/codewhispererChatClient'
 import { downloadExportResultArchive } from '../../../shared/utilities/download'
 import { ExportContext, ExportIntent, TransformationDownloadArtifactType } from '@amzn/codewhisperer-streaming'
@@ -695,6 +690,9 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
 
             const errorMessage = response.transformationJob.reason
             if (errorMessage !== undefined) {
+                getLogger().error(
+                    `CodeTransformation: GetTransformation returned transformation error reason = ${errorMessage}`
+                )
                 transformByQState.setJobFailureErrorChatMessage(
                     `${CodeWhispererConstants.failedToCompleteJobGenericChatMessage} ${errorMessage}`
                 )
@@ -781,9 +779,7 @@ async function downloadClientInstructions(jobId: string, artifactId: string) {
     }
 
     await downloadAndExtractResultArchive(jobId, exportZipPath, exportContext)
-
-    const clientInstructionsManifest = await loadManifestFile(exportZipPath)
-    return path.join(exportZipPath, clientInstructionsManifest.diffFileName)
+    return path.join(exportZipPath, 'diff.patch')
 }
 
 async function processClientInstructions(jobId: string, clientInstructionsPath: any, artifactId: string) {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -54,6 +54,7 @@ import { UserWrittenCodeTracker } from '../../tracker/userWrittenCodeTracker'
 import { AuthUtil } from '../../util/authUtil'
 import { DiffModel } from './transformationResultsViewProvider'
 import { spawnSync } from 'child_process' // eslint-disable-line no-restricted-imports
+import { isClientSideBuildEnabled } from '../../../dev/config'
 
 export function getSha256(buffer: Buffer) {
     const hasher = crypto.createHash('sha256')
@@ -395,6 +396,7 @@ export async function zipCode(
             dependenciesCopied = true
         }
 
+        // TO-DO: decide where exactly to put the YAML file / what to name it
         if (transformByQState.getCustomDependencyVersionFilePath() && zipManifest instanceof ZipManifest) {
             zip.addLocalFile(
                 transformByQState.getCustomDependencyVersionFilePath(),
@@ -701,7 +703,9 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
                 break
             }
 
+            // TO-DO: remove isClientSideBuildEnabled when releasing CSB
             if (
+                isClientSideBuildEnabled &&
                 status === 'TRANSFORMING' &&
                 transformByQState.getTransformationType() === TransformationType.LANGUAGE_UPGRADE
             ) {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -828,17 +828,13 @@ export async function runClientSideBuild(projectCopyPath: string, clientInstruct
         },
     }
     getLogger().info(`CodeTransformation: uploading client build results at ${uploadZipPath} and resuming job now`)
-    await uploadPayload(uploadZipPath, AuthUtil.instance.regionProfileManager.activeRegionProfile, uploadContext)
-    await resumeTransformationJob(transformByQState.getJobId(), 'COMPLETED')
     try {
+        await uploadPayload(uploadZipPath, AuthUtil.instance.regionProfileManager.activeRegionProfile, uploadContext)
+        await resumeTransformationJob(transformByQState.getJobId(), 'COMPLETED')
+    } finally {
         await fs.delete(projectCopyPath, { recursive: true })
         await fs.delete(uploadZipBaseDir, { recursive: true })
-        // TODO: do we need to delete the downloaded client instructions and uploadZipPath?
-        // Check with AppSec, but they can help in debugging
-    } catch {
-        getLogger().error(
-            `CodeTransformation: failed to delete project copy and uploadZipBaseDir after client-side build`
-        )
+        getLogger().info(`CodeTransformation: Just deleted project copy and uploadZipBaseDir after client-side build`)
     }
 }
 

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -797,7 +797,12 @@ async function processClientInstructions(jobId: string, clientInstructionsPath: 
 export async function runClientSideBuild(projectPath: string, clientInstructionArtifactId: string) {
     // baseCommand will be one of: '.\mvnw.cmd', './mvnw', 'mvn'
     const baseCommand = transformByQState.getMavenName()
-    const args = ['test']
+    const args = ['clean']
+    if (transformByQState.getCustomBuildCommand() === CodeWhispererConstants.skipUnitTestsBuildCommand) {
+        args.push('test-compile')
+    } else {
+        args.push('test')
+    }
     // TO-DO / QUESTION: why not use the build command from the downloaded manifest?
     transformByQState.appendToBuildLog(`Running ${baseCommand} ${args}`)
     const environment = { ...process.env, JAVA_HOME: transformByQState.getTargetJavaHome() }

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -260,8 +260,7 @@ export async function uploadPayload(
  */
 const mavenExcludedExtensions = ['.repositories', '.sha1']
 
-// TO-DO: should we exclude mvnw and mvnw.cmd?
-const sourceExcludedExtensions = ['.DS_Store', 'mvnw', 'mvnw.cmd']
+const sourceExcludedExtensions = ['.DS_Store']
 
 /**
  * Determines if the specified file path corresponds to a Maven metadata file
@@ -370,7 +369,6 @@ export async function zipCode(
                     sctFileName: metadataZip.getEntries().filter((entry) => entry.name.endsWith('.sct'))[0].name,
                 },
             }
-            // TO-DO: later consider making this add to path.join(zipManifest.dependenciesRoot, 'qct-sct-metadata', entry.entryName) so that it's more organized
             for (const entry of metadataZip.getEntries()) {
                 zip.addFile(path.join(zipManifest.dependenciesRoot, entry.name), entry.getData())
             }
@@ -863,8 +861,6 @@ export function findDownloadArtifactProgressUpdate(transformationSteps: Transfor
                     progressUpdates[j].status === 'AWAITING_CLIENT_ACTION' &&
                     progressUpdates[j].downloadArtifacts?.[0]?.downloadArtifactId
                 ) {
-                    // TO-DO: make sure length is always 1
-                    console.log(`found progress update; length = ${progressUpdates[j].downloadArtifacts?.length}`)
                     return progressUpdates[j]
                 }
             }

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -840,7 +840,8 @@ export async function runClientSideBuild(projectCopyPath: string, clientInstruct
     try {
         await fs.delete(projectCopyPath, { recursive: true })
         await fs.delete(uploadZipBaseDir, { recursive: true })
-        // TODO: do we need to delete the downloaded client instructions and uploadZipPath? they can help in debugging
+        // TODO: do we need to delete the downloaded client instructions and uploadZipPath?
+        // Check with AppSec, but they can help in debugging
     } catch {
         getLogger().error(
             `CodeTransformation: failed to delete project copy and uploadZipBaseDir after client-side build`

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -58,7 +58,7 @@ import { getAuthType } from '../../../auth/utils'
 import { UserWrittenCodeTracker } from '../../tracker/userWrittenCodeTracker'
 import { AuthUtil } from '../../util/authUtil'
 import { DiffModel } from './transformationResultsViewProvider'
-import { spawnSync } from 'child_process'
+import { spawnSync } from 'child_process' // eslint-disable-line no-restricted-imports
 
 export function getSha256(buffer: Buffer) {
     const hasher = crypto.createHash('sha256')
@@ -399,6 +399,14 @@ export async function zipCode(
             }
             getLogger().info(`CodeTransformation: dependency files size = ${dependencyFilesSize}`)
             dependenciesCopied = true
+        }
+
+        if (transformByQState.getCustomDependencyVersionFilePath() && zipManifest instanceof ZipManifest) {
+            zip.addLocalFile(
+                transformByQState.getCustomDependencyVersionFilePath(),
+                'custom-upgrades',
+                'dependency-versions.yaml'
+            )
         }
 
         zip.addFile('manifest.json', Buffer.from(JSON.stringify(zipManifest)), 'utf-8')

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -645,10 +645,7 @@ export async function getTransformationPlan(jobId: string, profile: RegionProfil
     }
 }
 
-export async function getTransformationSteps(
-    jobId: string,
-    profile: RegionProfile | undefined
-) {
+export async function getTransformationSteps(jobId: string, profile: RegionProfile | undefined) {
     try {
         const response = await codeWhisperer.codeWhispererClient.codeModernizerGetCodeTransformationPlan({
             transformationJobId: jobId,
@@ -901,7 +898,12 @@ export async function downloadResultArchive(jobId: string, pathToArchive: string
                   exportId: jobId,
                   exportIntent: ExportIntent.TRANSFORMATION,
               }
-        await downloadExportResultArchive(cwStreamingClient, args, pathToArchive, AuthUtil.instance.regionProfileManager.activeRegionProfile)
+        await downloadExportResultArchive(
+            cwStreamingClient,
+            args,
+            pathToArchive,
+            AuthUtil.instance.regionProfileManager.activeRegionProfile
+        )
     } catch (e: any) {
         getLogger().error(`CodeTransformation: ExportResultArchive error = %O`, e)
         throw e

--- a/packages/core/src/codewhisperer/service/transformByQ/transformFileHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformFileHandler.ts
@@ -38,14 +38,6 @@ export async function writeAndShowBuildLogs() {
     return logFilePath
 }
 
-export async function loadManifestFile(directory: string) {
-    const manifestFile = path.join(directory, 'manifest.json')
-    const data = await fs.readFileText(manifestFile)
-    const manifest = JSON.parse(data)
-    getLogger().info(`CodeTransformation: loaded and parsed manifest file from ${manifestFile}`)
-    return manifest
-}
-
 export async function createLocalBuildUploadZip(baseDir: string, exitCode: number | null, stdout: string) {
     const manifestFilePath = path.join(baseDir, 'manifest.json')
     const buildResultsManifest = {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformFileHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformFileHandler.ts
@@ -9,7 +9,7 @@ import * as os from 'os'
 import xml2js = require('xml2js')
 import * as CodeWhispererConstants from '../../models/constants'
 import { existsSync, readFileSync, writeFileSync } from 'fs' // eslint-disable-line no-restricted-imports
-import { BuildSystem, DB, FolderInfo, transformByQState } from '../../models/model'
+import { BuildSystem, DB, FolderInfo, TransformationType, transformByQState } from '../../models/model'
 import { IManifestFile } from '../../../amazonqFeatureDev/models'
 import fs from '../../../shared/fs/fs'
 import globals from '../../../shared/extensionGlobals'
@@ -31,7 +31,10 @@ export async function writeAndShowBuildLogs(isLocalInstall: boolean = false) {
     const logFilePath = path.join(os.tmpdir(), 'build-logs.txt')
     writeFileSync(logFilePath, transformByQState.getBuildLog())
     const doc = await vscode.workspace.openTextDocument(logFilePath)
-    if (!transformByQState.getBuildLog().includes('clean install succeeded')) {
+    if (
+        !transformByQState.getBuildLog().includes('clean install succeeded') &&
+        transformByQState.getTransformationType() !== TransformationType.SQL_CONVERSION
+    ) {
         // only show the log if the build failed; show it in second column for intermediate builds only
         const options = isLocalInstall ? undefined : { viewColumn: vscode.ViewColumn.Two }
         await vscode.window.showTextDocument(doc, options)

--- a/packages/core/src/codewhisperer/service/transformByQ/transformFileHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformFileHandler.ts
@@ -48,7 +48,7 @@ export async function loadManifestFile(directory: string) {
 }
 
 export async function copyDirectory(sourcePath: string, destinationPath: string) {
-    fs.mkdir(destinationPath)
+    await fs.mkdir(destinationPath)
     const files = await fs.readdir(sourcePath)
 
     for (const file of files) {
@@ -78,7 +78,7 @@ export async function createLocalBuildUploadZip(baseDir: string, exitCode: numbe
         exitCode: exitCode,
         commandLogFileName: 'clientBuildLogs.log',
     }
-    const formattedManifest = JSON.stringify(buildResultsManifest, null, 2)
+    const formattedManifest = JSON.stringify(buildResultsManifest)
     await fs.writeFile(manifestFilePath, formattedManifest, 'utf8')
 
     const buildLogsFilePath = path.join(baseDir, 'clientBuildLogs.log')

--- a/packages/core/src/codewhisperer/service/transformByQ/transformFileHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformFileHandler.ts
@@ -28,6 +28,7 @@ export function getDependenciesFolderInfo(): FolderInfo {
     }
 }
 
+// TO-DO: what happens when intermediate build logs are massive from downloading dependencies? exlude those lines?
 export async function writeAndShowBuildLogs() {
     const logFilePath = path.join(os.tmpdir(), 'build-logs.txt')
     writeFileSync(logFilePath, transformByQState.getBuildLog())
@@ -135,6 +136,18 @@ export async function parseBuildFile() {
         getLogger().error(`CodeTransformation: error scanning for absolute paths, tranformation continuing: ${err}`)
     }
     return undefined
+}
+
+export async function validateYamlFile(fileContents: string, message: any) {
+    const requiredKeys = ['dependencyManagement:', 'identifier:', 'targetVersion:']
+    for (const key of requiredKeys) {
+        if (!fileContents.includes(key)) {
+            getLogger().info(`CodeTransformation: missing yaml key: ${key}`)
+            transformByQState.getChatMessenger()?.sendUnrecoverableErrorResponse('missing-yaml-key', message.tabID)
+            return false
+        }
+    }
+    return true
 }
 
 export async function validateSQLMetadataFile(fileContents: string, message: any) {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
@@ -104,7 +104,7 @@ function copyProjectDependencies(dependenciesFolder: FolderInfo, modulePath: str
 }
 
 export async function prepareProjectDependencies(dependenciesFolder: FolderInfo, rootPomPath: string) {
-    await setMaven()
+    setMaven()
     getLogger().info('CodeTransformation: running Maven copy-dependencies')
     // pause to give chat time to update
     await sleep(100)

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
@@ -193,6 +193,8 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
                 return '<p><span class="spinner status-PENDING"> ↻ </span></p>'
             case 'COMPLETED':
                 return '<p><span class="status-COMPLETED"> ✓ </span></p>'
+            case 'AWAITING_CLIENT_ACTION':
+                return '<p><span class="spinner status-PENDING"> ↻ </span></p>'
             case 'FAILED':
             default:
                 return '<p><span class="status-FAILED"> 𐔧 </span></p>'
@@ -327,7 +329,7 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
             transformByQState.isRunning()
         ) {
             const profile = AuthUtil.instance.regionProfileManager.activeRegionProfile
-            planSteps = await getTransformationSteps(transformByQState.getJobId(), false, profile)
+            planSteps = await getTransformationSteps(transformByQState.getJobId(), profile)
             transformByQState.setPlanSteps(planSteps)
         }
         let progressHtml

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
@@ -351,6 +351,8 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
                 CodeWhispererConstants.uploadingCodeStepMessage,
                 activeStepId === 0
             )
+            // TO-DO: remove this step entirely since we do entirely client-side builds
+            // TO-DO: do we still show the "Building in Java 17/21 environment" progress update?
             const buildMarkup =
                 activeStepId >= 1 && transformByQState.getTransformationType() !== TransformationType.SQL_CONVERSION // for SQL conversions, don't show buildCode step
                     ? simpleStep(

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
@@ -329,7 +329,10 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
             transformByQState.isRunning()
         ) {
             try {
-                planSteps = await getTransformationSteps(transformByQState.getJobId(), AuthUtil.instance.regionProfileManager.activeRegionProfile)
+                planSteps = await getTransformationSteps(
+                    transformByQState.getJobId(),
+                    AuthUtil.instance.regionProfileManager.activeRegionProfile
+                )
                 transformByQState.setPlanSteps(planSteps)
             } catch (e: any) {
                 // no-op; re-use current plan steps and try again in next polling cycle

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -168,7 +168,8 @@ export class DiffModel {
         pathToDiff: string,
         pathToWorkspace: string,
         diffDescription: PatchInfo | undefined,
-        totalDiffPatches: number
+        totalDiffPatches: number,
+        isIntermediateBuild: boolean = false
     ): PatchFileNode {
         this.patchFileNodes = []
         const diffContents = fs.readFileSync(pathToDiff, 'utf8')
@@ -181,7 +182,9 @@ export class DiffModel {
         const changedFiles = parsePatch(diffContents)
         getLogger().info('CodeTransformation: parsed patch file successfully')
         // path to the directory containing copy of the changed files in the transformed project
-        const pathToTmpSrcDir = this.copyProject(pathToWorkspace, changedFiles)
+        // if doing intermediate client-side build, pathToWorkspace is the already-copied project directory
+        // otherwise, we are at the very end of the transformation and need to copy the project to show the changes
+        const pathToTmpSrcDir = isIntermediateBuild ? pathToWorkspace : this.copyProject(pathToWorkspace, changedFiles)
         transformByQState.setProjectCopyFilePath(pathToTmpSrcDir)
 
         applyPatches(changedFiles, {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -181,9 +181,8 @@ export class DiffModel {
 
         const changedFiles = parsePatch(diffContents)
         getLogger().info('CodeTransformation: parsed patch file successfully')
-        // path to the directory containing copy of the changed files in the transformed project
-        // if doing intermediate client-side build, pathToWorkspace is the already-copied project directory
-        // otherwise, we are at the very end of the transformation and need to copy the project to show the changes
+        // if doing intermediate client-side build, pathToWorkspace is the path to the unzipped project's 'sources' directory (re-using upload ZIP)
+        // otherwise, we are at the very end of the transformation and need to copy the changed files in the project to show the diff(s)
         const pathToTmpSrcDir = isIntermediateBuild ? pathToWorkspace : this.copyProject(pathToWorkspace, changedFiles)
         transformByQState.setProjectCopyFilePath(pathToTmpSrcDir)
 

--- a/packages/core/src/dev/config.ts
+++ b/packages/core/src/dev/config.ts
@@ -10,3 +10,6 @@ export const betaUrl = {
     amazonq: '',
     toolkit: '',
 }
+
+// TO-DO: remove when releasing CSB
+export const isClientSideBuildEnabled = false

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -317,8 +317,8 @@ dependencyManagement:
         const manifest = JSON.parse(manifestText)
         assert.strictEqual(manifest.capability, 'CLIENT_SIDE_BUILD')
         assert.strictEqual(manifest.exitCode, 0)
-        assert.strictEqual(manifest.commandLogFileName, 'clientBuildLogs.log')
-        assert.strictEqual(zip.getEntries().length, 2) // expecting only manifest.json and clientBuildLogs.log
+        assert.strictEqual(manifest.commandLogFileName, 'build-output.log')
+        assert.strictEqual(zip.getEntries().length, 2) // expecting only manifest.json and build-output.log
     })
 
     it('WHEN extractOriginalProjectSources THEN only source files are extracted to destination', async function () {

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -42,7 +42,7 @@ import {
     parseBuildFile,
     validateSQLMetadataFile,
     createLocalBuildUploadZip,
-    validateYamlFile,
+    validateCustomVersionsFile,
     extractOriginalProjectSources,
 } from '../../../codewhisperer/service/transformByQ/transformFileHandler'
 import { uploadArtifactToS3 } from '../../../codewhisperer/indexNode'
@@ -52,7 +52,7 @@ import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 describe('transformByQ', function () {
     let fetchStub: sinon.SinonStub
     let tempDir: string
-    const validYamlFile = `name: "custom-dependency-management"
+    const validCustomVersionsFile = `name: "custom-dependency-management"
 description: "Custom dependency version management for Java migration from JDK 8/11/17 to JDK 17/21"
 dependencyManagement:
   dependencies:
@@ -516,15 +516,15 @@ dependencyManagement:
         assert.strictEqual(expectedWarning, warningMessage)
     })
 
-    it(`WHEN validateYamlFile on fully valid .yaml file THEN passes validation`, async function () {
-        const isValidYaml = await validateYamlFile(validYamlFile, { tabID: 'abc123' })
-        assert.strictEqual(isValidYaml, true)
+    it(`WHEN validateCustomVersionsFile on fully valid .yaml file THEN passes validation`, async function () {
+        const isValidFile = await validateCustomVersionsFile(validCustomVersionsFile)
+        assert.strictEqual(isValidFile, true)
     })
 
-    it(`WHEN validateYamlFile on invalid .yaml file THEN fails validation`, async function () {
-        const invalidYamlFile = validYamlFile.replace('dependencyManagement', 'invalidKey')
-        const isValidYaml = await validateYamlFile(invalidYamlFile, { tabID: 'abc123' })
-        assert.strictEqual(isValidYaml, false)
+    it(`WHEN validateCustomVersionsFile on invalid .yaml file THEN fails validation`, async function () {
+        const invalidFile = validCustomVersionsFile.replace('dependencyManagement', 'invalidKey')
+        const isValidFile = await validateCustomVersionsFile(invalidFile)
+        assert.strictEqual(isValidFile, false)
     })
 
     it(`WHEN validateMetadataFile on fully valid .sct file THEN passes validation`, async function () {


### PR DESCRIPTION
## Problem

We should perform builds client-side (rather than server-side) to handle customers’ unique / challenging local environments, which often cause our server-side build to fail.

## Solution

Periodically download intermediate `diff.patch` files, apply them to a copy of the project, perform the local build, then upload the build logs and resume the transformation.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
