### PR TITLE
test(amazonq): update view diff test

### DIFF
--- a/packages/amazonq/test/e2e/amazonq/testGen.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/testGen.test.ts
@@ -194,10 +194,9 @@ describe('Amazon Q Test Generation', function () {
                         const viewDiffMessage = chatItems[5]
 
                         assert.deepStrictEqual(viewDiffMessage.type, 'answer')
-                        assert.deepStrictEqual(
-                            viewDiffMessage.body,
+                        const expectedEnding =
                             'Please see the unit tests generated below. Click “View diff” to review the changes in the code editor.'
-                        )
+                        assert.strictEqual(viewDiffMessage.body?.includes(expectedEnding), true)
                     })
                 })
 

--- a/packages/amazonq/test/e2e/amazonq/testGen.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/testGen.test.ts
@@ -196,7 +196,11 @@ describe('Amazon Q Test Generation', function () {
                         assert.deepStrictEqual(viewDiffMessage.type, 'answer')
                         const expectedEnding =
                             'Please see the unit tests generated below. Click “View diff” to review the changes in the code editor.'
-                        assert.strictEqual(viewDiffMessage.body?.includes(expectedEnding), true)
+                        assert.strictEqual(
+                            viewDiffMessage.body?.includes(expectedEnding),
+                            true,
+                            `View diff message does not contain phrase: ${expectedEnding}`
+                        )
                     })
                 })
 


### PR DESCRIPTION
## Problem
- source code change for /test which adds a test plan summary after generating tests, but did not update e2e test to account for this

## Solution
- update test

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
