### PR TITLE
fix(amazonq): allow extension activation during amazon q lsp initialization

### DIFF
--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -119,7 +119,11 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     // This contains every lsp agnostic things (auth, security scan, code scan)
     await activateCodeWhisperer(extContext as ExtContext)
     if (Experiments.instance.get('amazonqLSP', false)) {
-        await activateAmazonqLsp(context)
+        /**
+         * Allow extension to activate while language server
+         * downloads and starts async
+         **/
+        void activateAmazonqLsp(context)
     } else {
         await activateInlineCompletion()
     }


### PR DESCRIPTION
## Problem
- Downloading the manifest/language server blocks showing the chat UI, creating a 2+ second increase between the UI showing with the feature flag enabled vs disabled

## Solution
- Don't block extension activation on downloading
    - If any code requires the language server to be started it should live alongside it


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
