### PR TITLE
feat(amazonq): re-add basic chat through a language server

### DIFF
--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -157,7 +157,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
 
     context.subscriptions.push(
         Experiments.instance.onDidChange(async (event) => {
-            if (event.key === 'amazonqLSP') {
+            if (event.key === 'amazonqLSP' || event.key === 'amazonqChatLSP') {
                 await vscode.window
                     .showInformationMessage(
                         'Amazon Q LSP setting has changed. Reload VS Code for the changes to take effect.',

--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -7,7 +7,15 @@ import * as vscode from 'vscode'
 import { activateAmazonQCommon, amazonQContextPrefix, deactivateCommon } from './extension'
 import { DefaultAmazonQAppInitContext } from 'aws-core-vscode/amazonq'
 import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
-import { ExtContext, globals, CrashMonitoring, getLogger, isNetworkError, isSageMaker } from 'aws-core-vscode/shared'
+import {
+    ExtContext,
+    globals,
+    CrashMonitoring,
+    getLogger,
+    isNetworkError,
+    isSageMaker,
+    Experiments,
+} from 'aws-core-vscode/shared'
 import { filetypes, SchemaService } from 'aws-core-vscode/sharedNode'
 import { updateDevMode } from 'aws-core-vscode/dev'
 import { CommonAuthViewProvider } from 'aws-core-vscode/login'
@@ -43,8 +51,10 @@ async function activateAmazonQNode(context: vscode.ExtensionContext) {
         extensionContext: context,
     }
 
-    await activateCWChat(context)
-    await activateQGumby(extContext as ExtContext)
+    if (!Experiments.instance.get('amazonqChatLSP', false)) {
+        await activateCWChat(context)
+        await activateQGumby(extContext as ExtContext)
+    }
 
     const authProvider = new CommonAuthViewProvider(
         context,

--- a/packages/amazonq/src/lsp/chat/activation.ts
+++ b/packages/amazonq/src/lsp/chat/activation.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { window } from 'vscode'
+import { LanguageClient } from 'vscode-languageclient'
+import { AmazonQChatViewProvider } from './webviewProvider'
+import { registerCommands } from './commands'
+import { registerLanguageServerEventListener, registerMessageListeners } from './messages'
+import { focusAmazonQPanel, focusAmazonQPanelKeybinding } from 'aws-core-vscode/amazonq'
+import { globals } from 'aws-core-vscode/shared'
+
+export function activate(languageClient: LanguageClient, encryptionKey: Buffer, mynahUIPath: string) {
+    const provider = new AmazonQChatViewProvider(mynahUIPath)
+
+    globals.context.subscriptions.push(
+        window.registerWebviewViewProvider(AmazonQChatViewProvider.viewType, provider, {
+            webviewOptions: {
+                retainContextWhenHidden: true,
+            },
+        }),
+
+        focusAmazonQPanel.register(),
+        focusAmazonQPanelKeybinding.register()
+    )
+
+    /**
+     * Commands are registered independent of the webview being open because when they're executed
+     * they focus the webview
+     **/
+    registerCommands(provider)
+    registerLanguageServerEventListener(languageClient, provider)
+
+    provider.onDidResolveWebview(() => {
+        registerMessageListeners(languageClient, provider, encryptionKey)
+    })
+}

--- a/packages/amazonq/src/lsp/chat/activation.ts
+++ b/packages/amazonq/src/lsp/chat/activation.ts
@@ -8,7 +8,6 @@ import { LanguageClient } from 'vscode-languageclient'
 import { AmazonQChatViewProvider } from './webviewProvider'
 import { registerCommands } from './commands'
 import { registerLanguageServerEventListener, registerMessageListeners } from './messages'
-import { focusAmazonQPanel, focusAmazonQPanelKeybinding } from 'aws-core-vscode/amazonq'
 import { globals } from 'aws-core-vscode/shared'
 
 export function activate(languageClient: LanguageClient, encryptionKey: Buffer, mynahUIPath: string) {
@@ -19,10 +18,7 @@ export function activate(languageClient: LanguageClient, encryptionKey: Buffer, 
             webviewOptions: {
                 retainContextWhenHidden: true,
             },
-        }),
-
-        focusAmazonQPanel.register(),
-        focusAmazonQPanelKeybinding.register()
+        })
     )
 
     /**

--- a/packages/amazonq/src/lsp/chat/commands.ts
+++ b/packages/amazonq/src/lsp/chat/commands.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { focusAmazonQPanel } from 'aws-core-vscode/amazonq'
+import { Commands, globals, placeholder } from 'aws-core-vscode/shared'
+import { window } from 'vscode'
+import { AmazonQChatViewProvider } from './webviewProvider'
+
+export function registerCommands(provider: AmazonQChatViewProvider) {
+    globals.context.subscriptions.push(
+        registerGenericCommand('aws.amazonq.explainCode', 'Explain', provider),
+        registerGenericCommand('aws.amazonq.refactorCode', 'Refactor', provider),
+        registerGenericCommand('aws.amazonq.fixCode', 'Fix', provider),
+        registerGenericCommand('aws.amazonq.optimizeCode', 'Optimize', provider),
+        Commands.register('aws.amazonq.sendToPrompt', (data) => {
+            const triggerType = getCommandTriggerType(data)
+            const selection = getSelectedText()
+
+            void focusAmazonQPanel.execute(placeholder, 'aws.amazonq.sendToPrompt').then(() => {
+                void provider.webview?.postMessage({
+                    command: 'sendToPrompt',
+                    params: { selection: selection, triggerType },
+                })
+            })
+        }),
+        Commands.register('aws.amazonq.openTab', () => {
+            void focusAmazonQPanel.execute(placeholder, 'aws.amazonq.openTab').then(() => {
+                void provider.webview?.postMessage({
+                    command: 'aws/chat/openTab',
+                    params: {},
+                })
+            })
+        })
+    )
+}
+
+function getSelectedText(): string {
+    const editor = window.activeTextEditor
+    if (editor) {
+        const selection = editor.selection
+        const selectedText = editor.document.getText(selection)
+        return selectedText
+    }
+
+    return ' '
+}
+
+function getCommandTriggerType(data: any): string {
+    // data is undefined when commands triggered from keybinding or command palette. Currently no
+    // way to differentiate keybinding and command palette, so both interactions are recorded as keybinding
+    return data === undefined ? 'hotkeys' : 'contextMenu'
+}
+
+function registerGenericCommand(commandName: string, genericCommand: string, provider: AmazonQChatViewProvider) {
+    return Commands.register(commandName, (data) => {
+        const triggerType = getCommandTriggerType(data)
+        const selection = getSelectedText()
+
+        void focusAmazonQPanel.execute(placeholder, commandName).then(() => {
+            void provider.webview?.postMessage({
+                command: 'genericCommand',
+                params: { genericCommand, selection, triggerType },
+            })
+        })
+    })
+}

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -1,0 +1,225 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    isValidAuthFollowUpType,
+    INSERT_TO_CURSOR_POSITION,
+    AUTH_FOLLOW_UP_CLICKED,
+    CHAT_OPTIONS,
+    COPY_TO_CLIPBOARD,
+} from '@aws/chat-client-ui-types'
+import {
+    ChatResult,
+    chatRequestType,
+    ChatParams,
+    followUpClickNotificationType,
+    quickActionRequestType,
+    QuickActionResult,
+    QuickActionParams,
+    insertToCursorPositionNotificationType,
+} from '@aws/language-server-runtimes/protocol'
+import { v4 as uuidv4 } from 'uuid'
+import { window } from 'vscode'
+import { Disposable, LanguageClient, Position, State, TextDocumentIdentifier } from 'vscode-languageclient'
+import * as jose from 'jose'
+import { AmazonQChatViewProvider } from './webviewProvider'
+
+export function registerLanguageServerEventListener(languageClient: LanguageClient, provider: AmazonQChatViewProvider) {
+    languageClient.onDidChangeState(({ oldState, newState }) => {
+        if (oldState === State.Starting && newState === State.Running) {
+            languageClient.info(
+                'Language client received initializeResult from server:',
+                JSON.stringify(languageClient.initializeResult)
+            )
+
+            const chatOptions = languageClient.initializeResult?.awsServerCapabilities?.chatOptions
+
+            void provider.webview?.postMessage({
+                command: CHAT_OPTIONS,
+                params: chatOptions,
+            })
+        }
+    })
+
+    languageClient.onTelemetry((e) => {
+        languageClient.info(`[VSCode Client] Received telemetry event from server ${JSON.stringify(e)}`)
+    })
+}
+
+export function registerMessageListeners(
+    languageClient: LanguageClient,
+    provider: AmazonQChatViewProvider,
+    encryptionKey: Buffer
+) {
+    provider.webview?.onDidReceiveMessage(async (message) => {
+        languageClient.info(`[VSCode Client]  Received ${JSON.stringify(message)} from chat`)
+
+        switch (message.command) {
+            case COPY_TO_CLIPBOARD:
+                // TODO see what we need to hook this up
+                languageClient.info('[VSCode Client] Copy to clipboard event received')
+                break
+            case INSERT_TO_CURSOR_POSITION: {
+                const editor = window.activeTextEditor
+                let textDocument: TextDocumentIdentifier | undefined = undefined
+                let cursorPosition: Position | undefined = undefined
+                if (editor) {
+                    cursorPosition = editor.selection.active
+                    textDocument = { uri: editor.document.uri.toString() }
+                }
+
+                languageClient.sendNotification(insertToCursorPositionNotificationType.method, {
+                    ...message.params,
+                    cursorPosition,
+                    textDocument,
+                })
+                break
+            }
+            case AUTH_FOLLOW_UP_CLICKED:
+                // TODO hook this into auth
+                languageClient.info('[VSCode Client] AuthFollowUp clicked')
+                break
+            case chatRequestType.method: {
+                const partialResultToken = uuidv4()
+                const chatDisposable = languageClient.onProgress(chatRequestType, partialResultToken, (partialResult) =>
+                    handlePartialResult<ChatResult>(partialResult, encryptionKey, provider, message.params.tabId)
+                )
+
+                const editor =
+                    window.activeTextEditor ||
+                    window.visibleTextEditors.find((editor) => editor.document.languageId !== 'Log')
+                if (editor) {
+                    message.params.cursorPosition = [editor.selection.active]
+                    message.params.textDocument = { uri: editor.document.uri.toString() }
+                }
+
+                const chatRequest = await encryptRequest<ChatParams>(message.params, encryptionKey)
+                const chatResult = (await languageClient.sendRequest(chatRequestType.method, {
+                    ...chatRequest,
+                    partialResultToken,
+                })) as string | ChatResult
+                void handleCompleteResult<ChatResult>(
+                    chatResult,
+                    encryptionKey,
+                    provider,
+                    message.params.tabId,
+                    chatDisposable
+                )
+                break
+            }
+            case quickActionRequestType.method: {
+                const quickActionPartialResultToken = uuidv4()
+                const quickActionDisposable = languageClient.onProgress(
+                    quickActionRequestType,
+                    quickActionPartialResultToken,
+                    (partialResult) =>
+                        handlePartialResult<QuickActionResult>(
+                            partialResult,
+                            encryptionKey,
+                            provider,
+                            message.params.tabId
+                        )
+                )
+
+                const quickActionRequest = await encryptRequest<QuickActionParams>(message.params, encryptionKey)
+                const quickActionResult = (await languageClient.sendRequest(quickActionRequestType.method, {
+                    ...quickActionRequest,
+                    partialResultToken: quickActionPartialResultToken,
+                })) as string | ChatResult
+                void handleCompleteResult<ChatResult>(
+                    quickActionResult,
+                    encryptionKey,
+                    provider,
+                    message.params.tabId,
+                    quickActionDisposable
+                )
+                break
+            }
+            case followUpClickNotificationType.method:
+                if (!isValidAuthFollowUpType(message.params.followUp.type)) {
+                    languageClient.sendNotification(followUpClickNotificationType.method, message.params)
+                }
+                break
+            default:
+                if (isServerEvent(message.command)) {
+                    languageClient.sendNotification(message.command, message.params)
+                }
+                break
+        }
+    }, undefined)
+}
+
+function isServerEvent(command: string) {
+    return command.startsWith('aws/chat/') || command === 'telemetry/event'
+}
+
+async function encryptRequest<T>(params: T, encryptionKey: Buffer): Promise<{ message: string } | T> {
+    const payload = new TextEncoder().encode(JSON.stringify(params))
+
+    const encryptedMessage = await new jose.CompactEncrypt(payload)
+        .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+        .encrypt(encryptionKey)
+
+    return { message: encryptedMessage }
+}
+
+async function decodeRequest<T>(request: string, key: Buffer): Promise<T> {
+    const result = await jose.jwtDecrypt(request, key, {
+        clockTolerance: 60, // Allow up to 60 seconds to account for clock differences
+        contentEncryptionAlgorithms: ['A256GCM'],
+        keyManagementAlgorithms: ['dir'],
+    })
+
+    if (!result.payload) {
+        throw new Error('JWT payload not found')
+    }
+    return result.payload as T
+}
+
+/**
+ * Decodes partial chat responses from the language server before sending them to mynah UI
+ */
+async function handlePartialResult<T extends ChatResult>(
+    partialResult: string | T,
+    encryptionKey: Buffer | undefined,
+    provider: AmazonQChatViewProvider,
+    tabId: string
+) {
+    const decryptedMessage =
+        typeof partialResult === 'string' && encryptionKey
+            ? await decodeRequest<T>(partialResult, encryptionKey)
+            : (partialResult as T)
+
+    if (decryptedMessage.body) {
+        void provider.webview?.postMessage({
+            command: chatRequestType.method,
+            params: decryptedMessage,
+            isPartialResult: true,
+            tabId: tabId,
+        })
+    }
+}
+
+/**
+ * Decodes the final chat responses from the language server before sending it to mynah UI.
+ * Once this is called the answer response is finished
+ */
+async function handleCompleteResult<T>(
+    result: string | T,
+    encryptionKey: Buffer | undefined,
+    provider: AmazonQChatViewProvider,
+    tabId: string,
+    disposable: Disposable
+) {
+    const decryptedMessage =
+        typeof result === 'string' && encryptionKey ? await decodeRequest(result, encryptionKey) : result
+
+    void provider.webview?.postMessage({
+        command: chatRequestType.method,
+        params: decryptedMessage,
+        tabId: tabId,
+    })
+    disposable.dispose()
+}

--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -15,7 +15,7 @@ import {
 import { LanguageServerResolver } from 'aws-core-vscode/shared'
 
 export class AmazonQChatViewProvider implements WebviewViewProvider {
-    public static readonly viewType = 'aws.AmazonQChatView'
+    public static readonly viewType = 'aws.amazonq.AmazonQChatView'
     private readonly onDidResolveWebviewEmitter = new EventEmitter<void>()
     public readonly onDidResolveWebview = this.onDidResolveWebviewEmitter.event
 

--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    EventEmitter,
+    CancellationToken,
+    Webview,
+    WebviewView,
+    WebviewViewProvider,
+    WebviewViewResolveContext,
+    Uri,
+} from 'vscode'
+import { LanguageServerResolver } from 'aws-core-vscode/shared'
+
+export class AmazonQChatViewProvider implements WebviewViewProvider {
+    public static readonly viewType = 'aws.AmazonQChatView'
+    private readonly onDidResolveWebviewEmitter = new EventEmitter<void>()
+    public readonly onDidResolveWebview = this.onDidResolveWebviewEmitter.event
+
+    webview: Webview | undefined
+
+    constructor(private readonly mynahUIPath: string) {}
+
+    public resolveWebviewView(webviewView: WebviewView, context: WebviewViewResolveContext, _token: CancellationToken) {
+        this.webview = webviewView.webview
+
+        const lspDir = Uri.parse(LanguageServerResolver.defaultDir)
+        webviewView.webview.options = {
+            enableScripts: true,
+            enableCommandUris: true,
+            localResourceRoots: [lspDir],
+        }
+
+        const uiPath = webviewView.webview.asWebviewUri(Uri.parse(this.mynahUIPath)).toString()
+        webviewView.webview.html = getWebviewContent(uiPath)
+
+        this.onDidResolveWebviewEmitter.fire()
+    }
+}
+
+function getWebviewContent(mynahUIPath: string) {
+    return `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Chat</title>
+        <style>
+            body,
+            html {
+                background-color: var(--mynah-color-bg);
+                color: var(--mynah-color-text-default);
+                height: 100%;
+                width: 100%;
+                overflow: hidden;
+                margin: 0;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <script type="text/javascript" src="${mynahUIPath.toString()}" defer onload="init()"></script>
+        <script type="text/javascript">
+            const init = () => {
+                amazonQChat.createChat(acquireVsCodeApi(), {disclaimerAcknowledged: false});
+            }
+        </script>
+    </body>
+    </html>`
+}

--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -8,7 +8,11 @@ import path from 'path'
 import { getAmazonQLspConfig } from './config'
 import { LspConfig } from 'aws-core-vscode/amazonq'
 
-export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller {
+export interface AmazonQResourcePaths extends ResourcePaths {
+    mynahUI: string
+}
+
+export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<AmazonQResourcePaths> {
     constructor(lspConfig: LspConfig = getAmazonQLspConfig()) {
         super(lspConfig, 'amazonqLsp')
     }
@@ -18,11 +22,12 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller {
         await fs.chmod(resourcePaths.node, 0o755)
     }
 
-    protected override resourcePaths(assetDirectory?: string): ResourcePaths {
+    protected override resourcePaths(assetDirectory?: string): AmazonQResourcePaths {
         if (!assetDirectory) {
             return {
                 lsp: this.config.path ?? '',
                 node: getNodeExecutableName(),
+                mynahUI: '', // TODO make mynah UI configurable
             }
         }
 
@@ -30,6 +35,7 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller {
         return {
             lsp: path.join(assetDirectory, 'servers/aws-lsp-codewhisperer.js'),
             node: nodePath,
+            mynahUI: path.join(assetDirectory, 'clients/amazonq-ui.js'),
         }
     }
 }

--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -14,7 +14,7 @@ import { Range } from 'semver'
 import { getLogger } from '../logger/logger'
 import type { Logger, LogTopic } from '../logger/logger'
 
-export abstract class BaseLspInstaller {
+export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths> {
     private logger: Logger
 
     constructor(
@@ -24,7 +24,7 @@ export abstract class BaseLspInstaller {
         this.logger = getLogger(loggerName)
     }
 
-    async resolve(): Promise<LspResolution> {
+    async resolve(): Promise<LspResolution<T>> {
         const { id, manifestUrl, supportedVersions, path } = this.config
         if (path) {
             const overrideMsg = `Using language server override location: ${path}`
@@ -61,5 +61,5 @@ export abstract class BaseLspInstaller {
     }
 
     protected abstract postInstall(assetDirectory: string): Promise<void>
-    protected abstract resourcePaths(assetDirectory?: string): ResourcePaths
+    protected abstract resourcePaths(assetDirectory?: string): T
 }

--- a/packages/core/src/shared/lsp/types.ts
+++ b/packages/core/src/shared/lsp/types.ts
@@ -18,12 +18,9 @@ export interface ResourcePaths {
     lsp: string
     node: string
 }
-export interface LspResolution extends LspResult {
-    resourcePaths: ResourcePaths
-}
 
-export interface LspResolver {
-    resolve(): Promise<LspResolution>
+export interface LspResolution<T extends ResourcePaths> extends LspResult {
+    resourcePaths: T
 }
 
 export interface TargetContent {

--- a/packages/core/src/shared/settings-toolkit.gen.ts
+++ b/packages/core/src/shared/settings-toolkit.gen.ts
@@ -42,7 +42,8 @@ export const toolkitSettings = {
     },
     "aws.experiments": {
         "jsonResourceModification": {},
-        "amazonqLSP": {}
+        "amazonqLSP": {},
+        "amazonqChatLSP": {}
     },
     "aws.resources.enabledResources": {},
     "aws.lambda.recentlyUploaded": {},

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -250,6 +250,10 @@
                         "amazonqLSP": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "amazonqChatLSP": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
## Problem
- We removed chat a while ago from the `feature/amazonqLSP` branch because we were just starting with inline suggestions

## Solution
- Now that we're moving to use chat we can re-add it
- Implement explain, refactor, fix, optimize, sendToPrompt, openTab
- Add a feature flag for enabling/disabling chat
    - **note**: amazonqLSP and amazonqChatLSP must be enabled in order for chat support to work 
- extended the baseinstaller so that individual lsps installers can provider their own resource paths

## Notes
- this is the equivalent of https://github.com/aws/language-servers/blob/55253ea258b2d34bcc47b93e9998b1e9898e8f2a/client/vscode/src/chatActivation.ts but integrated with our codebase
- since commands require the webview we pass in the view provider to all commands so we can lazy evaluate the webview when required
- certain message listeners are only registered _after_ the UI is resolved

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
