### PR TITLE
telemetry(webview): Emit toolkit_X module telemetry on auth webview

### DIFF
--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -63,7 +63,7 @@ export const createMynahUI = (
         const { error, message } = e
         ideApi.postMessage({
             type: 'error',
-            event: connector.isUIReady ? 'webview_error' : 'webview_load',
+            event: connector.isUIReady ? 'webview_error' : 'toolkit_didLoadModule',
             errorMessage: error ? error.toString() : message,
         })
     })

--- a/packages/core/src/login/webview/commonAuthViewProvider.ts
+++ b/packages/core/src/login/webview/commonAuthViewProvider.ts
@@ -135,9 +135,10 @@ export class CommonAuthViewProvider implements WebviewViewProvider {
             enableCommandUris: true,
             localResourceRoots: [dist, resources],
         }
-        webviewView.webview.html = this._getHtmlForWebview(this.extensionContext.extensionUri, webviewView.webview)
         // register the webview server
         await this.webView?.setup(webviewView.webview)
+
+        webviewView.webview.html = this._getHtmlForWebview(this.extensionContext.extensionUri, webviewView.webview)
     }
 
     private _getHtmlForWebview(extensionURI: Uri, webview: vscode.Webview) {

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -27,6 +27,7 @@ const className = 'AmazonQLoginWebview'
 export class AmazonQLoginWebview extends CommonAuthWebview {
     public override id: string = 'aws.amazonq.AmazonCommonAuth'
     public static sourcePath: string = 'vue/src/login/webview/vue/amazonq/index.js'
+    public override supportsLoadTelemetry: boolean = true
 
     override onActiveConnectionModified = new vscode.EventEmitter<void>()
 

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -62,18 +62,25 @@ export abstract class CommonAuthWebview extends VueWebview {
     }
 
     private didCall: { login: boolean; reauth: boolean } = { login: false, reauth: false }
-    public setUiReady(state: 'login' | 'reauth') {
-        // Prevent telemetry spam, since showing/hiding chat triggers this each time.
-        // So only emit once.
+    /**
+     * Called when the UI load process is completed, regardless of success or failure
+     *
+     * @param errorMessage IF an error is caught on the frontend, this is the message. It will result in a failure metric.
+     *                     Otherwise we assume success.
+     */
+    public setUiReady(state: 'login' | 'reauth', errorMessage?: string) {
+        // Only emit once to prevent telemetry spam, since showing/hiding chat triggers this each time.
+        // TODO: Research how to not trigger this on every show/hide
         if (this.didCall[state]) {
             return
         }
 
-        telemetry.webview_load.emit({
-            passive: true,
-            webviewName: state,
-            result: 'Succeeded',
-        })
+        if (errorMessage) {
+            this.setLoadFailure(state, errorMessage)
+        } else {
+            this.setDidLoad(state)
+        }
+
         this.didCall[state] = true
     }
 

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -145,6 +145,7 @@
                 ></SelectableItem>
                 <button
                     class="continue-button"
+                    id="connection-selection-continue-button"
                     :disabled="selectedLoginOption === 0"
                     v-on:click="handleContinueClick()"
                 >
@@ -368,8 +369,6 @@ export default defineComponent({
         // Pre-select the first available login option
         await this.preselectLoginOption()
         await this.handleUrlInput() // validate the default startUrl
-
-        await client.setUiReady('login')
     },
     methods: {
         toggleItemSelection(itemId: number) {
@@ -590,6 +589,18 @@ export default defineComponent({
         },
     },
 })
+
+/**
+ * The ID of the element we will use to determine that the UI has completed its initial load.
+ *
+ * This makes assumptions that we will be in a certain state of the UI (eg showing a form vs. a loading bar).
+ * So if the UI flow changes, this may need to be updated.
+ */
+export function getReadyElementId() {
+    // On every initial load, we ASSUME that the user will always be in the connection selection state,
+    // which is why we specifically look for this button.
+    return 'connection-selection-continue-button'
+}
 </script>
 
 <style>

--- a/packages/core/src/login/webview/vue/reauthenticate.vue
+++ b/packages/core/src/login/webview/vue/reauthenticate.vue
@@ -61,7 +61,7 @@ and the final results are retrieved by the frontend. For this Component to updat
                 </div>
 
                 <div>
-                    <button id="reauthenticate" v-on:click="reauthenticate">Re-authenticate</button>
+                    <button id="reauthenticate-button" v-on:click="reauthenticate">Re-authenticate</button>
                     <div v-if="errorMessage" id="error-message" style="color: red">{{ errorMessage }}</div>
                 </div>
 
@@ -127,9 +127,6 @@ export default defineComponent({
 
         this.doShow = true
     },
-    async mounted() {
-        await client.setUiReady('reauth')
-    },
     methods: {
         async reauthenticate() {
             client.emitUiClick('auth_reauthenticate')
@@ -148,6 +145,16 @@ export default defineComponent({
         },
     },
 })
+
+/**
+ * The ID of the element we will use to determine that the UI has completed its initial load.
+ *
+ * This makes assumptions that we will be in a certain state of the UI (eg showing a form vs. a loading bar).
+ * So if the UI flow changes, this may need to be updated.
+ */
+export function getReadyElementId() {
+    return 'reauthenticate-button'
+}
 </script>
 <style>
 @import './base.css';
@@ -199,7 +206,7 @@ export default defineComponent({
     flex-direction: column;
 }
 
-button#reauthenticate {
+button#reauthenticate-button {
     cursor: pointer;
     background-color: var(--vscode-button-background);
     color: white;
@@ -231,7 +238,7 @@ button#cancel {
     cursor: pointer;
 }
 
-body.vscode-high-contrast:not(body.vscode-high-contrast-light) button#reauthenticate {
+body.vscode-high-contrast:not(body.vscode-high-contrast-light) button#reauthenticate-button {
     background-color: white;
     color: black;
 }

--- a/packages/core/src/login/webview/vue/root.vue
+++ b/packages/core/src/login/webview/vue/root.vue
@@ -85,7 +85,8 @@ export default defineComponent({
 // TODO: Move this in to a reusable class for other webviews, it feels a bit messy here
 let didSetReady = false
 
-// Setup error handlers to report 
+// Setup error handlers to report. This may not actually be able to catch certain errors that we'd expect,
+// so this may have to be revisited.
 window.onerror = function (message) {
     if (didSetReady) {
         return
@@ -119,7 +120,7 @@ const handleLoaded = () => {
     if (!foundElement) {
         setUiReady((window as any).uiState, `Could not find element: ${(window as any).uiReadyElementId}`)
     } else {
-        // Successful load!    
+        // Successful load!
         setUiReady((window as any).uiState)
     }
 }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -986,16 +986,6 @@
             "passive": true
         },
         {
-            "name": "webview_load",
-            "description": "Represents a webview load event",
-            "metadata": [
-                {
-                    "type": "webviewName",
-                    "required": true
-                }
-            ]
-        },
-        {
             "name": "webview_error",
             "description": "Represents an error that occurs in a webview",
             "metadata": [


### PR DESCRIPTION
## Problem:

With our telemetry, we do not know when the frontend webview UI has actually loaded.

The current process looks like the following:
- We create a webview and set the HTML to load, but after that we do not have a formal way to detect if the webview actually loaded the HTML/JS successfully. We only know that the process started (`toolkit_willOpenModule`)

## Solution:

Emit certain metrics during the webview loading process to get a better idea of if the webview UI successfully completed its initial load.

- `toolkit_willOpenModule`, indicates intent to render a webview. It does not mean the user is seeing anything.
- `toolkit_didLoadModule`, indicates the final result of loading the webview
  - We know a `result: Succeeded` when the frontend send a successful message to the backend. It knows this by ensuring there were no errors and that a certain HTML element can be found, then once the page finishes its initial load it will send a success message to the backend.
  - On `result: Failed`, what happens is a timer has timed out after 10 seconds. We assume that since there was no response from the frontend, it failed to fully execute the HTML/JS.
  - State is shared between `toolkit_willOpenModule` and `toolkit_didLoadModule` so that we can connect them through telemetry. This includes `traceId` and the `duration` which is the time between the 2 metrics.

This PR only applies to the Login and Reauth page for now, and future Vue webviews will need to implement some things on their end to get this functionality.

## TODO
- Generalize this solution in a more robust way for other webviews to easily implement this functionality

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
