### PR TITLE
fix(amazonq): update the bearer token in the language server every 5 minutes

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -11,7 +11,14 @@ import { registerInlineCompletion } from '../app/inline/completion'
 import { AmazonQLspAuth, encryptionKey, notificationTypes } from './auth'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { ConnectionMetadata } from '@aws/language-server-runtimes/protocol'
-import { ResourcePaths, Settings, oidcClientName, createServerOptions, globals } from 'aws-core-vscode/shared'
+import {
+    ResourcePaths,
+    Settings,
+    oidcClientName,
+    createServerOptions,
+    globals,
+    getLogger,
+} from 'aws-core-vscode/shared'
 
 const localize = nls.loadMessageBundle()
 
@@ -101,8 +108,13 @@ export async function startLanguageServer(extensionContext: vscode.ExtensionCont
         })
 
         // Temporary code for pen test. Will be removed when we switch to the real flare auth
-        setInterval(async () => {
-            await auth.init()
+        const authInterval = setInterval(async () => {
+            try {
+                await auth.init()
+            } catch (e) {
+                getLogger('amazonqLsp').error('Unable to update bearer token: %s', (e as Error).message)
+                clearInterval(authInterval)
+            }
         }, 300000) // every 5 minutes
 
         toDispose.push(

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -100,6 +100,11 @@ export async function startLanguageServer(extensionContext: vscode.ExtensionCont
             }
         })
 
+        // Temporary code for pen test. Will be removed when we switch to the real flare auth
+        setInterval(async () => {
+            await auth.init()
+        }, 300000) // every 5 minutes
+
         toDispose.push(
             AuthUtil.instance.auth.onDidChangeActiveConnection(async () => {
                 await auth.init()


### PR DESCRIPTION
## Problem
- When the bearer token updates in the background we never re-notify the language server

## Solution
- update it every 5 minutes as a hack to unblock the pentest


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
