### PR TITLE
fix(cw): allow retries in the cw streaming sdk client. 

### DIFF
--- a/packages/core/src/shared/clients/codewhispererChatClient.ts
+++ b/packages/core/src/shared/clients/codewhispererChatClient.ts
@@ -17,7 +17,7 @@ export async function createCodeWhispererChatStreamingClient(): Promise<CodeWhis
         endpoint: cwsprConfig.endpoint,
         token: { token: bearerToken },
         customUserAgent: getUserAgent(),
-        retryStrategy: new ConfiguredRetryStrategy(5, (attempt: number) => 500 + attempt ** 10),
+        retryStrategy: new ConfiguredRetryStrategy(3, (attempt: number) => 500 + attempt ** 10),
     })
     return streamingClient
 }

--- a/packages/core/src/shared/clients/codewhispererChatClient.ts
+++ b/packages/core/src/shared/clients/codewhispererChatClient.ts
@@ -17,7 +17,7 @@ export async function createCodeWhispererChatStreamingClient(): Promise<CodeWhis
         endpoint: cwsprConfig.endpoint,
         token: { token: bearerToken },
         customUserAgent: getUserAgent(),
-        retryStrategy: new ConfiguredRetryStrategy(3, (attempt: number) => 500 + attempt ** 10),
+        retryStrategy: new ConfiguredRetryStrategy(1, (attempt: number) => 500 + attempt ** 10),
     })
     return streamingClient
 }

--- a/packages/core/src/shared/clients/codewhispererChatClient.ts
+++ b/packages/core/src/shared/clients/codewhispererChatClient.ts
@@ -17,9 +17,7 @@ export async function createCodeWhispererChatStreamingClient(): Promise<CodeWhis
         endpoint: cwsprConfig.endpoint,
         token: { token: bearerToken },
         customUserAgent: getUserAgent(),
-        // SETTING max attempts to 0 FOR BETA. RE-ENABLE FOR RE-INVENT
-        // Implement exponential back off starting with a base of 500ms (500 + attempt^10)
-        retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
+        retryStrategy: new ConfiguredRetryStrategy(5, (attempt: number) => 500 + attempt ** 10),
     })
     return streamingClient
 }


### PR DESCRIPTION
## Problem
This client is used in many Q features and does not currently allow retries. This means a single SDK request failure will cause the operation to fail. 

It appears based on the code that this is not intentional, and was accidentally left unfinished. 

## Solution
- allow up to 1 retry.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
