### PR TITLE
fix(review): code issues ellipses menu displaying toolkit options

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-385a5132-b128-4acb-920a-53990ebdb7c4.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-385a5132-b128-4acb-920a-53990ebdb7c4.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/review: Code Issues ellipses menu displays AWS Toolkit options, if installed."
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -220,7 +220,7 @@
                 },
                 {
                     "type": "webview",
-                    "id": "aws.AmazonQChatView",
+                    "id": "aws.amazonq.AmazonQChatView",
                     "name": "%AWS.amazonq.chat%",
                     "when": "!aws.isWebExtHost && !aws.amazonq.showLoginView"
                 }
@@ -340,32 +340,32 @@
                 },
                 {
                     "command": "aws.amazonq.openReferencePanel",
-                    "when": "view == aws.AmazonQChatView",
+                    "when": "view == aws.amazonq.AmazonQChatView",
                     "group": "0_topAmazonQ@1"
                 },
                 {
                     "command": "aws.amazonq.learnMore",
-                    "when": "view == aws.AmazonQChatView || view == aws.amazonq.AmazonCommonAuth",
+                    "when": "view =~ /^aws\\.amazonq/",
                     "group": "1_amazonQ@1"
                 },
                 {
                     "command": "aws.amazonq.signout",
-                    "when": "(view == aws.AmazonQChatView) && aws.codewhisperer.connected",
+                    "when": "(view == aws.amazonq.AmazonQChatView) && aws.codewhisperer.connected",
                     "group": "2_amazonQ@4"
                 },
                 {
                     "command": "aws.amazonq.reconnect",
-                    "when": "(view == aws.AmazonQChatView) && aws.codewhisperer.connectionExpired",
+                    "when": "(view == aws.amazonq.AmazonQChatView) && aws.codewhisperer.connectionExpired",
                     "group": "2_amazonQ@3"
                 },
                 {
                     "submenu": "aws.amazonq.submenu.feedback",
-                    "when": "view == aws.AmazonQChatView || view == aws.amazonq.AmazonCommonAuth",
+                    "when": "view =~ /^aws\\.amazonq/",
                     "group": "y_toolkitMeta@1"
                 },
                 {
                     "submenu": "aws.amazonq.submenu.help",
-                    "when": "view == aws.AmazonQChatView || view == aws.amazonq.AmazonCommonAuth",
+                    "when": "view =~ /^aws\\.amazonq/",
                     "group": "y_toolkitMeta@2"
                 },
                 {

--- a/packages/core/src/amazonq/webview/webView.ts
+++ b/packages/core/src/amazonq/webview/webView.ts
@@ -22,7 +22,7 @@ import { TabType } from './ui/storages/tabsStorage'
 import { amazonqMark } from '../../shared/performance/marks'
 
 export class AmazonQChatViewProvider implements WebviewViewProvider {
-    public static readonly viewType = 'aws.AmazonQChatView'
+    public static readonly viewType = 'aws.amazonq.AmazonQChatView'
 
     webViewContentGenerator: WebViewContentGenerator
     webView: Webview | undefined

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -603,7 +603,7 @@ export class FeatureDevController {
                         open
                     )
                     if (resp === open) {
-                        await vscode.commands.executeCommand('aws.AmazonQChatView.focus')
+                        await vscode.commands.executeCommand('aws.amazonq.AmazonQChatView.focus')
                         // TODO add focusing on the specific tab once that's implemented
                     }
                 }

--- a/packages/core/src/codewhispererChat/commands/registerCommands.ts
+++ b/packages/core/src/codewhispererChat/commands/registerCommands.ts
@@ -25,7 +25,7 @@ export const focusAmazonQPanel = Commands.declare(
          * So when we try to focus the following Views, only one will show depending
          * on the context.
          */
-        await vscode.commands.executeCommand('aws.AmazonQChatView.focus')
+        await vscode.commands.executeCommand('aws.amazonq.AmazonQChatView.focus')
         await vscode.commands.executeCommand('aws.amazonq.AmazonCommonAuth.focus')
     }
 )

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1353,12 +1353,12 @@
                 },
                 {
                     "submenu": "aws.toolkit.submenu.feedback",
-                    "when": "view =~ /^aws\\./ && view != aws.AmazonQChatView && view != aws.amazonq.AmazonCommonAuth",
+                    "when": "view =~ /^aws\\./ && !(view =~ /^aws\\.amazonq/)",
                     "group": "y_toolkitMeta@1"
                 },
                 {
                     "submenu": "aws.toolkit.submenu.help",
-                    "when": "view =~ /^aws\\./ && view != aws.AmazonQChatView && view != aws.amazonq.AmazonCommonAuth",
+                    "when": "view =~ /^aws\\./ && !(view =~ /^aws\\.amazonq/)",
                     "group": "y_toolkitMeta@2"
                 },
                 {


### PR DESCRIPTION
Fixes https://github.com/aws/aws-toolkit-vscode/issues/6787.

Only happens when toolkit is installed otherwise there is no ellipses menu.

Before
<img width="687" alt="image" src="https://github.com/user-attachments/assets/d9b704e7-a136-4a73-9a0c-7fef004627c8" />

After
<img width="794" alt="image" src="https://github.com/user-attachments/assets/dea75e37-b106-43be-afd0-7516eb10b765" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
