### PR TITLE
feat(amazonq): Add changelog item for enabling inline code suggestions via Amazon Q Language Server

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-7a3c930e-cc8e-4323-9ecd-c1bf767fd2ed.json
+++ b/packages/amazonq/.changes/next-release/Feature-7a3c930e-cc8e-4323-9ecd-c1bf767fd2ed.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "(Experimental) Amazon Q inline code suggestions via Amazon Q Language Server. (enable with `aws.experiments.amazonqLSP: true`)"
+}


### PR DESCRIPTION
## Problem
- Missing changelog

## Solution
- Add it before releasing


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
