### PR TITLE
refactor(workspaceutil): unify file collecting utilities. (WIP)

### DIFF
--- a/packages/core/src/amazonq/util/files.ts
+++ b/packages/core/src/amazonq/util/files.ts
@@ -88,7 +88,7 @@ export async function prepareRepoData(
         }
 
         const files = await collectFiles(repoRootPaths, workspaceFolders, {
-            maxSizeBytes: maxRepoSizeBytes,
+            maxTotalSizeBytes: maxRepoSizeBytes,
             excludeByGitIgnore: true,
             excludePatterns: excludePatterns,
             filterFn: filterFn,

--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -420,7 +420,7 @@ export class ZipUtil {
                   )
                 : vscode.workspace.workspaceFolders) as CurrentWsFolders,
             {
-                maxSizeBytes: this.getProjectScanPayloadSizeLimitInBytes(),
+                maxTotalSizeBytes: this.getProjectScanPayloadSizeLimitInBytes(),
                 excludePatterns:
                     useCase === FeatureUseCase.TEST_GENERATION
                         ? [...CodeWhispererConstants.testGenExcludePatterns, ...defaultExcludePatterns]

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -462,19 +462,20 @@ describe('workspaceUtils', () => {
     })
 
     describe('collectFilesForIndex', function () {
+        let workspaceFolder: vscode.WorkspaceFolder
+
+        const writeFile = (pathParts: string[], fileContent: string) => {
+            return toFile(fileContent, path.join(workspaceFolder.uri.fsPath, ...pathParts))
+        }
+
+        beforeEach(async function () {
+            workspaceFolder = await createTestWorkspaceFolder()
+            sandbox.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder])
+        })
+
         it('returns all files in the workspace not excluded by gitignore and is a supported programming language', async function () {
-            // these variables are a manual selection of settings for the test in order to test the collectFiles function
-            const fileAmount = 3
-            const fileNamePrefix = 'file'
             const fileContent = 'test content'
 
-            const workspaceFolder = await createTestWorkspace(fileAmount, { fileNamePrefix, fileContent })
-
-            const writeFile = (pathParts: string[], fileContent: string) => {
-                return toFile(fileContent, path.join(workspaceFolder.uri.fsPath, ...pathParts))
-            }
-
-            sandbox.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder])
             const gitignoreContent = `file2
             # different formats of prefixes
             /build
@@ -535,18 +536,7 @@ describe('workspaceUtils', () => {
         })
 
         it('does not include build related files', async function () {
-            // these variables are a manual selection of settings for the test in order to test the collectFiles function
-            const fileAmount = 3
-            const fileNamePrefix = 'file'
             const fileContent = 'this is a file'
-
-            const workspaceFolder = await createTestWorkspace(fileAmount, { fileNamePrefix, fileContent })
-
-            const writeFile = (pathParts: string[], fileContent: string) => {
-                return toFile(fileContent, path.join(workspaceFolder.uri.fsPath, ...pathParts))
-            }
-
-            sandbox.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder])
 
             await writeFile(['bin', `ignored1`], fileContent)
             await writeFile(['bin', `ignored2`], fileContent)
@@ -581,18 +571,7 @@ describe('workspaceUtils', () => {
         })
 
         it('returns top level files when max size is reached', async function () {
-            // these variables are a manual selection of settings for the test in order to test the collectFiles function
-            const fileAmount = 3
-            const fileNamePrefix = 'file'
             const fileContent = 'this is a file'
-
-            const workspaceFolder = await createTestWorkspace(fileAmount, { fileNamePrefix, fileContent })
-
-            const writeFile = (pathParts: string[], fileContent: string) => {
-                return toFile(fileContent, path.join(workspaceFolder.uri.fsPath, ...pathParts))
-            }
-
-            sandbox.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder])
 
             await writeFile(['path', 'to', 'file', 'a2.js'], fileContent)
             await writeFile(['path', 'to', 'file', `b2.java`], fileContent)


### PR DESCRIPTION
## Problem
`collectFiles` and `collectFilesForIndex` serve different purposes, but implement the same core functionality. This core functionality should be not duplicated in two places. 

## Solution
- Increase testing coverage for both methods. 
- Refactor `collectFiles` to be general enough to handle `collectFilesForIndex` use case. Most importantly, avoid reading the files when we are indexing. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
