### PR TITLE
fix(amazonq): Improve responses for saved prompts and workspace rules

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-62081c53-09b4-46b0-80b0-6eb853ffabd6.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-62081c53-09b4-46b0-80b0-6eb853ffabd6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q chat: Improve responses for saved prompts and workspace rules"
+}

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -980,12 +980,12 @@ export class ChatController {
         if (Array.isArray(prompts) && prompts.length > 0) {
             triggerPayload.additionalContextLengths = this.telemetryHelper.getContextLengths(prompts)
             for (const prompt of prompts.slice(0, 20)) {
-                let description = prompt.description
                 // Add system prompt for user prompts and workspace rules
                 const contextType = this.telemetryHelper.getContextType(prompt)
-                if (contextType === 'rule' || contextType === 'prompt') {
-                    description = `You must follow the instructions in ${prompt.relativePath}. Below are lines ${prompt.startLine}-${prompt.endLine} of this file:\n`
-                }
+                const description =
+                    contextType === 'rule' || contextType === 'prompt'
+                        ? `You must follow the instructions in ${prompt.relativePath}. Below are lines ${prompt.startLine}-${prompt.endLine} of this file:\n`
+                        : prompt.description
                 const entry = {
                     name: prompt.name.substring(0, aditionalContentNameLimit),
                     description: description.substring(0, aditionalContentNameLimit),

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -980,9 +980,15 @@ export class ChatController {
         if (Array.isArray(prompts) && prompts.length > 0) {
             triggerPayload.additionalContextLengths = this.telemetryHelper.getContextLengths(prompts)
             for (const prompt of prompts.slice(0, 20)) {
+                let description = prompt.description
+                // Add system prompt for user prompts and workspace rules
+                const contextType = this.telemetryHelper.getContextType(prompt)
+                if (contextType === 'rule' || contextType === 'prompt') {
+                    description = `You must follow the instructions in ${prompt.relativePath}. Below are lines ${prompt.startLine}-${prompt.endLine} of this file:\n`
+                }
                 const entry = {
                     name: prompt.name.substring(0, aditionalContentNameLimit),
-                    description: prompt.description.substring(0, aditionalContentNameLimit),
+                    description: description.substring(0, aditionalContentNameLimit),
                     innerContext: prompt.content.substring(0, additionalContentInnerContextLimit),
                 }
                 // make sure the relevantDocument + additionalContext
@@ -994,7 +1000,6 @@ export class ChatController {
                     break
                 }
 
-                const contextType = this.telemetryHelper.getContextType(prompt)
                 if (contextType === 'rule') {
                     triggerPayload.truncatedAdditionalContextLengths.ruleContextLength += entry.innerContext.length
                 } else if (contextType === 'prompt') {

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -42,7 +42,7 @@ import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { getSelectedCustomization } from '../../../codewhisperer/util/customizationUtil'
 import { undefinedIfEmpty } from '../../../shared/utilities/textUtilities'
 import { AdditionalContextPrompt } from '../../../amazonq/lsp/types'
-import { getUserPromptsDirectory } from '../../constants'
+import { getUserPromptsDirectory, promptFileExtension } from '../../constants'
 
 export function logSendTelemetryEventFailure(error: any) {
     let requestId: string | undefined
@@ -148,13 +148,14 @@ export class CWCTelemetryHelper {
     }
 
     public getContextType(prompt: AdditionalContextPrompt): string {
-        if (prompt.relativePath.startsWith(path.join('.amazonq', 'rules'))) {
-            return 'rule'
-        } else if (prompt.filePath.startsWith(getUserPromptsDirectory())) {
-            return 'prompt'
-        } else {
-            return 'file'
+        if (prompt.filePath.endsWith(promptFileExtension)) {
+            if (prompt.relativePath.startsWith(path.join('.amazonq', 'rules'))) {
+                return 'rule'
+            } else if (prompt.filePath.startsWith(getUserPromptsDirectory())) {
+                return 'prompt'
+            }
         }
+        return 'file'
     }
 
     public getContextLengths(prompts: AdditionalContextPrompt[]): AdditionalContextLengths {

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -43,6 +43,7 @@ import { getSelectedCustomization } from '../../../codewhisperer/util/customizat
 import { undefinedIfEmpty } from '../../../shared/utilities/textUtilities'
 import { AdditionalContextPrompt } from '../../../amazonq/lsp/types'
 import { getUserPromptsDirectory, promptFileExtension } from '../../constants'
+import { isInDirectory } from '../../../shared/filesystemUtilities'
 
 export function logSendTelemetryEventFailure(error: any) {
     let requestId: string | undefined
@@ -149,9 +150,9 @@ export class CWCTelemetryHelper {
 
     public getContextType(prompt: AdditionalContextPrompt): string {
         if (prompt.filePath.endsWith(promptFileExtension)) {
-            if (prompt.relativePath.startsWith(path.join('.amazonq', 'rules'))) {
+            if (isInDirectory(path.join('.amazonq', 'rules'), prompt.relativePath)) {
                 return 'rule'
-            } else if (prompt.filePath.startsWith(getUserPromptsDirectory())) {
+            } else if (isInDirectory(getUserPromptsDirectory(), prompt.filePath)) {
                 return 'prompt'
             }
         }


### PR DESCRIPTION
## Problem
The system prompt for saved prompts and workspace rules is too vague, users reporting they are sometimes ignored entirely.

## Solution
Add system prompt for saved prompt and workspace rules to improve quality of responses

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
