### PR TITLE
build(deps): remove `@aws/fully-qualified-names` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10505,14 +10505,6 @@
                 "yargs": "^17.0.1"
             }
         },
-        "node_modules/@aws/fully-qualified-names": {
-            "version": "2.1.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "web-tree-sitter": "^0.20.8"
-            }
-        },
         "node_modules/@aws/mynah-ui": {
             "version": "4.25.1",
             "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.25.1.tgz",
@@ -24399,7 +24391,6 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
-                "@aws/fully-qualified-names": "^2.1.4",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",

--- a/packages/amazonq/scripts/build/copyFiles.ts
+++ b/packages/amazonq/scripts/build/copyFiles.ts
@@ -56,17 +56,6 @@ const tasks: CopyTask[] = [
         destination: 'vue/',
     },
 
-    // Mynah
-    {
-        target: path.join(
-            '../../node_modules',
-            '@aws',
-            'fully-qualified-names',
-            'node',
-            'aws_fully_qualified_names_bg.wasm'
-        ),
-        destination: path.join('src', 'aws_fully_qualified_names_bg.wasm'),
-    },
     {
         target: path.join('../../node_modules', 'web-tree-sitter', 'tree-sitter.wasm'),
         destination: path.join('src', 'tree-sitter.wasm'),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -440,7 +440,6 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws/fully-qualified-names": "^2.1.4",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",
@@ -497,6 +496,7 @@
         "@amzn/amazon-q-developer-streaming-client": "file:../../src.gen/@amzn/amazon-q-developer-streaming-client",
         "@amzn/codewhisperer-streaming": "file:../../src.gen/@amzn/codewhisperer-streaming",
         "@aws-sdk/client-api-gateway": "<3.696.0",
+        "@aws-sdk/client-cloudcontrol": "<3.696.0",
         "@aws-sdk/client-cloudformation": "<3.696.0",
         "@aws-sdk/client-cloudwatch-logs": "<3.696.0",
         "@aws-sdk/client-codecatalyst": "<3.696.0",
@@ -510,7 +510,6 @@
         "@aws-sdk/client-ssm": "<3.696.0",
         "@aws-sdk/client-sso": "<3.696.0",
         "@aws-sdk/client-sso-oidc": "<3.696.0",
-        "@aws-sdk/client-cloudcontrol": "<3.696.0",
         "@aws-sdk/credential-provider-env": "<3.696.0",
         "@aws-sdk/credential-provider-process": "<3.696.0",
         "@aws-sdk/credential-provider-sso": "<3.696.0",

--- a/packages/toolkit/scripts/build/copyFiles.ts
+++ b/packages/toolkit/scripts/build/copyFiles.ts
@@ -95,18 +95,6 @@ const tasks: CopyTask[] = [
         target: path.join('../../node_modules/aws-core-vscode/dist', 'vue'),
         destination: 'vue/',
     },
-
-    // Mynah
-    {
-        target: path.join(
-            '../../node_modules',
-            '@aws',
-            'fully-qualified-names',
-            'node',
-            'aws_fully_qualified_names_bg.wasm'
-        ),
-        destination: path.join('src', 'aws_fully_qualified_names_bg.wasm'),
-    },
     {
         target: path.join('../../node_modules', 'web-tree-sitter', 'tree-sitter.wasm'),
         destination: path.join('src', 'tree-sitter.wasm'),


### PR DESCRIPTION
## Problem
FQN not used since 6484c98c3ecd4a2b665e7ee8fa3d96e8ba9ce935. And it adds ~1 MB to the vsix size.

## Solution
- Drop FQN dependency.
- Remove "temporary" hack added a long time ago for mynah: b2dc00ab7431







---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
