### PR TITLE
fix(amazonq): invalid version in language server cache causes crash

### DIFF
--- a/packages/core/src/shared/lsp/utils/cleanup.ts
+++ b/packages/core/src/shared/lsp/utils/cleanup.ts
@@ -7,10 +7,10 @@ import path from 'path'
 import { LspVersion } from '../types'
 import { fs } from '../../../shared/fs/fs'
 import { partition } from '../../../shared/utilities/tsUtils'
-import { sort } from 'semver'
+import { parse, sort } from 'semver'
 
-async function getDownloadedVersions(installLocation: string) {
-    return (await fs.readdir(installLocation)).map(([f, _], __) => f)
+export async function getDownloadedVersions(installLocation: string) {
+    return (await fs.readdir(installLocation)).filter((x) => parse(x[0]) !== null).map(([f, _], __) => f)
 }
 
 function isDelisted(manifestVersions: LspVersion[], targetVersion: string): boolean {

--- a/packages/core/src/test/shared/lsp/utils/cleanup.test.ts
+++ b/packages/core/src/test/shared/lsp/utils/cleanup.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { Uri } from 'vscode'
-import { cleanLspDownloads, fs } from '../../../../shared'
+import { cleanLspDownloads, fs, getDownloadedVersions } from '../../../../shared'
 import { createTestWorkspaceFolder } from '../../../testUtil'
 import path from 'path'
 import assert from 'assert'
@@ -98,6 +98,18 @@ describe('cleanLSPDownloads', function () {
         )
 
         const result = (await fs.readdir(installationDir.fsPath)).map(([filename, _filetype], _index) => filename)
+        assert.strictEqual(result.length, 0)
+        assert.strictEqual(deleted.length, 1)
+    })
+
+    it('ignores invalid versions', async function () {
+        await fakeInstallVersions(['1.0.0', '.DS_STORE'], installationDir.fsPath)
+        const deleted = await cleanLspDownloads(
+            [{ serverVersion: '1.0.0', isDelisted: true, targets: [] }],
+            installationDir.fsPath
+        )
+
+        const result = await getDownloadedVersions(installationDir.fsPath)
         assert.strictEqual(result.length, 0)
         assert.strictEqual(deleted.length, 1)
     })


### PR DESCRIPTION
## Problem
If you have a `.DS_STORE` file in the same directory of the language server cache versions your language server will crash

## Solution
Only look for valid semver versions when cleaning up your cache

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
