### PR TITLE
docs: add "Q Developer" marketplace tag

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -32,7 +32,8 @@
         "Codewhisperer",
         "AI",
         "Assistant",
-        "Chatbot"
+        "Chatbot",
+        "Q Developer"
     ],
     "preview": false,
     "qna": "https://github.com/aws/aws-toolkit-vscode/issues",


### PR DESCRIPTION
The Q product name should find amazon-q-vscode.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
