### PR TITLE
fix(amazonq): Open multiple VSCode instances crashes Amazon Q Language Server

### DIFF
--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -308,7 +308,14 @@ export class LanguageServerResolver {
                 // attempt to unzip
                 const zipFile = new AdmZip(zip)
                 const extractPath = zip.replace('.zip', '')
-                zipFile.extractAllTo(extractPath, true)
+
+                /**
+                 * Avoid overwriting existing files during extraction to prevent file corruption.
+                 * On Mac ARM64 when a language server is already running in one VS Code window,
+                 * attempting to extract and overwrite its files from another window can cause
+                 * the newly started language server to crash with 'EXC_CRASH (SIGKILL (Code Signature Invalid))'.
+                 */
+                zipFile.extractAllTo(extractPath, false)
             } catch (e) {
                 return false
             }


### PR DESCRIPTION
## Problem
When running multiple VSCode windows on mac arm64, Amazon Q's language server works correctly in the first window but crashes in additional windows with the error: `EXC_CRASH (SIGKILL (Code Signature Invalid))`

## Root Cause
The crash occurs because:
- The first VSCode window starts the language server and extracts everything (including the node binary from flare)
- When additional VSCode windows are opened, they attempt to re-extract the zip from flare, overriding the current contents
- On mac arm64, overwriting the node binary while it's in use by the first VSCode window can apparently cause code signing validation to fail for the next callers of it
    - This didn't effect windows when I was playing around with it yesterday
    - Weirdly enough, if you start the language server outside of VSCode, unzip servers.zip again, and then spawn a new language server it doesn't seem to have an issue. My guess is there's some weird interplay with electron owning the spawning of the processes

## Solution
Instead of forcefully overriding contents in flare, only copy over the file if its necessary

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
