### PR TITLE
feat(amazonq): add open chat command

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-fa845e78-1e76-407a-be8a-e64c63b98795.json
+++ b/packages/amazonq/.changes/next-release/Feature-fa845e78-1e76-407a-be8a-e64c63b98795.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Command Palette: Add `Amazon Q: Open Chat` command."
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -741,6 +741,11 @@
                 "enablement": "aws.codewhisperer.connected"
             },
             {
+                "command": "aws.amazonq.focusChat",
+                "title": "%AWS.amazonq.openChat%",
+                "category": "%AWS.amazonq.title%"
+            },
+            {
                 "command": "aws.amazonq.exploreAgents",
                 "title": "%AWS.amazonq.exploreAgents%",
                 "category": "%AWS.amazonq.title%",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -323,6 +323,7 @@
     "AWS.codewhisperer.customization.notification.new_customizations.learn_more": "Learn More",
     "AWS.amazonq.title": "Amazon Q",
     "AWS.amazonq.chat": "Chat",
+    "AWS.amazonq.openChat": "Open Chat",
     "AWS.amazonq.context.folders.title": "Folders",
     "AWS.amazonq.context.folders.description": "Add all files in a folder to context",
     "AWS.amazonq.context.files.title": "Files",


### PR DESCRIPTION
There is no hard command to focus the chat view from command palette. There exists Amazon Q: Focus on Chat View, but if the user moves the chat it can change names, e.g. Terminal: Focus on Chat View, which is confusing.
CoPilot also has this issue, which is why they have the Chat: Open Chat command.

Note: This command will work whether the user is logged in or not, for ease of use. If they are not logged in then it will open the login window.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
