### PR TITLE
feat(amazonq): passing referenceTrackerConfiguration to StartCodeFixJob

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-25bf4b40-331e-4b28-8a89-0a19075b6b79.json
+++ b/packages/amazonq/.changes/next-release/Feature-25bf4b40-331e-4b28-8a89-0a19075b6b79.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "/review: passing referenceTrackerConfiguration to StartCodeFixJob"
+}

--- a/packages/core/src/codewhisperer/client/user-service-2.json
+++ b/packages/core/src/codewhisperer/client/user-service-2.json
@@ -2206,7 +2206,8 @@
                 "uploadId": { "shape": "UploadId" },
                 "description": { "shape": "StartCodeFixJobRequestDescriptionString" },
                 "ruleId": { "shape": "StartCodeFixJobRequestRuleIdString" },
-                "codeFixName": { "shape": "CodeFixName" }
+                "codeFixName": { "shape": "CodeFixName" },
+                "referenceTrackerConfiguration": { "shape": "ReferenceTrackerConfiguration" }
             }
         },
         "StartCodeFixJobRequestDescriptionString": {

--- a/packages/core/src/codewhisperer/commands/startCodeFixGeneration.ts
+++ b/packages/core/src/codewhisperer/commands/startCodeFixGeneration.ts
@@ -18,6 +18,7 @@ import AdmZip from 'adm-zip'
 import path from 'path'
 import { TelemetryHelper } from '../util/telemetryHelper'
 import { tempDirPath } from '../../shared/filesystemUtilities'
+import { CodeWhispererSettings } from '../util/codewhispererSettings'
 
 export async function startCodeFixGeneration(
     client: DefaultCodeWhispererClient,
@@ -69,6 +70,11 @@ export async function startCodeFixGeneration(
                 end: { line: issue.endLine, character: 0 },
             },
             issue.recommendation.text,
+            {
+                recommendationsWithReferences: CodeWhispererSettings.instance.isSuggestionsWithCodeReferencesEnabled()
+                    ? 'ALLOW'
+                    : 'BLOCK',
+            },
             codeFixName,
             issue.ruleId
         )

--- a/packages/core/src/codewhisperer/service/codeFixHandler.ts
+++ b/packages/core/src/codewhisperer/service/codeFixHandler.ts
@@ -50,6 +50,7 @@ export async function createCodeFixJob(
     uploadId: string,
     snippetRange: CodeWhispererUserClient.Range,
     description: string,
+    referenceTrackerConfiguration: CodeWhispererUserClient.ReferenceTrackerConfiguration,
     codeFixName?: string,
     ruleId?: string
 ) {
@@ -60,6 +61,7 @@ export async function createCodeFixJob(
         codeFixName,
         ruleId,
         description,
+        referenceTrackerConfiguration,
     }
 
     const resp = await client.startCodeFixJob(req).catch((err) => {


### PR DESCRIPTION
## Problem

When Q generates code fixes, it some times can get code from external links. For these fixes, it is required to return the reference along with the code fixes.

## Solution

This change gives customer the choice to either accept or block the code fix with references.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
