### PR TITLE
telemetry(amazonq):Add metric telemetry for /doc

### DIFF
--- a/packages/core/src/amazonqDoc/errors.ts
+++ b/packages/core/src/amazonqDoc/errors.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ToolkitError } from '../shared/errors'
+import { ClientError, ContentLengthError as CommonContentLengthError } from '../shared/errors'
 import { i18n } from '../shared/i18n-helper'
 
-export class DocServiceError extends ToolkitError {
+export class DocClientError extends ClientError {
     remainingIterations?: number
     constructor(message: string, code: string, remainingIterations?: number) {
         super(message, { code })
@@ -14,49 +14,49 @@ export class DocServiceError extends ToolkitError {
     }
 }
 
-export class ReadmeTooLargeError extends DocServiceError {
+export class ReadmeTooLargeError extends DocClientError {
     constructor() {
         super(i18n('AWS.amazonq.doc.error.readmeTooLarge'), ReadmeTooLargeError.name)
     }
 }
 
-export class ReadmeUpdateTooLargeError extends DocServiceError {
+export class ReadmeUpdateTooLargeError extends DocClientError {
     constructor(remainingIterations: number) {
         super(i18n('AWS.amazonq.doc.error.readmeUpdateTooLarge'), ReadmeUpdateTooLargeError.name, remainingIterations)
     }
 }
 
-export class WorkspaceEmptyError extends DocServiceError {
+export class WorkspaceEmptyError extends DocClientError {
     constructor() {
         super(i18n('AWS.amazonq.doc.error.workspaceEmpty'), WorkspaceEmptyError.name)
     }
 }
 
-export class NoChangeRequiredException extends DocServiceError {
+export class NoChangeRequiredException extends DocClientError {
     constructor() {
         super(i18n('AWS.amazonq.doc.error.noChangeRequiredException'), NoChangeRequiredException.name)
     }
 }
 
-export class PromptRefusalException extends DocServiceError {
+export class PromptRefusalException extends DocClientError {
     constructor(remainingIterations: number) {
         super(i18n('AWS.amazonq.doc.error.promptRefusal'), PromptRefusalException.name, remainingIterations)
     }
 }
 
-export class ContentLengthError extends DocServiceError {
+export class ContentLengthError extends CommonContentLengthError {
     constructor() {
-        super(i18n('AWS.amazonq.doc.error.contentLengthError'), ContentLengthError.name)
+        super(i18n('AWS.amazonq.doc.error.contentLengthError'), { code: ContentLengthError.name })
     }
 }
 
-export class PromptTooVagueError extends DocServiceError {
+export class PromptTooVagueError extends DocClientError {
     constructor(remainingIterations: number) {
         super(i18n('AWS.amazonq.doc.error.promptTooVague'), PromptTooVagueError.name, remainingIterations)
     }
 }
 
-export class PromptUnrelatedError extends DocServiceError {
+export class PromptUnrelatedError extends DocClientError {
     constructor(remainingIterations: number) {
         super(i18n('AWS.amazonq.doc.error.promptUnrelated'), PromptUnrelatedError.name, remainingIterations)
     }

--- a/packages/core/src/amazonqDoc/session/session.ts
+++ b/packages/core/src/amazonqDoc/session/session.ts
@@ -14,13 +14,14 @@ import { FeatureDevClient } from '../../amazonqFeatureDev/client/featureDev'
 import { TelemetryHelper } from '../../amazonq/util/telemetryHelper'
 import { ConversationNotStartedState } from '../../amazonqFeatureDev/session/sessionState'
 import { logWithConversationId } from '../../amazonqFeatureDev/userFacingText'
-import { ConversationIdNotFoundError } from '../../amazonqFeatureDev/errors'
+import { ConversationIdNotFoundError, IllegalStateError } from '../../amazonqFeatureDev/errors'
 import { referenceLogText } from '../../amazonqFeatureDev/constants'
 import {
     DocInteractionType,
     DocV2AcceptanceEvent,
     DocV2GenerationEvent,
     SendTelemetryEventRequest,
+    MetricData,
 } from '../../codewhisperer/client/codewhispereruserclient'
 import { getClientId, getOperatingSystem, getOptOutPreference } from '../../shared/telemetry/util'
 import { DocMessenger } from '../messenger'
@@ -72,7 +73,7 @@ export class Session {
 
     get state() {
         if (!this._state) {
-            throw new Error("State should be initialized before it's read")
+            throw new IllegalStateError("State should be initialized before it's read")
         }
         return this._state
     }
@@ -269,15 +270,40 @@ export class Session {
         return { leftPath, rightPath, ...diff }
     }
 
+    public async sendDocMetricData(operationName: string, result: string) {
+        const metricData = {
+            metricName: 'Operation',
+            metricValue: 1,
+            timestamp: new Date(),
+            product: 'DocGeneration',
+            dimensions: [
+                {
+                    name: 'operationName',
+                    value: operationName,
+                },
+                {
+                    name: 'result',
+                    value: result,
+                },
+            ],
+        }
+        await this.sendDocTelemetryEvent(metricData, 'metric')
+    }
+
     public async sendDocTelemetryEvent(
-        telemetryEvent: DocV2GenerationEvent | DocV2AcceptanceEvent,
-        eventType: 'generation' | 'acceptance'
+        telemetryEvent: DocV2GenerationEvent | DocV2AcceptanceEvent | MetricData,
+        eventType: 'generation' | 'acceptance' | 'metric'
     ) {
         const client = await this.proxyClient.getClient()
+        const telemetryEventKey = {
+            generation: 'docV2GenerationEvent',
+            acceptance: 'docV2AcceptanceEvent',
+            metric: 'metricData',
+        }[eventType]
         try {
             const params: SendTelemetryEventRequest = {
                 telemetryEvent: {
-                    [eventType === 'generation' ? 'docV2GenerationEvent' : 'docV2AcceptanceEvent']: telemetryEvent,
+                    [telemetryEventKey]: telemetryEvent,
                 },
                 optOutPreference: getOptOutPreference(),
                 userContext: {
@@ -290,14 +316,23 @@ export class Session {
             }
 
             const response = await client.sendTelemetryEvent(params).promise()
-            getLogger().debug(
-                `${featureName}: successfully sent docV2${eventType === 'generation' ? 'GenerationEvent' : 'AcceptanceEvent'}: ConversationId: ${telemetryEvent.conversationId} RequestId: ${response.$response.requestId}`
-            )
+            if (eventType === 'metric') {
+                getLogger().debug(
+                    `${featureName}: successfully sent metricData: RequestId: ${response.$response.requestId}`
+                )
+            } else {
+                getLogger().debug(
+                    `${featureName}: successfully sent docV2${eventType === 'generation' ? 'GenerationEvent' : 'AcceptanceEvent'}: ` +
+                        `ConversationId: ${(telemetryEvent as DocV2GenerationEvent | DocV2AcceptanceEvent).conversationId} ` +
+                        `RequestId: ${response.$response.requestId}`
+                )
+            }
         } catch (e) {
+            const error = e as Error
+            const eventTypeString = eventType === 'metric' ? 'metricData' : `doc ${eventType}`
             getLogger().error(
-                `${featureName}: failed to send doc ${eventType} telemetry: ${(e as Error).name}: ${
-                    (e as Error).message
-                } RequestId: ${(e as any).requestId}`
+                `${featureName}: failed to send ${eventTypeString} telemetry: ${error.name}: ${error.message} ` +
+                    `RequestId: ${(e as any).$response?.requestId}`
             )
         }
     }
@@ -308,7 +343,7 @@ export class Session {
 
     get uploadId() {
         if (!('uploadId' in this.state)) {
-            throw new Error("UploadId has to be initialized before it's read")
+            throw new IllegalStateError("UploadId has to be initialized before it's read")
         }
         return this.state.uploadId
     }

--- a/packages/core/src/amazonqDoc/types.ts
+++ b/packages/core/src/amazonqDoc/types.ts
@@ -55,6 +55,18 @@ export interface SessionStateAction extends FeatureDevSessionStateAction {
     folderPath?: string
 }
 
+export enum MetricDataOperationName {
+    StartDocGeneration = 'StartDocGeneration',
+    EndDocGeneration = 'EndDocGeneration',
+}
+
+export enum MetricDataResult {
+    Success = 'Success',
+    Fault = 'Fault',
+    Error = 'Error',
+    LlmFailure = 'LLMFailure',
+}
+
 export {
     LLMResponseType,
     SessionStorage,

--- a/packages/core/src/test/amazonqDoc/utils.ts
+++ b/packages/core/src/test/amazonqDoc/utils.ts
@@ -18,7 +18,11 @@ import { docChat } from '../../amazonqDoc/constants'
 import { DocMessenger } from '../../amazonqDoc/messenger'
 import { AppToWebViewMessageDispatcher } from '../../amazonq/commons/connector/connectorMessages'
 import { createSessionConfig } from '../../amazonq/commons/session/sessionConfigFactory'
-import { DocV2GenerationEvent, DocV2AcceptanceEvent } from '../../amazonqFeatureDev/client/featuredevproxyclient'
+import {
+    DocV2GenerationEvent,
+    DocV2AcceptanceEvent,
+    MetricData,
+} from '../../amazonqFeatureDev/client/featuredevproxyclient'
 import { FollowUpTypes } from '../../amazonq/commons/types'
 
 export function createMessenger(sandbox: sinon.SinonSandbox): DocMessenger {
@@ -192,16 +196,33 @@ export function createExpectedEvent(params: EventParams) {
     }
 }
 
+export function createExpectedMetricData(operationName: string, result: string) {
+    return {
+        metricName: 'Operation',
+        metricValue: 1,
+        timestamp: new Date(),
+        product: 'DocGeneration',
+        dimensions: [
+            {
+                name: 'operationName',
+                value: operationName,
+            },
+            {
+                name: 'result',
+                value: result,
+            },
+        ],
+    }
+}
+
 export async function assertTelemetry(params: {
     spy: sinon.SinonStub
-    expectedEvent: DocV2GenerationEvent | DocV2AcceptanceEvent
-    type: 'generation' | 'acceptance'
-    callIndex?: number
+    expectedEvent: DocV2GenerationEvent | DocV2AcceptanceEvent | MetricData
+    type: 'generation' | 'acceptance' | 'metric'
     sandbox: sinon.SinonSandbox
 }) {
     await new Promise((resolve) => setTimeout(resolve, 100))
-    const spyCall = params.callIndex !== undefined ? params.spy.getCall(params.callIndex) : params.spy
-    params.sandbox.assert.calledWith(spyCall, params.sandbox.match(params.expectedEvent), params.type)
+    params.sandbox.assert.calledWith(params.spy, params.sandbox.match(params.expectedEvent), params.type)
 }
 
 export async function updateFilePaths(


### PR DESCRIPTION
## Problem
Emit metric telemetry when doc generation invoked

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
