### PR TITLE
fix: normalize path for /doc scope

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-3f6a2026-9dd8-4b50-8a73-765ead8717b4.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-3f6a2026-9dd8-4b50-8a73-765ead8717b4.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Choosing a nested subfolder for /doc on Windows results in a \"The folder you chose did not contain any source files\""
+}

--- a/packages/core/src/amazonqDoc/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqDoc/controllers/chat/controller.ts
@@ -45,6 +45,7 @@ import { getPathsFromZipFilePath, SvgFileExtension } from '../../../amazonq/util
 import { FollowUpTypes } from '../../../amazonq/commons/types'
 import { DocGenerationTask, DocGenerationTasks } from '../docGenerationTask'
 import { DevPhase } from '../../types'
+import { normalize } from '../../../shared/utilities/pathUtils'
 
 export interface ChatControllerEventEmitters {
     readonly processHumanChatMessage: EventEmitter<any>
@@ -160,7 +161,9 @@ export class DocController {
                 // Display path should always include workspace folder name
                 displayPath = path.join(relativePath.workspaceFolder.name, relativePath.relativePath)
                 // Only include workspace folder name in API call if multi-root workspace
-                docGenerationTask.folderPath = isMultiRootWorkspace() ? displayPath : relativePath.relativePath
+                docGenerationTask.folderPath = normalize(
+                    isMultiRootWorkspace() ? displayPath : relativePath.relativePath
+                )
 
                 if (!relativePath.relativePath) {
                     docGenerationTask.folderLevel = 'ENTIRE_WORKSPACE'


### PR DESCRIPTION
## Problem
On Windows, if a /doc user changes a folder to a nested subfolder more than one level below the workspace level, the folderPath sent to the API includes backslashes, which results in a `The folder you chose did not contain any source files` error.

## Solution
Normalize folderPath before making API request

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
