### PR TITLE
fix(amazonq): add missing lsp manifest messages from amazonq/package.json

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -119,6 +119,14 @@
                         "ssoCacheError": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "amazonQLspManifestMessage": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "amazonQWorkspaceLspManifestMessage": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -9,7 +9,8 @@ import { LspConfig } from 'aws-core-vscode/amazonq'
 export const defaultAmazonQLspConfig: LspConfig = {
     manifestUrl: 'https://aws-toolkit-language-servers.amazonaws.com/codewhisperer/0/manifest.json',
     supportedVersions: '^3.1.1',
-    id: 'AmazonQ', // used for identification in global storage/local disk location. Do not change.
+    id: 'AmazonQ', // used across IDEs for identifying global storage/local disk locations. Do not change.
+    suppressPromptPrefix: 'amazonQ',
     path: undefined,
 }
 

--- a/packages/amazonq/test/e2e/lsp/lspInstallerUtil.ts
+++ b/packages/amazonq/test/e2e/lsp/lspInstallerUtil.ts
@@ -249,7 +249,7 @@ export function createLspInstallerTests({
             })
 
             it('resolves release candidiates', async () => {
-                const original = new ManifestResolver(lspConfig.manifestUrl, lspConfig.id).resolve()
+                const original = new ManifestResolver(lspConfig.manifestUrl, lspConfig.id, '').resolve()
                 sandbox.stub(ManifestResolver.prototype, 'resolve').callsFake(async () => {
                     const originalManifest = await original
 

--- a/packages/amazonq/test/unit/amazonq/lsp/config.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/config.test.ts
@@ -52,6 +52,7 @@ for (const [name, config, defaultConfig, setEnv, resetEnv] of [
             manifestUrl: 'https://custom.url/manifest.json',
             supportedVersions: '4.0.0',
             id: 'AmazonQSetting',
+            suppressPromptPrefix: 'amazonQSetting',
             path: '/custom/path',
         }
 
@@ -95,6 +96,7 @@ for (const [name, config, defaultConfig, setEnv, resetEnv] of [
                 manifestUrl: 'https://another-custom.url/manifest.json',
                 supportedVersions: '5.1.1',
                 id: 'AmazonQEnv',
+                suppressPromptPrefix: 'amazonQEnv',
                 path: '/some/new/custom/path',
             }
 

--- a/packages/amazonq/test/unit/amazonq/lsp/config.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/config.test.ts
@@ -95,8 +95,8 @@ for (const [name, config, defaultConfig, setEnv, resetEnv] of [
             const envConfig: LspConfig = {
                 manifestUrl: 'https://another-custom.url/manifest.json',
                 supportedVersions: '5.1.1',
-                id: 'AmazonQEnv',
-                suppressPromptPrefix: 'amazonQEnv',
+                id: 'AmazonQSetting',
+                suppressPromptPrefix: 'amazonQSetting',
                 path: '/some/new/custom/path',
             }
 

--- a/packages/core/src/amazonq/lsp/config.ts
+++ b/packages/core/src/amazonq/lsp/config.ts
@@ -10,13 +10,15 @@ export interface LspConfig {
     manifestUrl: string
     supportedVersions: string
     id: string
+    suppressPromptPrefix: string
     path?: string
 }
 
 export const defaultAmazonQWorkspaceLspConfig: LspConfig = {
     manifestUrl: 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json',
     supportedVersions: '0.1.46',
-    id: 'AmazonQ-Workspace', // used for identification in global storage/local disk location. Do not change.
+    id: 'AmazonQ-Workspace', // used across IDEs for identifying global storage/local disk locations. Do not change.
+    suppressPromptPrefix: 'amazonQWorkspace',
     path: undefined,
 }
 

--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -25,7 +25,7 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths> 
     }
 
     async resolve(): Promise<LspResolution<T>> {
-        const { id, manifestUrl, supportedVersions, path } = this.config
+        const { id, manifestUrl, supportedVersions, path, suppressPromptPrefix } = this.config
         if (path) {
             const overrideMsg = `Using language server override location: ${path}`
             this.logger.info(overrideMsg)
@@ -38,7 +38,7 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths> 
             }
         }
 
-        const manifest = await new ManifestResolver(manifestUrl, id).resolve()
+        const manifest = await new ManifestResolver(manifestUrl, id, suppressPromptPrefix).resolve()
         const installationResult = await new LanguageServerResolver(
             manifest,
             id,

--- a/packages/core/src/shared/lsp/manifestResolver.ts
+++ b/packages/core/src/shared/lsp/manifestResolver.ts
@@ -29,7 +29,8 @@ const manifestTimeoutMs = 15000
 export class ManifestResolver {
     constructor(
         private readonly manifestURL: string,
-        private readonly lsName: string
+        private readonly lsName: string,
+        private readonly supressPrefix: string
     ) {}
 
     /**
@@ -109,9 +110,9 @@ export class ManifestResolver {
      */
     private async checkDeprecation(manifest: Manifest): Promise<void> {
         const prompts = AmazonQPromptSettings.instance
-        const lspId = `${this.lsName}LspManifestMessage` as keyof typeof amazonQPrompts
+        const lspId = `${this.supressPrefix}LspManifestMessage` as keyof typeof amazonQPrompts
 
-        // Sanity check, if the lsName is changed then we also need to update the prompt keys in settings-amazonq.gen
+        // Sanity check, if the lsName is changed then we also need to update the prompt keys in core/package.json
         if (!(lspId in amazonQPrompts)) {
             logger.error(`LSP ID "${lspId}" not found in amazonQPrompts.`)
             return

--- a/packages/core/src/shared/settings-amazonq.gen.ts
+++ b/packages/core/src/shared/settings-amazonq.gen.ts
@@ -19,8 +19,8 @@ export const amazonqSettings = {
         "amazonQSessionConfigurationMessage": {},
         "minIdeVersion": {},
         "ssoCacheError": {},
-        "AmazonQLspManifestMessage": {},
-        "AmazonQ-WorkspaceLspManifestMessage":{}
+        "amazonQLspManifestMessage": {},
+        "amazonQWorkspaceLspManifestMessage": {}
     },
     "amazonQ.showCodeWithReferences": {},
     "amazonQ.allowFeatureDevelopmentToRunCodeAndTests": {},

--- a/packages/core/src/test/shared/lsp/manifestResolver.test.ts
+++ b/packages/core/src/test/shared/lsp/manifestResolver.test.ts
@@ -44,7 +44,7 @@ describe('manifestResolver', function () {
     it('attempts to fetch from remote first', async function () {
         remoteStub.resolves(manifestResult('remote'))
 
-        const r = await new ManifestResolver('remote-manifest.com', serverName).resolve()
+        const r = await new ManifestResolver('remote-manifest.com', serverName, '').resolve()
         assert.strictEqual(r.location, 'remote')
         assertTelemetry('languageServer_setup', {
             manifestLocation: 'remote',
@@ -59,7 +59,7 @@ describe('manifestResolver', function () {
         remoteStub.rejects(new Error('failed to fetch'))
         localStub.resolves(manifestResult('cache'))
 
-        const r = await new ManifestResolver('remote-manifest.com', serverName).resolve()
+        const r = await new ManifestResolver('remote-manifest.com', serverName, '').resolve()
         assert.strictEqual(r.location, 'cache')
         assertTelemetry('languageServer_setup', [
             {
@@ -82,7 +82,7 @@ describe('manifestResolver', function () {
         remoteStub.rejects(new Error('failed to fetch'))
         localStub.rejects(new Error('failed to fetch'))
 
-        await assert.rejects(new ManifestResolver('remote-manifest.com', serverName).resolve(), /failed to fetch/)
+        await assert.rejects(new ManifestResolver('remote-manifest.com', serverName, '').resolve(), /failed to fetch/)
         assertTelemetry('languageServer_setup', [
             {
                 manifestLocation: 'remote',


### PR DESCRIPTION
## Problem
- manifest suppression messages were missing from package.json and directly written to settings gen, causing them to be overridden on every `npm install`

## Solution
- add manifest suppression to package.json
- make this field available in the config 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
