### PR TITLE
fix(amazonq): align inline completion document selectors

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -22,40 +22,11 @@ import {
     logInlineCompletionSessionResultsNotificationType,
     LogInlineCompletionSessionResultsParams,
 } from '@aws/language-server-runtimes/protocol'
-
-export const CodewhispererInlineCompletionLanguages = [
-    { scheme: 'file', language: 'typescript' },
-    { scheme: 'file', language: 'javascript' },
-    { scheme: 'file', language: 'json' },
-    { scheme: 'file', language: 'yaml' },
-    { scheme: 'file', language: 'java' },
-    { scheme: 'file', language: 'go' },
-    { scheme: 'file', language: 'php' },
-    { scheme: 'file', language: 'rust' },
-    { scheme: 'file', language: 'kotlin' },
-    { scheme: 'file', language: 'terraform' },
-    { scheme: 'file', language: 'ruby' },
-    { scheme: 'file', language: 'shellscript' },
-    { scheme: 'file', language: 'dart' },
-    { scheme: 'file', language: 'lua' },
-    { scheme: 'file', language: 'powershell' },
-    { scheme: 'file', language: 'r' },
-    { scheme: 'file', language: 'swift' },
-    { scheme: 'file', language: 'systemverilog' },
-    { scheme: 'file', language: 'scala' },
-    { scheme: 'file', language: 'vue' },
-    { scheme: 'file', language: 'csharp' },
-    { scheme: 'file', language: 'python' },
-    { scheme: 'file', language: 'c' },
-    { scheme: 'file', language: 'cpp' },
-    { scheme: 'file', language: 'sql' },
-    { scheme: 'file', language: 'tsx' },
-    { scheme: 'file', language: 'jsx' },
-]
+import { CodeWhispererConstants } from 'aws-core-vscode/codewhisperer'
 
 export function registerInlineCompletion(languageClient: LanguageClient) {
     const inlineCompletionProvider = new AmazonQInlineCompletionItemProvider(languageClient)
-    languages.registerInlineCompletionItemProvider(CodewhispererInlineCompletionLanguages, inlineCompletionProvider)
+    languages.registerInlineCompletionItemProvider(CodeWhispererConstants.platformLanguageIds, inlineCompletionProvider)
 
     const onInlineAcceptance = async (
         sessionId: string,


### PR DESCRIPTION
## Problem
The inline completion document selectors between vscode's currently implementation and the new implementation aren't aligned

## Solution
Rather than providing our own implementation that was originally stolen from [here](https://github.com/aws/language-servers/blob/main/client/vscode/src/inlineCompletionActivation.ts#L22) and expanding it, we should just use the exact document selectors that vscode already uses from [here](https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/codewhisperer/models/constants.ts#L104)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
