### PR TITLE
feat(amazonq): get logs generated by the Agent

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-86f056f5-4ac4-47be-8167-09c19a529a1e.json
+++ b/packages/amazonq/.changes/next-release/Feature-86f056f5-4ac4-47be-8167-09c19a529a1e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Save user command execution logs to plugin output."
+}

--- a/packages/core/src/amazonq/session/sessionState.ts
+++ b/packages/core/src/amazonq/session/sessionState.ts
@@ -112,7 +112,6 @@ export abstract class CodeGenBase {
                     )
                     if (logFileInfo) {
                         logFileInfo.fileContent = truncate(logFileInfo.fileContent, 10000000, '\n... [truncated]') // Limit to max 20MB
-                        }
                         getLogger().info(`sessionState: Run Command logs, ${logFileInfo.fileContent}`)
                         newFileContents.splice(newFileContents.indexOf(logFileInfo), 1)
                     }

--- a/packages/core/src/amazonq/session/sessionState.ts
+++ b/packages/core/src/amazonq/session/sessionState.ts
@@ -111,9 +111,7 @@ export abstract class CodeGenBase {
                             file.zipFilePath === RunCommandLogFileName
                     )
                     if (logFileInfo) {
-                        logFileInfo.fileContent = truncate(logFileInfo.fileContent, 10000000) // Limit to max 20MB
-                        if (logFileInfo.fileContent.length === 10000000) {
-                            logFileInfo.fileContent += '\n... [truncated]'
+                        logFileInfo.fileContent = truncate(logFileInfo.fileContent, 10000000, '\n... [truncated]') // Limit to max 20MB
                         }
                         getLogger().info(`sessionState: Run Command logs, ${logFileInfo.fileContent}`)
                         newFileContents.splice(newFileContents.indexOf(logFileInfo), 1)

--- a/packages/core/src/amazonq/session/sessionState.ts
+++ b/packages/core/src/amazonq/session/sessionState.ts
@@ -27,8 +27,10 @@ import {
 } from '../commons/types'
 import { prepareRepoData, getDeletedFileInfos, registerNewFiles, PrepareRepoDataOptions } from '../util/files'
 import { uploadCode } from '../util/upload'
+import { truncate } from '../../shared/utilities/textUtilities'
 
 export const EmptyCodeGenID = 'EMPTY_CURRENT_CODE_GENERATION_ID'
+export const RunCommandLogFileName = '.amazonq/dev/run_command.log'
 
 export interface BaseMessenger {
     sendAnswer(params: any): void
@@ -103,6 +105,20 @@ export abstract class CodeGenBase {
                 case CodeGenerationStatus.COMPLETE: {
                     const { newFileContents, deletedFiles, references } =
                         await this.config.proxyClient.exportResultArchive(this.conversationId)
+
+                    const logFileInfo = newFileContents.find(
+                        (file: { zipFilePath: string; fileContent: string }) =>
+                            file.zipFilePath === RunCommandLogFileName
+                    )
+                    if (logFileInfo) {
+                        logFileInfo.fileContent = truncate(logFileInfo.fileContent, 10000000) // Limit to max 20MB
+                        if (logFileInfo.fileContent.length === 10000000) {
+                            logFileInfo.fileContent += '\n... [truncated]'
+                        }
+                        getLogger().info(`sessionState: Run Command logs, ${logFileInfo.fileContent}`)
+                        newFileContents.splice(newFileContents.indexOf(logFileInfo), 1)
+                    }
+
                     const newFileInfo = registerNewFiles(
                         fs,
                         newFileContents,

--- a/packages/core/src/test/amazonq/session/sessionState.test.ts
+++ b/packages/core/src/test/amazonq/session/sessionState.test.ts
@@ -1,0 +1,153 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import sinon from 'sinon'
+import { CodeGenBase } from '../../../amazonq/session/sessionState'
+import { RunCommandLogFileName } from '../../../amazonq/session/sessionState'
+import assert from 'assert'
+import * as workspaceUtils from '../../../shared/utilities/workspaceUtils'
+import { TelemetryHelper } from '../../../amazonq/util/telemetryHelper'
+import { assertLogsContain } from '../../globalSetup.test'
+
+describe('CodeGenBase generateCode log file handling', () => {
+    class TestCodeGen extends CodeGenBase {
+        public generatedFiles: any[] = []
+        constructor(config: any, tabID: string) {
+            super(config, tabID)
+        }
+        protected handleProgress(_messenger: any): void {
+            // No-op for test.
+        }
+        protected getScheme(): string {
+            return 'file'
+        }
+        protected getTimeoutErrorCode(): string {
+            return 'test_timeout'
+        }
+        protected handleGenerationComplete(_messenger: any, newFileInfo: any[]): void {
+            this.generatedFiles = newFileInfo
+        }
+        protected handleError(_messenger: any, _codegenResult: any): Error {
+            throw new Error('handleError called')
+        }
+    }
+
+    let fakeProxyClient: any
+    let testConfig: any
+    let fsMock: any
+    let messengerMock: any
+    let testAction: any
+
+    beforeEach(async () => {
+        const ret = {
+            testworkspacefolder: {
+                uri: vscode.Uri.file('/path/to/testworkspacefolder'),
+                name: 'testworkspacefolder',
+                index: 0,
+            },
+        }
+        sinon.stub(workspaceUtils, 'getWorkspaceFoldersByPrefixes').returns(ret)
+
+        fakeProxyClient = {
+            getCodeGeneration: sinon.stub().resolves({
+                codeGenerationStatus: { status: 'Complete' },
+                codeGenerationRemainingIterationCount: 0,
+                codeGenerationTotalIterationCount: 1,
+            }),
+            exportResultArchive: sinon.stub(),
+        }
+
+        testConfig = {
+            conversationId: 'conv_test',
+            uploadId: 'upload_test',
+            workspaceRoots: ['/path/to/testworkspacefolder'],
+            proxyClient: fakeProxyClient,
+        }
+
+        fsMock = {
+            writeFile: sinon.stub().resolves(),
+            registerProvider: sinon.stub().resolves(),
+        }
+
+        messengerMock = { sendAnswer: sinon.spy() }
+
+        testAction = {
+            fs: fsMock,
+            messenger: messengerMock,
+            tokenSource: {
+                token: {
+                    isCancellationRequested: false,
+                    onCancellationRequested: () => {},
+                },
+            },
+        }
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    const runGenerateCode = async (codeGenerationId: string) => {
+        const testCodeGen = new TestCodeGen(testConfig, 'tab1')
+        return await testCodeGen.generateCode({
+            messenger: messengerMock,
+            fs: fsMock,
+            codeGenerationId,
+            telemetry: new TelemetryHelper(),
+            workspaceFolders: [testConfig.workspaceRoots[0]],
+            action: testAction,
+        })
+    }
+
+    const createExpectedNewFile = (fileObj: { zipFilePath: string; fileContent: string }) => ({
+        zipFilePath: fileObj.zipFilePath,
+        fileContent: fileObj.fileContent,
+        changeApplied: false,
+        rejected: false,
+        relativePath: fileObj.zipFilePath,
+        virtualMemoryUri: vscode.Uri.file(`/upload_test/${fileObj.zipFilePath}`),
+        workspaceFolder: {
+            index: 0,
+            name: 'testworkspacefolder',
+            uri: vscode.Uri.file('/path/to/testworkspacefolder'),
+        },
+    })
+
+    it('adds the log content to logger if present and excludes it from new files', async () => {
+        const logFileInfo = {
+            zipFilePath: RunCommandLogFileName,
+            fileContent: 'Log content',
+        }
+        const otherFile = { zipFilePath: 'other.ts', fileContent: 'other content' }
+        fakeProxyClient.exportResultArchive.resolves({
+            newFileContents: [logFileInfo, otherFile],
+            deletedFiles: [],
+            references: [],
+        })
+        const result = await runGenerateCode('codegen1')
+
+        assertLogsContain(`sessionState: Run Command logs, Log content`, false, 'info')
+
+        const expectedNewFile = createExpectedNewFile(otherFile)
+        assert.deepStrictEqual(result.newFiles[0].fileContent, expectedNewFile.fileContent)
+    })
+
+    it('skips log file handling if log file is not present', async () => {
+        const file1 = { zipFilePath: 'file1.ts', fileContent: 'content1' }
+        fakeProxyClient.exportResultArchive.resolves({
+            newFileContents: [file1],
+            deletedFiles: [],
+            references: [],
+        })
+
+        const result = await runGenerateCode('codegen2')
+
+        assert.throws(() => assertLogsContain(`sessionState: Run Command logs, Log content`, false, 'info'))
+
+        const expectedNewFile = createExpectedNewFile(file1)
+        assert.deepStrictEqual(result.newFiles[0].fileContent, expectedNewFile.fileContent)
+    })
+})


### PR DESCRIPTION
## Problem

Users currently cannot access logs generated by the Agent when it executes user commands during code generation.

## Solution
The output generated by the Agent during user command execution will be captured and written to the user's `logs`. This ensures that:

- Command execution logs are persisted locally
- Users can access the logs directly from their repository for troubleshooting.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
