### PR TITLE
refactor(auth): dont manual refresh auth webview on hide

### DIFF
--- a/packages/core/src/login/webview/commonAuthViewProvider.ts
+++ b/packages/core/src/login/webview/commonAuthViewProvider.ts
@@ -124,8 +124,6 @@ export class CommonAuthViewProvider implements WebviewViewProvider {
             }
 
             this.onDidChangeVisibility?.fire(webviewView.visible)
-            // force webview to reload
-            await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction')
         })
 
         const dist = Uri.joinPath(this.extensionContext.extensionUri, 'dist')

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -61,7 +61,6 @@ export abstract class CommonAuthWebview extends VueWebview {
         return globals.regionProvider.getRegions().reverse()
     }
 
-    private didCall: { login: boolean; reauth: boolean } = { login: false, reauth: false }
     /**
      * Called when the UI load process is completed, regardless of success or failure
      *
@@ -69,19 +68,11 @@ export abstract class CommonAuthWebview extends VueWebview {
      *                     Otherwise we assume success.
      */
     public setUiReady(state: 'login' | 'reauth', errorMessage?: string) {
-        // Only emit once to prevent telemetry spam, since showing/hiding chat triggers this each time.
-        // TODO: Research how to not trigger this on every show/hide
-        if (this.didCall[state]) {
-            return
-        }
-
         if (errorMessage) {
             this.setLoadFailure(state, errorMessage)
         } else {
             this.setDidLoad(state)
         }
-
-        this.didCall[state] = true
     }
 
     /**


### PR DESCRIPTION
## Problem:

We have an explicit force refresh of the auth webview when it is shown/hidden. There is not an obvious reason why we do this.

This causes problems since we expect that show/hiding of the webview does not trigger any functional changes since we have configured the webview to continue running even while hidden. This means that our handlers for auth changes are still running even when auth is hidden.

For my specific issue, by force reloading the webview on every show/hide it triggered the webview loading code each time, causing webview telemetry events to be triggered more than expected.

## Solution:

Remove the force reload line. With this change we can move the edge case handling code which throttled the telemetry emitted when it was triggered on every hide/show.

I've done manual testing and have not noted any obvious regressions to the expected user flow.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
