### PR TITLE
feat(amazonq): handle reference for inline with language server

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -19,7 +19,7 @@ import { LanguageClient } from 'vscode-languageclient'
 import { LogInlineCompletionSessionResultsParams } from '@aws/language-server-runtimes/protocol'
 import { SessionManager } from './sessionManager'
 import { RecommendationService } from './recommendationService'
-import { CodeWhispererConstants } from 'aws-core-vscode/codewhisperer'
+import { CodeWhispererConstants, ReferenceInlineProvider } from 'aws-core-vscode/codewhisperer'
 
 export class InlineCompletionManager implements Disposable {
     private disposable: Disposable
@@ -181,6 +181,11 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                     session.firstCompletionDisplayLatency,
                 ],
             }
+            ReferenceInlineProvider.instance.setInlineReference(
+                position.line,
+                item.insertText as string,
+                item.references
+            )
         }
         return items as InlineCompletionItem[]
     }


### PR DESCRIPTION
## Problem
need to log reference for inline with language server

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
