### PR TITLE
feat(lambda): adding SNS pattern for ServerlessLand

### DIFF
--- a/packages/core/src/awsService/appBuilder/serverlessLand/metadata.json
+++ b/packages/core/src/awsService/appBuilder/serverlessLand/metadata.json
@@ -53,7 +53,7 @@
             ]
         },
         "Process SQS Records with Lambda": {
-            "name": "Rest API",
+            "name": "Process SQS Records with Lambda",
             "description": "Lambda, SQS • Python, Javascript, Java, .NET • SAM",
             "implementation": [
                 {
@@ -75,6 +75,32 @@
                     "iac": "sam",
                     "runtime": "dotnet",
                     "assetName": "sqs-lambda-dotnet-sam"
+                }
+            ]
+        },
+        "Process SNS notification messages with Lambda": {
+            "name": "Process SNS notification messages with Lambda",
+            "description": "Lambda, SNS • Python, Javascript, Java, .NET • SAM",
+            "implementation": [
+                {
+                    "iac": "sam",
+                    "runtime": "python",
+                    "assetName": "sns-lambda-python-sam"
+                },
+                {
+                    "iac": "sam",
+                    "runtime": "javascript",
+                    "assetName": "sns-lambda-nodejs-sam"
+                },
+                {
+                    "iac": "sam",
+                    "runtime": "java",
+                    "assetName": "sns-lambda-java-sam"
+                },
+                {
+                    "iac": "sam",
+                    "runtime": "dotnet",
+                    "assetName": "sns-lambda-dotnet-sam"
                 }
             ]
         }

--- a/packages/toolkit/.changes/next-release/Feature-279a0842-feff-4089-8529-61376bf8cf97.json
+++ b/packages/toolkit/.changes/next-release/Feature-279a0842-feff-4089-8529-61376bf8cf97.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Adding pattern for Serverless Land feature"
+	"description": "Lambda: Add 'Process SNS notification messages with Lambda' Serverless Land pattern."
 }

--- a/packages/toolkit/.changes/next-release/Feature-279a0842-feff-4089-8529-61376bf8cf97.json
+++ b/packages/toolkit/.changes/next-release/Feature-279a0842-feff-4089-8529-61376bf8cf97.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Adding pattern for Serverless Land feature"
+}


### PR DESCRIPTION
## Problem
Adding new pattern for ServerlessLand feature. 

## Solution
Added pattern for SNS integration with Lambda in python, nodejs, java and dotnet runtime, supporting SAM IaC.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
