### PR TITLE
feat(amazonq): Adding openDiff and acceptDiff UX to the agentic chat.

### DIFF
--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -63,6 +63,7 @@ export interface CWCChatItem extends ChatItem {
     userIntent?: UserIntent
     codeBlockLanguage?: string
     contextList?: Context[]
+    title?: string
 }
 
 export interface Context {
@@ -711,7 +712,7 @@ export class Connector {
                         tabType: 'cwc',
                     })
                 } else {
-                    this.cwChatConnector.onCustomFormAction(tabId, action)
+                    this.cwChatConnector.onCustomFormAction(tabId, messageId ?? '', action)
                 }
                 break
             case 'agentWalkthrough': {

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -352,6 +352,7 @@ export const createMynahUI = (
                     ...(item.followUp !== undefined ? { followUp: item.followUp } : {}),
                     ...(item.fileList !== undefined ? { fileList: item.fileList } : {}),
                     ...(item.header !== undefined ? { header: item.header } : { header: undefined }),
+                    ...(item.buttons !== undefined ? { buttons: item.buttons } : { buttons: undefined }),
                 })
                 if (
                     item.messageId !== undefined &&
@@ -374,7 +375,7 @@ export const createMynahUI = (
                     fileList: {
                         fileTreeTitle: '',
                         filePaths: item.contextList.map((file) => file.relativeFilePath),
-                        rootFolderTitle: 'Context',
+                        rootFolderTitle: item.title,
                         flatList: true,
                         collapsed: true,
                         hideFileCount: true,

--- a/packages/core/src/codewhispererChat/app.ts
+++ b/packages/core/src/codewhispererChat/app.ts
@@ -28,6 +28,7 @@ import {
     AcceptDiff,
     QuickCommandGroupActionClick,
     FileClick,
+    OpenDiff,
 } from './controllers/chat/model'
 import { EditorContextCommand, registerCommands } from './commands/registerCommands'
 import { ContextSelectedMessage, CustomFormActionMessage } from './view/connector/connector'
@@ -41,6 +42,7 @@ export function init(appContext: AmazonQAppInitContext) {
         processInsertCodeAtCursorPosition: new EventEmitter<InsertCodeAtCursorPosition>(),
         processAcceptDiff: new EventEmitter<AcceptDiff>(),
         processViewDiff: new EventEmitter<ViewDiff>(),
+        processOpenDiff: new EventEmitter<OpenDiff>(),
         processCopyCodeToClipboard: new EventEmitter<CopyCodeToClipboard>(),
         processContextMenuCommand: new EventEmitter<EditorContextCommand>(),
         processTriggerTabIDReceived: new EventEmitter<TriggerTabIDReceived>(),
@@ -76,6 +78,7 @@ export function init(appContext: AmazonQAppInitContext) {
         ),
         processAcceptDiff: new MessageListener<AcceptDiff>(cwChatControllerEventEmitters.processAcceptDiff),
         processViewDiff: new MessageListener<ViewDiff>(cwChatControllerEventEmitters.processViewDiff),
+        processOpenDiff: new MessageListener<OpenDiff>(cwChatControllerEventEmitters.processOpenDiff),
         processCopyCodeToClipboard: new MessageListener<CopyCodeToClipboard>(
             cwChatControllerEventEmitters.processCopyCodeToClipboard
         ),
@@ -137,6 +140,7 @@ export function init(appContext: AmazonQAppInitContext) {
         ),
         processAcceptDiff: new MessagePublisher<AcceptDiff>(cwChatControllerEventEmitters.processAcceptDiff),
         processViewDiff: new MessagePublisher<ViewDiff>(cwChatControllerEventEmitters.processViewDiff),
+        processOpenDiff: new MessagePublisher<OpenDiff>(cwChatControllerEventEmitters.processOpenDiff),
         processCopyCodeToClipboard: new MessagePublisher<CopyCodeToClipboard>(
             cwChatControllerEventEmitters.processCopyCodeToClipboard
         ),

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -18,11 +18,11 @@ import { UserWrittenCodeTracker } from '../../../../codewhisperer/tracker/userWr
 export class ChatSession {
     private sessionId?: string
     /**
-     * _listOfReadFiles = list of files read from the project to gather context before generating response.
+     * _readFiles = list of files read from the project to gather context before generating response.
      * _filePath = The path helps the system locate exactly where to make the necessary changes in the project structure
      * _tempFilePath = Used to show the code diff view in the editor including LLM changes.
      */
-    private _listOfReadFiles: string[] = []
+    private _readFiles: string[] = []
     private _filePath: string | undefined
     private _tempFilePath: string | undefined
     private _toolUse: ToolUse | undefined
@@ -57,7 +57,7 @@ export class ChatSession {
         this.sessionId = id
     }
     public get listOfReadFiles(): string[] {
-        return this._listOfReadFiles
+        return this._readFiles
     }
     public get filePath(): string | undefined {
         return this._filePath
@@ -72,10 +72,10 @@ export class ChatSession {
         this._tempFilePath = tempFilePath
     }
     public pushToListOfReadFiles(filePath: string) {
-        this._listOfReadFiles.push(filePath)
+        this._readFiles.push(filePath)
     }
     public clearListOfReadFiles() {
-        this._listOfReadFiles = []
+        this._readFiles = []
     }
     async chatIam(chatRequest: SendMessageRequest): Promise<SendMessageCommandOutput> {
         const client = await createQDeveloperStreamingClient()

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -13,6 +13,11 @@ import { UserWrittenCodeTracker } from '../../../../codewhisperer/tracker/userWr
 
 export class ChatSession {
     private sessionId?: string
+    /**
+     * _listOfReadFiles = list of files read from the project to gather context before generating response.
+     * _filePath = The path helps the system locate exactly where to make the necessary changes in the project structure
+     * _tempFilePath = Used to show the code diff view in the editor including LLM changes.
+     */
     private _listOfReadFiles: string[] = []
     private _filePath: string | undefined
     private _tempFilePath: string | undefined
@@ -41,10 +46,10 @@ export class ChatSession {
     public get listOfReadFiles(): string[] {
         return this._listOfReadFiles
     }
-    public get getFilePath(): string | undefined {
+    public get filePath(): string | undefined {
         return this._filePath
     }
-    public get getTempFilePath(): string | undefined {
+    public get tempFilePath(): string | undefined {
         return this._tempFilePath
     }
     public setFilePath(filePath: string | undefined) {
@@ -53,12 +58,11 @@ export class ChatSession {
     public setTempFilePath(tempFilePath: string | undefined) {
         this._tempFilePath = tempFilePath
     }
-    public pushToListOfReadFiles(filePath?: string) {
-        if (filePath) {
-            this._listOfReadFiles.push(filePath)
-        } else {
-            this._listOfReadFiles = []
-        }
+    public pushToListOfReadFiles(filePath: string) {
+        this._listOfReadFiles.push(filePath)
+    }
+    public clearListOfReadFiles() {
+        this._listOfReadFiles = []
     }
     async chatIam(chatRequest: SendMessageRequest): Promise<SendMessageCommandOutput> {
         const client = await createQDeveloperStreamingClient()

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -13,6 +13,9 @@ import { UserWrittenCodeTracker } from '../../../../codewhisperer/tracker/userWr
 
 export class ChatSession {
     private sessionId?: string
+    private _listOfReadFiles: string[] = []
+    private _filePath: string | undefined
+    private _tempFilePath: string | undefined
 
     contexts: Map<string, { first: number; second: number }[]> = new Map()
     // TODO: doesn't handle the edge case when two files share the same relativePath string but from different root
@@ -34,6 +37,28 @@ export class ChatSession {
 
     public setSessionID(id?: string) {
         this.sessionId = id
+    }
+    public get listOfReadFiles(): string[] {
+        return this._listOfReadFiles
+    }
+    public get getFilePath(): string | undefined {
+        return this._filePath
+    }
+    public get getTempFilePath(): string | undefined {
+        return this._tempFilePath
+    }
+    public setFilePath(filePath: string | undefined) {
+        this._filePath = filePath
+    }
+    public setTempFilePath(tempFilePath: string | undefined) {
+        this._tempFilePath = tempFilePath
+    }
+    public pushToListOfReadFiles(filePath?: string) {
+        if (filePath) {
+            this._listOfReadFiles.push(filePath)
+        } else {
+            this._listOfReadFiles = []
+        }
     }
     async chatIam(chatRequest: SendMessageRequest): Promise<SendMessageCommandOutput> {
         const client = await createQDeveloperStreamingClient()

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -398,23 +398,23 @@ export class ChatController {
 
     private async processOpenDiff(message: OpenDiff) {
         const session = this.sessionStorage.getSession(message.tabID)
-        const filePath = session.getFilePath ?? message.filePath
+        const filePath = session.filePath ?? message.filePath
         const fileExists = await fs.existsFile(filePath)
         // Check if fileExists=false, If yes, return instead of showing broken diff experience.
-        if (!session.getTempFilePath) {
+        if (!session.tempFilePath) {
             return
         }
         const leftUri = fileExists ? vscode.Uri.file(filePath) : vscode.Uri.from({ scheme: 'untitled' })
-        const rightUri = vscode.Uri.file(session.getTempFilePath ?? filePath)
+        const rightUri = vscode.Uri.file(session.tempFilePath ?? filePath)
         const fileName = path.basename(filePath)
         await vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, `${fileName} ${amazonQTabSuffix}`)
     }
 
     private async processAcceptCodeDiff(message: CustomFormActionMessage) {
         const session = this.sessionStorage.getSession(message.tabID ?? '')
-        const filePath = session.getFilePath ?? ''
+        const filePath = session.filePath ?? ''
         const fileExists = await fs.existsFile(filePath)
-        const tempFilePath = session.getTempFilePath
+        const tempFilePath = session.tempFilePath
         const tempFileExists = await fs.existsFile(tempFilePath ?? '')
         if (fileExists && tempFileExists) {
             const fileContent = await fs.readFileText(filePath)
@@ -889,7 +889,7 @@ export class ChatController {
 
     private async processPromptMessageAsNewThread(message: PromptMessage) {
         const session = this.sessionStorage.getSession(message.tabID)
-        session.pushToListOfReadFiles(undefined)
+        session.clearListOfReadFiles()
         this.editorContextExtractor
             .extractContextForTrigger('ChatMessage')
             .then((context) => {

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -85,6 +85,10 @@ export class Messenger {
                     userIntent: undefined,
                     codeBlockLanguage: undefined,
                     contextList: mergedRelevantDocuments,
+                    title: 'Context',
+                    buttons: undefined,
+                    fileList: undefined,
+                    canBeVoted: false,
                 },
                 tabID
             )
@@ -436,6 +440,7 @@ export class Messenger {
                     userIntent: undefined,
                     codeBlockLanguage: undefined,
                     contextList: undefined,
+                    title: undefined,
                 },
                 tabID
             )

--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -89,6 +89,14 @@ export interface ViewDiff {
     totalCodeBlocks?: number
 }
 
+export interface OpenDiff {
+    command: string | undefined
+    tabID: string
+    messageId: string
+    filePath: string
+    referenceTrackerInformation?: CodeReference[]
+}
+
 export type ChatPromptCommandType =
     | 'help'
     | 'clear'

--- a/packages/core/src/codewhispererChat/view/connector/connector.ts
+++ b/packages/core/src/codewhispererChat/view/connector/connector.ts
@@ -110,6 +110,12 @@ export interface CodeReference {
     }
 }
 
+export interface FileList {
+    fileTreeTitle?: string
+    rootFolderTitle?: string
+    filePaths?: string[]
+}
+
 export interface AuthNeededExceptionProps {
     readonly message: string
     readonly authType: AuthFollowUpType
@@ -208,6 +214,10 @@ export interface ChatMessageProps {
     readonly userIntent: string | undefined
     readonly codeBlockLanguage: string | undefined
     readonly contextList: DocumentReference[] | undefined
+    readonly title?: string
+    readonly buttons?: ChatItemButton[]
+    readonly fileList?: FileList
+    readonly canBeVoted?: boolean
 }
 
 export class ChatMessage extends UiMessage {
@@ -223,6 +233,10 @@ export class ChatMessage extends UiMessage {
     readonly userIntent: string | undefined
     readonly codeBlockLanguage: string | undefined
     readonly contextList: DocumentReference[] | undefined
+    readonly title?: string
+    readonly buttons?: ChatItemButton[]
+    readonly fileList?: FileList
+    readonly canBeVoted?: boolean = false
     override type = 'chatMessage'
 
     constructor(props: ChatMessageProps, tabID: string) {
@@ -238,6 +252,10 @@ export class ChatMessage extends UiMessage {
         this.userIntent = props.userIntent
         this.codeBlockLanguage = props.codeBlockLanguage
         this.contextList = props.contextList
+        this.title = props.title
+        this.buttons = props.buttons
+        this.fileList = props.fileList
+        this.canBeVoted = props.canBeVoted
     }
 }
 
@@ -316,6 +334,10 @@ export class AppToWebViewMessageDispatcher {
     }
 
     public sendShowCustomFormMessage(message: ShowCustomFormMessage) {
+        this.appsToWebViewMessagePublisher.publish(message)
+    }
+
+    public sendCustomFormActionMessage(message: CustomFormActionMessage) {
         this.appsToWebViewMessagePublisher.publish(message)
     }
 }

--- a/packages/core/src/codewhispererChat/view/connector/connector.ts
+++ b/packages/core/src/codewhispererChat/view/connector/connector.ts
@@ -7,7 +7,7 @@ import { Timestamp } from 'aws-sdk/clients/apigateway'
 import { MessagePublisher } from '../../../amazonq/messages/messagePublisher'
 import { EditorContextCommandType } from '../../commands/registerCommands'
 import { AuthFollowUpType } from '../../../amazonq/auth/model'
-import { ChatItemButton, ChatItemFormItem, MynahUIDataModel, QuickActionCommand } from '@aws/mynah-ui'
+import { ChatItemButton, ChatItemContent, ChatItemFormItem, MynahUIDataModel, QuickActionCommand } from '@aws/mynah-ui'
 import { DocumentReference } from '../../controllers/chat/model'
 
 class UiMessage {
@@ -110,12 +110,6 @@ export interface CodeReference {
     }
 }
 
-export interface FileList {
-    fileTreeTitle?: string
-    rootFolderTitle?: string
-    filePaths?: string[]
-}
-
 export interface AuthNeededExceptionProps {
     readonly message: string
     readonly authType: AuthFollowUpType
@@ -216,7 +210,7 @@ export interface ChatMessageProps {
     readonly contextList: DocumentReference[] | undefined
     readonly title?: string
     readonly buttons?: ChatItemButton[]
-    readonly fileList?: FileList
+    readonly fileList?: ChatItemContent['fileList']
     readonly canBeVoted?: boolean
 }
 
@@ -235,7 +229,7 @@ export class ChatMessage extends UiMessage {
     readonly contextList: DocumentReference[] | undefined
     readonly title?: string
     readonly buttons?: ChatItemButton[]
-    readonly fileList?: FileList
+    readonly fileList?: ChatItemContent['fileList']
     readonly canBeVoted?: boolean = false
     override type = 'chatMessage'
 

--- a/packages/core/src/codewhispererChat/view/messages/messageListener.ts
+++ b/packages/core/src/codewhispererChat/view/messages/messageListener.ts
@@ -69,6 +69,9 @@ export class UIMessageListener {
             case 'view_diff':
                 this.processViewDiff(msg)
                 break
+            case 'open-diff':
+                this.processOpenDiff(msg)
+                break
             case 'code_was_copied_to_clipboard':
                 this.processCodeWasCopiedToClipboard(msg)
                 break
@@ -215,6 +218,14 @@ export class UIMessageListener {
 
     private processViewDiff(msg: any) {
         this.chatControllerMessagePublishers.processViewDiff.publish({
+            command: msg.command,
+            tabID: msg.tabID || msg.tabId,
+            ...msg,
+        })
+    }
+
+    private processOpenDiff(msg: any) {
+        this.chatControllerMessagePublishers.processOpenDiff.publish({
             command: msg.command,
             tabID: msg.tabID || msg.tabId,
             ...msg,


### PR DESCRIPTION
## Problem
- Agentic chat does not view the generated code diff and no option for accept or reject the code diff
- Splitting this bulk PR: https://github.com/aws/aws-toolkit-vscode/pull/6843

## Solution
- Adding UX improvements and agent loop mechanism to Q chat.

https://github.com/user-attachments/assets/81ab88b3-ffb9-4db7-a38f-e0562848cb6f

---
### TODO:
- Metrics
- Refactoring code
- More UX improvements
- Pending part 2 of https://github.com/aws/aws-toolkit-vscode/pull/6843


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
