### PR TITLE
feat(chat): fix for q agentic chat loop

### DIFF
--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -73,6 +73,8 @@ export class ChatSession {
     async chatSso(chatRequest: GenerateAssistantResponseRequest): Promise<GenerateAssistantResponseCommandOutput> {
         const client = await createCodeWhispererChatStreamingClient()
 
+        // eslint-disable-next-line aws-toolkits/no-console-log
+        console.log(chatRequest)
         const response = await client.generateAssistantResponse(chatRequest)
         if (!response.generateAssistantResponseResponse) {
             throw new ToolkitError(

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -73,8 +73,6 @@ export class ChatSession {
     async chatSso(chatRequest: GenerateAssistantResponseRequest): Promise<GenerateAssistantResponseCommandOutput> {
         const client = await createCodeWhispererChatStreamingClient()
 
-        // eslint-disable-next-line aws-toolkits/no-console-log
-        console.log(chatRequest)
         const response = await client.generateAssistantResponse(chatRequest)
         if (!response.generateAssistantResponseResponse) {
             throw new ToolkitError(

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -9,6 +9,7 @@ import {
     AuthNeededException,
     CodeReference,
     ContextCommandData,
+    CustomFormActionMessage,
     EditorContextCommandMessage,
     OpenSettingsMessage,
     QuickActionMessage,
@@ -228,13 +229,14 @@ export class Messenger {
                                 tabID
                             )
                         )
+
+                        this.dispatcher.sendCustomFormActionMessage(
+                            new CustomFormActionMessage(tabID, {
+                                id: 'confirm-tool-use',
+                            })
+                        )
                         // TODO: setup permission action
                         // if (!isConfirmationRequired) {
-                        //     this.dispatcher.sendCustomFormActionMessage(
-                        //         new CustomFormActionMessage(tabID, {
-                        //             id: 'confirm-tool-use',
-                        //         })
-                        //     )
                         // }
                     }
 
@@ -388,7 +390,9 @@ export class Messenger {
                         messageId: messageID,
                         content: message,
                         references: codeReference,
-                        toolUses: [{ ...toolUse }],
+                        ...(toolUse &&
+                            toolUse.input !== undefined &&
+                            toolUse.input !== '' && { toolUses: [{ ...toolUse }] }),
                     },
                 })
 

--- a/packages/core/src/codewhispererChat/storages/chatHistory.ts
+++ b/packages/core/src/codewhispererChat/storages/chatHistory.ts
@@ -69,7 +69,7 @@ export class ChatHistoryManager {
         if (!newMessage.userInputMessage?.content || newMessage.userInputMessage?.content.trim() === '') {
             this.logger.warn('input must not be empty when adding new messages')
         }
-        this.history.push(this.lastUserMessage)
+        this.history.push(this.formatChatHistoryMessage(this.lastUserMessage))
     }
 
     /**
@@ -195,5 +195,20 @@ export class ChatHistoryManager {
         if (this.lastUserMessage?.userInputMessage) {
             this.lastUserMessage.userInputMessage = msg
         }
+    }
+
+    private formatChatHistoryMessage(message: ChatMessage): ChatMessage {
+        if (message.userInputMessage !== undefined) {
+            return {
+                userInputMessage: {
+                    ...message.userInputMessage,
+                    userInputMessageContext: {
+                        ...message.userInputMessage.userInputMessageContext,
+                        tools: undefined,
+                    },
+                },
+            }
+        }
+        return message
     }
 }


### PR DESCRIPTION
## Problem
Earlier PR only add setup for Q Agentic chat loop. But Agentic loop does not work yet.

## Solution
This PR fixes the Q Agentic chat loop and is set for fsRead Tool.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
