### PR TITLE
fix(amazonq): FollowUp PR to reuse file-click function to show the diff view

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -305,7 +305,7 @@ export class Connector extends BaseConnector {
 
     onFileClick = (tabID: string, filePath: string, messageId?: string) => {
         this.sendMessageToExtension({
-            command: messageId === '' ? 'file-click' : 'open-diff',
+            command: 'file-click',
             tabID,
             messageId,
             filePath,

--- a/packages/core/src/codewhispererChat/app.ts
+++ b/packages/core/src/codewhispererChat/app.ts
@@ -28,7 +28,6 @@ import {
     AcceptDiff,
     QuickCommandGroupActionClick,
     FileClick,
-    OpenDiff,
 } from './controllers/chat/model'
 import { EditorContextCommand, registerCommands } from './commands/registerCommands'
 import { ContextSelectedMessage, CustomFormActionMessage } from './view/connector/connector'
@@ -42,7 +41,6 @@ export function init(appContext: AmazonQAppInitContext) {
         processInsertCodeAtCursorPosition: new EventEmitter<InsertCodeAtCursorPosition>(),
         processAcceptDiff: new EventEmitter<AcceptDiff>(),
         processViewDiff: new EventEmitter<ViewDiff>(),
-        processOpenDiff: new EventEmitter<OpenDiff>(),
         processCopyCodeToClipboard: new EventEmitter<CopyCodeToClipboard>(),
         processContextMenuCommand: new EventEmitter<EditorContextCommand>(),
         processTriggerTabIDReceived: new EventEmitter<TriggerTabIDReceived>(),
@@ -78,7 +76,6 @@ export function init(appContext: AmazonQAppInitContext) {
         ),
         processAcceptDiff: new MessageListener<AcceptDiff>(cwChatControllerEventEmitters.processAcceptDiff),
         processViewDiff: new MessageListener<ViewDiff>(cwChatControllerEventEmitters.processViewDiff),
-        processOpenDiff: new MessageListener<OpenDiff>(cwChatControllerEventEmitters.processOpenDiff),
         processCopyCodeToClipboard: new MessageListener<CopyCodeToClipboard>(
             cwChatControllerEventEmitters.processCopyCodeToClipboard
         ),
@@ -140,7 +137,6 @@ export function init(appContext: AmazonQAppInitContext) {
         ),
         processAcceptDiff: new MessagePublisher<AcceptDiff>(cwChatControllerEventEmitters.processAcceptDiff),
         processViewDiff: new MessagePublisher<ViewDiff>(cwChatControllerEventEmitters.processViewDiff),
-        processOpenDiff: new MessagePublisher<OpenDiff>(cwChatControllerEventEmitters.processOpenDiff),
         processCopyCodeToClipboard: new MessagePublisher<CopyCodeToClipboard>(
             cwChatControllerEventEmitters.processCopyCodeToClipboard
         ),

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -21,11 +21,13 @@ export class ChatSession {
      * _readFiles = list of files read from the project to gather context before generating response.
      * _filePath = The path helps the system locate exactly where to make the necessary changes in the project structure
      * _tempFilePath = Used to show the code diff view in the editor including LLM changes.
+     * _showDiffOnFileWrite = Controls whether to show diff view (true) or file context view (false) to the user
      */
     private _readFiles: string[] = []
     private _filePath: string | undefined
     private _tempFilePath: string | undefined
     private _toolUse: ToolUse | undefined
+    private _showDiffOnFileWrite: boolean = false
 
     contexts: Map<string, { first: number; second: number }[]> = new Map()
     // TODO: doesn't handle the edge case when two files share the same relativePath string but from different root
@@ -56,7 +58,7 @@ export class ChatSession {
     public setSessionID(id?: string) {
         this.sessionId = id
     }
-    public get listOfReadFiles(): string[] {
+    public get readFiles(): string[] {
         return this._readFiles
     }
     public get filePath(): string | undefined {
@@ -65,13 +67,19 @@ export class ChatSession {
     public get tempFilePath(): string | undefined {
         return this._tempFilePath
     }
+    public get showDiffOnFileWrite(): boolean {
+        return this._showDiffOnFileWrite
+    }
+    public setShowDiffOnFileWrite(value: boolean) {
+        this._showDiffOnFileWrite = value
+    }
     public setFilePath(filePath: string | undefined) {
         this._filePath = filePath
     }
     public setTempFilePath(tempFilePath: string | undefined) {
         this._tempFilePath = tempFilePath
     }
-    public pushToListOfReadFiles(filePath: string) {
+    public addListOfReadFiles(filePath: string) {
         this._readFiles.push(filePath)
     }
     public clearListOfReadFiles() {

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -79,7 +79,7 @@ export class ChatSession {
     public setTempFilePath(tempFilePath: string | undefined) {
         this._tempFilePath = tempFilePath
     }
-    public addListOfReadFiles(filePath: string) {
+    public addToReadFiles(filePath: string) {
         this._readFiles.push(filePath)
     }
     public clearListOfReadFiles() {

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -623,7 +623,7 @@ export class ChatController {
     }
     private async processFileClickMessage(message: FileClick) {
         const session = this.sessionStorage.getSession(message.tabID)
-        // Check if user clicked on filePath in the contextList or filePath in the fileListTress and perform the functionality accordingly.
+        // Check if user clicked on filePath in the contextList or in the fileListTree and perform the functionality accordingly.
         if (session.showDiffOnFileWrite) {
             const filePath = session.filePath ?? message.filePath
             const fileExists = await fs.existsFile(filePath)

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -32,7 +32,6 @@ import {
     DocumentReference,
     FileClick,
     RelevantTextDocumentAddition,
-    OpenDiff,
 } from './model'
 import {
     AppToWebViewMessageDispatcher,
@@ -93,7 +92,6 @@ export interface ChatControllerMessagePublishers {
     readonly processInsertCodeAtCursorPosition: MessagePublisher<InsertCodeAtCursorPosition>
     readonly processAcceptDiff: MessagePublisher<AcceptDiff>
     readonly processViewDiff: MessagePublisher<ViewDiff>
-    readonly processOpenDiff: MessagePublisher<OpenDiff>
     readonly processCopyCodeToClipboard: MessagePublisher<CopyCodeToClipboard>
     readonly processContextMenuCommand: MessagePublisher<EditorContextCommand>
     readonly processTriggerTabIDReceived: MessagePublisher<TriggerTabIDReceived>
@@ -119,7 +117,6 @@ export interface ChatControllerMessageListeners {
     readonly processInsertCodeAtCursorPosition: MessageListener<InsertCodeAtCursorPosition>
     readonly processAcceptDiff: MessageListener<AcceptDiff>
     readonly processViewDiff: MessageListener<ViewDiff>
-    readonly processOpenDiff: MessageListener<OpenDiff>
     readonly processCopyCodeToClipboard: MessageListener<CopyCodeToClipboard>
     readonly processContextMenuCommand: MessageListener<EditorContextCommand>
     readonly processTriggerTabIDReceived: MessageListener<TriggerTabIDReceived>
@@ -216,10 +213,6 @@ export class ChatController {
 
         this.chatControllerMessageListeners.processViewDiff.onMessage((data) => {
             return this.processViewDiff(data)
-        })
-
-        this.chatControllerMessageListeners.processOpenDiff.onMessage((data) => {
-            return this.processOpenDiff(data)
         })
 
         this.chatControllerMessageListeners.processCopyCodeToClipboard.onMessage((data) => {
@@ -395,20 +388,6 @@ export class ChatController {
             .catch((error) => {
                 this.telemetryHelper.recordInteractWithMessage(message, { result: 'Failed' })
             })
-    }
-
-    private async processOpenDiff(message: OpenDiff) {
-        const session = this.sessionStorage.getSession(message.tabID)
-        const filePath = session.filePath ?? message.filePath
-        const fileExists = await fs.existsFile(filePath)
-        // Check if fileExists=false, If yes, return instead of showing broken diff experience.
-        if (!session.tempFilePath) {
-            return
-        }
-        const leftUri = fileExists ? vscode.Uri.file(filePath) : vscode.Uri.from({ scheme: 'untitled' })
-        const rightUri = vscode.Uri.file(session.tempFilePath ?? filePath)
-        const fileName = path.basename(filePath)
-        await vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, `${fileName} ${amazonQTabSuffix}`)
     }
 
     private async processAcceptCodeDiff(message: CustomFormActionMessage) {
@@ -643,55 +622,70 @@ export class ChatController {
     }
     private async processFileClickMessage(message: FileClick) {
         const session = this.sessionStorage.getSession(message.tabID)
-        const lineRanges = session.contexts.get(message.filePath)
+        // Check if user clicked on filePath in the contextList or filePath in the fileListTress and perform the functionality accordingly.
+        if (session.showDiffOnFileWrite) {
+            const filePath = session.filePath ?? message.filePath
+            const fileExists = await fs.existsFile(filePath)
+            // Check if fileExists=false, If yes, return instead of showing broken diff experience.
+            if (!session.tempFilePath) {
+                void vscode.window.showInformationMessage('Generated code changes have been reviewed and processed.')
+                return
+            }
+            const leftUri = fileExists ? vscode.Uri.file(filePath) : vscode.Uri.from({ scheme: 'untitled' })
+            const rightUri = vscode.Uri.file(session.tempFilePath ?? filePath)
+            const fileName = path.basename(filePath)
+            await vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, `${fileName} ${amazonQTabSuffix}`)
+        } else {
+            const lineRanges = session.contexts.get(message.filePath)
 
-        if (!lineRanges) {
-            return
-        }
+            if (!lineRanges) {
+                return
+            }
 
-        // Check if clicked file is in a different workspace root
-        const projectRoot =
-            session.relativePathToWorkspaceRoot.get(message.filePath) || workspace.workspaceFolders?.[0]?.uri.fsPath
-        if (!projectRoot) {
-            return
-        }
-        let absoluteFilePath = path.join(projectRoot, message.filePath)
+            // Check if clicked file is in a different workspace root
+            const projectRoot =
+                session.relativePathToWorkspaceRoot.get(message.filePath) || workspace.workspaceFolders?.[0]?.uri.fsPath
+            if (!projectRoot) {
+                return
+            }
+            let absoluteFilePath = path.join(projectRoot, message.filePath)
 
-        // Handle clicking on a user prompt outside the workspace
-        if (message.filePath.endsWith(promptFileExtension)) {
+            // Handle clicking on a user prompt outside the workspace
+            if (message.filePath.endsWith(promptFileExtension)) {
+                try {
+                    await vscode.workspace.fs.stat(vscode.Uri.file(absoluteFilePath))
+                } catch {
+                    absoluteFilePath = path.join(getUserPromptsDirectory(), message.filePath)
+                }
+            }
+
             try {
-                await vscode.workspace.fs.stat(vscode.Uri.file(absoluteFilePath))
-            } catch {
-                absoluteFilePath = path.join(getUserPromptsDirectory(), message.filePath)
-            }
+                // Open the file in VSCode
+                const document = await workspace.openTextDocument(absoluteFilePath)
+                const editor = await window.showTextDocument(document, ViewColumn.Active)
+
+                // Create multiple selections based on line ranges
+                const selections: Selection[] = lineRanges
+                    .filter(({ first, second }) => first !== -1 && second !== -1)
+                    .map(({ first, second }) => {
+                        const startPosition = new Position(first - 1, 0) // Convert 1-based to 0-based
+                        const endPosition = new Position(second - 1, document.lineAt(second - 1).range.end.character)
+                        return new Selection(
+                            startPosition.line,
+                            startPosition.character,
+                            endPosition.line,
+                            endPosition.character
+                        )
+                    })
+
+                // Apply multiple selections to the editor
+                if (selections.length > 0) {
+                    editor.selection = selections[0] // Set the first selection as active
+                    editor.selections = selections // Apply multiple selections
+                    editor.revealRange(selections[0], vscode.TextEditorRevealType.InCenter)
+                }
+            } catch (error) {}
         }
-
-        try {
-            // Open the file in VSCode
-            const document = await workspace.openTextDocument(absoluteFilePath)
-            const editor = await window.showTextDocument(document, ViewColumn.Active)
-
-            // Create multiple selections based on line ranges
-            const selections: Selection[] = lineRanges
-                .filter(({ first, second }) => first !== -1 && second !== -1)
-                .map(({ first, second }) => {
-                    const startPosition = new Position(first - 1, 0) // Convert 1-based to 0-based
-                    const endPosition = new Position(second - 1, document.lineAt(second - 1).range.end.character)
-                    return new Selection(
-                        startPosition.line,
-                        startPosition.character,
-                        endPosition.line,
-                        endPosition.character
-                    )
-                })
-
-            // Apply multiple selections to the editor
-            if (selections.length > 0) {
-                editor.selection = selections[0] // Set the first selection as active
-                editor.selections = selections // Apply multiple selections
-                editor.revealRange(selections[0], vscode.TextEditorRevealType.InCenter)
-            }
-        } catch (error) {}
     }
 
     private processException(e: any, tabID: string) {
@@ -991,6 +985,7 @@ export class ChatController {
     private async processPromptMessageAsNewThread(message: PromptMessage) {
         const session = this.sessionStorage.getSession(message.tabID)
         session.clearListOfReadFiles()
+        session.setShowDiffOnFileWrite(false)
         this.editorContextExtractor
             .extractContextForTrigger('ChatMessage')
             .then(async (context) => {

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -213,6 +213,8 @@ export class Messenger {
                         const message = this.getToolUseMessage(toolUse)
                         // const isConfirmationRequired = this.getIsConfirmationRequired(toolUse)
 
+                        // TODO: If toolUse is fs_write then session.setShowDiffOnFileWrite(true)
+
                         this.dispatcher.sendChatMessage(
                             new ChatMessage(
                                 {

--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -96,14 +96,6 @@ export interface ViewDiff {
     totalCodeBlocks?: number
 }
 
-export interface OpenDiff {
-    command: string | undefined
-    tabID: string
-    messageId: string
-    filePath: string
-    referenceTrackerInformation?: CodeReference[]
-}
-
 export type ChatPromptCommandType =
     | 'help'
     | 'clear'

--- a/packages/core/src/codewhispererChat/view/messages/messageListener.ts
+++ b/packages/core/src/codewhispererChat/view/messages/messageListener.ts
@@ -69,9 +69,6 @@ export class UIMessageListener {
             case 'view_diff':
                 this.processViewDiff(msg)
                 break
-            case 'open-diff':
-                this.processOpenDiff(msg)
-                break
             case 'code_was_copied_to_clipboard':
                 this.processCodeWasCopiedToClipboard(msg)
                 break
@@ -218,14 +215,6 @@ export class UIMessageListener {
 
     private processViewDiff(msg: any) {
         this.chatControllerMessagePublishers.processViewDiff.publish({
-            command: msg.command,
-            tabID: msg.tabID || msg.tabId,
-            ...msg,
-        })
-    }
-
-    private processOpenDiff(msg: any) {
-        this.chatControllerMessagePublishers.processOpenDiff.publish({
             command: msg.command,
             tabID: msg.tabID || msg.tabId,
             ...msg,

--- a/packages/core/src/codewhispererChat/view/messages/messageListener.ts
+++ b/packages/core/src/codewhispererChat/view/messages/messageListener.ts
@@ -188,9 +188,8 @@ export class UIMessageListener {
         })
     }
 
-    private processInsertCodeAtCursorPosition(msg: any) {
-        this.referenceLogController.addReferenceLog(msg.codeReference, (msg.code as string) ?? '')
-        this.chatControllerMessagePublishers.processInsertCodeAtCursorPosition.publish({
+    private createCommonMessagePayload(msg: any) {
+        return {
             command: msg.command,
             tabID: msg.tabID,
             messageId: msg.messageId,
@@ -202,7 +201,16 @@ export class UIMessageListener {
             codeBlockIndex: msg.codeBlockIndex,
             totalCodeBlocks: msg.totalCodeBlocks,
             codeBlockLanguage: msg.codeBlockLanguage,
-        })
+        }
+    }
+    private processInsertCodeAtCursorPosition(msg: any) {
+        this.referenceLogController.addReferenceLog(msg.codeReference, (msg.code as string) ?? '')
+        this.chatControllerMessagePublishers.processInsertCodeAtCursorPosition.publish(
+            this.createCommonMessagePayload(msg)
+        )
+    }
+    private processCodeWasCopiedToClipboard(msg: any) {
+        this.chatControllerMessagePublishers.processCopyCodeToClipboard.publish(this.createCommonMessagePayload(msg))
     }
 
     private processAcceptDiff(msg: any) {
@@ -218,22 +226,6 @@ export class UIMessageListener {
             command: msg.command,
             tabID: msg.tabID || msg.tabId,
             ...msg,
-        })
-    }
-
-    private processCodeWasCopiedToClipboard(msg: any) {
-        this.chatControllerMessagePublishers.processCopyCodeToClipboard.publish({
-            command: msg.command,
-            tabID: msg.tabID,
-            messageId: msg.messageId,
-            userIntent: msg.userIntent,
-            code: msg.code,
-            insertionTargetType: msg.insertionTargetType,
-            codeReference: msg.codeReference,
-            eventId: msg.eventId,
-            codeBlockIndex: msg.codeBlockIndex,
-            totalCodeBlocks: msg.totalCodeBlocks,
-            codeBlockLanguage: msg.codeBlockLanguage,
         })
     }
 


### PR DESCRIPTION
## Problem

- Existing Q chat has `contextList` and `fileListTree` both component using same event to show the file and the diff view functionality respectively. IDE can not know what exact functionality to perform if user clicks on a filePath.

**ContextList:**
![image](https://github.com/user-attachments/assets/294be66f-cb61-472b-8d2c-c2ba982ad4e6)

**FileListTree:**
![image](https://github.com/user-attachments/assets/04dedd2f-c3cb-4f02-aaaa-f31be83e1d2f)

## Solution
- Adding a conditional check to open the diff view only if the IDE is doing a `fs_write` tool operation.
- Rest show open the file for contextList.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
