### PR TITLE
feat(chat): add fsWrite tool to agentic loop

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -58,7 +58,7 @@ import { randomUUID } from '../../../shared/crypto'
 import { LspController } from '../../../amazonq/lsp/lspController'
 import { CodeWhispererSettings } from '../../../codewhisperer/util/codewhispererSettings'
 import { getSelectedCustomization } from '../../../codewhisperer/util/customizationUtil'
-import { getHttpStatusCode, AwsClientResponseError } from '../../../shared/errors'
+import { getHttpStatusCode, AwsClientResponseError, ToolkitError } from '../../../shared/errors'
 import { uiEventRecorder } from '../../../amazonq/util/eventRecorder'
 import { telemetry } from '../../../shared/telemetry/telemetry'
 import { isSsoConnection } from '../../../auth/connection'
@@ -85,6 +85,8 @@ import { ChatSession } from '../../clients/chat/v0/chat'
 import { ChatHistoryManager } from '../../storages/chatHistory'
 import { amazonQTabSuffix } from '../../../shared/constants'
 import { FsRead, FsReadParams } from '../../tools/fsRead'
+import { InvokeOutput, OutputKind } from '../../tools/toolShared'
+import { FsWrite, FsWriteCommand } from '../../tools/fsWrite'
 
 export interface ChatControllerMessagePublishers {
     readonly processPromptChatMessage: MessagePublisher<PromptMessage>
@@ -900,7 +902,7 @@ export class ChatController {
                 }
                 session.setToolUse(undefined)
 
-                let result: any
+                let result: InvokeOutput | undefined = undefined
                 const toolResults: ToolResult[] = []
                 try {
                     switch (toolUse.name) {
@@ -916,22 +918,22 @@ export class ChatController {
                             result = await fsRead.invoke()
                             break
                         }
-                        // case 'fs_write': {
-                        //     const fsWrite = new FsWrite(toolUse.input as unknown as FsWriteParams)
-                        //     const ctx = new DefaultContext()
-                        //     result = await fsWrite.invoke(ctx, process.stdout)
-                        //     break
-                        // }
-                        // case 'open_file': {
-                        //     result = await openFile(toolUse.input as unknown as OpenFileParams)
-                        //     break
-                        // }
-                        default:
+                        case 'fsWrite': {
+                            const input = toolUse.input as unknown as FsWriteCommand
+                            await FsWrite.validate(input)
+                            result = await FsWrite.invoke(input)
                             break
+                        }
+                        default:
+                            getLogger().warn('Received invalid tool: %s', toolUse.name)
+                            break
+                    }
+                    if (!result) {
+                        throw new ToolkitError('Failed to execute tool and get results')
                     }
                     toolResults.push({
                         content: [
-                            result.output.kind === 'text'
+                            result.output.kind === OutputKind.Text
                                 ? { text: result.output.content }
                                 : { json: result.output.content },
                         ],

--- a/packages/core/src/codewhispererChat/tools/fsWrite.ts
+++ b/packages/core/src/codewhispererChat/tools/fsWrite.ts
@@ -19,7 +19,7 @@ export interface CreateCommand extends BaseCommand {
 }
 
 export interface StrReplaceCommand extends BaseCommand {
-    command: 'str_replace'
+    command: 'strReplace'
     oldStr: string
     newStr: string
 }
@@ -47,7 +47,7 @@ export class FsWrite {
             case 'create':
                 await this.handleCreate(command, sanitizedPath)
                 break
-            case 'str_replace':
+            case 'strReplace':
                 await this.handleStrReplace(command, sanitizedPath)
                 break
             case 'insert':
@@ -63,6 +63,32 @@ export class FsWrite {
                 kind: OutputKind.Text,
                 content: '',
             },
+        }
+    }
+
+    public static async validate(command: FsWriteCommand): Promise<void> {
+        switch (command.command) {
+            case 'create':
+                if (!command.path) {
+                    throw new Error('Path must not be empty')
+                }
+                break
+            case 'strReplace':
+            case 'insert': {
+                const fileExists = await fs.existsFile(command.path)
+                if (!fileExists) {
+                    throw new Error('The provided path must exist in order to replace or insert contents into it')
+                }
+                break
+            }
+            case 'append':
+                if (!command.path) {
+                    throw new Error('Path must not be empty')
+                }
+                if (!command.newStr) {
+                    throw new Error('Content to append must not be empty')
+                }
+                break
         }
     }
 

--- a/packages/core/src/codewhispererChat/tools/tool_index.json
+++ b/packages/core/src/codewhispererChat/tools/tool_index.json
@@ -19,5 +19,40 @@
             },
             "required": ["path"]
         }
+    },
+    "fsWrite": {
+        "name": "fsWrite",
+        "description": "A tool for creating and editing files\n * The `create` command will override the file at `path` if it already exists as a file, and otherwise create a new file\n * The `append` command will add content to the end of an existing file, automatically adding a newline if the file doesn't end with one. The file must exist.\n Notes for using the `strReplace` command:\n * The `oldStr` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!\n * If the `oldStr` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `oldStr` to make it unique\n * The `newStr` parameter should contain the edited lines that should replace the `oldStr`. The `insert` command will insert `newStr` after `insertLine` and place it on its own line.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "enum": ["create", "strReplace", "insert", "append"],
+                    "description": "The commands to run. Allowed options are: `create`, `strReplace`, `insert`, `append`."
+                },
+                "fileText": {
+                    "description": "Required parameter of `create` command, with the content of the file to be created.",
+                    "type": "string"
+                },
+                "insertLine": {
+                    "description": "Required parameter of `insert` command. The `newStr` will be inserted AFTER the line `insertLine` of `path`.",
+                    "type": "integer"
+                },
+                "newStr": {
+                    "description": "Required parameter of `strReplace` command containing the new string. Required parameter of `insert` command containing the string to insert. Required parameter of `append` command containing the content to append to the file.",
+                    "type": "string"
+                },
+                "oldStr": {
+                    "description": "Required parameter of `strReplace` command containing the string in `path` to replace.",
+                    "type": "string"
+                },
+                "path": {
+                    "description": "Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.",
+                    "type": "string"
+                }
+            },
+            "required": ["command", "path"]
+        }
     }
 }

--- a/packages/core/src/test/codewhispererChat/tools/fsWrite.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/fsWrite.test.ts
@@ -107,7 +107,7 @@ describe('FsWrite Tool', function () {
             await fs.writeFile(filePath, 'Hello World')
 
             const command: StrReplaceCommand = {
-                command: 'str_replace',
+                command: 'strReplace',
                 path: filePath,
                 oldStr: 'Hello',
                 newStr: 'Goodbye',
@@ -124,7 +124,7 @@ describe('FsWrite Tool', function () {
             const filePath = path.join(testFolder.path, 'file1.txt')
 
             const command: StrReplaceCommand = {
-                command: 'str_replace',
+                command: 'strReplace',
                 path: filePath,
                 oldStr: 'Invalid',
                 newStr: 'Goodbye',
@@ -138,7 +138,7 @@ describe('FsWrite Tool', function () {
             await fs.writeFile(filePath, 'Hello Hello World')
 
             const command: StrReplaceCommand = {
-                command: 'str_replace',
+                command: 'strReplace',
                 path: filePath,
                 oldStr: 'Hello',
                 newStr: 'Goodbye',
@@ -155,7 +155,7 @@ describe('FsWrite Tool', function () {
             await fs.writeFile(filePath, 'Text with special chars: .*+?^${}()|[]\\')
 
             const command: StrReplaceCommand = {
-                command: 'str_replace',
+                command: 'strReplace',
                 path: filePath,
                 oldStr: '.*+?^${}()|[]\\',
                 newStr: 'REPLACED',
@@ -173,7 +173,7 @@ describe('FsWrite Tool', function () {
             await fs.writeFile(filePath, 'Line 1\n  Indented line\nLine 3')
 
             const command: StrReplaceCommand = {
-                command: 'str_replace',
+                command: 'strReplace',
                 path: filePath,
                 oldStr: '  Indented line\n',
                 newStr: '    Double indented\n',


### PR DESCRIPTION
## Problem
FsWrite should be enabled in agentic loop


## Solution
- Updated tool index with fsWrite
- Updated the agentic loop to invoke fsWrite tool
- Added input validation


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
