### PR TITLE
feat(chat): pass workspace folders to IDE context

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/chatRequest/converter.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/chatRequest/converter.ts
@@ -14,6 +14,7 @@ import {
 import { ChatTriggerType, TriggerPayload } from '../model'
 import { undefinedIfEmpty } from '../../../../shared/utilities/textUtilities'
 import { tools } from '../../../constants'
+import vscode from 'vscode'
 
 const fqnNameSizeDownLimit = 1
 const fqnNameSizeUpLimit = 256
@@ -116,7 +117,7 @@ export function triggerPayloadToChatRequest(triggerPayload: TriggerPayload): { c
                             cursorState,
                             relevantDocuments,
                             useRelevantDocuments,
-                            // TODO: Need workspace folders here after model update.
+                            workspaceFolders: vscode.workspace.workspaceFolders?.map(({ uri }) => uri.fsPath) ?? [],
                         },
                         additionalContext: triggerPayload.additionalContents,
                         tools,

--- a/src.gen/@amzn/codewhisperer-streaming/src/commands/GenerateAssistantResponseCommand.ts
+++ b/src.gen/@amzn/codewhisperer-streaming/src/commands/GenerateAssistantResponseCommand.ts
@@ -100,6 +100,9 @@ export interface GenerateAssistantResponseCommandOutput extends GenerateAssistan
  *                 },
  *               ],
  *               useRelevantDocuments: true || false,
+ *               workspaceFolders: [ // WorkspaceFolderList
+ *                 "STRING_VALUE",
+ *               ],
  *             },
  *             shellState: { // ShellState
  *               shellName: "STRING_VALUE", // required
@@ -287,6 +290,9 @@ export interface GenerateAssistantResponseCommandOutput extends GenerateAssistan
  *               },
  *             ],
  *             useRelevantDocuments: true || false,
+ *             workspaceFolders: [
+ *               "STRING_VALUE",
+ *             ],
  *           },
  *           shellState: {
  *             shellName: "STRING_VALUE", // required

--- a/src.gen/@amzn/codewhisperer-streaming/src/commands/GenerateTaskAssistPlanCommand.ts
+++ b/src.gen/@amzn/codewhisperer-streaming/src/commands/GenerateTaskAssistPlanCommand.ts
@@ -100,6 +100,9 @@ export interface GenerateTaskAssistPlanCommandOutput extends GenerateTaskAssistP
  *                 },
  *               ],
  *               useRelevantDocuments: true || false,
+ *               workspaceFolders: [ // WorkspaceFolderList
+ *                 "STRING_VALUE",
+ *               ],
  *             },
  *             shellState: { // ShellState
  *               shellName: "STRING_VALUE", // required
@@ -287,6 +290,9 @@ export interface GenerateTaskAssistPlanCommandOutput extends GenerateTaskAssistP
  *               },
  *             ],
  *             useRelevantDocuments: true || false,
+ *             workspaceFolders: [
+ *               "STRING_VALUE",
+ *             ],
  *           },
  *           shellState: {
  *             shellName: "STRING_VALUE", // required

--- a/src.gen/@amzn/codewhisperer-streaming/src/commands/SendMessageCommand.ts
+++ b/src.gen/@amzn/codewhisperer-streaming/src/commands/SendMessageCommand.ts
@@ -101,6 +101,9 @@ export interface SendMessageCommandOutput extends SendMessageResponse, __Metadat
  *                 },
  *               ],
  *               useRelevantDocuments: true || false,
+ *               workspaceFolders: [ // WorkspaceFolderList
+ *                 "STRING_VALUE",
+ *               ],
  *             },
  *             shellState: { // ShellState
  *               shellName: "STRING_VALUE", // required
@@ -288,6 +291,9 @@ export interface SendMessageCommandOutput extends SendMessageResponse, __Metadat
  *               },
  *             ],
  *             useRelevantDocuments: true || false,
+ *             workspaceFolders: [
+ *               "STRING_VALUE",
+ *             ],
  *           },
  *           shellState: {
  *             shellName: "STRING_VALUE", // required

--- a/src.gen/@amzn/codewhisperer-streaming/src/models/models_0.ts
+++ b/src.gen/@amzn/codewhisperer-streaming/src/models/models_0.ts
@@ -1270,6 +1270,12 @@ export interface EditorState {
    * @public
    */
   useRelevantDocuments?: boolean | undefined;
+
+  /**
+   * Represents IDE provided list of workspace folders
+   * @public
+   */
+  workspaceFolders?: (string)[] | undefined;
 }
 
 /**
@@ -1288,6 +1294,9 @@ export const EditorStateFilterSensitiveLog = (obj: EditorState): any => ({
       item =>
       RelevantTextDocumentFilterSensitiveLog(item)
     )
+  }),
+  ...(obj.workspaceFolders && { workspaceFolders:
+    SENSITIVE_STRING
   }),
 })
 

--- a/src.gen/@amzn/codewhisperer-streaming/src/protocols/Aws_restJson1.ts
+++ b/src.gen/@amzn/codewhisperer-streaming/src/protocols/Aws_restJson1.ts
@@ -1089,6 +1089,8 @@ const de_CommandError = async(
 
   // se_UserSettings omitted.
 
+  // se_WorkspaceFolderList omitted.
+
   // se_WorkspaceState omitted.
 
   // de_AssistantResponseEvent omitted.


### PR DESCRIPTION
## Problem
IDE context should know about the workspace


## Solution
Update codewhisperer-streaming client and pass in workspaceFolders

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
