### PR TITLE
fix(ziputil): ensure codeDiff is generated when there are uncommitted changes

### DIFF
--- a/packages/core/src/codewhisperer/util/zipUtil.ts
+++ b/packages/core/src/codewhisperer/util/zipUtil.ts
@@ -218,7 +218,7 @@ export class ZipUtil {
         filePath?: string,
         scope?: CodeWhispererConstants.CodeAnalysisScope
     ) {
-        const gitDiffContent = await getGitDiffContentForProjects(projectPaths, filePath)
+        const gitDiffContent = await getGitDiffContentForProjects(projectPaths, filePath, scope)
         if (gitDiffContent) {
             zip.writeString(gitDiffContent, ZipConstants.codeDiffFilePath)
         }


### PR DESCRIPTION
## Problem
`codeDiff` folder was missing from zip output. 

## Solution
- optional parameter was not passed when it wasn't really optional. 
- The source of this issue is addressed in https://github.com/aws/aws-toolkit-vscode/pull/6838 by avoiding these scopes entirely. 

## Verify
The following test case now passes when there are uncommitted changes to the repo. 
```
// packages/core/src/test/codewhisperer/zipUtil.test.ts
it('should generate a codeDiff folder when there are uncommitted changes', async function () {
            const zipMetadata = await zipUtil.generateZip(vscode.Uri.file(appCodePath), CodeAnalysisScope.PROJECT)
            const zipFileData = await fs.readFileBytes(zipMetadata.zipFilePath)
            const zip = await JSZip.loadAsync(zipFileData)
            const files = Object.keys(zip.files)
            assert.ok(files.find((f) => f === ZipConstants.codeDiffFilePath))
}) 
```
I did not commit this test case because it fails when there are aren't uncommitted changes. Currently this is difficult to test due to the nature of the code. This partly addressed in the same PR above. 


## Future Work 
Rework/refactor the gitdiff logic to be more testable. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
