### PR TITLE
feat(chat): Adding execute bash tool setup in Q Agentic chat loop

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -41,6 +41,8 @@ import { extractAuthFollowUp } from '../../../../amazonq/util/authUtils'
 import { helpMessage } from '../../../../amazonq/webview/ui/texts/constants'
 import { ChatItemButton, ChatItemFormItem, MynahUIDataModel } from '@aws/mynah-ui'
 import { ChatHistoryManager } from '../../../storages/chatHistory'
+import { ExecuteBashParams } from '../../../tools/executeBash'
+import { FsWriteCommand } from '../../../tools/fsWrite'
 
 export type StaticTextResponseType = 'quick-action-help' | 'onboarding-help' | 'transform' | 'help'
 
@@ -604,57 +606,57 @@ export class Messenger {
     //     return toolUse.name === 'fs_write'
     // }
     private getToolUseMessage(toolUse: ToolUse) {
-        if (toolUse.name === 'fs_read') {
-            return `Reading the file at \`${(toolUse.input as any)?.path}\` using the \`fs_read\` tool.`
+        if (toolUse.name === 'fsRead') {
+            return `Reading the file at \`${(toolUse.input as any)?.path}\` using the \`fsRead\` tool.`
         }
-        //     if (toolUse.name === 'execute_bash') {
-        //         const input = toolUse.input as unknown as ExecuteBashParams
-        //         return `Executing the bash command
-        // \`\`\`bash
-        // ${input.command}
-        // \`\`\`
-        // using the \`execute_bash\` tool.`
-        //     }
-        //     if (toolUse.name === 'fs_write') {
-        //         const input = toolUse.input as unknown as FsWriteParams
-        //         switch (input.command) {
-        //             case 'create': {
-        //                 return `Writing
-        // \`\`\`
-        // ${input.file_text}
-        // \`\`\`
-        // into the file at \`${input.path}\` using the \`fs_write\` tool.`
-        //             }
-        //             case 'str_replace': {
-        //                 return `Replacing
-        // \`\`\`
-        // ${input.old_str}
-        // \`\`\`
-        // with
-        // \`\`\`
-        // ${input.new_str}
-        // \`\`\`
-        // at \`${input.path}\` using the \`fs_write\` tool.`
-        //             }
-        //             case 'insert': {
-        //                 return `Inserting
-        // \`\`\`
-        // ${input.new_str}
-        // \`\`\`
-        // at line
-        // \`\`\`
-        // ${input.insert_line}
-        // \`\`\`
-        // at \`${input.path}\` using the \`fs_write\` tool.`
-        //             }
-        //             case 'append': {
-        //                 return `Appending
-        // \`\`\`
-        // ${input.new_str}
-        // \`\`\`
-        // at \`${input.path}\` using the \`fs_write\` tool.`
-        //             }
-        //         }
-        //     }
+        if (toolUse.name === 'executeBash') {
+            const input = toolUse.input as unknown as ExecuteBashParams
+            return `Executing the bash command
+        \`\`\`bash
+        ${input.command}
+        \`\`\`
+        using the \`executeBash\` tool.`
+        }
+        if (toolUse.name === 'fsWrite') {
+            const input = toolUse.input as unknown as FsWriteCommand
+            switch (input.command) {
+                case 'create': {
+                    return `Writing
+        \`\`\`
+        ${input.fileText}
+        \`\`\`
+        into the file at \`${input.path}\` using the \`fsWrite\` tool.`
+                }
+                case 'strReplace': {
+                    return `Replacing
+        \`\`\`
+        ${input.oldStr}
+        \`\`\`
+        with
+        \`\`\`
+        ${input.newStr}
+        \`\`\`
+        at \`${input.path}\` using the \`fsWrite\` tool.`
+                }
+                case 'insert': {
+                    return `Inserting
+        \`\`\`
+        ${input.newStr}
+        \`\`\`
+        at line
+        \`\`\`
+        ${input.insertLine}
+        \`\`\`
+        at \`${input.path}\` using the \`fsWrite\` tool.`
+                }
+                case 'append': {
+                    return `Appending
+        \`\`\`
+        ${input.newStr}
+        \`\`\`
+        at \`${input.path}\` using the \`fsWrite\` tool.`
+                }
+            }
+        }
     }
 }

--- a/packages/core/src/codewhispererChat/tools/executeBash.ts
+++ b/packages/core/src/codewhispererChat/tools/executeBash.ts
@@ -111,27 +111,32 @@ export class ExecuteBash {
                     stderr: stderrTrunc + (stderrSuffix ? ' ... truncated' : ''),
                 }
 
-                return {
+                resolve({
                     output: {
                         kind: OutputKind.Json,
                         content: outputJson,
                     },
-                }
+                })
             } catch (err: any) {
                 this.logger.error(`Failed to execute bash command '${this.command}': ${err.message}`)
-                throw new Error(`Failed to execute command: ${err.message}`)
+                reject(new Error(`Failed to execute command: ${err.message}`))
             }
         })
     }
 
     private static handleChunk(chunk: string, buffer: string[], updates: Writable) {
-        const lines = chunk.split(/\r?\n/)
-        for (const line of lines) {
-            updates.write(`${line}\n`)
-            buffer.push(line)
-            if (buffer.length > lineCount) {
-                buffer.shift()
+        try {
+            const lines = chunk.split(/\r?\n/)
+            for (const line of lines) {
+                updates.write(`${line}\n`)
+                buffer.push(line)
+                if (buffer.length > lineCount) {
+                    buffer.shift()
+                }
             }
+        } catch (error) {
+            // Log the error but don't let it crash the process
+            throw new Error('Error handling output chunk')
         }
     }
 

--- a/packages/core/src/codewhispererChat/tools/toolShared.ts
+++ b/packages/core/src/codewhispererChat/tools/toolShared.ts
@@ -16,7 +16,7 @@ export enum OutputKind {
 export interface InvokeOutput {
     output: {
         kind: OutputKind
-        content: string
+        content: string | any
     }
 }
 

--- a/packages/core/src/codewhispererChat/tools/tool_index.json
+++ b/packages/core/src/codewhispererChat/tools/tool_index.json
@@ -54,5 +54,23 @@
             },
             "required": ["command", "path"]
         }
+    },
+    "executeBash": {
+        "name": "executeBash",
+        "description": "Execute the specified bash command.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Bash command to execute"
+                },
+                "cwd": {
+                    "type": "string",
+                    "description": "Parameter to set the current working directory for the bash command."
+                }
+            },
+            "required": ["command", "cwd"]
+        }
     }
 }

--- a/packages/core/src/test/codewhispererChat/tools/fsRead.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/fsRead.test.ts
@@ -53,8 +53,8 @@ describe('FsRead Tool', () => {
         const result = await fsRead.invoke()
 
         const lines = result.output.content.split('\n')
-        const hasFileA = lines.some((line) => line.includes('- ') && line.includes('fileA.txt'))
-        const hasSubfolder = lines.some((line) => line.includes('d ') && line.includes('subfolder'))
+        const hasFileA = lines.some((line: string | string[]) => line.includes('- ') && line.includes('fileA.txt'))
+        const hasSubfolder = lines.some((line: string | string[]) => line.includes('d ') && line.includes('subfolder'))
 
         assert.ok(hasFileA, 'Should list fileA.txt in the directory output')
         assert.ok(hasSubfolder, 'Should list the subfolder in the directory output')


### PR DESCRIPTION
## Problem
Execute bash tool is added but is not hooked to the Q Agentic chat yet.

## Solution
Adding execute bash tool setup in Q Agentic chat loop.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
