### PR TITLE
refactor(amazonq): expose lsp inline completion as an experiment

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -45,8 +45,16 @@ sequenceDiagram
     npm run package
     ```
     to get the project setup
-3. Uncomment the `__AMAZONQLSP_PATH` variable in `amazonq/.vscode/launch.json` Extension configuration
-4. Use the `Launch LSP with Debugging` configuration and set breakpoints in VSCode or the language server
+3. Enable the lsp experiment:
+    ```
+    "aws.experiments": {
+      "amazonqLSP": true,
+      "amazonqLSPInline": true, // optional: enables inline completion from flare
+      "amazonqLSPChat": true // optional: enables chat from flare
+    }
+    ```
+4. Uncomment the `__AMAZONQLSP_PATH` variable in `amazonq/.vscode/launch.json` Extension configuration
+5. Use the `Launch LSP with Debugging` configuration and set breakpoints in VSCode or the language server
 
 ## Amazon Q Inline Activation
 

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -120,7 +120,9 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     await activateCodeWhisperer(extContext as ExtContext)
     if (Experiments.instance.get('amazonqLSP', false)) {
         await activateAmazonqLsp(context)
-    } else {
+    }
+
+    if (!Experiments.instance.get('amazonqLSPInline', false)) {
         await activateInlineCompletion()
     }
 
@@ -157,7 +159,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
 
     context.subscriptions.push(
         Experiments.instance.onDidChange(async (event) => {
-            if (event.key === 'amazonqLSP' || event.key === 'amazonqChatLSP') {
+            if (event.key === 'amazonqLSP' || event.key === 'amazonqChatLSP' || event.key === 'amazonqLSPInline') {
                 await vscode.window
                     .showInformationMessage(
                         'Amazon Q LSP setting has changed. Reload VS Code for the changes to take effect.',

--- a/packages/amazonq/src/lsp/activation.ts
+++ b/packages/amazonq/src/lsp/activation.ts
@@ -6,7 +6,7 @@
 import vscode from 'vscode'
 import { startLanguageServer } from './client'
 import { AmazonQLspInstaller } from './lspInstaller'
-import { Commands, lspSetupStage, ToolkitError } from 'aws-core-vscode/shared'
+import { lspSetupStage, ToolkitError } from 'aws-core-vscode/shared'
 
 export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     try {
@@ -14,14 +14,6 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
             const installResult = await new AmazonQLspInstaller().resolve()
             await lspSetupStage('launch', async () => await startLanguageServer(ctx, installResult.resourcePaths))
         })
-        ctx.subscriptions.push(
-            Commands.register({ id: 'aws.amazonq.invokeInlineCompletion', autoconnect: true }, async () => {
-                await vscode.commands.executeCommand('editor.action.inlineSuggest.trigger')
-            }),
-            vscode.workspace.onDidCloseTextDocument(async () => {
-                await vscode.commands.executeCommand('aws.amazonq.rejectCodeSuggestion')
-            })
-        )
     } catch (err) {
         const e = err as ToolkitError
         void vscode.window.showInformationMessage(`Unable to launch amazonq language server: ${e.message}`)

--- a/packages/core/src/shared/settings-toolkit.gen.ts
+++ b/packages/core/src/shared/settings-toolkit.gen.ts
@@ -43,6 +43,7 @@ export const toolkitSettings = {
     "aws.experiments": {
         "jsonResourceModification": {},
         "amazonqLSP": {},
+        "amazonqLSPInline": {},
         "amazonqChatLSP": {}
     },
     "aws.resources.enabledResources": {},

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -251,6 +251,10 @@
                             "type": "boolean",
                             "default": false
                         },
+                        "amazonqLSPInline": {
+                            "type": "boolean",
+                            "default": false
+                        },
                         "amazonqChatLSP": {
                             "type": "boolean",
                             "default": false


### PR DESCRIPTION
## Problem
- We previously thought inline completion was going to be launched first so we didn't end up putting it behind a feature flag

## Solution
- Add inline completion behind a feature flag

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
