### PR TITLE
feat(chat): Stream executeBash output to chat

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -88,6 +88,7 @@ import { FsRead, FsReadParams } from '../../tools/fsRead'
 import { InvokeOutput, OutputKind } from '../../tools/toolShared'
 import { FsWrite, FsWriteCommand } from '../../tools/fsWrite'
 import { ExecuteBash, ExecuteBashParams } from '../../tools/executeBash'
+import { ChatStream } from '../../tools/chatStream'
 
 export interface ChatControllerMessagePublishers {
     readonly processPromptChatMessage: MessagePublisher<PromptMessage>
@@ -951,7 +952,8 @@ export class ChatController {
                         case 'executeBash': {
                             const executeBash = new ExecuteBash(toolUse.input as unknown as ExecuteBashParams)
                             await executeBash.validate()
-                            result = await executeBash.invoke(process.stdout)
+                            const chatStream = new ChatStream(this.messenger, tabID, triggerID, toolUse.toolUseId)
+                            result = await executeBash.invoke(chatStream)
                             break
                         }
                         case 'fsRead': {

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -438,6 +438,27 @@ export class Messenger {
         )
     }
 
+    public sendPartialBashToolLog(message: string, tabID: string, triggerID: string, toolUseId: string | undefined) {
+        this.dispatcher.sendChatMessage(
+            new ChatMessage(
+                {
+                    message,
+                    messageType: 'answer-part',
+                    followUps: undefined,
+                    followUpsHeader: undefined,
+                    relatedSuggestions: undefined,
+                    triggerID,
+                    messageID: toolUseId ?? `tool-output`,
+                    userIntent: undefined,
+                    codeBlockLanguage: 'plaintext',
+                    contextList: undefined,
+                    canBeVoted: false,
+                },
+                tabID
+            )
+        )
+    }
+
     private editorContextMenuCommandVerbs: Map<EditorContextCommandType, string> = new Map([
         ['aws.amazonq.explainCode', 'Explain'],
         ['aws.amazonq.explainIssue', 'Explain'],

--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Writable } from 'stream'
+import { getLogger } from '../../shared/logger/logger'
+import { Messenger } from '../controllers/chat/messenger/messenger'
+
+/**
+ * A writable stream that feeds each chunk/line to the chat UI.
+ * Used for streaming tool output (like bash execution) to the chat interface.
+ */
+export class ChatStream extends Writable {
+    private accumulatedLogs = ''
+
+    public constructor(
+        private readonly messenger: Messenger,
+        private readonly tabID: string,
+        private readonly triggerID: string,
+        private readonly toolUseId: string | undefined,
+        private readonly logger = getLogger('chatStream')
+    ) {
+        super()
+        this.logger.debug(`ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}`)
+    }
+
+    override _write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+        const text = chunk.toString()
+        this.accumulatedLogs += text
+        this.logger.debug(`ChatStream received chunk: ${text}`)
+        this.messenger.sendPartialBashToolLog(
+            `\`\`\`bash\n${this.accumulatedLogs}\`\`\``,
+            this.tabID,
+            this.triggerID,
+            this.toolUseId
+        )
+        callback()
+    }
+
+    override _final(callback: (error?: Error | null) => void): void {
+        if (this.accumulatedLogs.trim().length > 0) {
+            this.messenger.sendPartialBashToolLog(
+                `\`\`\`bash\n${this.accumulatedLogs}\`\`\``,
+                this.tabID,
+                this.triggerID,
+                this.toolUseId
+            )
+        }
+        callback()
+    }
+}

--- a/packages/core/src/codewhispererChat/tools/executeBash.ts
+++ b/packages/core/src/codewhispererChat/tools/executeBash.ts
@@ -126,9 +126,9 @@ export class ExecuteBash {
 
     private static handleChunk(chunk: string, buffer: string[], updates: Writable) {
         try {
+            updates.write(chunk)
             const lines = chunk.split(/\r?\n/)
             for (const line of lines) {
-                updates.write(`${line}\n`)
                 buffer.push(line)
                 if (buffer.length > lineCount) {
                     buffer.shift()

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -19,6 +19,7 @@ export type LogTopic =
     | 'fsRead'
     | 'fsWrite'
     | 'executeBash'
+    | 'chatStream'
     | 'unknown'
 
 class ErrorLog {


### PR DESCRIPTION




## Problem
We need to be able to stream the command tool execution logs to the chat in real-time

## Solution

- Added a new ChatStream class that extends Node's Writable stream to capture and stream bash command output to the chat UI in real-time
- Implemented a sendPartialBashToolLog method in the Messenger class to display command output as it's generated
- Modified the chat controller to use the new streaming functionality instead of waiting for commands to complete
-  Added appropriate logging and error handling for the streaming functionality
-  Fixed a duplicate write operation in the handleChunk method of executeBash.ts

https://github.com/user-attachments/assets/a27900d1-5c0e-4690-a7d3-33f7712f255a
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
