### PR TITLE
test(amazonq): add mock for IntersectionObserver

### DIFF
--- a/packages/amazonq/test/e2e/amazonq/framework/jsdomInjector.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/jsdomInjector.ts
@@ -48,3 +48,16 @@ export function injectJSDOM() {
     // jsdom doesn't have support for structuredClone. See https://github.com/jsdom/jsdom/issues/3363
     global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val))
 }
+
+global.IntersectionObserver = class IntersectionObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+        return []
+    }
+    // eslint-disable-next-line unicorn/no-null
+    root = null
+    rootMargin = ''
+    thresholds = []
+}

--- a/packages/amazonq/test/e2e/amazonq/framework/jsdomInjector.ts
+++ b/packages/amazonq/test/e2e/amazonq/framework/jsdomInjector.ts
@@ -47,17 +47,17 @@ export function injectJSDOM() {
 
     // jsdom doesn't have support for structuredClone. See https://github.com/jsdom/jsdom/issues/3363
     global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val))
-}
 
-global.IntersectionObserver = class IntersectionObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-    takeRecords() {
-        return []
+    global.IntersectionObserver = class IntersectionObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords() {
+            return []
+        }
+        // eslint-disable-next-line unicorn/no-null
+        root = null
+        rootMargin = ''
+        thresholds = []
     }
-    // eslint-disable-next-line unicorn/no-null
-    root = null
-    rootMargin = ''
-    thresholds = []
 }


### PR DESCRIPTION
## Problem
`ReferenceError: IntersectionObserver is not defined` in E2E tests due to JSDOM 


## Solution
Add mock for IntersectionObserver

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
