### PR TITLE
build: ensure npm is used for watch task

### DIFF
--- a/packages/amazonq/.vscode/tasks.json
+++ b/packages/amazonq/.vscode/tasks.json
@@ -5,8 +5,9 @@
     "tasks": [
         {
             "label": "watch",
-            "type": "npm",
-            "script": "watch",
+            "type": "shell",
+            "command": "npm",
+            "args": ["run", "watch"],
             "problemMatcher": "$tsc-watch",
             "isBackground": true,
             "group": {

--- a/packages/core/.vscode/tasks.json
+++ b/packages/core/.vscode/tasks.json
@@ -10,8 +10,9 @@
         },
         {
             "label": "watch",
-            "type": "npm",
-            "script": "watch",
+            "type": "shell",
+            "command": "npm",
+            "args": ["run", "watch"],
             "problemMatcher": "$tsc-watch",
             "isBackground": true
         },

--- a/packages/toolkit/.vscode/tasks.json
+++ b/packages/toolkit/.vscode/tasks.json
@@ -14,8 +14,9 @@
         },
         {
             "label": "watch",
-            "type": "npm",
-            "script": "watch",
+            "type": "shell",
+            "command": "npm",
+            "args": ["run", "watch"],
             "problemMatcher": "$tsc-watch",
             "isBackground": true,
             "group": {


### PR DESCRIPTION
## Problem

```
 *  Executing task in folder amazonq: yarn run watch 

zsh:1: command not found: yarn

 *  The terminal process "/opt/homebrew/bin/zsh '-l', '-c', 'yarn run watch'" failed to launch (exit code: 127). 
 *  Terminal will be reused by tasks, press any key to close it. 
```

Seems to be a vscode issue. 
- https://github.com/microsoft/vscode/issues/181006
- https://github.com/microsoft/vscode/issues/159465

Given that we already have `npm.packageManager` set to `npm` in this repo, I'm not sure why it keeps trying to use `yarn`.


## Solution

Run the watch task as a shell script


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
