### PR TITLE
feat(chat): use ChatStream to show tool description

### DIFF
--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -23,29 +23,20 @@ export class ChatStream extends Writable {
     ) {
         super()
         this.logger.debug(`ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}`)
+        this.messenger.sendInitalStream(tabID, triggerID, undefined)
     }
 
     override _write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
         const text = chunk.toString()
         this.accumulatedLogs += text
         this.logger.debug(`ChatStream received chunk: ${text}`)
-        this.messenger.sendPartialBashToolLog(
-            `\`\`\`bash\n${this.accumulatedLogs}\`\`\``,
-            this.tabID,
-            this.triggerID,
-            this.toolUseId
-        )
+        this.messenger.sendPartialToolLog(this.accumulatedLogs, this.tabID, this.triggerID, this.toolUseId)
         callback()
     }
 
     override _final(callback: (error?: Error | null) => void): void {
         if (this.accumulatedLogs.trim().length > 0) {
-            this.messenger.sendPartialBashToolLog(
-                `\`\`\`bash\n${this.accumulatedLogs}\`\`\``,
-                this.tabID,
-                this.triggerID,
-                this.toolUseId
-            )
+            this.messenger.sendPartialToolLog(this.accumulatedLogs, this.tabID, this.triggerID, this.toolUseId)
         }
         callback()
     }

--- a/packages/core/src/codewhispererChat/tools/executeBash.ts
+++ b/packages/core/src/codewhispererChat/tools/executeBash.ts
@@ -74,6 +74,7 @@ export class ExecuteBash {
             const stdoutBuffer: string[] = []
             const stderrBuffer: string[] = []
 
+            let firstChunk = true
             const childProcessOptions: ChildProcessOptions = {
                 spawnOptions: {
                     cwd: this.workingDirectory,
@@ -82,7 +83,8 @@ export class ExecuteBash {
                 collect: false,
                 waitForStreams: true,
                 onStdout: (chunk: string) => {
-                    ExecuteBash.handleChunk(chunk, stdoutBuffer, updates)
+                    ExecuteBash.handleChunk(firstChunk ? '```console\n' + chunk : chunk, stdoutBuffer, updates)
+                    firstChunk = false
                 },
                 onStderr: (chunk: string) => {
                     ExecuteBash.handleChunk(chunk, stderrBuffer, updates)
@@ -203,11 +205,8 @@ export class ExecuteBash {
     }
 
     public queueDescription(updates: Writable): void {
-        updates.write(`I will run the following shell command: `)
-
-        if (this.command.length > 20) {
-            updates.write('\n')
-        }
-        updates.write(`\x1b[32m${this.command}\x1b[0m\n`)
+        updates.write(`I will run the following shell command:\n`)
+        updates.write('```bash\n' + this.command + '\n```')
+        updates.end()
     }
 }


### PR DESCRIPTION
## Problem

ChatStream should be able to send messages for more use cases than just bash output.


## Solution

Reuse the chat stream class for all tool messages

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
