### PR TITLE
feat(chat): add confirmation buttons and tool descriptions

### DIFF
--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -19,6 +19,7 @@ export class ChatStream extends Writable {
         private readonly tabID: string,
         private readonly triggerID: string,
         private readonly toolUseId: string | undefined,
+        private readonly requiresAcceptance = false,
         private readonly logger = getLogger('chatStream')
     ) {
         super()
@@ -30,13 +31,25 @@ export class ChatStream extends Writable {
         const text = chunk.toString()
         this.accumulatedLogs += text
         this.logger.debug(`ChatStream received chunk: ${text}`)
-        this.messenger.sendPartialToolLog(this.accumulatedLogs, this.tabID, this.triggerID, this.toolUseId)
+        this.messenger.sendPartialToolLog(
+            this.accumulatedLogs,
+            this.tabID,
+            this.triggerID,
+            this.toolUseId,
+            this.requiresAcceptance
+        )
         callback()
     }
 
     override _final(callback: (error?: Error | null) => void): void {
         if (this.accumulatedLogs.trim().length > 0) {
-            this.messenger.sendPartialToolLog(this.accumulatedLogs, this.tabID, this.triggerID, this.toolUseId)
+            this.messenger.sendPartialToolLog(
+                this.accumulatedLogs,
+                this.tabID,
+                this.triggerID,
+                this.toolUseId,
+                this.requiresAcceptance
+            )
         }
         callback()
     }

--- a/packages/core/src/codewhispererChat/tools/fsRead.ts
+++ b/packages/core/src/codewhispererChat/tools/fsRead.ts
@@ -8,6 +8,7 @@ import { readDirectoryRecursively } from '../../shared/utilities/workspaceUtils'
 import fs from '../../shared/fs/fs'
 import { InvokeOutput, maxToolResponseSize, OutputKind, sanitizePath } from './toolShared'
 import { Writable } from 'stream'
+import path from 'path'
 
 export interface FsReadParams {
     path: string
@@ -49,7 +50,12 @@ export class FsRead {
         this.logger.debug(`Validation succeeded for path: ${this.fsPath}`)
     }
 
-    public queueDescription(updates: Writable): void {}
+    public queueDescription(updates: Writable): void {
+        const fileName = path.basename(this.fsPath)
+        const fileUri = vscode.Uri.file(this.fsPath)
+        updates.write(`Reading: [${fileName}](${fileUri})`)
+        updates.end()
+    }
 
     public async invoke(updates: Writable): Promise<InvokeOutput> {
         try {

--- a/packages/core/src/codewhispererChat/tools/fsWrite.ts
+++ b/packages/core/src/codewhispererChat/tools/fsWrite.ts
@@ -8,6 +8,7 @@ import { getLogger } from '../../shared/logger/logger'
 import vscode from 'vscode'
 import { fs } from '../../shared/fs/fs'
 import { Writable } from 'stream'
+import path from 'path'
 
 interface BaseParams {
     path: string
@@ -69,7 +70,12 @@ export class FsWrite {
         }
     }
 
-    public queueDescription(updates: Writable): void {}
+    public queueDescription(updates: Writable): void {
+        const fileName = path.basename(this.params.path)
+        const fileUri = vscode.Uri.file(this.params.path)
+        updates.write(`Writing to: [${fileName}](${fileUri})`)
+        updates.end()
+    }
 
     public async validate(): Promise<void> {
         switch (this.params.command) {


### PR DESCRIPTION
## Problem

Tool acceptance confirmation is not implemented.
Some tools are missing descriptions.


## Solution
Add confirmation button to tool message if required


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
