### PR TITLE
feat(amazonq lsp): Make chat client assets configurable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -437,6 +437,7 @@ Example:
     "supportedVersions": "4.0.0",
     "id": "AmazonQ",
     "path": "/custom/path/to/local/lsp/folder",
+    "ui": "/custom/path/to/chat-client/ui"
 }
 ```
 
@@ -501,11 +502,12 @@ Unlike the user setting overrides, not all of these environment variables have t
 -   `__AMAZONQLSP_MANIFEST_URL`: for aws.dev.amazonqLsp.manifestUrl
 -   `__AMAZONQLSP_SUPPORTED_VERSIONS`: for aws.dev.amazonqLsp.supportedVersions
 -   `__AMAZONQLSP_ID`: for aws.dev.amazonqLsp.id
--   `__AMAZONQLSP_PATH`: for aws.dev.amazonqWorkspaceLsp.locationOverride
+-   `__AMAZONQLSP_PATH`: for aws.dev.amazonqLsp.path
+-   `__AMAZONQLSP_UI`: for aws.dev.amazonqLsp.ui
 -   `__AMAZONQWORKSPACELSP_MANIFEST_URL`: for aws.dev.amazonqWorkspaceLsp.manifestUrl
 -   `__AMAZONQWORKSPACELSP_SUPPORTED_VERSIONS`: for aws.dev.amazonqWorkspaceLsp.supportedVersions
 -   `__AMAZONQWORKSPACELSP_ID`: for aws.dev.amazonqWorkspaceLsp.id
--   `__AMAZONQWORKSPACELSP_PATH`: for aws.dev.amazonqWorkspaceLsp.locationOverride
+-   `__AMAZONQWORKSPACELSP_PATH`: for aws.dev.amazonqWorkspaceLsp.path
 
 #### Lambda
 

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -45,7 +45,8 @@ sequenceDiagram
     npm run package
     ```
     to get the project setup
-3. Uncomment the `__AMAZONQLSP_PATH` variable in `amazonq/.vscode/launch.json` Extension configuration
+3. Uncomment the `__AMAZONQLSP_PATH` variable in `amazonq/.vscode/launch.json` Extension configuration if you just want basic inline completion support
+    1. Uncomment the `__AMAZONQLSP_UI` variable in `amazonq/.vscode/launch.json` Extension configuration if you want chat support as well
 4. Use the `Launch LSP with Debugging` configuration and set breakpoints in VSCode or the language server
 
 ## Amazon Q Inline Activation

--- a/packages/amazonq/.vscode/launch.json
+++ b/packages/amazonq/.vscode/launch.json
@@ -15,6 +15,7 @@
                 "SSMDOCUMENT_LANGUAGESERVER_PORT": "6010",
                 "WEBPACK_DEVELOPER_SERVER": "http://localhost:8080"
                 // "__AMAZONQLSP_PATH": "${workspaceFolder}/../../../language-servers/app/aws-lsp-codewhisperer-runtimes/out/token-standalone.js",
+                // "__AMAZONQLSP_UI": "${workspaceFolder}/../../../language-servers/chat-client/build/amazonq-ui.js"
             },
             "envFile": "${workspaceFolder}/.local.env",
             "outFiles": ["${workspaceFolder}/dist/**/*.js", "${workspaceFolder}/../core/dist/**/*.js"],

--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -13,6 +13,7 @@ import {
     Uri,
 } from 'vscode'
 import { LanguageServerResolver } from 'aws-core-vscode/shared'
+import * as path from 'path'
 
 export class AmazonQChatViewProvider implements WebviewViewProvider {
     public static readonly viewType = 'aws.amazonq.AmazonQChatView'
@@ -30,7 +31,7 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
         webviewView.webview.options = {
             enableScripts: true,
             enableCommandUris: true,
-            localResourceRoots: [lspDir],
+            localResourceRoots: [lspDir, Uri.parse(path.dirname(this.mynahUIPath))],
         }
 
         const uiPath = webviewView.webview.asWebviewUri(Uri.parse(this.mynahUIPath)).toString()

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -97,7 +97,7 @@ export async function startLanguageServer(
         const inlineManager = new InlineCompletionManager(client)
         inlineManager.registerInlineCompletion()
         if (Experiments.instance.get('amazonqChatLSP', false)) {
-            activate(client, encryptionKey, resourcePaths.mynahUI)
+            activate(client, encryptionKey, resourcePaths.ui)
         }
 
         // Request handler for when the server wants to know about the clients auth connnection

--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -6,17 +6,22 @@
 import { DevSettings, getServiceEnvVarConfig } from 'aws-core-vscode/shared'
 import { LspConfig } from 'aws-core-vscode/amazonq'
 
-export const defaultAmazonQLspConfig: LspConfig = {
+export interface ExtendedAmazonQLSPConfig extends LspConfig {
+    ui?: string
+}
+
+export const defaultAmazonQLspConfig: ExtendedAmazonQLSPConfig = {
     manifestUrl: 'https://aws-toolkit-language-servers.amazonaws.com/codewhisperer/0/manifest.json',
     supportedVersions: '^3.1.1',
     id: 'AmazonQ', // used for identification in global storage/local disk location. Do not change.
     path: undefined,
+    ui: undefined,
 }
 
-export function getAmazonQLspConfig(): LspConfig {
+export function getAmazonQLspConfig(): ExtendedAmazonQLSPConfig {
     return {
         ...defaultAmazonQLspConfig,
-        ...(DevSettings.instance.getServiceConfig('amazonqLsp', {}) as LspConfig),
+        ...(DevSettings.instance.getServiceConfig('amazonqLsp', {}) as ExtendedAmazonQLSPConfig),
         ...getServiceEnvVarConfig('amazonqLsp', Object.keys(defaultAmazonQLspConfig)),
     }
 }

--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -5,15 +5,17 @@
 
 import { fs, getNodeExecutableName, BaseLspInstaller, ResourcePaths } from 'aws-core-vscode/shared'
 import path from 'path'
-import { getAmazonQLspConfig } from './config'
-import { LspConfig } from 'aws-core-vscode/amazonq'
+import { ExtendedAmazonQLSPConfig, getAmazonQLspConfig } from './config'
 
 export interface AmazonQResourcePaths extends ResourcePaths {
-    mynahUI: string
+    ui: string
 }
 
-export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<AmazonQResourcePaths> {
-    constructor(lspConfig: LspConfig = getAmazonQLspConfig()) {
+export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
+    AmazonQResourcePaths,
+    ExtendedAmazonQLSPConfig
+> {
+    constructor(lspConfig: ExtendedAmazonQLSPConfig = getAmazonQLspConfig()) {
         super(lspConfig, 'amazonqLsp')
     }
 
@@ -27,7 +29,7 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<Amazo
             return {
                 lsp: this.config.path ?? '',
                 node: getNodeExecutableName(),
-                mynahUI: '', // TODO make mynah UI configurable
+                ui: this.config.ui ?? '',
             }
         }
 
@@ -35,7 +37,7 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<Amazo
         return {
             lsp: path.join(assetDirectory, 'servers/aws-lsp-codewhisperer.js'),
             node: nodePath,
-            mynahUI: path.join(assetDirectory, 'clients/amazonq-ui.js'),
+            ui: path.join(assetDirectory, 'clients/amazonq-ui.js'),
         }
     }
 }

--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -14,11 +14,11 @@ import { Range } from 'semver'
 import { getLogger } from '../logger/logger'
 import type { Logger, LogTopic } from '../logger/logger'
 
-export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths> {
+export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, Config extends LspConfig = LspConfig> {
     private logger: Logger
 
     constructor(
-        protected config: LspConfig,
+        protected config: Config,
         loggerName: Extract<LogTopic, 'amazonqLsp' | 'amazonqWorkspaceLsp'>
     ) {
         this.logger = getLogger(loggerName)


### PR DESCRIPTION
## Problem
You can't point to a local chat client instance from flare

## Solution
Make that configurable


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
