### PR TITLE
fix(amazonq lsp): add getConnectionMetadata handler before auth initialiation

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -93,14 +93,7 @@ export async function startLanguageServer(
     const auth = new AmazonQLspAuth(client)
 
     return client.onReady().then(async () => {
-        await auth.init()
-        const inlineManager = new InlineCompletionManager(client)
-        inlineManager.registerInlineCompletion()
-        if (Experiments.instance.get('amazonqChatLSP', false)) {
-            activate(client, encryptionKey, resourcePaths.mynahUI)
-        }
-
-        // Request handler for when the server wants to know about the clients auth connnection
+        // Request handler for when the server wants to know about the clients auth connnection. Must be registered before the initial auth init call
         client.onRequest<ConnectionMetadata, Error>(notificationTypes.getConnectionMetadata.method, () => {
             return {
                 sso: {
@@ -108,6 +101,13 @@ export async function startLanguageServer(
                 },
             }
         })
+
+        await auth.init()
+        const inlineManager = new InlineCompletionManager(client)
+        inlineManager.registerInlineCompletion()
+        if (Experiments.instance.get('amazonqChatLSP', false)) {
+            activate(client, encryptionKey, resourcePaths.mynahUI)
+        }
 
         // Temporary code for pen test. Will be removed when we switch to the real flare auth
         const authInterval = setInterval(async () => {


### PR DESCRIPTION
## Problem
auth init was sending an update credentials request before the handlers were registered

## Solution
move the getConnectionMetadata registration before the initial auth call

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
