### PR TITLE
fix(chat): file links open in other apps

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -305,7 +305,20 @@ export class ChatController {
     }
 
     private processResponseBodyLinkClick(click: ResponseBodyLinkClickMessage) {
-        this.openLinkInExternalBrowser(click)
+        const uri = vscode.Uri.parse(click.link)
+        if (uri.scheme === 'file') {
+            void this.openFile(uri.fsPath)
+        } else {
+            this.openLinkInExternalBrowser(click)
+        }
+    }
+
+    private async openFile(absolutePath: string) {
+        const fileExists = await fs.existsFile(absolutePath)
+        if (fileExists) {
+            const document = await vscode.workspace.openTextDocument(absolutePath)
+            await vscode.window.showTextDocument(document)
+        }
     }
 
     private processSourceLinkClick(click: SourceLinkClickMessage) {


### PR DESCRIPTION
## Problem

Clicking on file links opens the file in other apps.


## Solution

Use VSCode API to open if it's a file


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
