### PR TITLE
feat(amazonq lsp): add authFollowUpClicked implementation

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -9,6 +9,7 @@ import {
     AUTH_FOLLOW_UP_CLICKED,
     CHAT_OPTIONS,
     COPY_TO_CLIPBOARD,
+    AuthFollowUpType,
 } from '@aws/chat-client-ui-types'
 import {
     ChatResult,
@@ -25,6 +26,7 @@ import { window } from 'vscode'
 import { Disposable, LanguageClient, Position, State, TextDocumentIdentifier } from 'vscode-languageclient'
 import * as jose from 'jose'
 import { AmazonQChatViewProvider } from './webviewProvider'
+import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 
 export function registerLanguageServerEventListener(languageClient: LanguageClient, provider: AmazonQChatViewProvider) {
     languageClient.onDidChangeState(({ oldState, newState }) => {
@@ -77,10 +79,33 @@ export function registerMessageListeners(
                 })
                 break
             }
-            case AUTH_FOLLOW_UP_CLICKED:
-                // TODO hook this into auth
+            case AUTH_FOLLOW_UP_CLICKED: {
                 languageClient.info('[VSCode Client] AuthFollowUp clicked')
+                let authType = message.params.authFollowupType
+                const reAuthTypes: AuthFollowUpType[] = ['re-auth', 'missing_scopes']
+                const fullAuthTypes: AuthFollowUpType[] = ['full-auth', 'use-supported-auth']
+
+                if (reAuthTypes.includes(authType)) {
+                    try {
+                        await AuthUtil.instance.reauthenticate()
+                    } catch (e) {
+                        languageClient.error(
+                            `[VSCode Client] Failed to re-authenticate after AUTH_FOLLOW_UP_CLICKED: ${e}`
+                        )
+                    }
+                }
+
+                if (fullAuthTypes.includes(authType)) {
+                    try {
+                        await AuthUtil.instance.secondaryAuth.deleteConnection()
+                    } catch (e) {
+                        languageClient.error(
+                            `[VSCode Client] Failed to authenticate after AUTH_FOLLOW_UP_CLICKED: ${e}`
+                        )
+                    }
+                }
                 break
+            }
             case chatRequestType.method: {
                 const partialResultToken = uuidv4()
                 const chatDisposable = languageClient.onProgress(chatRequestType, partialResultToken, (partialResult) =>

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -90,7 +90,7 @@ export function registerMessageListeners(
                         await AuthUtil.instance.reauthenticate()
                     } catch (e) {
                         languageClient.error(
-                            `[VSCode Client] Failed to re-authenticate after AUTH_FOLLOW_UP_CLICKED: ${e}`
+                            `[VSCode Client] Failed to re-authenticate after AUTH_FOLLOW_UP_CLICKED: ${(e as Error).message}`
                         )
                     }
                 }
@@ -100,7 +100,7 @@ export function registerMessageListeners(
                         await AuthUtil.instance.secondaryAuth.deleteConnection()
                     } catch (e) {
                         languageClient.error(
-                            `[VSCode Client] Failed to authenticate after AUTH_FOLLOW_UP_CLICKED: ${e}`
+                            `[VSCode Client] Failed to authenticate after AUTH_FOLLOW_UP_CLICKED: ${(e as Error).message}`
                         )
                     }
                 }

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -81,7 +81,7 @@ export function registerMessageListeners(
             }
             case AUTH_FOLLOW_UP_CLICKED: {
                 languageClient.info('[VSCode Client] AuthFollowUp clicked')
-                let authType = message.params.authFollowupType
+                const authType = message.params.authFollowupType
                 const reAuthTypes: AuthFollowUpType[] = ['re-auth', 'missing_scopes']
                 const fullAuthTypes: AuthFollowUpType[] = ['full-auth', 'use-supported-auth']
 

--- a/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
@@ -8,7 +8,7 @@ import { LanguageClient } from 'vscode-languageclient'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { registerMessageListeners } from '../../../../../src/lsp/chat/messages'
 import { AmazonQChatViewProvider } from '../../../../../src/lsp/chat/webviewProvider'
-import { SecondaryAuth, Connection, AuthFollowUpType } from 'aws-core-vscode/amazonq'
+import { secondaryAuth, authConnection, AuthFollowUpType } from 'aws-core-vscode/amazonq'
 
 describe('registerMessageListeners', () => {
     let languageClient: LanguageClient
@@ -80,7 +80,7 @@ describe('registerMessageListeners', () => {
                 reauthenticate: reauthenticateStub,
                 secondaryAuth: {
                     deleteConnection: deleteConnectionStub,
-                } as unknown as SecondaryAuth<Connection>,
+                } as unknown as secondaryAuth.SecondaryAuth<authConnection.Connection>,
             } as unknown as AuthUtil
 
             sandbox.replaceGetter(AuthUtil, 'instance', () => mockAuthUtil)

--- a/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
@@ -1,0 +1,111 @@
+import * as sinon from 'sinon'
+import { LanguageClient } from 'vscode-languageclient'
+import { AuthUtil } from 'aws-core-vscode/codewhisperer'
+import { registerMessageListeners } from '../../../../../src/lsp/chat/messages'
+import { AmazonQChatViewProvider } from '../../../../../src/lsp/chat/webviewProvider'
+import { SecondaryAuth } from '../../../../../../core/dist/src/auth/secondaryAuth'
+import { Connection } from '../../../../../../core/dist/src/auth/connection'
+
+describe('registerMessageListeners', () => {
+    let languageClient: LanguageClient
+    let provider: AmazonQChatViewProvider
+    let sandbox: sinon.SinonSandbox
+    let messageHandler: (message: any) => void | Promise<void>
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+
+        languageClient = {
+            info: sandbox.stub(),
+            error: sandbox.stub(),
+            sendNotification: sandbox.stub(),
+        } as unknown as LanguageClient
+
+        provider = {
+            webview: {
+                onDidReceiveMessage: (callback: (message: any) => void | Promise<void>) => {
+                    messageHandler = callback
+                    return { dispose: () => {} }
+                },
+            },
+        } as any
+
+        registerMessageListeners(languageClient, provider, Buffer.from('test-key'))
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    describe('AUTH_FOLLOW_UP_CLICKED', () => {
+        let mockAuthUtil: AuthUtil
+        let deleteConnectionStub: sinon.SinonStub
+        let reauthenticateStub: sinon.SinonStub
+
+        beforeEach(() => {
+            deleteConnectionStub = sandbox.stub().resolves()
+            reauthenticateStub = sandbox.stub().resolves()
+
+            mockAuthUtil = {
+                reauthenticate: reauthenticateStub,
+                secondaryAuth: {
+                    deleteConnection: deleteConnectionStub,
+                } as unknown as SecondaryAuth<Connection>,
+            } as unknown as AuthUtil
+
+            sandbox.replaceGetter(AuthUtil, 'instance', () => mockAuthUtil)
+        })
+
+        it('should handle re-authentication request', async () => {
+            await messageHandler({
+                command: 'authFollowUpClicked',
+                params: {
+                    authFollowupType: 're-auth',
+                },
+            })
+
+            sinon.assert.calledOnce(reauthenticateStub)
+            sinon.assert.notCalled(deleteConnectionStub)
+        })
+
+        it('should handle full authentication request', async () => {
+            await messageHandler({
+                command: 'authFollowUpClicked',
+                params: {
+                    authFollowupType: 'full-auth',
+                },
+            })
+
+            sinon.assert.notCalled(reauthenticateStub)
+            sinon.assert.calledOnce(deleteConnectionStub)
+        })
+
+        it('should log error if re-authentication fails', async () => {
+            reauthenticateStub.rejects(new Error())
+
+            await messageHandler({
+                command: 'authFollowUpClicked',
+                params: {
+                    authFollowupType: 're-auth',
+                },
+            })
+
+            sinon.assert.calledOnce(languageClient.error as sinon.SinonStub)
+            sinon.assert.calledWith(languageClient.error as sinon.SinonStub, sinon.match(/Failed to re-authenticate/))
+        })
+
+        it('should log error if full authentication fails', async () => {
+            deleteConnectionStub.rejects(new Error())
+
+            await messageHandler({
+                command: 'authFollowUpClicked',
+                params: {
+                    authFollowupType: 'full-auth',
+                },
+            })
+
+            sinon.assert.calledOnce(languageClient.error as sinon.SinonStub)
+            sinon.assert.calledWith(languageClient.error as sinon.SinonStub, sinon.match(/Failed to authenticate/))
+        })
+    })
+})

--- a/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
@@ -1,23 +1,29 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as sinon from 'sinon'
 import { LanguageClient } from 'vscode-languageclient'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { registerMessageListeners } from '../../../../../src/lsp/chat/messages'
 import { AmazonQChatViewProvider } from '../../../../../src/lsp/chat/webviewProvider'
-import { SecondaryAuth } from '../../../../../../core/dist/src/auth/secondaryAuth'
-import { Connection } from '../../../../../../core/dist/src/auth/connection'
+import { SecondaryAuth, Connection } from 'aws-core-vscode/amazonq'
 
 describe('registerMessageListeners', () => {
     let languageClient: LanguageClient
     let provider: AmazonQChatViewProvider
     let sandbox: sinon.SinonSandbox
     let messageHandler: (message: any) => void | Promise<void>
+    let errorStub: sinon.SinonStub
 
     beforeEach(() => {
         sandbox = sinon.createSandbox()
+        errorStub = sandbox.stub()
 
         languageClient = {
             info: sandbox.stub(),
-            error: sandbox.stub(),
+            error: errorStub,
             sendNotification: sandbox.stub(),
         } as unknown as LanguageClient
 
@@ -25,7 +31,9 @@ describe('registerMessageListeners', () => {
             webview: {
                 onDidReceiveMessage: (callback: (message: any) => void | Promise<void>) => {
                     messageHandler = callback
-                    return { dispose: () => {} }
+                    return {
+                        dispose: (): void => {},
+                    }
                 },
             },
         } as any
@@ -90,8 +98,8 @@ describe('registerMessageListeners', () => {
                 },
             })
 
-            sinon.assert.calledOnce(languageClient.error as sinon.SinonStub)
-            sinon.assert.calledWith(languageClient.error as sinon.SinonStub, sinon.match(/Failed to re-authenticate/))
+            sinon.assert.calledOnce(errorStub)
+            sinon.assert.calledWith(errorStub, sinon.match(/Failed to re-authenticate/))
         })
 
         it('should log error if full authentication fails', async () => {
@@ -104,8 +112,8 @@ describe('registerMessageListeners', () => {
                 },
             })
 
-            sinon.assert.calledOnce(languageClient.error as sinon.SinonStub)
-            sinon.assert.calledWith(languageClient.error as sinon.SinonStub, sinon.match(/Failed to authenticate/))
+            sinon.assert.calledOnce(errorStub)
+            sinon.assert.calledWith(errorStub, sinon.match(/Failed to authenticate/))
         })
     })
 })

--- a/packages/core/src/amazonq/index.ts
+++ b/packages/core/src/amazonq/index.ts
@@ -46,8 +46,8 @@ export { extractAuthFollowUp } from './util/authUtils'
 export { Messenger } from './commons/connector/baseMessenger'
 export * from './lsp/config'
 export * as WorkspaceLspInstaller from './lsp/workspaceInstaller'
-export { SecondaryAuth } from '../auth/secondaryAuth'
-export { Connection } from '../auth/connection'
+export * as secondaryAuth from '../auth/secondaryAuth'
+export * as authConnection from '../auth/connection'
 import { FeatureContext } from '../shared/featureConfig'
 
 /**

--- a/packages/core/src/amazonq/index.ts
+++ b/packages/core/src/amazonq/index.ts
@@ -46,6 +46,8 @@ export { extractAuthFollowUp } from './util/authUtils'
 export { Messenger } from './commons/connector/baseMessenger'
 export * from './lsp/config'
 export * as WorkspaceLspInstaller from './lsp/workspaceInstaller'
+export { SecondaryAuth } from '../auth/secondaryAuth'
+export { Connection } from '../auth/connection'
 import { FeatureContext } from '../shared/featureConfig'
 
 /**


### PR DESCRIPTION
## Problem
There was no implementation for the `authFollowUpClicked` message received from LSP for Amazon Q. Because of that, the `authenticate` button that appears in case of expired SSO connection had no effect.

## Solution
I added the implementation as follows:
* If the received `authFollowUpType` is `'re-auth'` or `'missing_scopes'`, initiate a re-authentication
* If the received `authFollowUpType` is `'full-auth'` or `'use-supported-auth'`, delete the connection so a new full authentication flow kicks off

I added a unit test file for this message type, which is extendable for every command handled in `registerLanguageServerEventListener`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
