### PR TITLE
fix(ci): skip duplicate code check on push events. (WIP)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -59,7 +59,7 @@ jobs:
 
     lint-duplicate-code:
         needs: lint-commits
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name == 'push'}}
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -59,7 +59,7 @@ jobs:
 
     lint-duplicate-code:
         needs: lint-commits
-        if: ${{ github.event_name == 'pull_request'}}
+        if: github.event_name == 'push'
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -59,7 +59,7 @@ jobs:
 
     lint-duplicate-code:
         needs: lint-commits
-        if: github.event_name != 'pull_request'
+        if: ${{ github.event_name != 'pull_request' }}
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -59,7 +59,7 @@ jobs:
 
     lint-duplicate-code:
         needs: lint-commits
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         runs-on: ubuntu-latest
         strategy:
             matrix:


### PR DESCRIPTION
## Problem
This check `${{ github.event_name == 'pull_request'}}` appears to be flaky recently, as this action is running on push events on main. 

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
