### PR TITLE
fix(chat): fsRead doesn't show readRange

### DIFF
--- a/packages/core/src/codewhispererChat/tools/fsRead.ts
+++ b/packages/core/src/codewhispererChat/tools/fsRead.ts
@@ -53,7 +53,21 @@ export class FsRead {
     public queueDescription(updates: Writable): void {
         const fileName = path.basename(this.fsPath)
         const fileUri = vscode.Uri.file(this.fsPath)
-        updates.write(`Reading: [${fileName}](${fileUri})`)
+        updates.write(`Reading file: [${fileName}](${fileUri}), `)
+
+        const [start, end] = this.readRange ?? []
+
+        if (start && end) {
+            updates.write(`from line ${start} to ${end}`)
+        } else if (start) {
+            if (start > 0) {
+                updates.write(`from line ${start} to end of file`)
+            } else {
+                updates.write(`${start} line from the end of file to end of file`)
+            }
+        } else {
+            updates.write('all lines')
+        }
         updates.end()
     }
 


### PR DESCRIPTION
## Problem

FsRead doesn't show readRange so there can be duplicate messages when a file is read in chunks.


## Solution

Stream the readRange info to the chat. 
Assumes the changes in https://github.com/aws/aws-toolkit-vscode/pull/6888 will be merged so that fsRead will not support reading directories anymore.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
