### PR TITLE
feat(chat): Add warning UI for high risk bash command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24096,6 +24096,13 @@
             "dev": true,
             "license": "BSD-2-Clause"
         },
+        "node_modules/shlex": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/shlex/-/shlex-2.1.2.tgz",
+            "integrity": "sha512-Nz6gtibMVgYeMEhUjp2KuwAgqaJA1K155dU/HuDaEJUGgnmYfVtVZah+uerVWdH8UGnyahhDCgABbYTbs254+w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/side-channel": {
             "version": "1.0.6",
             "license": "MIT",
@@ -26843,6 +26850,7 @@
                 "readline-sync": "^1.4.9",
                 "sass": "^1.49.8",
                 "sass-loader": "^16.0.2",
+                "shlex": "^2.1.2",
                 "sinon": "^14.0.0",
                 "style-loader": "^3.3.1",
                 "ts-node": "^10.9.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -492,7 +492,8 @@
         "umd-compat-loader": "^2.1.2",
         "vue-loader": "^17.2.2",
         "vue-style-loader": "^4.1.3",
-        "webfont": "^11.2.26"
+        "webfont": "^11.2.26",
+        "shlex": "^2.1.2"
     },
     "dependencies": {
         "@amzn/amazon-q-developer-streaming-client": "file:../../src.gen/@amzn/amazon-q-developer-streaming-client",

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -662,7 +662,9 @@ export class ChatController {
                     try {
                         await ToolUtils.validate(tool)
 
-                        const chatStream = new ChatStream(this.messenger, tabID, triggerID, toolUse)
+                        const chatStream = new ChatStream(this.messenger, tabID, triggerID, toolUse, {
+                            requiresAcceptance: false,
+                        })
                         const output = await ToolUtils.invoke(tool, chatStream)
 
                         toolResults.push({

--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -7,6 +7,7 @@ import { Writable } from 'stream'
 import { getLogger } from '../../shared/logger/logger'
 import { Messenger } from '../controllers/chat/messenger/messenger'
 import { ToolUse } from '@amzn/codewhisperer-streaming'
+import { CommandValidation } from './executeBash'
 
 /**
  * A writable stream that feeds each chunk/line to the chat UI.
@@ -20,7 +21,7 @@ export class ChatStream extends Writable {
         private readonly tabID: string,
         private readonly triggerID: string,
         private readonly toolUse: ToolUse | undefined,
-        private readonly requiresAcceptance = false,
+        private readonly validation: CommandValidation,
         private readonly logger = getLogger('chatStream')
     ) {
         super()
@@ -37,7 +38,7 @@ export class ChatStream extends Writable {
             this.tabID,
             this.triggerID,
             this.toolUse,
-            this.requiresAcceptance
+            this.validation
         )
         callback()
     }
@@ -49,7 +50,7 @@ export class ChatStream extends Writable {
                 this.tabID,
                 this.triggerID,
                 this.toolUse,
-                this.requiresAcceptance
+                this.validation
             )
         }
         callback()

--- a/packages/core/src/codewhispererChat/tools/toolUtils.ts
+++ b/packages/core/src/codewhispererChat/tools/toolUtils.ts
@@ -5,7 +5,7 @@
 import { Writable } from 'stream'
 import { FsRead, FsReadParams } from './fsRead'
 import { FsWrite, FsWriteParams } from './fsWrite'
-import { ExecuteBash, ExecuteBashParams } from './executeBash'
+import { CommandValidation, ExecuteBash, ExecuteBashParams } from './executeBash'
 import { ToolResult, ToolResultContentBlock, ToolResultStatus, ToolUse } from '@amzn/codewhisperer-streaming'
 import { InvokeOutput } from './toolShared'
 import { ListDirectory, ListDirectoryParams } from './listDirectory'
@@ -37,16 +37,16 @@ export class ToolUtils {
         }
     }
 
-    static requiresAcceptance(tool: Tool) {
+    static requiresAcceptance(tool: Tool): CommandValidation {
         switch (tool.type) {
             case ToolType.FsRead:
-                return false
+                return { requiresAcceptance: false }
             case ToolType.FsWrite:
-                return true
+                return { requiresAcceptance: true }
             case ToolType.ExecuteBash:
                 return tool.tool.requiresAcceptance()
             case ToolType.ListDirectory:
-                return false
+                return { requiresAcceptance: false }
         }
     }
 

--- a/packages/core/src/test/codewhispererChat/tools/executeBash.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/executeBash.test.ts
@@ -44,13 +44,13 @@ describe('ExecuteBash Tool', () => {
 
     it('set requiresAcceptance=true if the command has dangerous patterns', () => {
         const execBash = new ExecuteBash({ command: 'ls && rm -rf /' })
-        const needsAcceptance = execBash.requiresAcceptance()
+        const needsAcceptance = execBash.requiresAcceptance().requiresAcceptance
         assert.equal(needsAcceptance, true, 'Should require acceptance for dangerous pattern')
     })
 
     it('set requiresAcceptance=false if it is a read-only command', () => {
         const execBash = new ExecuteBash({ command: 'cat file.txt' })
-        const needsAcceptance = execBash.requiresAcceptance()
+        const needsAcceptance = execBash.requiresAcceptance().requiresAcceptance
         assert.equal(needsAcceptance, false, 'Read-only command should not require acceptance')
     })
 

--- a/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
@@ -64,28 +64,28 @@ describe('ToolUtils', function () {
     describe('requiresAcceptance', function () {
         it('returns false for FsRead tool', function () {
             const tool: Tool = { type: ToolType.FsRead, tool: mockFsRead as unknown as FsRead }
-            assert.strictEqual(ToolUtils.requiresAcceptance(tool), false)
+            assert.strictEqual(ToolUtils.requiresAcceptance(tool).requiresAcceptance, false)
         })
 
         it('returns true for FsWrite tool', function () {
             const tool: Tool = { type: ToolType.FsWrite, tool: mockFsWrite as unknown as FsWrite }
-            assert.strictEqual(ToolUtils.requiresAcceptance(tool), true)
+            assert.strictEqual(ToolUtils.requiresAcceptance(tool).requiresAcceptance, true)
         })
 
         it('delegates to the tool for ExecuteBash', function () {
-            mockExecuteBash.requiresAcceptance.returns(true)
+            mockExecuteBash.requiresAcceptance.returns({ requiresAcceptance: true })
             const tool: Tool = { type: ToolType.ExecuteBash, tool: mockExecuteBash as unknown as ExecuteBash }
-            assert.strictEqual(ToolUtils.requiresAcceptance(tool), true)
+            assert.strictEqual(ToolUtils.requiresAcceptance(tool).requiresAcceptance, true)
 
-            mockExecuteBash.requiresAcceptance.returns(false)
-            assert.strictEqual(ToolUtils.requiresAcceptance(tool), false)
+            mockExecuteBash.requiresAcceptance.returns({ requiresAcceptance: false })
+            assert.strictEqual(ToolUtils.requiresAcceptance(tool).requiresAcceptance, false)
 
             assert(mockExecuteBash.requiresAcceptance.calledTwice)
         })
 
         it('returns false for ListDirectory tool', function () {
             const tool: Tool = { type: ToolType.ListDirectory, tool: mockListDirectory as unknown as ListDirectory }
-            assert.strictEqual(ToolUtils.requiresAcceptance(tool), false)
+            assert.strictEqual(ToolUtils.requiresAcceptance(tool).requiresAcceptance, false)
         })
     })
 


### PR DESCRIPTION
## Problem
AppSec has required that we give the user an indication if they are about to run a potentially dangerous command

## Solution

- Parse bash command to determine whether or not commands are dangerous or not.
- Display message warning to user

## Tests


![Screenshot 2025-03-31 at 1 03 14 PM](https://github.com/user-attachments/assets/a3bcd519-46de-47c9-a947-32f58dd6ca51)



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
