### PR TITLE
fix(amazonq): @-prompts not added to context

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-ccbc5e50-0a90-4340-b6d5-e57537949898.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-ccbc5e50-0a90-4340-b6d5-e57537949898.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q chat: @Prompts not added to context"
+	"description": "Amazon Q chat: `@prompts` not added to context"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-ccbc5e50-0a90-4340-b6d5-e57537949898.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-ccbc5e50-0a90-4340-b6d5-e57537949898.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q chat: @Prompts not added to context"
+}

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -498,6 +498,7 @@ export class ChatController {
                             command: path.basename(name, promptFileExtension),
                             icon: 'magic' as MynahIconsType,
                             id: 'prompt',
+                            label: 'file' as ContextCommandItemType,
                             route: [userPromptsDirectory, name],
                         }))
                 )


### PR DESCRIPTION
## Problem
`@Prompts` not being sent to context due to change in [last week's release](https://github.com/aws/aws-toolkit-vscode/pull/6831/files#r2021948984)

## Solution
Add 'file' label to user prompts 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
