### PR TITLE
fix(lambda): checking if folder exists

### DIFF
--- a/packages/core/src/awsService/appBuilder/serverlessLand/main.ts
+++ b/packages/core/src/awsService/appBuilder/serverlessLand/main.ts
@@ -15,7 +15,7 @@ import { ExtContext } from '../../../shared/extensions'
 import { addFolderToWorkspace } from '../../../shared/utilities/workspaceUtils'
 import { ToolkitError } from '../../../shared/errors'
 import { fs } from '../../../shared/fs/fs'
-import { confirmOverwriteIfExists } from '../../../shared/utilities/messages'
+import { handleOverwriteConflict } from '../../../shared/utilities/messages'
 import { getPattern } from '../../../shared/utilities/downloadPatterns'
 import { MetadataManager } from './metadataManager'
 
@@ -91,14 +91,8 @@ export async function downloadPatternCode(config: CreateServerlessLandWizardForm
     const fullAssetName = assetName + '.zip'
     const location = vscode.Uri.joinPath(config.location, config.name)
 
-    const shouldProceed = await confirmOverwriteIfExists(location, config.name)
-    if (!shouldProceed) {
-        throw new ToolkitError(`Folder already exists: ${config.name}`)
-    }
+    await handleOverwriteConflict(location)
 
-    if (await fs.exists(location)) {
-        await fs.delete(location, { recursive: true, force: true })
-    }
     try {
         await getPattern(serverlessLandOwner, serverlessLandRepo, fullAssetName, location, true)
     } catch (error) {

--- a/packages/core/src/shared/utilities/messages.ts
+++ b/packages/core/src/shared/utilities/messages.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
+import * as path from 'path'
 import * as localizedText from '../localizedText'
 import { getLogger } from '../../shared/logger/logger'
 import { ProgressEntry } from '../../shared/vscode/window'
@@ -14,6 +15,7 @@ import { Timeout } from './timeoutUtils'
 import { addCodiconToString } from './textUtilities'
 import { getIcon, codicon } from '../icons'
 import globals from '../extensionGlobals'
+import { ToolkitError } from '../../shared/errors'
 import { fs } from '../../shared/fs/fs'
 import { openUrl } from './vsCodeUtils'
 import { AmazonQPromptSettings, ToolkitPromptSettings } from '../../shared/settings'
@@ -147,21 +149,33 @@ export async function showViewLogsMessage(
  * @param itemName The name of the item for display in the message
  * @returns Promise<boolean> - true if should proceed (path doesn't exist or user confirmed overwrite)
  */
-export async function confirmOverwriteIfExists(path: vscode.Uri, itemName: string): Promise<boolean> {
-    if (!(await fs.exists(path))) {
+export async function handleOverwriteConflict(location: vscode.Uri): Promise<boolean> {
+    if (!(await fs.exists(location))) {
         return true
     }
 
-    return showConfirmationMessage({
+    const choice = showConfirmationMessage({
         prompt: localize(
             'AWS.toolkit.confirmOverwrite',
             '{0} already exists in the selected directory, overwrite?',
-            itemName
+            location.fsPath
         ),
         confirm: localize('AWS.generic.overwrite', 'Yes'),
         cancel: localize('AWS.generic.cancel', 'No'),
         type: 'warning',
     })
+
+    if (!choice) {
+        throw new ToolkitError(`Folder already exists: ${path.basename(location.fsPath)}`)
+    }
+
+    try {
+        await fs.delete(location, { recursive: true, force: true })
+    } catch (error) {
+        throw ToolkitError.chain(error, `Failed to delete existing folder: ${path.basename(location.fsPath)}`)
+    }
+
+    return true
 }
 
 /**

--- a/packages/core/src/test/awsService/appBuilder/serverlessLand/main.test.ts
+++ b/packages/core/src/test/awsService/appBuilder/serverlessLand/main.test.ts
@@ -117,21 +117,20 @@ describe('downloadPatternCode', () => {
         getPatternStub.restore()
     })
     it('successfully downloads pattern code', async () => {
-        sandbox.stub(messages, 'confirmOverwriteIfExists').resolves(true)
+        sandbox.stub(messages, 'handleOverwriteConflict').resolves(true)
 
         await downloadPatternCode(mockConfig, mockConfig.assetName)
         assertDownloadPatternCall(getPatternStub, mockConfig)
     })
     it('downloads pattern when directory exists and user confirms overwrite', async function () {
-        sandbox.stub(messages, 'confirmOverwriteIfExists').resolves(true)
-        sandbox.stub(fs, 'delete').resolves()
+        sandbox.stub(messages, 'handleOverwriteConflict').resolves(true)
 
         await downloadPatternCode(mockConfig, mockConfig.assetName)
         assertDownloadPatternCall(getPatternStub, mockConfig)
     })
     it('throws error when directory exists and user cancels overwrite', async function () {
-        sandbox.stub(fs, 'exists').resolves(true)
-        sandbox.stub(messages, 'confirmOverwriteIfExists').resolves(false)
+        const handleOverwriteStub = sandbox.stub(messages, 'handleOverwriteConflict')
+        handleOverwriteStub.rejects(new Error('Folder already exists: test-project'))
 
         await assert.rejects(
             () => downloadPatternCode(mockConfig, mockConfig.assetName),


### PR DESCRIPTION
## Problem
In the existing Serverless Land project, we need to check if a folder with the same name already exists before downloading the code. This could help avoid potential issues that might arise from overwriting existing files or folders. 

## Solution
The code checks if a folder with the same name already exists, and prompts the user to choose whether to override it or not. This allows the user to decide how to handle potential conflicts with existing files or folders.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
