### PR TITLE
fix(amazonq): fix /transform test and remove feedback form

### DIFF
--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -65,7 +65,7 @@ describe('Amazon Q Code Transformation', function () {
     })
 
     describe('Starting a transformation from chat', () => {
-        it.only('Can click through all user input forms for a Java upgrade', async () => {
+        it('Can click through all user input forms for a Java upgrade', async () => {
             sinon.stub(startTransformByQ, 'getValidSQLConversionCandidateProjects').resolves([])
             sinon.stub(GumbyController.prototype, 'validateLanguageUpgradeProjects' as keyof GumbyController).resolves([
                 {

--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -65,7 +65,7 @@ describe('Amazon Q Code Transformation', function () {
     })
 
     describe('Starting a transformation from chat', () => {
-        it.skip('Can click through all user input forms for a Java upgrade', async () => {
+        it.only('Can click through all user input forms for a Java upgrade', async () => {
             sinon.stub(startTransformByQ, 'getValidSQLConversionCandidateProjects').resolves([])
             sinon.stub(GumbyController.prototype, 'validateLanguageUpgradeProjects' as keyof GumbyController).resolves([
                 {
@@ -168,39 +168,18 @@ describe('Amazon Q Code Transformation', function () {
                 .getChatMessenger()
                 ?.sendJobFinishedMessage(tab.tabID, CodeWhispererConstants.viewProposedChangesChatMessage)
 
-            // wait for download message and feedback form to be sent
-            await tab.waitForEvent(() => tab.getChatItems().length > 15, {
-                waitTimeoutInMs: 5000,
-                waitIntervalInMs: 1000,
-            })
-
-            const submitFeedbackForm = tab.getChatItems().pop()
-            assert.strictEqual(submitFeedbackForm?.formItems?.[0]?.id ?? undefined, 'TransformFeedbackRerunJob')
-            assert.strictEqual(submitFeedbackForm?.formItems?.[1]?.id ?? undefined, 'TransformFeedbackViewLogs')
-
-            const submitFeedbackFormItemValues = {
-                TransformFeedbackRerunJob: 'No',
-                TransformFeedbackViewLogs: 'Yes',
-            }
-            const submitFeedbackFormValues: Record<string, string> = { ...submitFeedbackFormItemValues }
-
-            const viewSummaryChatItem = tab.getChatItems()[tab.getChatItems().length - 2]
-            assert.strictEqual(viewSummaryChatItem?.body?.includes('view a summary'), true)
-
             tab.clickCustomFormButton({
-                id: 'gumbyFeedbackFormConfirm',
-                text: 'Confirm',
-                formItemValues: submitFeedbackFormValues,
+                id: 'gumbyViewSummary',
+                text: 'View summary',
             })
 
-            // wait for feedback received message to be sent
-            await tab.waitForEvent(() => tab.getChatItems().length > 16, {
+            await tab.waitForEvent(() => tab.getChatItems().length > 14, {
                 waitTimeoutInMs: 5000,
                 waitIntervalInMs: 1000,
             })
 
-            const feedbackReceivedMessage = tab.getChatItems().pop()
-            assert.strictEqual(feedbackReceivedMessage?.body?.includes('Feedback received') ?? undefined, true)
+            const viewSummaryChatItem = tab.getChatItems().pop()
+            assert.strictEqual(viewSummaryChatItem?.body?.includes('view a summary'), true)
         })
 
         it('CANNOT do a Java 21 to Java 17 transformation', async () => {

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -28,7 +28,6 @@ import {
     validateCanCompileProject,
     getValidSQLConversionCandidateProjects,
     openHilPomFile,
-    getFeedbackCommentData,
 } from '../../../codewhisperer/commands/startTransformByQ'
 import { JDKVersion, TransformationCandidateProject, transformByQState } from '../../../codewhisperer/models/model'
 import {
@@ -62,7 +61,6 @@ import {
     validateSQLMetadataFile,
 } from '../../../codewhisperer/service/transformByQ/transformFileHandler'
 import { getAuthType } from '../../../auth/utils'
-import globals from '../../../shared/extensionGlobals'
 
 // These events can be interactions within the chat,
 // or elsewhere in the IDE
@@ -372,9 +370,6 @@ export class GumbyController {
             case ButtonActions.CONFIRM_SKIP_TESTS_FORM:
                 await this.handleSkipTestsSelection(message)
                 break
-            case ButtonActions.CONFIRM_FEEDBACK_FORM:
-                await this.handleFeedback(message)
-                break
             case ButtonActions.CONFIRM_SELECTIVE_TRANSFORMATION_FORM:
                 await this.handleOneOrMultipleDiffs(message)
                 break
@@ -636,17 +631,6 @@ export class GumbyController {
         // at this point job is either completed, partially_completed, cancelled, or failed
         if (data.message) {
             this.messenger.sendJobFinishedMessage(data.tabID, data.message, data.includeStartNewTransformationButton)
-        }
-    }
-
-    private async handleFeedback(message: any) {
-        const canRerunJob = message.formSelectedValues['TransformFeedbackRerunJob']
-        const canViewLogs = message.formSelectedValues['TransformFeedbackViewLogs']
-        const comment = `Permission to re-run job: ${canRerunJob}\nPermission to view logs: ${canViewLogs}\n${getFeedbackCommentData()}`
-        this.messenger.sendFeedbackReceivedMessage(canRerunJob, canViewLogs, message.tabID)
-        if (comment.toLowerCase().includes('yes')) {
-            // post feedback if user says yes to at least one of the questions
-            await globals.telemetry.postFeedback({ comment: comment, sentiment: 'Positive' })
         }
     }
 

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -542,15 +542,6 @@ export class Messenger {
             })
         }
 
-        if (
-            transformByQState.isPartiallySucceeded() &&
-            message === CodeWhispererConstants.viewProposedChangesChatMessage
-        ) {
-            // get permission to re-run job and view logs after partially successful job is downloaded
-            // TODO: uncomment this when feature is ready
-            // this.sendFeedbackFormMessage(tabID)
-        }
-
         this.dispatcher.sendChatMessage(
             new ChatMessage(
                 {
@@ -807,65 +798,5 @@ ${codeSnippet}
                 tabID
             )
         )
-    }
-
-    public sendFeedbackFormMessage(tabID: string) {
-        const formItems: ChatItemFormItem[] = []
-        formItems.push({
-            id: 'TransformFeedbackRerunJob',
-            type: 'radiogroup',
-            title: 'To improve our service, do we have permission to re-run your job? (you will *not* be charged)',
-            mandatory: true,
-            options: [
-                {
-                    value: 'Yes',
-                    label: 'Yes',
-                },
-                {
-                    value: 'No',
-                    label: 'No',
-                },
-            ],
-        })
-
-        formItems.push({
-            id: 'TransformFeedbackViewLogs',
-            type: 'radiogroup',
-            title: 'Do we also have permission to view the logs associated with your job?',
-            mandatory: true,
-            options: [
-                {
-                    value: 'Yes',
-                    label: 'Yes',
-                },
-                {
-                    value: 'No',
-                    label: 'No',
-                },
-            ],
-        })
-
-        this.dispatcher.sendChatPrompt(
-            new ChatPrompt(
-                {
-                    message: 'Amazon Q Permissions Form',
-                    formItems: formItems,
-                },
-                'FeedbackForm',
-                tabID,
-                false
-            )
-        )
-    }
-
-    public sendFeedbackReceivedMessage(canRerunJob: string, canViewLogs: string, tabID: string) {
-        const message = `### Response received
--------------
-| | |
-| :------------------- | -------: |
-| **Permission to re-run job**             |   ${canRerunJob}   |
-| **Permission to view logs** |  ${canViewLogs}   |
-    `
-        this.dispatcher.sendChatMessage(new ChatMessage({ message, messageType: 'prompt' }, tabID))
     }
 }

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
@@ -18,7 +18,6 @@ export enum ButtonActions {
     CONFIRM_SQL_CONVERSION_TRANSFORMATION_FORM = 'gumbySQLConversionTransformFormConfirm',
     CANCEL_TRANSFORMATION_FORM = 'gumbyTransformFormCancel', // shared between Language Upgrade & SQL Conversion
     CONFIRM_SKIP_TESTS_FORM = 'gumbyTransformSkipTestsFormConfirm',
-    CONFIRM_FEEDBACK_FORM = 'gumbyFeedbackFormConfirm',
     CONFIRM_SELECTIVE_TRANSFORMATION_FORM = 'gumbyTransformOneOrMultipleDiffsFormConfirm',
     SELECT_SQL_CONVERSION_METADATA_FILE = 'gumbySQLConversionMetadataTransformFormConfirm',
     CONFIRM_DEPENDENCY_FORM = 'gumbyTransformDependencyFormConfirm',


### PR DESCRIPTION
## Problem

We don't yet have legal approval to show users a feedback form. It is currently disabled / commented out, but better to remove the unused code until we get approval, since it may take a while and may not even happen.

## Solution

Remove unused code and fix test.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
