### PR TITLE
deps(amazonq): Bumping up the mynah UI version to v4.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11966,10 +11966,11 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.26.1.tgz",
-            "integrity": "sha512-qUgQ6NVmiCSp6qF43cM6522U8QtBTBbqDv5yKS/5tl9cEQuZJSfKDq2zFUstQNZmsw0GE8p/NboTDo3mRv4sSQ==",
+            "version": "4.27.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.27.0.tgz",
+            "integrity": "sha512-DkwenNLU+BHUYf0ntwkGllfjM+LrQXvCTiV2Eh7zV3HA59+ba5e34zge3sf7F71XukR9ckoKHXrxc0GjvVchbA==",
             "hasInstallScript": true,
+            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "highlight.js": "^11.11.0",
@@ -26744,7 +26745,7 @@
                 "@aws-sdk/s3-request-presigner": "<3.731.0",
                 "@aws-sdk/smithy-client": "<3.731.0",
                 "@aws-sdk/util-arn-parser": "<3.731.0",
-                "@aws/mynah-ui": "^4.26.1",
+                "@aws/mynah-ui": "^4.27.0",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/fetch-http-handler": "^5.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -522,7 +522,7 @@
         "@aws-sdk/s3-request-presigner": "<3.731.0",
         "@aws-sdk/smithy-client": "<3.731.0",
         "@aws-sdk/util-arn-parser": "<3.731.0",
-        "@aws/mynah-ui": "^4.26.1",
+        "@aws/mynah-ui": "^4.27.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/fetch-http-handler": "^5.0.1",


### PR DESCRIPTION
- Bumping up the mynah UI version to v4.27.0
- More information: [MynahUI v4.27.0](https://github.com/aws/mynah-ui/releases/tag/v4.27.0)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
