### PR TITLE
fix(chat): fix for chat history for multuple tabs and user tool ignore

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -710,7 +710,7 @@ export class ChatController {
                         customization: getSelectedCustomization(),
                         toolResults: toolResults,
                         origin: Origin.IDE,
-                        chatHistory: this.chatHistoryStorage.getHistory(tabID).getHistory(),
+                        chatHistory: this.chatHistoryStorage.getTabHistory(tabID).getHistory(),
                         context: session.context ?? [],
                         relevantTextDocuments: [],
                         additionalContents: [],
@@ -1010,7 +1010,7 @@ export class ChatController {
         switch (message.command) {
             case 'clear':
                 this.sessionStorage.deleteSession(message.tabID)
-                this.chatHistoryStorage.getHistory(message.tabID).clear()
+                this.chatHistoryStorage.getTabHistory(message.tabID).clear()
                 this.triggerEventsStorage.removeTabEvents(message.tabID)
                 recordTelemetryChatRunCommand('clear')
                 return
@@ -1049,7 +1049,7 @@ export class ChatController {
                     codeQuery: lastTriggerEvent.context?.focusAreaContext?.names,
                     userIntent: message.userIntent,
                     customization: getSelectedCustomization(),
-                    chatHistory: this.chatHistoryStorage.getHistory(message.tabID).getHistory(),
+                    chatHistory: this.chatHistoryStorage.getTabHistory(message.tabID).getHistory(),
                     contextLengths: {
                         ...defaultContextLengths,
                     },
@@ -1098,7 +1098,7 @@ export class ChatController {
                         codeQuery: context?.focusAreaContext?.names,
                         userIntent: this.userIntentRecognizer.getFromPromptChatMessage(message),
                         customization: getSelectedCustomization(),
-                        chatHistory: this.chatHistoryStorage.getHistory(message.tabID).getHistory(),
+                        chatHistory: this.chatHistoryStorage.getTabHistory(message.tabID).getHistory(),
                         origin: Origin.IDE,
                         context: message.context ?? [],
                         relevantTextDocuments: [],
@@ -1326,7 +1326,7 @@ export class ChatController {
         triggerPayload.contextLengths.userInputContextLength = triggerPayload.message.length
         triggerPayload.contextLengths.focusFileContextLength = triggerPayload.fileText.length
 
-        const chatHistory = this.chatHistoryStorage.getHistory(tabID)
+        const chatHistory = this.chatHistoryStorage.getTabHistory(tabID)
         const newUserMessage = {
             userInputMessage: {
                 content: triggerPayload.message,

--- a/packages/core/src/codewhispererChat/storages/chatHistoryStorage.ts
+++ b/packages/core/src/codewhispererChat/storages/chatHistoryStorage.ts
@@ -19,7 +19,7 @@ export class ChatHistoryStorage {
      * @param tabId The ID of the tab
      * @returns The ChatHistoryManager for the specified tab
      */
-    public getHistory(tabId: string): ChatHistoryManager {
+    public getTabHistory(tabId: string): ChatHistoryManager {
         const historyFromStorage = this.histories.get(tabId)
         if (historyFromStorage !== undefined) {
             return historyFromStorage

--- a/packages/core/src/codewhispererChat/storages/chatHistoryStorage.ts
+++ b/packages/core/src/codewhispererChat/storages/chatHistoryStorage.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ChatHistoryManager } from './chatHistory'
+
+/**
+ * ChatHistoryStorage manages ChatHistoryManager instances for multiple tabs.
+ * Each tab has its own ChatHistoryManager to maintain separate chat histories.
+ */
+export class ChatHistoryStorage {
+    private histories: Map<string, ChatHistoryManager> = new Map()
+
+    /**
+     * Gets the ChatHistoryManager for a specific tab.
+     * If no history exists for the tab, creates a new one.
+     *
+     * @param tabId The ID of the tab
+     * @returns The ChatHistoryManager for the specified tab
+     */
+    public getHistory(tabId: string): ChatHistoryManager {
+        const historyFromStorage = this.histories.get(tabId)
+        if (historyFromStorage !== undefined) {
+            return historyFromStorage
+        }
+
+        // Create a new ChatHistoryManager with the tabId
+        const newHistory = new ChatHistoryManager(tabId)
+        this.histories.set(tabId, newHistory)
+
+        return newHistory
+    }
+
+    /**
+     * Deletes the ChatHistoryManager for a specific tab.
+     *
+     * @param tabId The ID of the tab
+     */
+    public deleteHistory(tabId: string) {
+        this.histories.delete(tabId)
+    }
+}


### PR DESCRIPTION
## Problem
- History storage not set up for each tabs.
- If user ignores tool use and moves on, then request fails.

## Solution
- Fixed chat history for multiple tab support
- User cancellation message is added to request in this case.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
