### PR TITLE
(fix)chat: fix the bash output is not formatted

### DIFF
--- a/packages/core/src/codewhispererChat/tools/executeBash.ts
+++ b/packages/core/src/codewhispererChat/tools/executeBash.ts
@@ -75,6 +75,7 @@ export class ExecuteBash {
             const stderrBuffer: string[] = []
 
             let firstChunk = true
+            let firstStderrChunk = true
             const childProcessOptions: ChildProcessOptions = {
                 spawnOptions: {
                     cwd: this.workingDirectory,
@@ -87,7 +88,8 @@ export class ExecuteBash {
                     firstChunk = false
                 },
                 onStderr: (chunk: string) => {
-                    ExecuteBash.handleChunk(chunk, stderrBuffer, updates)
+                    ExecuteBash.handleChunk(firstStderrChunk ? '```console\n' + chunk : chunk, stderrBuffer, updates)
+                    firstStderrChunk = false
                 },
             }
 


### PR DESCRIPTION
## Problem
When the excutable command fails, the output is not formatted.

## Solution
Format the stderr the same as stdout.

![image](https://github.com/user-attachments/assets/ea2ac8e0-ca0e-4097-9bc6-d0b1989c9323)
![image](https://github.com/user-attachments/assets/649ff4c1-2333-48de-9d2b-a2b63e66436c)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
