### PR TITLE
feat(chat): Split commands by additonal operators

### DIFF
--- a/packages/core/src/test/codewhispererChat/tools/executeBash.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/executeBash.test.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from 'assert'
 import sinon from 'sinon'
-import { ExecuteBash } from '../../../codewhispererChat/tools/executeBash'
+import { destructiveCommandWarningMessage, ExecuteBash } from '../../../codewhispererChat/tools/executeBash'
 import { ChildProcess } from '../../../shared/utilities/processUtils'
 
 describe('ExecuteBash Tool', () => {
@@ -46,6 +46,11 @@ describe('ExecuteBash Tool', () => {
         const execBash = new ExecuteBash({ command: 'ls && rm -rf /' })
         const needsAcceptance = execBash.requiresAcceptance().requiresAcceptance
         assert.equal(needsAcceptance, true, 'Should require acceptance for dangerous pattern')
+        assert.equal(
+            execBash.requiresAcceptance().warning,
+            destructiveCommandWarningMessage,
+            'Warning message should match the destructiveCommandWarningMessage'
+        )
     })
 
     it('set requiresAcceptance=false if it is a read-only command', () => {


### PR DESCRIPTION
## Problem
Regular read-only commands are being categorized as high risk.

## Solution
- Split commands by additional operators
- Do not automatically default to return false on readOnly command

## Testing
- Tested manually via plugin build
- Updated unit tests

<img width="1624" alt="Screenshot 2025-04-01 at 3 50 48 PM" src="https://github.com/user-attachments/assets/8751cf18-948a-4467-8646-e6dc45e62144" />
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
