### PR TITLE
fix(deps): Add explicit @aws/language-server-runtimes-types dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26801,6 +26801,7 @@
                 "@aws-sdk/types": "^3.13.1",
                 "@aws/chat-client-ui-types": "^0.0.8",
                 "@aws/language-server-runtimes": "^0.2.49",
+                "@aws/language-server-runtimes-types": "^0.1.10",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",
@@ -27959,6 +27960,16 @@
                 "aws-crt": {
                     "optional": true
                 }
+            }
+        },
+        "packages/core/node_modules/@aws/language-server-runtimes-types": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.10.tgz",
+            "integrity": "sha512-SIzwtSKG0IFrQFDREVdIIzpMOCVbcV45Nk/LufXIux523KlNSvxpQViIIQThqO4KmoyOZZ3ZWsUELdzpxc//iQ==",
+            "dev": true,
+            "dependencies": {
+                "vscode-languageserver-textdocument": "^1.0.12",
+                "vscode-languageserver-types": "^3.17.5"
             }
         },
         "packages/core/node_modules/@smithy/fetch-http-handler": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -442,6 +442,7 @@
         "@aws-sdk/types": "^3.13.1",
         "@aws/chat-client-ui-types": "^0.0.8",
         "@aws/language-server-runtimes": "^0.2.49",
+        "@aws/language-server-runtimes-types": "^0.1.10",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",


### PR DESCRIPTION
## Problem
[sessionManager](https://github.com/aws/aws-toolkit-vscode/blob/master/packages/amazonq/src/app/inline/sessionManager.ts#L6) has an implicit dependency on `@aws/language-server-runtimes-types` that isn't present in the package.json

## Solution
Add an explicit dependency, that way when the underling package currently controlling runtime-types's version changes it doesn't cause a build error as current observed in https://github.com/aws/aws-toolkit-vscode/pull/6825


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
