### PR TITLE
fix(amazonq): export and delete icons are swapped in chat history

### DIFF
--- a/packages/core/src/shared/db/chatDb/util.ts
+++ b/packages/core/src/shared/db/chatDb/util.ts
@@ -193,12 +193,12 @@ export function groupTabsByDate(tabs: Tab[]): DetailedListItemGroup[] {
 const getConversationActions = (historyId: string): ChatItemButton[] => [
     {
         text: 'Export',
-        icon: 'trash' as MynahIconsType,
+        icon: 'external' as MynahIconsType,
         id: historyId,
     },
     {
         text: 'Delete',
-        icon: 'external' as MynahIconsType,
+        icon: 'trash' as MynahIconsType,
         id: historyId,
     },
 ]


### PR DESCRIPTION
## Problem
Export and delete icons are swapped

## Solution
Before
<img width="171" alt="Screenshot 2025-04-02 at 3 56 15 PM" src="https://github.com/user-attachments/assets/11248478-bd24-4d47-802a-78ea62beebed" />


After
<img width="467" alt="Screenshot 2025-04-02 at 4 32 25 PM" src="https://github.com/user-attachments/assets/b2cf2b73-a3f5-4f3c-ac45-c7c8c1a48a64" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
