### PR TITLE
fix(chat): Remove userIntent from agentic chat window input

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1097,7 +1097,7 @@ export class ChatController {
                         filePath: context?.activeFileContext?.filePath,
                         matchPolicy: context?.activeFileContext?.matchPolicy,
                         codeQuery: context?.focusAreaContext?.names,
-                        userIntent: this.userIntentRecognizer.getFromPromptChatMessage(message),
+                        userIntent: undefined,
                         customization: getSelectedCustomization(),
                         chatHistory: this.chatHistoryStorage.getTabHistory(message.tabID).getHistory(),
                         origin: Origin.IDE,

--- a/packages/core/src/codewhispererChat/tools/listDirectory.ts
+++ b/packages/core/src/codewhispererChat/tools/listDirectory.ts
@@ -44,7 +44,7 @@ export class ListDirectory {
 
     public queueDescription(updates: Writable): void {
         const fileName = path.basename(this.fsPath)
-        updates.write(`Listing directory on filePath: ${fileName}`)
+        updates.write(`Listing directory: ${fileName}`)
         updates.end()
     }
 


### PR DESCRIPTION
## Problem
- UserIntent is populated when certain keyword is detected, which causes the request to not hit agentic code path
- list directory description is verbose


## Solution
- Remove the userIntent from the agentic chat window input 
- Minor fix: adjust the list directory description

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
