### PR TITLE
fix(amazonq): hide export chat button

### DIFF
--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -969,11 +969,12 @@ export const createMynahUI = (
                     icon: MynahIcons.COMMENT,
                     description: 'View chat history',
                 },
+                /* Temporarily hide export chat button from tab bar
                 {
                     id: 'export_chat',
                     icon: MynahIcons.EXTERNAL,
                     description: 'Export chat',
-                },
+                }, */
             ],
         },
     })


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
