### PR TITLE
test(ec2): unreliable test "SSH Agent can start the agent on windows"

### DIFF
--- a/packages/core/src/shared/utilities/processUtils.ts
+++ b/packages/core/src/shared/utilities/processUtils.ts
@@ -367,7 +367,7 @@ export class ChildProcess {
                     if (typeof rejectOnErrorCode === 'function') {
                         reject(rejectOnErrorCode(code))
                     } else {
-                        reject(new Error(`Command exited with non-zero code: ${code}`))
+                        reject(new Error(`Command exited with non-zero code (${code}): ${this.toString()}`))
                     }
                 }
                 if (options.waitForStreams === false) {

--- a/packages/core/src/test/shared/extensions/ssh.test.ts
+++ b/packages/core/src/test/shared/extensions/ssh.test.ts
@@ -15,19 +15,22 @@ import { isWin } from '../../../shared/vscode/env'
 
 describe('SSH Agent', function () {
     it('can start the agent on windows', async function () {
+        this.retries(2)
+
         // TODO: we should also skip this test if not running in CI
         // Local machines probably won't have admin permissions in the spawned processes
         if (process.platform !== 'win32') {
             this.skip()
         }
 
-        const runCommand = (command: string) => {
-            const args = ['-Command', command]
-            return new ChildProcess('powershell.exe', args).run({ rejectOnErrorCode: true })
+        async function runCommand(command: string) {
+            const args = ['-NoLogo', '-NonInteractive', '-ExecutionPolicy', 'RemoteSigned', '-Command', command]
+            return await new ChildProcess('pwsh.exe', args).run({ rejectOnErrorCode: true })
         }
 
-        const getStatus = () => {
-            return runCommand('echo (Get-Service ssh-agent).Status').then((o) => o.stdout)
+        async function getStatus() {
+            const c = await runCommand('echo (Get-Service ssh-agent).Status')
+            return c.stdout
         }
 
         await runCommand('Stop-Service ssh-agent')


### PR DESCRIPTION
Problem:

    SSH Agent
      can start the agent on windows:
      Error: Test length exceeded max duration: 30 seconds
    [No Pending UI Elements Found]
      at Timeout._onTimeout (D:\a\aws-toolkit-vscode\aws-toolkit-vscode\packages\core\src\test\setupUtil.ts:46:32)

Solution:
- retry 2 times.
- set short timeout.

fix https://github.com/aws/aws-toolkit-vscode/issues/6891

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
