### PR TITLE
feat(amazonq): Remove unsupported message for non-java python languages in /test

### DIFF
--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -548,16 +548,12 @@ export class TestController {
             */
             if (!['java', 'python'].includes(language) || workspaceFolder === undefined) {
                 let unsupportedMessage: string
-                const unsupportedLanguage = language ? language.charAt(0).toUpperCase() + language.slice(1) : ''
                 if (!workspaceFolder) {
                     // File is outside of workspace
                     unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I can't generate tests for ${fileName}</b> because the file is outside of workspace scope.<br></span> I can still provide examples, instructions and code suggestions.`
-                } else if (unsupportedLanguage) {
-                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> While ${unsupportedLanguage} is not supported, I will generate a suggestion below.`
-                } else {
-                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> I will still generate a suggestion below.`
+                    this.messenger.sendMessage(unsupportedMessage, tabID, 'answer')
                 }
-                this.messenger.sendMessage(unsupportedMessage, tabID, 'answer')
+                // Keeping this metric as is. TODO - Change to true once we support through other feature
                 session.isSupportedLanguage = false
                 await this.onCodeGeneration(
                     session,


### PR DESCRIPTION
## Problem
In /test feature, test generation in languages other than Java and Python display message that they were not supported. Tests are generated for all languages, so this message needs to be removed.

## Solution

Removed message to the user that /test only supports Python and Java
<img width="590" alt="Screenshot - Removed unsupporte message" src="https://github.com/user-attachments/assets/5acc759d-bbfd-41ca-8fa5-07d25ad4ac42" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
