### PR TITLE
feat(chat): group consecutive read tool messages

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -154,6 +154,28 @@ export class Connector extends BaseConnector {
         }
     }
 
+    private processToolMessage = async (messageData: any): Promise<void> => {
+        if (this.onChatAnswerUpdated === undefined) {
+            return
+        }
+        const answer: CWCChatItem = {
+            type: messageData.messageType,
+            messageId: messageData.messageID ?? messageData.triggerID,
+            body: messageData.message,
+            followUp: messageData.followUps,
+            canBeVoted: messageData.canBeVoted ?? false,
+            codeReference: messageData.codeReference,
+            userIntent: messageData.contextList,
+            codeBlockLanguage: messageData.codeBlockLanguage,
+            contextList: messageData.contextList,
+            title: messageData.title,
+            buttons: messageData.buttons,
+            fileList: messageData.fileList,
+        }
+        this.onChatAnswerUpdated(messageData.tabID, answer)
+        return
+    }
+
     processContextCommandData(messageData: any) {
         if (messageData.data) {
             this.onContextCommandDataReceived(messageData.data)
@@ -196,6 +218,11 @@ export class Connector extends BaseConnector {
     handleMessageReceive = async (messageData: any): Promise<void> => {
         if (messageData.type === 'chatMessage') {
             await this.processChatMessage(messageData)
+            return
+        }
+
+        if (messageData.type === 'toolMessage') {
+            await this.processToolMessage(messageData)
             return
         }
 

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -331,6 +331,7 @@ export const createMynahUI = (
                     ...(item.followUp !== undefined ? { followUp: item.followUp } : {}),
                     ...(item.footer !== undefined ? { footer: item.footer } : {}),
                     ...(item.canBeVoted !== undefined ? { canBeVoted: item.canBeVoted } : {}),
+                    ...(item.fileList !== undefined ? { fileList: item.fileList } : {}),
                 })
             } else {
                 mynahUI.updateLastChatAnswer(tabID, {

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -22,11 +22,13 @@ export class ChatSession {
      * _readFiles = list of files read from the project to gather context before generating response.
      * _showDiffOnFileWrite = Controls whether to show diff view (true) or file context view (false) to the user
      * _context = Additional context to be passed to the LLM for generating the response
+     * _messageIdToUpdate = messageId of a chat message to be updated, used for reducing consecutive tool messages
      */
     private _readFiles: string[] = []
     private _toolUse: ToolUse | undefined
     private _showDiffOnFileWrite: boolean = false
     private _context: PromptMessage['context']
+    private _messageIdToUpdate: string | undefined
 
     contexts: Map<string, { first: number; second: number }[]> = new Map()
     // TODO: doesn't handle the edge case when two files share the same relativePath string but from different root
@@ -50,6 +52,14 @@ export class ChatSession {
 
     public setContext(context: PromptMessage['context']) {
         this._context = context
+    }
+
+    public get messageIdToUpdate(): string | undefined {
+        return this._messageIdToUpdate
+    }
+
+    public setMessageIdToUpdate(messageId: string | undefined) {
+        this._messageIdToUpdate = messageId
     }
 
     public tokenSource!: vscode.CancellationTokenSource

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -663,9 +663,16 @@ export class ChatController {
                     try {
                         await ToolUtils.validate(tool)
 
-                        const chatStream = new ChatStream(this.messenger, tabID, triggerID, toolUse, {
-                            requiresAcceptance: false,
-                        })
+                        const chatStream = new ChatStream(
+                            this.messenger,
+                            tabID,
+                            triggerID,
+                            // Pass in a different toolUseId so that the output does not overwrite
+                            // any previous messages
+                            { ...toolUse, toolUseId: `${toolUse.toolUseId}-output` },
+                            { requiresAcceptance: false },
+                            undefined
+                        )
                         const output = await ToolUtils.invoke(tool, chatStream)
 
                         toolResults.push({

--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -22,11 +22,16 @@ export class ChatStream extends Writable {
         private readonly triggerID: string,
         private readonly toolUse: ToolUse | undefined,
         private readonly validation: CommandValidation,
+        private readonly messageIdToUpdate: string | undefined,
         private readonly logger = getLogger('chatStream')
     ) {
         super()
         this.logger.debug(`ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}`)
-        this.messenger.sendInitalStream(tabID, triggerID, undefined)
+        if (!messageIdToUpdate) {
+            // If messageIdToUpdate is undefined, we need to first create an empty message
+            // with messageId so it can be updated later
+            this.messenger.sendInitialToolMessage(tabID, triggerID, toolUse?.toolUseId)
+        }
     }
 
     override _write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
@@ -38,21 +43,13 @@ export class ChatStream extends Writable {
             this.tabID,
             this.triggerID,
             this.toolUse,
-            this.validation
+            this.validation,
+            this.messageIdToUpdate
         )
         callback()
     }
 
     override _final(callback: (error?: Error | null) => void): void {
-        if (this.accumulatedLogs.trim().length > 0) {
-            this.messenger.sendPartialToolLog(
-                this.accumulatedLogs,
-                this.tabID,
-                this.triggerID,
-                this.toolUse,
-                this.validation
-            )
-        }
         callback()
     }
 }

--- a/packages/core/src/codewhispererChat/view/connector/connector.ts
+++ b/packages/core/src/codewhispererChat/view/connector/connector.ts
@@ -253,6 +253,10 @@ export class ChatMessage extends UiMessage {
     }
 }
 
+export class ToolMessage extends ChatMessage {
+    override type = 'toolMessage'
+}
+
 export interface FollowUp {
     readonly type: string
     readonly pillText: string
@@ -304,6 +308,10 @@ export class AppToWebViewMessageDispatcher {
     }
 
     public sendChatMessage(message: ChatMessage) {
+        this.appsToWebViewMessagePublisher.publish(message)
+    }
+
+    public sendToolMessage(message: ToolMessage) {
         this.appsToWebViewMessagePublisher.publish(message)
     }
 


### PR DESCRIPTION
## Problem

LLM will sometimes try to execute the `fsRead` tool (and `listDirectory` tool) many times in succession, when this happens we don't want to show every read message.

## Solution

Update the existing chat message that already shows a read message if it exists.

### Detailed changes
- Added a new type of UiMessage `ToolMessage` specifically for handling tool chat messages
- `ToolMessage` will call MynahUI's `updateChatAnswerWithMessageId` API
- For every "group" of consecutive read messages we store the first occurrence of the read tool's toolUseId in session storage and use that as the messageId to update
- Updated `ChatStream` class to take in this messageId to update for the current message

https://github.com/user-attachments/assets/8df75d4d-c15f-4e21-9867-4ad3ca8f3233



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
