### PR TITLE
feat(chat): Adding state Management to stop the response for new user input prompt

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -368,6 +368,7 @@ export class ChatController {
     private async processStopResponseMessage(message: StopResponseMessage) {
         const session = this.sessionStorage.getSession(message.tabID)
         session.tokenSource.cancel()
+        this.chatHistoryStorage.getTabHistory(message.tabID).clearRecentHistory()
     }
 
     private async processTriggerTabIDReceived(message: TriggerTabIDReceived) {
@@ -650,6 +651,8 @@ export class ChatController {
                 const session = this.sessionStorage.getSession(tabID)
                 const toolUse = session.toolUse
                 if (!toolUse || !toolUse.input) {
+                    // Turn off AgentLoop flag if there's no tool use
+                    this.sessionStorage.setAgentLoopInProgress(tabID, false)
                     return
                 }
                 session.setToolUse(undefined)
@@ -711,7 +714,6 @@ export class ChatController {
                         customization: getSelectedCustomization(),
                         toolResults: toolResults,
                         origin: Origin.IDE,
-                        chatHistory: this.chatHistoryStorage.getTabHistory(tabID).getHistory(),
                         context: session.context ?? [],
                         relevantTextDocuments: [],
                         additionalContents: [],
@@ -887,10 +889,16 @@ export class ChatController {
             errorMessage = e.message
         }
 
+        // Turn off AgentLoop flag in case of exception
+        if (tabID) {
+            this.sessionStorage.setAgentLoopInProgress(tabID, false)
+        }
+
         this.messenger.sendErrorMessage(errorMessage, tabID, requestID)
         getLogger().error(`error: ${errorMessage} tabID: ${tabID} requestID: ${requestID}`)
 
         this.sessionStorage.deleteSession(tabID)
+        this.chatHistoryStorage.getTabHistory(tabID).clearRecentHistory()
     }
 
     private async processContextMenuCommand(command: EditorContextCommand) {
@@ -1050,7 +1058,6 @@ export class ChatController {
                     codeQuery: lastTriggerEvent.context?.focusAreaContext?.names,
                     userIntent: message.userIntent,
                     customization: getSelectedCustomization(),
-                    chatHistory: this.chatHistoryStorage.getTabHistory(message.tabID).getHistory(),
                     contextLengths: {
                         ...defaultContextLengths,
                     },
@@ -1099,7 +1106,6 @@ export class ChatController {
                         codeQuery: context?.focusAreaContext?.names,
                         userIntent: this.userIntentRecognizer.getFromPromptChatMessage(message),
                         customization: getSelectedCustomization(),
-                        chatHistory: this.chatHistoryStorage.getTabHistory(message.tabID).getHistory(),
                         origin: Origin.IDE,
                         context: message.context ?? [],
                         relevantTextDocuments: [],
@@ -1281,6 +1287,16 @@ export class ChatController {
         }
 
         const tabID = triggerEvent.tabID
+        if (this.sessionStorage.isAgentLoopInProgress(tabID)) {
+            // If a response is already in progress, stop it first
+            const stopResponseMessage: StopResponseMessage = {
+                tabID: tabID,
+            }
+            await this.processStopResponseMessage(stopResponseMessage)
+        }
+
+        // Ensure AgentLoop flag is set to true during response generation
+        this.sessionStorage.setAgentLoopInProgress(tabID, true)
 
         const credentialsState = await AuthUtil.instance.getChatAuthState()
 
@@ -1343,6 +1359,7 @@ export class ChatController {
         if (fixedHistoryMessage.userInputMessage?.userInputMessageContext) {
             triggerPayload.toolResults = fixedHistoryMessage.userInputMessage.userInputMessageContext.toolResults
         }
+        triggerPayload.chatHistory = chatHistory.getHistory()
         const request = triggerPayloadToChatRequest(triggerPayload)
         const conversationId = chatHistory.getConversationId() || randomUUID()
         chatHistory.setConversationId(conversationId)
@@ -1405,8 +1422,13 @@ export class ChatController {
                 } metadata: ${inspect(response.$metadata, { depth: 12 })}`
             )
             await this.messenger.sendAIResponse(response, session, tabID, triggerID, triggerPayload, chatHistory)
+
+            // Turn off AgentLoop flag after sending the AI response
+            this.sessionStorage.setAgentLoopInProgress(tabID, false)
         } catch (e: any) {
             this.telemetryHelper.recordMessageResponseError(triggerPayload, tabID, getHttpStatusCode(e) ?? 0)
+            // Turn off AgentLoop flag in case of exception
+            this.sessionStorage.setAgentLoopInProgress(tabID, false)
             // clears session, record telemetry before this call
             this.processException(e, tabID)
         }

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -295,7 +295,7 @@ export class Messenger {
                 }
                 return true
             },
-            { timeout: 60000, truthy: true }
+            { timeout: 600000, truthy: true }
         )
             .catch((error: any) => {
                 let errorMessage = 'Error reading chat stream.'

--- a/packages/core/src/codewhispererChat/storages/chatHistory.ts
+++ b/packages/core/src/codewhispererChat/storages/chatHistory.ts
@@ -188,37 +188,6 @@ export class ChatHistoryManager {
                         return newUserMessage
                     }
                 }
-            } else {
-                if (
-                    newUserMessage.userInputMessage?.userInputMessageContext?.toolResults &&
-                    newUserMessage.userInputMessage?.userInputMessageContext?.toolResults.length > 0
-                ) {
-                    // correct toolUse section of lastAssistantResponse in case of empty toolUse for user message with tool Results.
-                    const toolResults = newUserMessage.userInputMessage.userInputMessageContext.toolResults
-                    const updatedToolUses = toolResults.map((toolResult) => ({
-                        toolUseId: toolResult.toolUseId,
-                        name: lastHistoryMessage.assistantResponseMessage.toolUses?.find(
-                            (tu) => tu.toolUseId === toolResult.toolUseId
-                        )?.name,
-                        input: lastHistoryMessage.assistantResponseMessage.toolUses?.find(
-                            (tu) => tu.toolUseId === toolResult.toolUseId
-                        )?.input,
-                    }))
-
-                    // Create a new assistant response message with updated toolUses
-                    const updatedAssistantResponseMessage = {
-                        ...lastHistoryMessage.assistantResponseMessage,
-                        toolUses: updatedToolUses,
-                    }
-
-                    // Create a new chat message with the updated assistant response
-                    const updatedChatMessage: ChatMessage = {
-                        assistantResponseMessage: updatedAssistantResponseMessage,
-                    }
-
-                    // Replace the last message in history
-                    this.history[this.history.length - 1] = updatedChatMessage
-                }
             }
         }
 

--- a/packages/core/src/codewhispererChat/storages/chatHistory.ts
+++ b/packages/core/src/codewhispererChat/storages/chatHistory.ts
@@ -7,6 +7,7 @@ import {
     Tool,
     ToolResult,
     ToolResultStatus,
+    ToolUse,
     UserInputMessage,
     UserInputMessageContext,
 } from '@amzn/codewhisperer-streaming'
@@ -105,115 +106,99 @@ export class ChatHistoryManager {
      *    message is set without tool results, then the user message will have cancelled tool results.
      */
     public fixHistory(newUserMessage: ChatMessage): ChatMessage {
-        // Trim the conversation history if it exceeds the maximum length
-        if (this.history.length > MaxConversationHistoryLength) {
-            // Find the second oldest user message without tool results
-            let indexToTrim: number | undefined
+        this.trimConversationHistory()
+        this.ensureLastMessageFromAssistant()
+        return this.handleToolUses(newUserMessage)
+    }
 
-            for (let i = 1; i < this.history.length; i++) {
-                const message = this.history[i]
-                if (message.userInputMessage) {
-                    const userMessage = message.userInputMessage
-                    const ctx = userMessage.userInputMessageContext
-                    const hasNoToolResults = ctx && (!ctx.toolResults || ctx.toolResults.length === 0)
-                    if (hasNoToolResults && userMessage.content !== '') {
-                        indexToTrim = i
-                        break
-                    }
-                }
-            }
-            if (indexToTrim !== undefined) {
-                this.logger.debug(`Removing the first ${indexToTrim} elements in the history`)
-                this.history.splice(0, indexToTrim)
-            } else {
-                this.logger.debug('No valid starting user message found in the history, clearing')
-                this.history = []
-            }
+    private trimConversationHistory(): void {
+        if (this.history.length <= MaxConversationHistoryLength) {
+            return
         }
 
-        // Ensure the last message is from the assistant
+        const indexToTrim = this.findIndexToTrim()
+        if (indexToTrim !== undefined) {
+            this.logger.debug(`Removing the first ${indexToTrim} elements in the history`)
+            this.history.splice(0, indexToTrim)
+        } else {
+            this.logger.debug('No valid starting user message found in the history, clearing')
+            this.history = []
+        }
+    }
+
+    private findIndexToTrim(): number | undefined {
+        for (let i = 1; i < this.history.length; i++) {
+            const message = this.history[i]
+            if (this.isValidUserMessageWithoutToolResults(message)) {
+                return i
+            }
+        }
+        return undefined
+    }
+
+    private isValidUserMessageWithoutToolResults(message: ChatMessage): boolean {
+        if (!message.userInputMessage) {
+            return false
+        }
+        const ctx = message.userInputMessage.userInputMessageContext
+        return Boolean(
+            ctx && (!ctx.toolResults || ctx.toolResults.length === 0) && message.userInputMessage.content !== ''
+        )
+    }
+
+    private ensureLastMessageFromAssistant(): void {
         if (this.history.length > 0 && this.history[this.history.length - 1].userInputMessage !== undefined) {
             this.logger.debug('Last message in history is from the user, dropping')
             this.history.pop()
         }
+    }
 
-        // If the last message from the assistant contains tool uses, ensure the next user message contains tool results
-
+    private handleToolUses(newUserMessage: ChatMessage): ChatMessage {
         const lastHistoryMessage = this.history[this.history.length - 1]
+        if (!lastHistoryMessage || !lastHistoryMessage.assistantResponseMessage || !newUserMessage) {
+            return newUserMessage
+        }
 
-        if (
-            lastHistoryMessage &&
-            (lastHistoryMessage.assistantResponseMessage ||
-                lastHistoryMessage.assistantResponseMessage !== undefined) &&
-            newUserMessage
-        ) {
-            const toolUses = lastHistoryMessage.assistantResponseMessage.toolUses
+        const toolUses = lastHistoryMessage.assistantResponseMessage.toolUses
+        if (!toolUses || toolUses.length === 0) {
+            return newUserMessage
+        }
 
-            if (toolUses && toolUses.length > 0) {
-                if (newUserMessage.userInputMessage) {
-                    if (newUserMessage.userInputMessage.userInputMessageContext) {
-                        const ctx = newUserMessage.userInputMessage.userInputMessageContext
+        return this.addToolResultsToUserMessage(newUserMessage, toolUses)
+    }
 
-                        if (!ctx.toolResults || ctx.toolResults.length === 0) {
-                            ctx.toolResults = toolUses.map((toolUse) => ({
-                                toolUseId: toolUse.toolUseId,
-                                content: [
-                                    {
-                                        type: 'Text',
-                                        text: 'Tool use was cancelled by the user',
-                                    },
-                                ],
-                                status: ToolResultStatus.ERROR,
-                            }))
-                        }
-                    } else {
-                        const toolResults = toolUses.map((toolUse) => ({
-                            toolUseId: toolUse.toolUseId,
-                            content: [
-                                {
-                                    type: 'Text',
-                                    text: 'Tool use was cancelled by the user',
-                                },
-                            ],
-                            status: ToolResultStatus.ERROR,
-                        }))
+    private addToolResultsToUserMessage(newUserMessage: ChatMessage, toolUses: ToolUse[]): ChatMessage {
+        if (!newUserMessage.userInputMessage) {
+            return newUserMessage
+        }
 
-                        newUserMessage.userInputMessage.userInputMessageContext = {
-                            shellState: undefined,
-                            envState: undefined,
-                            toolResults: toolResults,
-                            tools: this.tools.length === 0 ? undefined : [...this.tools],
-                        }
+        const toolResults = this.createToolResults(toolUses)
 
-                        return newUserMessage
-                    }
-                }
+        if (newUserMessage.userInputMessage.userInputMessageContext) {
+            newUserMessage.userInputMessage.userInputMessageContext.toolResults = toolResults
+        } else {
+            newUserMessage.userInputMessage.userInputMessageContext = {
+                shellState: undefined,
+                envState: undefined,
+                toolResults: toolResults,
+                tools: this.tools.length === 0 ? undefined : [...this.tools],
             }
         }
 
-        // Always return the message to fix the TypeScript error
         return newUserMessage
     }
 
-    /**
-     * Adds tool results to the conversation.
-     */
-    addToolResults(toolResults: ToolResult[]): void {
-        const userInputMessageContext: UserInputMessageContext = {
-            shellState: undefined,
-            envState: undefined,
-            toolResults: toolResults,
-            tools: this.tools.length === 0 ? undefined : [...this.tools],
-        }
-
-        const msg: UserInputMessage = {
-            content: '',
-            userInputMessageContext: userInputMessageContext,
-        }
-
-        if (this.lastUserMessage?.userInputMessage) {
-            this.lastUserMessage.userInputMessage = msg
-        }
+    private createToolResults(toolUses: ToolUse[]): ToolResult[] {
+        return toolUses.map((toolUse) => ({
+            toolUseId: toolUse.toolUseId,
+            content: [
+                {
+                    type: 'Text',
+                    text: 'Tool use was cancelled by the user',
+                },
+            ],
+            status: ToolResultStatus.ERROR,
+        }))
     }
 
     private formatChatHistoryMessage(message: ChatMessage): ChatMessage {

--- a/packages/core/src/codewhispererChat/storages/chatHistory.ts
+++ b/packages/core/src/codewhispererChat/storages/chatHistory.ts
@@ -2,15 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import {
-    ChatMessage,
-    Tool,
-    ToolResult,
-    ToolResultStatus,
-    ToolUse,
-    UserInputMessage,
-    UserInputMessageContext,
-} from '@amzn/codewhisperer-streaming'
+import { ChatMessage, Tool, ToolResult, ToolResultStatus, ToolUse } from '@amzn/codewhisperer-streaming'
 import { randomUUID } from '../../shared/crypto'
 import { getLogger } from '../../shared/logger/logger'
 import { tools } from '../constants'

--- a/packages/core/src/codewhispererChat/storages/chatSession.ts
+++ b/packages/core/src/codewhispererChat/storages/chatSession.ts
@@ -7,6 +7,7 @@ import { ChatSession } from '../clients/chat/v0/chat'
 
 export class ChatSessionStorage {
     private sessions: Map<string, ChatSession> = new Map()
+    private agentLoopInProgress: Map<string, boolean> = new Map()
 
     public getSession(tabID: string): ChatSession {
         const sessionFromStorage = this.sessions.get(tabID)
@@ -22,5 +23,24 @@ export class ChatSessionStorage {
 
     public deleteSession(tabID: string) {
         this.sessions.delete(tabID)
+        this.agentLoopInProgress.delete(tabID)
+    }
+
+    /**
+     * Check if agent loop is in progress for a specific tab
+     * @param tabID The tab ID to check
+     * @returns True if agent loop is in progress, false otherwise
+     */
+    public isAgentLoopInProgress(tabID: string): boolean {
+        return this.agentLoopInProgress.get(tabID) === true
+    }
+
+    /**
+     * Set agent loop in progress state for a specific tab
+     * @param tabID The tab ID to set state for
+     * @param inProgress Whether the agent loop is in progress
+     */
+    public setAgentLoopInProgress(tabID: string, inProgress: boolean): void {
+        this.agentLoopInProgress.set(tabID, inProgress)
     }
 }


### PR DESCRIPTION
## Problem
Responses need to stop for new user prompt and fix user history

## Solution
- featureflag to check the response state to stop the responses.
- Fixing history incase of exception or stopped responses.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
