### PR TITLE
feat(amazonq): Remove unsupported message for non-java python languages in /test

### DIFF
--- a/packages/amazonq/test/e2e/amazonq/testGen.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/testGen.test.ts
@@ -31,19 +31,6 @@ describe('Amazon Q Test Generation', function () {
         },
     ]
 
-    const unsupportedLanguages = [
-        // move these over to testFiles once these languages are supported
-        // must be atleast one unsupported language here for testing
-        {
-            language: 'typescript',
-            filePath: 'testGenFolder/src/main/math.ts',
-        },
-        {
-            language: 'javascript',
-            filePath: 'testGenFolder/src/main/math.js',
-        },
-    ]
-
     // handles opening the file since /test must be called on an active file
     async function setupTestDocument(filePath: string, language: string) {
         const document = await waitUntil(async () => {
@@ -125,28 +112,6 @@ describe('Amazon Q Test Generation', function () {
     })
 
     describe('/test entry', () => {
-        describe('Unsupported language file', () => {
-            const { language, filePath } = unsupportedLanguages[0]
-
-            beforeEach(async () => {
-                await setupTestDocument(filePath, language)
-            })
-
-            it(`/test for unsupported language redirects to chat`, async () => {
-                tab.addChatMessage({ command: '/test' })
-                await tab.waitForChatFinishesLoading()
-
-                await waitForChatItems(3)
-                const unsupportedLanguageMessage = tab.getChatItems()[3]
-
-                assert.deepStrictEqual(unsupportedLanguageMessage.type, 'answer')
-                assert.deepStrictEqual(
-                    unsupportedLanguageMessage.body,
-                    `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> While ${language.charAt(0).toUpperCase() + language.slice(1)} is not supported, I will generate a suggestion below.`
-                )
-            })
-        })
-
         describe('External file out of project', async () => {
             let testFolder: TestFolder
             let fileName: string

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -548,16 +548,12 @@ export class TestController {
             */
             if (!['java', 'python'].includes(language) || workspaceFolder === undefined) {
                 let unsupportedMessage: string
-                const unsupportedLanguage = language ? language.charAt(0).toUpperCase() + language.slice(1) : ''
                 if (!workspaceFolder) {
                     // File is outside of workspace
                     unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I can't generate tests for ${fileName}</b> because the file is outside of workspace scope.<br></span> I can still provide examples, instructions and code suggestions.`
-                } else if (unsupportedLanguage) {
-                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> While ${unsupportedLanguage} is not supported, I will generate a suggestion below.`
-                } else {
-                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I'm sorry, but /test only supports Python and Java</b><br></span> I will still generate a suggestion below.`
+                    this.messenger.sendMessage(unsupportedMessage, tabID, 'answer')
                 }
-                this.messenger.sendMessage(unsupportedMessage, tabID, 'answer')
+                // Keeping this metric as is. TODO - Change to true once we support through other feature
                 session.isSupportedLanguage = false
                 await this.onCodeGeneration(
                     session,

--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -547,10 +547,9 @@ export class TestController {
                 For Re:Invent 2024 we are supporting only java and python for unit test generation, rest of the languages shows the similar experience as CWC
             */
             if (!['java', 'python'].includes(language) || workspaceFolder === undefined) {
-                let unsupportedMessage: string
                 if (!workspaceFolder) {
                     // File is outside of workspace
-                    unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I can't generate tests for ${fileName}</b> because the file is outside of workspace scope.<br></span> I can still provide examples, instructions and code suggestions.`
+                    const unsupportedMessage = `<span style="color: #EE9D28;">&#9888;<b>I can't generate tests for ${fileName}</b> because the file is outside of workspace scope.<br></span> I can still provide examples, instructions and code suggestions.`
                     this.messenger.sendMessage(unsupportedMessage, tabID, 'answer')
                 }
                 // Keeping this metric as is. TODO - Change to true once we support through other feature


### PR DESCRIPTION
## Problem
In /test feature, test generation in languages other than Java and Python display message that they were not supported. Tests are generated for all languages, so this message needs to be removed.

## Solution
Removed message to the user that /test only supports Python and Java
<img width="590" alt="Screenshot - Removed unsupporte message" src="https://github.com/user-attachments/assets/e122a3df-a18d-4dc0-9a47-01caf5dbf6ca" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
