### PR TITLE
fix(chat): request fails if character limit exceeded

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -88,7 +88,7 @@ import {
 } from '../../constants'
 import { ChatSession } from '../../clients/chat/v0/chat'
 import { amazonQTabSuffix } from '../../../shared/constants'
-import { OutputKind } from '../../tools/toolShared'
+import { maxToolOutputCharacterLength, OutputKind } from '../../tools/toolShared'
 import { ToolUtils, Tool, ToolType } from '../../tools/toolUtils'
 import { ChatStream } from '../../tools/chatStream'
 import { ChatHistoryStorage } from '../../storages/chatHistoryStorage'
@@ -667,6 +667,11 @@ export class ChatController {
                             requiresAcceptance: false,
                         })
                         const output = await ToolUtils.invoke(tool, chatStream)
+                        if (output.output.content.length > maxToolOutputCharacterLength) {
+                            throw Error(
+                                `Tool output exceeds maximum character limit of ${maxToolOutputCharacterLength}`
+                            )
+                        }
 
                         toolResults.push({
                             content: [

--- a/packages/core/src/codewhispererChat/tools/toolShared.ts
+++ b/packages/core/src/codewhispererChat/tools/toolShared.ts
@@ -7,6 +7,7 @@ import path from 'path'
 import fs from '../../shared/fs/fs'
 
 export const maxToolResponseSize = 30720 // 30KB
+export const maxToolOutputCharacterLength = 800_000
 
 export enum OutputKind {
     Text = 'text',


### PR DESCRIPTION
## Problem

Chat request fails if tool output exceeds the character length limit of 800,000.


## Solution

Handle this and send a error result instead of a success result back to the LLM.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
