### PR TITLE
fix(chat): fix for userInputMessage to include all context

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1426,7 +1426,9 @@ export class ChatController {
             }
             this.telemetryHelper.recordEnterFocusConversation(triggerEvent.tabID)
             this.telemetryHelper.recordStartConversation(triggerEvent, triggerPayload)
-            chatHistory.appendUserMessage(fixedHistoryMessage)
+            if (request.conversationState.currentMessage) {
+                chatHistory.appendUserMessage(request.conversationState.currentMessage)
+            }
 
             getLogger().info(
                 `response to tab: ${tabID} conversationID: ${session.sessionIdentifier} requestID: ${


### PR DESCRIPTION
## Problem
Chat history is not storing user input context 

## Solution

fix for userInputMessage to include all context
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
