### PR TITLE
fix(amazonq): Fix Q chat webview freezes & crash

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-65c16a0a-8891-48ea-83bf-3e86ae538d23.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-65c16a0a-8891-48ea-83bf-3e86ae538d23.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix bug when Q chat webview occasionally freezes and become gray"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -524,7 +524,7 @@
         "@aws-sdk/s3-request-presigner": "<3.731.0",
         "@aws-sdk/smithy-client": "<3.731.0",
         "@aws-sdk/util-arn-parser": "<3.731.0",
-        "@aws/mynah-ui": "^4.27.0",
+        "@aws/mynah-ui": "^4.28.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/fetch-http-handler": "^5.0.1",

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -577,13 +577,7 @@ export class ChatController {
                         id: contextCommandItem.id,
                         icon: 'folder' as MynahIconsType,
                     })
-                }
-                // TODO: Remove the limit of 25k once the performance issue of mynahUI in webview is fixed.
-                else if (
-                    contextCommandItem.symbol &&
-                    symbolsCmd.children &&
-                    symbolsCmd.children[0].commands.length < 25_000
-                ) {
+                } else if (contextCommandItem.symbol && symbolsCmd.children) {
                     symbolsCmd.children?.[0].commands.push({
                         command: contextCommandItem.symbol.name,
                         description: `${contextCommandItem.symbol.kind}, ${path.join(wsFolderName, contextCommandItem.relativePath)}, L${contextCommandItem.symbol.range.start.line}-${contextCommandItem.symbol.range.end.line}`,


### PR DESCRIPTION
## Problem
Q chat webview occasionally crashes.

## Solution
1. Update mynahUI library.
2. At the same time, lift the size limit of symbols in context menu.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
