### PR TITLE
feat(chat): Restrict the file access to only current workspaces directory

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -325,7 +325,7 @@ export class Connector extends BaseConnector {
 
         if (
             !this.onChatAnswerUpdated ||
-            !['accept-code-diff', 'reject-code-diff', 'confirm-tool-use'].includes(action.id)
+            !['accept-code-diff', 'reject-code-diff', 'confirm-tool-use', 'reject-tool-use'].includes(action.id)
         ) {
             return
         }
@@ -370,6 +370,18 @@ export class Connector extends BaseConnector {
                         text: 'Confirmed',
                         id: 'confirmed-tool-use',
                         status: 'success',
+                        position: 'outside',
+                        disabled: true,
+                    },
+                ]
+                break
+            case 'reject-tool-use':
+                answer.buttons = [
+                    {
+                        keepCardAfterClick: true,
+                        text: 'Rejected',
+                        id: 'rejected-tool-use',
+                        status: 'error',
                         position: 'outside',
                         disabled: true,
                     },

--- a/packages/core/src/codewhisperer/client/codewhisperer.ts
+++ b/packages/core/src/codewhisperer/client/codewhisperer.ts
@@ -31,8 +31,8 @@ export interface CodeWhispererConfig {
 }
 
 export const defaultServiceConfig: CodeWhispererConfig = {
-    region: 'us-east-1',
-    endpoint: 'https://codewhisperer.us-east-1.amazonaws.com/',
+    region: 'us-west-2',
+    endpoint: 'https://rts.alpha-us-west-2.codewhisperer.ai.aws.dev/',
 }
 
 export function getCodewhispererConfig(): CodeWhispererConfig {

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -762,6 +762,7 @@ export class ChatController {
                 await this.processToolUseMessage(message)
                 break
             case 'reject-code-diff':
+            case 'reject-tool-use':
                 await this.closeDiffView()
                 break
             default:

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -45,7 +45,7 @@ import { ChatHistoryManager } from '../../../storages/chatHistory'
 import { ToolType, ToolUtils } from '../../../tools/toolUtils'
 import { ChatStream } from '../../../tools/chatStream'
 import path from 'path'
-import { CommandValidation } from '../../../tools/executeBash'
+import { CommandValidation } from '../../../tools/toolShared'
 import { Change } from 'diff'
 import { FsWriteParams } from '../../../tools/fsWrite'
 
@@ -499,6 +499,17 @@ export class Messenger {
             if (validation.warning) {
                 message = validation.warning + message
             }
+        } else if (validation.requiresAcceptance && toolUse?.name === ToolType.ListDirectory) {
+            buttons.push({
+                id: 'reject-tool-use',
+                text: 'Reject',
+                status: 'info',
+            })
+            buttons.push({
+                id: 'confirm-tool-use',
+                text: 'Confirm',
+                status: 'info',
+            })
         } else if (toolUse?.name === ToolType.FsWrite) {
             const input = toolUse.input as unknown as FsWriteParams
             const fileName = path.basename(input.path)

--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -7,7 +7,7 @@ import { Writable } from 'stream'
 import { getLogger } from '../../shared/logger/logger'
 import { Messenger } from '../controllers/chat/messenger/messenger'
 import { ToolUse } from '@amzn/codewhisperer-streaming'
-import { CommandValidation } from './executeBash'
+import { CommandValidation } from './toolShared'
 import { Change } from 'diff'
 
 /**

--- a/packages/core/src/codewhispererChat/tools/executeBash.ts
+++ b/packages/core/src/codewhispererChat/tools/executeBash.ts
@@ -7,7 +7,7 @@ import { Writable } from 'stream'
 import { getLogger } from '../../shared/logger/logger'
 import { fs } from '../../shared/fs/fs'
 import { ChildProcess, ChildProcessOptions } from '../../shared/utilities/processUtils'
-import { InvokeOutput, OutputKind, sanitizePath } from './toolShared'
+import { CommandValidation, InvokeOutput, OutputKind, sanitizePath } from './toolShared'
 import { split } from 'shlex'
 
 export enum CommandCategory {
@@ -124,11 +124,6 @@ export const highRiskCommandWarningMessage = '⚠️ WARNING: High risk command 
 export interface ExecuteBashParams {
     command: string
     cwd?: string
-}
-
-export interface CommandValidation {
-    requiresAcceptance: boolean
-    warning?: string
 }
 
 export class ExecuteBash {

--- a/packages/core/src/codewhispererChat/tools/toolShared.ts
+++ b/packages/core/src/codewhispererChat/tools/toolShared.ts
@@ -21,6 +21,11 @@ export interface InvokeOutput {
     }
 }
 
+export interface CommandValidation {
+    requiresAcceptance: boolean
+    warning?: string
+}
+
 export function sanitizePath(inputPath: string): string {
     let sanitized = inputPath.trim()
 

--- a/packages/core/src/codewhispererChat/tools/toolUtils.ts
+++ b/packages/core/src/codewhispererChat/tools/toolUtils.ts
@@ -5,10 +5,11 @@
 import { Writable } from 'stream'
 import { FsRead, FsReadParams } from './fsRead'
 import { FsWrite, FsWriteParams } from './fsWrite'
-import { CommandValidation, ExecuteBash, ExecuteBashParams } from './executeBash'
+import { ExecuteBash, ExecuteBashParams } from './executeBash'
 import { ToolResult, ToolResultContentBlock, ToolResultStatus, ToolUse } from '@amzn/codewhisperer-streaming'
 import { InvokeOutput } from './toolShared'
 import { ListDirectory, ListDirectoryParams } from './listDirectory'
+import { CommandValidation } from './toolShared'
 
 export enum ToolType {
     FsRead = 'fsRead',
@@ -46,7 +47,7 @@ export class ToolUtils {
             case ToolType.ExecuteBash:
                 return tool.tool.requiresAcceptance()
             case ToolType.ListDirectory:
-                return { requiresAcceptance: false }
+                return tool.tool.requiresAcceptance()
         }
     }
 


### PR DESCRIPTION
## Problem
ListDirectory allows listing files outside of current workspaces directories

## Solution
Provide Accept/Reject options to the user to list files outside of current workspaces directories
<img width="427" alt="Buttons" src="https://github.com/user-attachments/assets/294d2b63-5d01-4de6-a5dc-298bfbe5a898" />
<img width="373" alt="confirmed" src="https://github.com/user-attachments/assets/2b35dbea-8edb-4a1b-828d-21a8b87f004e" />
<img width="391" alt="rejected" src="https://github.com/user-attachments/assets/afce6293-bbfa-4bb7-af43-b8d415465471" />


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
