### PR TITLE
refactor(chat): simplify history logic

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/chatRequest/converter.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/chatRequest/converter.ts
@@ -175,7 +175,6 @@ export function triggerPayloadToChatRequest(triggerPayload: TriggerPayload): { c
             },
             chatTriggerType,
             customizationArn: customizationArn,
-            history: triggerPayload.chatHistory,
         },
     }
 }

--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -6,7 +6,6 @@
 import * as vscode from 'vscode'
 import {
     AdditionalContentEntry,
-    ChatMessage,
     Origin,
     RelevantTextDocument,
     ToolResult,
@@ -203,7 +202,6 @@ export interface TriggerPayload {
     traceId?: string
     contextLengths: ContextLengths
     workspaceRulesCount?: number
-    chatHistory?: ChatMessage[]
     toolResults?: ToolResult[]
     origin?: Origin
 }


### PR DESCRIPTION
## Problem
History logic cleanup

## Solution
- History does not need to be in triggerPayload
- ChatHistory does not need tools
- We don't need to create and maintain a separate newUserMessage object

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
