### PR TITLE
feat(chat): Add header for execute shell command

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -325,7 +325,7 @@ export class Connector extends BaseConnector {
 
         if (
             !this.onChatAnswerUpdated ||
-            !['accept-code-diff', 'reject-code-diff', 'confirm-tool-use'].includes(action.id)
+            !['accept-code-diff', 'reject-code-diff', 'run-shell-command', 'reject-shell-command'].includes(action.id)
         ) {
             return
         }
@@ -363,17 +363,27 @@ export class Connector extends BaseConnector {
                     answer.body = ' '
                 }
                 break
-            case 'confirm-tool-use':
-                answer.buttons = [
-                    {
-                        keepCardAfterClick: true,
-                        text: 'Confirmed',
-                        id: 'confirmed-tool-use',
+            case 'run-shell-command':
+                answer.header = {
+                    icon: 'code-block' as MynahIconsType,
+                    body: 'shell',
+                    status: {
+                        icon: 'ok' as MynahIconsType,
+                        text: 'Accepted',
                         status: 'success',
-                        position: 'outside',
-                        disabled: true,
                     },
-                ]
+                }
+                break
+            case 'reject-shell-command':
+                answer.header = {
+                    icon: 'code-block' as MynahIconsType,
+                    body: 'shell',
+                    status: {
+                        icon: 'cancel' as MynahIconsType,
+                        text: 'Rejected',
+                        status: 'error',
+                    },
+                }
                 break
             default:
                 break

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -818,19 +818,34 @@ export class ChatController {
         }
     }
 
+    private async rejectShellCommand(message: CustomFormActionMessage) {
+        const triggerId = randomUUID()
+        this.triggerEventsStorage.addTriggerEvent({
+            id: triggerId,
+            tabID: message.tabID,
+            message: undefined,
+            type: 'chat_message',
+            context: undefined,
+        })
+        await this.generateStaticTextResponse('reject-shell-command', triggerId)
+    }
+
     private async processCustomFormAction(message: CustomFormActionMessage) {
         switch (message.action.id) {
             case 'submit-create-prompt':
                 await this.handleCreatePrompt(message)
                 break
             case 'accept-code-diff':
-            case 'confirm-tool-use':
+            case 'run-shell-command':
             case 'generic-tool-execution':
                 await this.closeDiffView()
                 await this.processToolUseMessage(message)
                 break
             case 'reject-code-diff':
                 await this.closeDiffView()
+                break
+            case 'reject-shell-command':
+                await this.rejectShellCommand(message)
                 break
             case 'tool-unavailable':
                 await this.processUnavailableToolUseMessage(message)

--- a/packages/core/src/codewhispererChat/tools/executeBash.ts
+++ b/packages/core/src/codewhispererChat/tools/executeBash.ts
@@ -327,7 +327,6 @@ export class ExecuteBash {
     }
 
     public queueDescription(updates: Writable): void {
-        updates.write(`I will run the following shell command:\n`)
         updates.write('```shell\n' + this.command + '\n```')
         updates.end()
     }


### PR DESCRIPTION
## Problem
- Add header for execute shell command

## Solution
- when shell command un-destructive, directly execute the command
![image](https://github.com/user-attachments/assets/579891bd-dff8-4e6e-b4af-411190248a52)

- when when shell command destructive, customer can decide to run or reject the command execution
![image](https://github.com/user-attachments/assets/24c4c09d-0135-495c-a8df-8c7a9d90e566)

-- reject
![image](https://github.com/user-attachments/assets/2935a630-f1af-473a-b65e-283ddccc49fa)

-- run
![image](https://github.com/user-attachments/assets/20eb4c55-6981-4296-9beb-a5d02fda97d3)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
