### PR TITLE
fix(amazonq): Fixing bugs for agentic chat

### DIFF
--- a/packages/core/src/amazonq/webview/ui/tabs/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/generator.ts
@@ -72,23 +72,26 @@ export class TabDataGenerator {
                       },
                   ]
                 : [],
-            promptInputOptions: [
-                {
-                    type: 'toggle',
-                    id: 'prompt-type',
-                    value: 'ask',
-                    options: [
-                        {
-                            value: 'pair-programming-on',
-                            icon: 'code-block', // TODO: correct icons
-                        },
-                        {
-                            value: 'pair-programming-off',
-                            icon: 'chat', // TODO: correct icons
-                        },
-                    ],
-                },
-            ],
+            promptInputOptions:
+                tabType === 'cwc'
+                    ? [
+                          {
+                              type: 'toggle',
+                              id: 'prompt-type',
+                              value: 'ask',
+                              options: [
+                                  {
+                                      value: 'pair-programming-on',
+                                      icon: 'code-block', // TODO: correct icons
+                                  },
+                                  {
+                                      value: 'pair-programming-off',
+                                      icon: 'chat', // TODO: correct icons
+                                  },
+                              ],
+                          },
+                      ]
+                    : [],
         }
         return tabData
     }

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -284,9 +284,7 @@ export class Messenger {
                         } else {
                             // TODO: Handle the error
                         }
-                    } else if (cwChatEvent.toolUseEvent?.stop === undefined && toolUseInput !== '') {
-                        // This is for the case when writing tool is executed. The toolUseEvent is non stop but in toolUseInput is not empty. In this case we need show user the current spinner UI.
-                        this.sendInitalStream(tabID, triggerID, undefined)
+                        // TODO: Add a spinner component for fsWrite, previous implementation is causing lag in mynah UX.
                     }
 
                     if (


### PR DESCRIPTION
## Problem
- Pair programming features should be restricted to Q Chat but right now its available in other tabs like `/test`
- Multiple spinner loading events were causing delayed display of code difference views

## Solution
- Improved performance by adding a specific check for 'cwc' tab type
- Optimized loading by eliminating redundant spinner events sent to the Mynah UI.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
