### PR TITLE
feat(amazonq): Disable Q agentic commands not supported in SageMaker apps and skip agentic welcome prompt

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-80edcce3-4e32-4e74-a35a-af2242782181.json
+++ b/packages/amazonq/.changes/next-release/Feature-80edcce3-4e32-4e74-a35a-af2242782181.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SageMaker: Disable the unsupported agentic commands and welcome prompt"
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -434,6 +434,7 @@
                 },
                 {
                     "command": "aws.amazonq.generateUnitTests",
+                    "when": "!aws.isSageMaker",
                     "group": "cw_chat@5"
                 },
                 {
@@ -469,6 +470,7 @@
                 },
                 {
                     "command": "aws.amazonq.exploreAgents",
+                    "when": "!aws.isSageMaker",
                     "group": "1_help@2"
                 },
                 {
@@ -523,7 +525,7 @@
                 "command": "aws.amazonq.security.scan-statusbar",
                 "title": "%AWS.command.amazonq.security.scan%",
                 "category": "%AWS.amazonq.title%",
-                "enablement": "aws.codewhisperer.connected"
+                "enablement": "aws.codewhisperer.connected && !aws.isSageMaker"
             },
             {
                 "command": "aws.amazonq.refactorCode",
@@ -553,7 +555,7 @@
                 "command": "aws.amazonq.generateUnitTests",
                 "title": "%AWS.command.amazonq.generateUnitTests%",
                 "category": "%AWS.amazonq.title%",
-                "enablement": "aws.codewhisperer.connected"
+                "enablement": "aws.codewhisperer.connected && !aws.isSageMaker"
             },
             {
                 "command": "aws.amazonq.reconnect",
@@ -757,7 +759,7 @@
                 "command": "aws.amazonq.exploreAgents",
                 "title": "%AWS.amazonq.exploreAgents%",
                 "category": "%AWS.amazonq.title%",
-                "enablement": "aws.codewhisperer.connected"
+                "enablement": "aws.codewhisperer.connected && !aws.isSageMaker"
             },
             {
                 "command": "aws.amazonq.walkthrough.show",

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -147,6 +147,9 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     // Hide the Amazon Q tree in toolkit explorer
     await setContext('aws.toolkit.amazonq.dismissed', true)
 
+    // set context var to check if its SageMaker AI or not
+    await setContext('aws.isSageMaker', isSageMaker())
+
     // set context var to check if its SageMaker Unified Studio or not
     await setContext('aws.isSageMakerUnifiedStudio', isSageMaker('SMUS'))
 

--- a/packages/core/src/amazonq/webview/generators/webViewContent.ts
+++ b/packages/core/src/amazonq/webview/generators/webViewContent.ts
@@ -78,12 +78,13 @@ export class WebViewContentGenerator {
 
         // Fetch featureConfigs and use it within the script
         const featureConfigsString = await this.generateFeatureConfigsData()
+        const isSM = isSageMaker('SMAI')
+        const isSMUS = isSageMaker('SMUS')
 
-        const disabledCommandsString = isSageMaker() ? `['/dev', '/transform']` : '[]'
+        const disabledCommandsString = isSM ? `['/dev', '/transform', '/test', '/review', '/doc']` : '[]'
         const disclaimerAcknowledged = globals.globalState.tryGet('aws.amazonq.disclaimerAcknowledged', Boolean, false)
 
         const welcomeLoadCount = globals.globalState.tryGet('aws.amazonq.welcomeChatShowCount', Number, 0)
-        const isSMUS = isSageMaker('SMUS')
 
         return `
         <script type="text/javascript" src="${javascriptEntrypoint.toString()}" defer onload="init()"></script>
@@ -92,7 +93,7 @@ export class WebViewContentGenerator {
             const init = () => {
                 createMynahUI(acquireVsCodeApi(), ${
                     (await AuthUtil.instance.getChatAuthState()).amazonQ === 'connected'
-                },${featureConfigsString},${welcomeLoadCount},${disclaimerAcknowledged},${disabledCommandsString},${isSMUS});
+                },${featureConfigsString},${welcomeLoadCount},${disclaimerAcknowledged},${disabledCommandsString},${isSMUS},${isSM});
             }
         </script>
         `

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -49,7 +49,8 @@ export const createMynahUI = (
     welcomeCount: number,
     disclaimerAcknowledged: boolean,
     disabledCommands?: string[],
-    isSMUS?: boolean
+    isSMUS?: boolean,
+    isSM?: boolean
 ) => {
     let disclaimerCardActive = !disclaimerAcknowledged
     // eslint-disable-next-line prefer-const
@@ -84,7 +85,10 @@ export const createMynahUI = (
     })
 
     const showWelcomePage = () => {
-        return welcomeCount < welcomeCountThreshold
+        /*
+         * skip Agent Capability welcome page for SageMaker cases (SMAI and SMUS) since the commands are not supported
+         */
+        return welcomeCount < welcomeCountThreshold && !isSM
     }
 
     const updateWelcomeCount = () => {

--- a/packages/core/src/amazonq/webview/ui/tabs/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/constants.ts
@@ -10,6 +10,11 @@ const qChatIntroMessage = `Hi, I'm Amazon Q. I can answer your software developm
   Ask me to explain, debug, or optimize your code.
   You can enter \`/\` to see a list of quick actions. Use \`@\` to add saved prompts, files, folders, or your entire workspace as context.`
 
+/**
+ * The below intro message is for SageMaker Unified Studio(SMUS) customers only.
+ * With upcoming release of SMUS, only Q Free Tier is being supported hence the requirement to show this messaging to customers.
+ * Once Pro Tier is supported with SMUS, the below message will be removed and is only added for the interim
+ */
 export const qChatIntroMessageForSMUS = `Hi, I'm Amazon Q. I can answer your software development questions.\n\
   Ask me to explain, debug, or optimize your code.\n\
   You can enter \`/\` to see a list of quick actions. Use \`@\` to add saved prompts, files, folders, or your entire workspace as context.

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -1115,3 +1115,13 @@ export function hasVendedIamCredentials(isC9?: boolean, isSM?: boolean) {
     isSM ??= isSageMaker()
     return isSM || isC9
 }
+
+/**
+ * Returns true if credentials are provided by the metadata files in environment (ex. for IAM via ~/.aws/ and in a future case with SSO, from /cache or /sso)
+ * @param isSMUS boolean if SageMaker Unified Studio is host
+ * @returns boolean if SMUS
+ */
+export function hasVendedCredentialsFromMetadata(isSMUS?: boolean) {
+    isSMUS ??= isSageMaker('SMUS')
+    return isSMUS
+}

--- a/packages/core/src/codewhisperer/ui/statusBarMenu.ts
+++ b/packages/core/src/codewhisperer/ui/statusBarMenu.ts
@@ -22,7 +22,7 @@ import {
     switchToAmazonQNode,
     createSecurityScan,
 } from './codeWhispererNodes'
-import { hasVendedIamCredentials } from '../../auth/auth'
+import { hasVendedIamCredentials, hasVendedCredentialsFromMetadata } from '../../auth/auth'
 import { AuthUtil } from '../util/authUtil'
 import { DataQuickPickItem, createQuickPick } from '../../shared/ui/pickerPrompter'
 import { CodeScansState, CodeSuggestionsState, vsCodeState } from '../models/model'
@@ -30,7 +30,6 @@ import { Commands } from '../../shared/vscode/commands2'
 import { createExitButton } from '../../shared/ui/buttons'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { getLogger } from '../../shared/logger/logger'
-import { isSageMaker } from '../../shared/extensionUtilities'
 
 function getAmazonQCodeWhispererNodes() {
     const autoTriggerEnabled = CodeSuggestionsState.instance.isSuggestionsEnabled()
@@ -93,7 +92,7 @@ export function getQuickPickItems(): DataQuickPickItem<string>[] {
         // Add settings and signout
         createSeparator(),
         createSettingsNode(),
-        ...(AuthUtil.instance.isConnected() && !(hasVendedIamCredentials() || isSageMaker('SMUS'))
+        ...(AuthUtil.instance.isConnected() && !hasVendedIamCredentials() && !hasVendedCredentialsFromMetadata()
             ? [createSignout()]
             : []),
     ]

--- a/packages/core/src/shared/extensionUtilities.ts
+++ b/packages/core/src/shared/extensionUtilities.ts
@@ -175,7 +175,7 @@ export function isCloud9(flavor: 'classic' | 'codecatalyst' | 'any' = 'any'): bo
  * @param appName to identify the proper SM instance
  * @returns true if the current system is SageMaker(SMAI or SMUS)
  */
-export function isSageMaker(appName: string = 'SMAI'): boolean {
+export function isSageMaker(appName: 'SMAI' | 'SMUS' = 'SMAI'): boolean {
     switch (appName) {
         case 'SMAI':
             return vscode.env.appName === sageMakerAppname


### PR DESCRIPTION
## Problem
SageMaker AI and Unified Studio currently in prod uses version `1.32` and with manual upgrade to the newer version `>1.54`, observing agentic prompt added along with new commands `/test, /review, /doc` which are not supported by SageMaker apps

## Solution

1. SageMaker doesnt support currently `/dev, /transform` commands and in addition to that disabling the above listed agentic Q commands that are not supported in SageMaker apps(both SMAI and SMUS). 
2. Also disabling the agentic options from quick pick items
3. Skip agentic welcome prompt

Testing
`npm run compile && npm run package` and tested with the artefacts manually in SMUS and SMAI
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
