### PR TITLE
fix(chat): Fix ChatStream error caused by tool error

### DIFF
--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -16,6 +16,11 @@ import { createQDeveloperStreamingClient } from '../../../../shared/clients/qDev
 import { UserWrittenCodeTracker } from '../../../../codewhisperer/tracker/userWrittenCodeTracker'
 import { PromptMessage } from '../../../controllers/chat/model'
 
+export type ToolUseWithError = {
+    toolUse: ToolUse
+    error: Error | undefined
+}
+
 export class ChatSession {
     private sessionId?: string
     /**
@@ -24,7 +29,7 @@ export class ChatSession {
      * _context = Additional context to be passed to the LLM for generating the response
      */
     private _readFiles: string[] = []
-    private _toolUse: ToolUse | undefined
+    private _toolUseWithError: ToolUseWithError | undefined
     private _showDiffOnFileWrite: boolean = false
     private _context: PromptMessage['context']
     private _pairProgrammingModeOn: boolean = true
@@ -49,12 +54,12 @@ export class ChatSession {
         this._pairProgrammingModeOn = pairProgrammingModeOn
     }
 
-    public get toolUse(): ToolUse | undefined {
-        return this._toolUse
+    public get toolUseWithError(): ToolUseWithError | undefined {
+        return this._toolUseWithError
     }
 
-    public setToolUse(toolUse: ToolUse | undefined) {
-        this._toolUse = toolUse
+    public setToolUseWithError(toolUseWithError: ToolUseWithError | undefined) {
+        this._toolUseWithError = toolUseWithError
     }
 
     public get context(): PromptMessage['context'] {

--- a/packages/core/src/shared/utilities/messageUtil.ts
+++ b/packages/core/src/shared/utilities/messageUtil.ts
@@ -13,7 +13,7 @@ export interface MessageErrorInfo {
 }
 
 export function extractErrorInfo(error: any): MessageErrorInfo {
-    let errorMessage = 'Error reading chat stream.'
+    let errorMessage = 'Error reading chat response stream: ' + error.message
     let statusCode = undefined
     let requestId = undefined
 


### PR DESCRIPTION
## Problem
- Sometimes we receive error in sendAIResponse where `await ToolUtils.queueDescription(tool, chatStream)` throws error and we don't handle it currently
- Minor refactoring to remove `tool-unavailble` custom action and `processUnavailableToolUseMessage` to re-use `processToolUseMessage` instead

## Solution
- Store the error along with toolUse in chatSession so that we can handle it correctly in `processToolUseMessage`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
