### PR TITLE
feat(chat): support multi file write with reject and open diff

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -454,6 +454,8 @@
     "AWS.amazonq.doc.pillText.makeChanges": "Make changes",
     "AWS.amazonq.inline.invokeChat": "Inline chat",
     "AWS.amazonq.opensettings:": "Open settings",
+    "AWS.amazonq.executeBash.run": "Run",
+    "AWS.amazonq.executeBash.reject": "Reject",
     "AWS.toolkit.lambda.walkthrough.quickpickTitle": "Application Builder Walkthrough",
     "AWS.toolkit.lambda.walkthrough.title": "Get started building your application",
     "AWS.toolkit.lambda.walkthrough.description": "Your quick guide to build an application visually, iterate locally, and deploy to the cloud!",

--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -185,7 +185,10 @@ export class Connector extends BaseConnector {
         this.chatItems.get(tabId)?.set(messageId, { ...item })
     }
 
-    private getCurrentChatItem(tabId: string, messageId: string): ChatItem | undefined {
+    private getCurrentChatItem(tabId: string, messageId: string | undefined): ChatItem | undefined {
+        if (!messageId) {
+            return
+        }
         return this.chatItems.get(tabId)?.get(messageId)
     }
 
@@ -293,7 +296,7 @@ export class Connector extends BaseConnector {
 
     onCustomFormAction(
         tabId: string,
-        messageId: string,
+        messageId: string | undefined,
         action: {
             id: string
             text?: string | undefined
@@ -302,6 +305,10 @@ export class Connector extends BaseConnector {
     ) {
         if (action === undefined) {
             return
+        }
+
+        if (messageId?.startsWith('tooluse_')) {
+            action.formItemValues = { ...action.formItemValues, toolUseId: messageId }
         }
 
         this.sendMessageToExtension({

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -15,6 +15,7 @@ import { createCodeWhispererChatStreamingClient } from '../../../../shared/clien
 import { createQDeveloperStreamingClient } from '../../../../shared/clients/qDeveloperChatClient'
 import { UserWrittenCodeTracker } from '../../../../codewhisperer/tracker/userWrittenCodeTracker'
 import { PromptMessage } from '../../../controllers/chat/model'
+import { FsWriteBackup } from '../../../../codewhispererChat/tools/fsWrite'
 
 export type ToolUseWithError = {
     toolUse: ToolUse
@@ -33,6 +34,7 @@ export class ChatSession {
     private _showDiffOnFileWrite: boolean = false
     private _context: PromptMessage['context']
     private _pairProgrammingModeOn: boolean = true
+    private _fsWriteBackups: Map<string, FsWriteBackup> = new Map()
     /**
      * True if messages from local history have been sent to session.
      */
@@ -68,6 +70,14 @@ export class ChatSession {
 
     public setContext(context: PromptMessage['context']) {
         this._context = context
+    }
+
+    public get fsWriteBackups(): Map<string, FsWriteBackup> {
+        return this._fsWriteBackups
+    }
+
+    public setFsWriteBackup(toolUseId: string, backup: FsWriteBackup) {
+        this._fsWriteBackups.set(toolUseId, backup)
     }
 
     public tokenSource!: vscode.CancellationTokenSource

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -97,7 +97,7 @@ import { maxToolOutputCharacterLength, OutputKind } from '../../tools/toolShared
 import { ToolUtils, Tool, ToolType } from '../../tools/toolUtils'
 import { ChatStream } from '../../tools/chatStream'
 import { ChatHistoryStorage } from '../../storages/chatHistoryStorage'
-import { FsWrite, FsWriteParams } from '../../tools/fsWrite'
+import { FsWriteParams } from '../../tools/fsWrite'
 import { tempDirPath } from '../../../shared/filesystemUtilities'
 import { Database } from '../../../shared/db/chatDb/chatDb'
 import { TabBarController } from './tabBarController'
@@ -722,6 +722,10 @@ export class ChatController {
                             const chatStream = new ChatStream(this.messenger, tabID, triggerID, toolUse, {
                                 requiresAcceptance: false,
                             })
+                            if (tool.type === ToolType.FsWrite && toolUse.toolUseId) {
+                                const backup = await tool.tool.getBackup()
+                                session.setFsWriteBackup(toolUse.toolUseId, backup)
+                            }
                             const output = await ToolUtils.invoke(tool, chatStream)
                             if (output.output.content.length > maxToolOutputCharacterLength) {
                                 throw Error(
@@ -814,13 +818,15 @@ export class ChatController {
             case 'submit-create-prompt':
                 await this.handleCreatePrompt(message)
                 break
-            case 'accept-code-diff':
             case 'run-shell-command':
             case 'generic-tool-execution':
-                await this.closeDiffView()
                 await this.processToolUseMessage(message)
                 break
+            case 'accept-code-diff':
+                await this.closeDiffView()
+                break
             case 'reject-code-diff':
+                await this.restoreBackup(message)
                 await this.closeDiffView()
                 break
             case 'reject-shell-command':
@@ -828,6 +834,22 @@ export class ChatController {
                 break
             default:
                 getLogger().warn(`Unhandled action: ${message.action.id}`)
+        }
+    }
+
+    private async restoreBackup(message: CustomFormActionMessage) {
+        const tabID = message.tabID
+        const toolUseId = message.action.formItemValues?.toolUseId
+        if (!tabID || !toolUseId) {
+            return
+        }
+
+        const session = this.sessionStorage.getSession(tabID)
+        const { content, filePath, isNew } = session.fsWriteBackups.get(toolUseId) ?? {}
+        if (filePath && isNew) {
+            await fs.delete(filePath)
+        } else if (filePath && content !== undefined) {
+            await fs.writeFile(filePath, content)
         }
     }
 
@@ -852,8 +874,15 @@ export class ChatController {
         const session = this.sessionStorage.getSession(message.tabID)
         // Check if user clicked on filePath in the contextList or in the fileListTree and perform the functionality accordingly.
         if (session.showDiffOnFileWrite) {
+            const toolUseId = message.messageId
+            const { filePath, content } = session.fsWriteBackups.get(toolUseId) ?? {}
+            if (!filePath || content === undefined) {
+                return
+            }
+
             try {
                 // Create a temporary file path to show the diff view
+                // TODO: Use amazonQDiffScheme for temp file
                 const pathToArchiveDir = path.join(tempDirPath, 'q-chat')
                 const archivePathExists = await fs.existsDir(pathToArchiveDir)
                 if (archivePathExists) {
@@ -862,39 +891,12 @@ export class ChatController {
                 await fs.mkdir(pathToArchiveDir)
                 const resultArtifactsDir = path.join(pathToArchiveDir, 'resultArtifacts')
                 await fs.mkdir(resultArtifactsDir)
-                const tempFilePath = path.join(
-                    resultArtifactsDir,
-                    `temp-${path.basename((session.toolUseWithError?.toolUse.input as unknown as FsWriteParams).path)}`
-                )
 
-                // If we have existing filePath copy file content from existing file to temporary file.
-                const filePath = (session.toolUseWithError?.toolUse.input as any).path ?? message.filePath
-                const fileExists = await fs.existsFile(filePath)
-                if (fileExists) {
-                    const fileContent = await fs.readFileText(filePath)
-                    await fs.writeFile(tempFilePath, fileContent)
-                }
+                const tempFilePath = path.join(resultArtifactsDir, `temp-${path.basename(filePath)}`)
+                await fs.writeFile(tempFilePath, content)
 
-                // Create a deep clone of the toolUse object and pass this toolUse to FsWrite tool execution to get the modified temporary file.
-                const clonedToolUse = structuredClone(session.toolUseWithError?.toolUse)
-                if (!clonedToolUse) {
-                    return
-                }
-                const input = clonedToolUse.input as unknown as FsWriteParams
-                input.path = tempFilePath
-
-                const fsWrite = new FsWrite(input)
-                await fsWrite.invoke()
-
-                // Check if fileExists=false, If yes, return instead of showing broken diff experience.
-                if (!tempFilePath) {
-                    void vscode.window.showInformationMessage(
-                        'Generated code changes have been reviewed and processed.'
-                    )
-                    return
-                }
-                const leftUri = fileExists ? vscode.Uri.file(filePath) : vscode.Uri.from({ scheme: 'untitled' })
-                const rightUri = vscode.Uri.file(tempFilePath ?? filePath)
+                const leftUri = vscode.Uri.file(tempFilePath)
+                const rightUri = vscode.Uri.file(filePath)
                 const fileName = path.basename(filePath)
                 await vscode.commands.executeCommand(
                     'vscode.diff',

--- a/packages/core/src/codewhispererChat/tools/toolUtils.ts
+++ b/packages/core/src/codewhispererChat/tools/toolUtils.ts
@@ -42,7 +42,7 @@ export class ToolUtils {
             case ToolType.FsRead:
                 return { requiresAcceptance: false }
             case ToolType.FsWrite:
-                return { requiresAcceptance: true }
+                return { requiresAcceptance: false }
             case ToolType.ExecuteBash:
                 return tool.tool.requiresAcceptance()
             case ToolType.ListDirectory:

--- a/packages/core/src/shared/utilities/diffUtils.ts
+++ b/packages/core/src/shared/utilities/diffUtils.ts
@@ -151,6 +151,31 @@ export function getDiffCharsAndLines(
 }
 
 /**
+ * Calculates the number of added and deleted lines from a set of changes.
+ *
+ * @param {Change[] | undefined} changes - An array of diff Change objects containing added, removed, or unchanged content
+ * @returns {Object} An object containing the number of added and deleted lines
+ * @example
+ * // Calculate the number of added and deleted lines from diff changes
+ * const diffChanges = diffLines(originalCode, newCode);
+ * const lineDiffs = getDiffLinesFromChanges(diffChanges);
+ * // Result will be an object with added and deleted line counts
+ */
+export function getDiffLinesFromChanges(changes: Change[] | undefined) {
+    return changes?.reduce(
+        (acc, { count = 0, added, removed }) => {
+            if (added) {
+                acc.added += count
+            } else if (removed) {
+                acc.deleted += count
+            }
+            return acc
+        },
+        { added: 0, deleted: 0 }
+    )
+}
+
+/**
  * Converts diff changes into a markdown-formatted string with syntax highlighting.
  * This function takes an array of diff changes and formats them as a markdown code block
  * with diff syntax, optionally including language-specific syntax highlighting.

--- a/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
@@ -67,9 +67,9 @@ describe('ToolUtils', function () {
             assert.strictEqual(ToolUtils.requiresAcceptance(tool).requiresAcceptance, false)
         })
 
-        it('returns true for FsWrite tool', function () {
+        it('returns false for FsWrite tool', function () {
             const tool: Tool = { type: ToolType.FsWrite, tool: mockFsWrite as unknown as FsWrite }
-            assert.strictEqual(ToolUtils.requiresAcceptance(tool).requiresAcceptance, true)
+            assert.strictEqual(ToolUtils.requiresAcceptance(tool).requiresAcceptance, false)
         })
 
         it('delegates to the tool for ExecuteBash', function () {


### PR DESCRIPTION
## Problem

Support workflows with multiple file writes without confirmation


## Solution
- Set `requiresAcceptance` to `false` for all FsWrite executions
- Store backups of each FsWrite so we can revert the changes if needed


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
