### PR TITLE
fix(chat): Remove enforceMaxSize from fsRead

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -93,7 +93,7 @@ import {
 } from '../../constants'
 import { ChatSession } from '../../clients/chat/v0/chat'
 import { amazonQTabSuffix } from '../../../shared/constants'
-import { maxToolOutputCharacterLength, OutputKind } from '../../tools/toolShared'
+import { OutputKind } from '../../tools/toolShared'
 import { ToolUtils, Tool, ToolType } from '../../tools/toolUtils'
 import { ChatStream } from '../../tools/chatStream'
 import { ChatHistoryStorage } from '../../storages/chatHistoryStorage'
@@ -723,11 +723,7 @@ export class ChatController {
                                 requiresAcceptance: false,
                             })
                             const output = await ToolUtils.invoke(tool, chatStream)
-                            if (output.output.content.length > maxToolOutputCharacterLength) {
-                                throw Error(
-                                    `Tool output exceeds maximum character limit of ${maxToolOutputCharacterLength}`
-                                )
-                            }
+                            ToolUtils.validateOutput(output)
 
                             toolResults.push({
                                 content: [

--- a/packages/core/src/codewhispererChat/tools/toolShared.ts
+++ b/packages/core/src/codewhispererChat/tools/toolShared.ts
@@ -6,8 +6,7 @@
 import path from 'path'
 import fs from '../../shared/fs/fs'
 
-export const maxToolResponseSize = 30720 // 30KB
-export const maxToolOutputCharacterLength = 800_000
+export const maxToolResponseSize = 800_000
 
 export enum OutputKind {
     Text = 'text',

--- a/packages/core/src/codewhispererChat/tools/toolUtils.ts
+++ b/packages/core/src/codewhispererChat/tools/toolUtils.ts
@@ -7,7 +7,7 @@ import { FsRead, FsReadParams } from './fsRead'
 import { FsWrite, FsWriteParams } from './fsWrite'
 import { CommandValidation, ExecuteBash, ExecuteBashParams } from './executeBash'
 import { ToolResult, ToolResultContentBlock, ToolResultStatus, ToolUse } from '@amzn/codewhisperer-streaming'
-import { InvokeOutput } from './toolShared'
+import { InvokeOutput, maxToolResponseSize } from './toolShared'
 import { ListDirectory, ListDirectoryParams } from './listDirectory'
 
 export enum ToolType {
@@ -60,6 +60,12 @@ export class ToolUtils {
                 return tool.tool.invoke(updates ?? undefined)
             case ToolType.ListDirectory:
                 return tool.tool.invoke(updates)
+        }
+    }
+
+    static validateOutput(output: InvokeOutput): void {
+        if (output.output.content.length > maxToolResponseSize) {
+            throw Error(`Tool output exceeds maximum character limit of ${maxToolResponseSize}`)
         }
     }
 

--- a/packages/core/src/test/codewhispererChat/tools/fsRead.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/fsRead.test.ts
@@ -54,20 +54,6 @@ describe('FsRead Tool', () => {
         )
     })
 
-    it('throws error if content exceeds 30KB', async function () {
-        const bigContent = 'x'.repeat(35_000)
-        const bigFilePath = await testFolder.write('bigFile.txt', bigContent)
-
-        const fsRead = new FsRead({ path: bigFilePath })
-        await fsRead.validate()
-
-        await assert.rejects(
-            fsRead.invoke(process.stdout),
-            /This tool only supports reading \d+ bytes at a time/i,
-            'Expected a size-limit error'
-        )
-    })
-
     it('invalid line range', async () => {
         const filePath = await testFolder.write('rangeTest.txt', '1\n2\n3')
         const fsRead = new FsRead({ path: filePath, readRange: [3, 2] })

--- a/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
@@ -155,6 +155,30 @@ describe('ToolUtils', function () {
         })
     })
 
+    describe('validateOutput', function () {
+        it('does not throw error if output is within size limit', function () {
+            const output: InvokeOutput = {
+                output: {
+                    kind: OutputKind.Text,
+                    content: 'a'.repeat(700_000),
+                },
+            }
+            assert.doesNotThrow(() => ToolUtils.validateOutput(output))
+        })
+        it('throws error if output exceeds max size', function () {
+            const output: InvokeOutput = {
+                output: {
+                    kind: OutputKind.Text,
+                    content: 'a'.repeat(900_000), // 900,000 characters
+                },
+            }
+            assert.throws(() => ToolUtils.validateOutput(output), {
+                name: 'Error',
+                message: 'Tool output exceeds maximum character limit of 800000',
+            })
+        })
+    })
+
     describe('queueDescription', function () {
         // TODO: Adding "void" to the following tests for the current implementation but in the next followup PR I will fix this issue.
         it('delegates to FsRead tool queueDescription method', function () {


### PR DESCRIPTION
## Problem
- fix(chat): Remove enforceMaxSize from fsRead
   - It had the wrong limit size of 30720

## Solution
- Remove it since we have toolResult size validation after executing the tool already

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
