### PR TITLE
deps(amazonq): Update to Mynah UI 4.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11957,9 +11957,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.27.0.tgz",
-            "integrity": "sha512-DkwenNLU+BHUYf0ntwkGllfjM+LrQXvCTiV2Eh7zV3HA59+ba5e34zge3sf7F71XukR9ckoKHXrxc0GjvVchbA==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.30.0.tgz",
+            "integrity": "sha512-ZUje97UxfhrxWoT8P4qKs3qRUq0c92gwFNxR6c4szpRZeEchPTqDP/HIX5KE6AEIeMFyiHx/qgDjmuNIc3kZyw==",
             "hasInstallScript": true,
             "dependencies": {
                 "escape-html": "^1.0.3",
@@ -26756,7 +26756,7 @@
                 "@aws-sdk/s3-request-presigner": "<3.731.0",
                 "@aws-sdk/smithy-client": "<3.731.0",
                 "@aws-sdk/util-arn-parser": "<3.731.0",
-                "@aws/mynah-ui": "^4.27.0",
+                "@aws/mynah-ui": "^4.30.0",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/fetch-http-handler": "^5.0.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-2daaf655-9a45-4104-94f9-06b9d8c703e2.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-2daaf655-9a45-4104-94f9-06b9d8c703e2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Update chat history icon"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-338b0a7b-81fd-460a-82f4-8e65e4a0614c.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-338b0a7b-81fd-460a-82f4-8e65e4a0614c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q chat: chat occasionally freezes and displays gray screen"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-338b0a7b-81fd-460a-82f4-8e65e4a0614c.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-338b0a7b-81fd-460a-82f4-8e65e4a0614c.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q chat: chat occasionally freezes and displays gray screen"
+	"description": "Amazon Q Chat: chat occasionally freezes and displays gray screen"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -524,7 +524,7 @@
         "@aws-sdk/s3-request-presigner": "<3.731.0",
         "@aws-sdk/smithy-client": "<3.731.0",
         "@aws-sdk/util-arn-parser": "<3.731.0",
-        "@aws/mynah-ui": "^4.27.0",
+        "@aws/mynah-ui": "^4.30.0",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/fetch-http-handler": "^5.0.1",

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -970,7 +970,7 @@ export const createMynahUI = (
             tabBarButtons: [
                 {
                     id: 'history_sheet',
-                    icon: MynahIcons.COMMENT,
+                    icon: MynahIcons.HISTORY,
                     description: 'View chat history',
                 },
                 /* Temporarily hide export chat button from tab bar


### PR DESCRIPTION
## Problem
* Amazon Q extension sometimes crashed with a grey screen
* Chat history icon was not easy for users to identify

## Solution
* Update to [Mynah UI 4.30.0](https://github.com/aws/mynah-ui/releases)

Before (old icon)
<img width="412" alt="Screenshot 2025-04-08 at 12 14 38 PM" src="https://github.com/user-attachments/assets/e388c30c-b671-45ff-9d6a-c548f2a9b139" />
After (new icon)
<img width="413" alt="Screenshot 2025-04-08 at 12 16 46 PM" src="https://github.com/user-attachments/assets/6e41e99d-9a44-4b4d-a68c-8830c5ac6721" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
