### PR TITLE
fix(amazonq): Set owner-only permissions for chat history and prompts

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b6e474f1-b7ef-4016-8e1c-c9e7e6a45cc2.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b6e474f1-b7ef-4016-8e1c-c9e7e6a45cc2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: Set owner-only permissions for chat history and saved prompt files"
+}

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -638,7 +638,7 @@ export class ChatController {
                 title ? `${title}${promptFileExtension}` : `default${promptFileExtension}`
             )
             const newFileContent = new Uint8Array(Buffer.from(''))
-            await fs.writeFile(newFilePath, newFileContent)
+            await fs.writeFile(newFilePath, newFileContent, { mode: 0o600 })
             const newFileDoc = await vscode.workspace.openTextDocument(newFilePath)
             await vscode.window.showTextDocument(newFileDoc)
             telemetry.ui_click.emit({ elementId: 'amazonq_createSavedPrompt' })

--- a/packages/core/src/shared/db/chatDb/util.ts
+++ b/packages/core/src/shared/db/chatDb/util.ts
@@ -142,7 +142,7 @@ export class FileSystemAdapter implements LokiPersistenceAdapter {
             await this.ensureDirectory()
             const filename = path.join(this.directory, dbname)
 
-            await fs.writeFile(filename, dbstring, 'utf8')
+            await fs.writeFile(filename, dbstring, { mode: 0o600, encoding: 'utf8' })
             callback(undefined)
         } catch (err: any) {
             callback(err)


### PR DESCRIPTION
## Problem
Chat history and saved prompt files are created with default global read permissions

## Solution
Add owner only read/write permissions to newly created saved prompt and chat history files

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
