### PR TITLE
feat(amazonq): enable export chat feature

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-4b7ab0af-2fe3-4e21-be78-5fcb1896257c.json
+++ b/packages/amazonq/.changes/next-release/Feature-4b7ab0af-2fe3-4e21-be78-5fcb1896257c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q chat: Click export icon to save chat transcript in Markdown or HTML"
+}

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -973,12 +973,11 @@ export const createMynahUI = (
                     icon: MynahIcons.COMMENT,
                     description: 'View chat history',
                 },
-                /* Temporarily hide export chat button from tab bar
                 {
                     id: 'export_chat',
                     icon: MynahIcons.EXTERNAL,
                     description: 'Export chat',
-                }, */
+                },
             ],
         },
     })

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -90,7 +90,7 @@ export class Messenger {
                     followUpsHeader: undefined,
                     relatedSuggestions: undefined,
                     triggerID,
-                    messageID: '',
+                    messageID: triggerID,
                     userIntent: undefined,
                     codeBlockLanguage: undefined,
                     contextList: mergedRelevantDocuments,

--- a/packages/core/src/shared/db/chatDb/util.ts
+++ b/packages/core/src/shared/db/chatDb/util.ts
@@ -251,12 +251,11 @@ export function groupTabsByDate(tabs: Tab[]): DetailedListItemGroup[] {
 }
 
 const getConversationActions = (historyId: string): ChatItemButton[] => [
-    /* Temporarily hide export chat button from tab bar
     {
         text: 'Export',
         icon: 'external' as MynahIconsType,
         id: historyId,
-    }, */
+    },
     {
         text: 'Delete',
         icon: 'trash' as MynahIconsType,


### PR DESCRIPTION

## Problem
Users don't have a way to export an Amazon Q chat

## Solution
Add an export icon to chat tab bar and, allow users to export conversations from chat history. Users can choose Markdown or HTML format

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
