### PR TITLE
feat(amazonq): Add @Code context for PHP, Ruby, Scala, Shell, and Swift

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-846afd38-d618-4bd1-a3aa-7c74597502f1.json
+++ b/packages/amazonq/.changes/next-release/Feature-846afd38-d618-4bd1-a3aa-7c74597502f1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q Chat: Add @Code context for PHP, Ruby, Scala, Shell, and Swift projects"
+}

--- a/packages/core/src/amazonq/lsp/config.ts
+++ b/packages/core/src/amazonq/lsp/config.ts
@@ -16,7 +16,7 @@ export interface LspConfig {
 
 export const defaultAmazonQWorkspaceLspConfig: LspConfig = {
     manifestUrl: 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json',
-    supportedVersions: '0.1.46',
+    supportedVersions: '0.1.47',
     id: 'AmazonQ-Workspace', // used across IDEs for identifying global storage/local disk locations. Do not change.
     suppressPromptPrefix: 'amazonQWorkspace',
     path: undefined,

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -188,7 +188,7 @@ export class LspClient {
                 GetContextCommandPromptRequestType,
                 await this.encrypt(request)
             )
-            return resp
+            return resp || []
         } catch (e) {
             getLogger().error(`LspClient: getContextCommandPrompt error: ${e}`)
             throw e

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -577,13 +577,7 @@ export class ChatController {
                         id: contextCommandItem.id,
                         icon: 'folder' as MynahIconsType,
                     })
-                }
-                // TODO: Remove the limit of 25k once the performance issue of mynahUI in webview is fixed.
-                else if (
-                    contextCommandItem.symbol &&
-                    symbolsCmd.children &&
-                    symbolsCmd.children[0].commands.length < 25_000
-                ) {
+                } else if (contextCommandItem.symbol && symbolsCmd.children) {
                     symbolsCmd.children?.[0].commands.push({
                         command: contextCommandItem.symbol.name,
                         description: `${contextCommandItem.symbol.kind}, ${path.join(wsFolderName, contextCommandItem.relativePath)}, L${contextCommandItem.symbol.range.start.line}-${contextCommandItem.symbol.range.end.line}`,


### PR DESCRIPTION

## Problem
Users can't add `@Code` context from PHP, Ruby, Scala, Shell, and Swift files

## Solution
Add support for adding `@Code` context for PHP, Ruby, Scala, Shell, and Swift

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
