### PR TITLE
feat(amazonq): Add conversation persistence to agentic chat

### DIFF
--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -21,6 +21,8 @@ export type ToolUseWithError = {
     toolUse: ToolUse
     error: Error | undefined
 }
+import { getLogger } from '../../../../shared/logger/logger'
+import { randomUUID } from '../../../../shared/crypto'
 
 export class ChatSession {
     private sessionId?: string
@@ -141,6 +143,10 @@ export class ChatSession {
         }
 
         this.sessionId = response.conversationId
+        if (this.sessionId?.length === 0) {
+            getLogger().debug(`Session ID: ${this.sessionId} is empty. Generating random UUID`)
+            this.sessionId = randomUUID()
+        }
 
         UserWrittenCodeTracker.instance.onQFeatureInvoked()
 

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1497,13 +1497,15 @@ export class ChatController {
             }
             this.telemetryHelper.recordEnterFocusConversation(triggerEvent.tabID)
             this.telemetryHelper.recordStartConversation(triggerEvent, triggerPayload)
-            if (currentMessage) {
+
+            if (currentMessage && session.sessionIdentifier) {
                 chatHistory.appendUserMessage(currentMessage)
-            }
-            if (session.sessionIdentifier) {
                 this.chatHistoryDb.addMessage(tabID, 'cwc', session.sessionIdentifier, {
                     body: triggerPayload.message,
                     type: 'prompt' as any,
+                    userIntent: currentMessage.userInputMessage?.userIntent,
+                    origin: currentMessage.userInputMessage?.origin,
+                    userInputMessageContext: currentMessage.userInputMessage?.userInputMessageContext,
                 })
             }
 

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -379,6 +379,11 @@ export class Messenger {
                         type: 'answer' as any,
                         codeReference: codeReference as any,
                         relatedContent: { title: 'Sources', content: relatedSuggestions as any },
+                        messageId: messageID,
+                        toolUses:
+                            toolUse && toolUse.input !== undefined && toolUse.input !== ''
+                                ? [{ ...toolUse }]
+                                : undefined,
                     })
                 }
                 if (

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -21,6 +21,7 @@ export type LogTopic =
     | 'executeBash'
     | 'listDirectory'
     | 'chatStream'
+    | 'chatHistoryDb'
     | 'unknown'
 
 class ErrorLog {


### PR DESCRIPTION
## Problem
Users lose all chats when they close VSCode, and there's no way to browse through chat history. Users also cant export their conversations to an easily shareable format.

## Solution
Automatically persist conversations to JSON files in ~/.aws/amazonq/history, one for each workspace where Amazon Q chats occur. Add chat history and chat export buttons to top of Amazon Q toolbar. Clicking on the chat history button allows users to browse and search through chat history. Users click on an old conversation to open it back up (currently open conversations are in bold). Clicking on chat export button allows users to save chat transcript as a markdown or html.

Note: persistence + history is only for Q Chat Tabs (not /dev, /doc, /transform, etc.)


![Screenshot 2025-04-08 at 12 03 11 PM](https://github.com/user-attachments/assets/9b383294-5e0a-499b-a4e8-993dd73b555c)

## Note
Agentic chat does not currently use this persisted history in it's context. Follow-up PR will address this issue.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
