### PR TITLE
feat(chat): Call LLM to get response of shell command rejection

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -806,6 +806,18 @@ export class ChatController {
             type: 'chat_message',
             context: undefined,
         })
+
+        const session = this.sessionStorage.getSession(message.tabID!)
+        const currentToolUse = session.toolUseWithError?.toolUse
+        if (currentToolUse && currentToolUse.name === ToolType.ExecuteBash) {
+            session.toolUseWithError.error = new Error('Tool use was rejected by the user.')
+        } else {
+            getLogger().error(
+                `toolUse name: ${currentToolUse!.name} of toolUseWithError in the stored session doesn't match when click shell command reject button.`
+            )
+            return
+        }
+
         await this.generateStaticTextResponse('reject-shell-command', triggerId)
     }
 
@@ -827,6 +839,7 @@ export class ChatController {
                 break
             case 'reject-shell-command':
                 await this.rejectShellCommand(message)
+                await this.processToolUseMessage(message)
                 break
             default:
                 getLogger().warn(`Unhandled action: ${message.action.id}`)


### PR DESCRIPTION
## Problem
- after user click the reject button of running shell command, we call LLM to get response of shell command rejection

## Solution
![image](https://github.com/user-attachments/assets/7ee4ad3f-44df-4941-80b3-c33dcbc9919f)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
