### PR TITLE
fix(chat): only show context on first message

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1177,9 +1177,6 @@ export class ChatController {
 
                 this.messenger.sendAsyncEventProgress(message.tabID, true, '')
 
-                // Save the context for the agentic loop
-                session.setContext(message.context)
-
                 await this.generateResponse(
                     {
                         message: message.message ?? '',
@@ -1480,7 +1477,12 @@ export class ChatController {
         let response: MessengerResponseType | undefined = undefined
         session.createNewTokenSource()
         try {
-            this.messenger.sendInitalStream(tabID, triggerID, triggerPayload.documentReferences)
+            if (!session.context) {
+                // Only show context for the first message in the loop
+                this.messenger.sendContextMessage(tabID, triggerID, triggerPayload.documentReferences)
+                session.setContext(triggerPayload.context)
+            }
+            this.messenger.sendInitalStream(tabID, triggerID)
             this.telemetryHelper.setConversationStreamStartTime(tabID)
             if (isSsoConnection(AuthUtil.instance.conn)) {
                 const { $metadata, generateAssistantResponseResponse } = await session.chatSso(request)

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -103,11 +103,7 @@ export class Messenger {
         )
     }
 
-    public sendInitalStream(
-        tabID: string,
-        triggerID: string,
-        mergedRelevantDocuments: DocumentReference[] | undefined
-    ) {
+    public sendInitalStream(tabID: string, triggerID: string) {
         this.dispatcher.sendChatMessage(
             new ChatMessage(
                 {
@@ -120,8 +116,7 @@ export class Messenger {
                     messageID: '',
                     userIntent: undefined,
                     codeBlockLanguage: undefined,
-                    contextList: mergedRelevantDocuments,
-                    title: 'Context',
+                    contextList: undefined,
                     buttons: undefined,
                     fileList: undefined,
                     canBeVoted: false,
@@ -130,6 +125,36 @@ export class Messenger {
             )
         )
     }
+
+    public sendContextMessage(
+        tabID: string,
+        triggerID: string,
+        mergedRelevantDocuments: DocumentReference[] | undefined
+    ) {
+        this.dispatcher.sendChatMessage(
+            new ChatMessage(
+                {
+                    message: '',
+                    messageType: 'answer',
+                    followUps: undefined,
+                    followUpsHeader: undefined,
+                    relatedSuggestions: undefined,
+                    triggerID,
+                    messageID: '',
+                    userIntent: undefined,
+                    codeBlockLanguage: undefined,
+                    contextList: mergedRelevantDocuments,
+                    title: 'Context',
+                    buttons: undefined,
+                    fileList: undefined,
+                    canBeVoted: false,
+                    padding: false,
+                },
+                tabID
+            )
+        )
+    }
+
     /**
      * Tries to calculate the total number of code blocks.
      * NOTES:
@@ -455,6 +480,11 @@ export class Messenger {
                             toolUse.input !== '' && { toolUses: [{ ...toolUse }] }),
                     },
                 })
+                const agenticLoopEnded = !eventCounts.has('toolUseEvent')
+                if (agenticLoopEnded) {
+                    // Reset context for the next request
+                    session.setContext(undefined)
+                }
 
                 getLogger().info(
                     `All events received. requestId=%s counts=%s`,

--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -28,7 +28,7 @@ export class ChatStream extends Writable {
     ) {
         super()
         this.logger.debug(`ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}`)
-        this.messenger.sendInitalStream(tabID, triggerID, undefined)
+        this.messenger.sendInitalStream(tabID, triggerID)
     }
 
     override _write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {


### PR DESCRIPTION
## Problem
Context is shown repeatedly in the UI if it is provided.

<img width="754" alt="image" src="https://github.com/user-attachments/assets/30f51f7c-e504-46a6-b416-9bbd9b06023e" />


## Solution
- Separate initial stream and context messages into separate functions
- Only show context on the first message of the loop

<img width="679" alt="image" src="https://github.com/user-attachments/assets/aefca516-e04f-4a29-b6e4-92236acc37c8" />




---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
