### PR TITLE
fix(amazonq): inline chat now activates independently of LSP chat

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-45379b8c-1faa-4b04-951a-26e234c6dc03.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-45379b8c-1faa-4b04-951a-26e234c6dc03.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "inline chat activates properly when using 'aws.experiments.amazonqChatLSP' feature flag"
+}

--- a/packages/amazonq/src/app/chat/activation.ts
+++ b/packages/amazonq/src/app/chat/activation.ts
@@ -10,7 +10,6 @@ import { AuthUtil, CodeWhispererSettings } from 'aws-core-vscode/codewhisperer'
 import { Commands, placeholder, funcUtil } from 'aws-core-vscode/shared'
 import * as amazonq from 'aws-core-vscode/amazonq'
 import { scanChatAppInit } from '../amazonqScan'
-import { init as inlineChatInit } from '../../inlineChat/app'
 
 export async function activate(context: ExtensionContext) {
     const appInitContext = amazonq.DefaultAmazonQAppInitContext.instance
@@ -72,7 +71,6 @@ function registerApps(appInitContext: amazonq.AmazonQAppInitContext, context: Ex
     amazonq.testChatAppInit(appInitContext)
     scanChatAppInit(appInitContext)
     amazonq.docChatAppInit(appInitContext)
-    inlineChatInit(context)
 }
 
 /**

--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -25,6 +25,7 @@ import { DevOptions } from 'aws-core-vscode/dev'
 import { Auth, AuthUtils, getTelemetryMetadataForConn, isAnySsoConnection } from 'aws-core-vscode/auth'
 import api from './api'
 import { activate as activateCWChat } from './app/chat/activation'
+import { activate as activateInlineChat } from './inlineChat/activation'
 import { beta } from 'aws-core-vscode/dev'
 import { activate as activateNotifications, NotificationsController } from 'aws-core-vscode/notifications'
 import { AuthState, AuthUtil } from 'aws-core-vscode/codewhisperer'
@@ -55,6 +56,7 @@ async function activateAmazonQNode(context: vscode.ExtensionContext) {
         await activateCWChat(context)
         await activateQGumby(extContext as ExtContext)
     }
+    activateInlineChat(context)
 
     const authProvider = new CommonAuthViewProvider(
         context,

--- a/packages/amazonq/src/inlineChat/activation.ts
+++ b/packages/amazonq/src/inlineChat/activation.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode'
-import { InlineChatController } from '../inlineChat/controller/inlineChatController'
-import { registerInlineCommands } from '../inlineChat/command/registerInlineCommands'
+import { InlineChatController } from './controller/inlineChatController'
+import { registerInlineCommands } from './command/registerInlineCommands'
 
-export function init(context: vscode.ExtensionContext) {
+export function activate(context: vscode.ExtensionContext) {
     const inlineChatController = new InlineChatController(context)
     registerInlineCommands(context, inlineChatController)
 }


### PR DESCRIPTION
## Problem
When toggling the experiment via, the `aws.experiments.amazonqChatLSP` flag in settings, inline chat fails to activate. Specifically, it appears the command fails to register.
```
command 'aws.amazonq.inline.invokeChat' not found
```

This happened because inline chat was activated as part of regular chat. When we use LSP chat, this then never gets activated. 

## Solution
- Activate inline chat independently of regular chat. 

## Testing 
- Verified the fix by running extension with and without `aws.experiments.amazonqChatLSP` flag and using inlineChat in both cases. One of these cases is shown in the demo below. 

## Notes
This will have to change once we consume LSP inline chat, as we don't want to activate both our inline chat and Flare's. 

## Quick Demo



https://github.com/user-attachments/assets/7e6f140d-2b3b-4ce4-9df1-01a1d713c02f



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
