### PR TITLE
fix(chat): Use shell icon in shell command header

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -361,7 +361,7 @@ export class Connector extends BaseConnector {
                 break
             case 'run-shell-command':
                 answer.header = {
-                    icon: 'code-block' as MynahIconsType,
+                    icon: 'shell' as MynahIconsType,
                     body: 'shell',
                     status: {
                         icon: 'ok' as MynahIconsType,
@@ -372,7 +372,7 @@ export class Connector extends BaseConnector {
                 break
             case 'reject-shell-command':
                 answer.header = {
-                    icon: 'code-block' as MynahIconsType,
+                    icon: 'shell' as MynahIconsType,
                     body: 'shell',
                     status: {
                         icon: 'cancel' as MynahIconsType,

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -812,10 +812,7 @@ export class ChatController {
             getLogger().error(
                 `toolUse name: ${currentToolUse!.name} of toolUseWithError in the stored session doesn't match when click shell command reject button.`
             )
-            return
         }
-
-        await this.generateStaticTextResponse('reject-shell-command', triggerId)
     }
 
     private async processCustomFormAction(message: CustomFormActionMessage) {

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -69,12 +69,7 @@ import { AsyncEventProgressMessage } from '../../../../amazonq/commons/connector
 import { localize } from '../../../../shared/utilities/vsCodeUtils'
 import { getDiffLinesFromChanges } from '../../../../shared/utilities/diffUtils'
 
-export type StaticTextResponseType =
-    | 'quick-action-help'
-    | 'onboarding-help'
-    | 'transform'
-    | 'help'
-    | 'reject-shell-command'
+export type StaticTextResponseType = 'quick-action-help' | 'onboarding-help' | 'transform' | 'help'
 
 export type MessengerResponseType = {
     $metadata: { requestId?: string; httpStatusCode?: number }
@@ -555,7 +550,7 @@ export class Messenger {
                     },
                 ]
                 header = {
-                    icon: 'code-block' as MynahIconsType,
+                    icon: 'shell' as MynahIconsType,
                     body: 'shell',
                     buttons,
                 }
@@ -675,10 +670,6 @@ export class Messenger {
                     },
                 ]
                 followUpsHeader = 'Try Examples:'
-                break
-            case 'reject-shell-command':
-                // need to update the string later
-                message = 'The shell command execution rejected. Abort.'
                 break
         }
 


### PR DESCRIPTION
Remove static response string for shell command reject

## Problem
- Use shell icon in shell command header
- Remove static response string for shell command reject

## Solution
![image](https://github.com/user-attachments/assets/d67b87c5-b103-4b84-a9ba-e08ed457b1d4)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
