### PR TITLE
fix(amazonq): Grouping read tool messages under contextList

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -178,6 +178,32 @@ export class Connector extends BaseConnector {
         }
     }
 
+    private processToolMessage = async (messageData: any): Promise<void> => {
+        if (this.onChatAnswerUpdated === undefined) {
+            return
+        }
+        const answer: CWCChatItem = {
+            type: messageData.messageType,
+            messageId: messageData.messageID ?? messageData.triggerID,
+            body: messageData.message,
+            followUp: messageData.followUps,
+            canBeVoted: messageData.canBeVoted ?? false,
+            codeReference: messageData.codeReference,
+            userIntent: messageData.contextList,
+            codeBlockLanguage: messageData.codeBlockLanguage,
+            contextList: messageData.contextList,
+            title: messageData.title,
+            buttons: messageData.buttons,
+            fileList: messageData.fileList,
+            header: messageData.header ?? undefined,
+            padding: messageData.padding ?? undefined,
+            fullWidth: messageData.fullWidth ?? undefined,
+            codeBlockActions: messageData.codeBlockActions ?? undefined,
+        }
+        this.onChatAnswerUpdated(messageData.tabID, answer)
+        return
+    }
+
     private storeChatItem(tabId: string, messageId: string, item: ChatItem): void {
         if (!this.chatItems.has(tabId)) {
             this.chatItems.set(tabId, new Map())
@@ -234,6 +260,11 @@ export class Connector extends BaseConnector {
     handleMessageReceive = async (messageData: any): Promise<void> => {
         if (messageData.type === 'chatMessage') {
             await this.processChatMessage(messageData)
+            return
+        }
+
+        if (messageData.type === 'toolMessage') {
+            await this.processToolMessage(messageData)
             return
         }
 

--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -200,6 +200,7 @@ export class Connector extends BaseConnector {
             padding: messageData.padding ?? undefined,
             fullWidth: messageData.fullWidth ?? undefined,
             codeBlockActions: messageData.codeBlockActions ?? undefined,
+            rootFolderTitle: messageData.rootFolderTitle,
         }
         this.onChatAnswerUpdated(messageData.tabID, answer)
         return

--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -392,7 +392,6 @@ export class Connector extends BaseConnector {
                 break
             case 'run-shell-command':
                 answer.header = {
-                    icon: 'shell' as MynahIconsType,
                     body: 'shell',
                     status: {
                         icon: 'ok' as MynahIconsType,
@@ -403,7 +402,6 @@ export class Connector extends BaseConnector {
                 break
             case 'reject-shell-command':
                 answer.header = {
-                    icon: 'shell' as MynahIconsType,
                     body: 'shell',
                     status: {
                         icon: 'cancel' as MynahIconsType,

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -77,7 +77,7 @@ export interface ConnectorProps {
     sendMessageToExtension: (message: ExtensionMessage) => void
     onMessageReceived?: (tabID: string, messageData: any, needToShowAPIDocsTab: boolean) => void
     onRunTestMessageReceived?: (tabID: string, showRunTestMessage: boolean) => void
-    onChatAnswerUpdated?: (tabID: string, message: ChatItem) => void
+    onChatAnswerUpdated?: (tabID: string, message: CWCChatItem) => void
     onChatAnswerReceived?: (tabID: string, message: ChatItem, messageData: any) => void
     onWelcomeFollowUpClicked: (tabID: string, welcomeFollowUpType: WelcomeFollowupType) => void
     onAsyncEventProgress: (tabID: string, inProgress: boolean, message: string | undefined) => void

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -101,15 +101,15 @@ export const createMynahUI = (
     /**
      * Creates a file list header from context list
      * @param contextList List of file contexts
-     * @param title Title for the root folder
+     * @param rootFolderTitle Title for the root folder
      * @returns Header object with file list
      */
-    const createFileListHeader = (contextList: any[], title?: string) => {
+    const createFileListHeader = (contextList: any[], rootFolderTitle?: string) => {
         return {
             fileList: {
                 fileTreeTitle: '',
                 filePaths: contextList.map((file) => file.relativeFilePath),
-                rootFolderTitle: title,
+                rootFolderTitle: rootFolderTitle,
                 flatList: true,
                 collapsed: true,
                 hideFileCount: true,
@@ -380,7 +380,7 @@ export const createMynahUI = (
         onChatAnswerUpdated: (tabID: string, item: CWCChatItem) => {
             if (item.messageId !== undefined) {
                 if (item.contextList !== undefined && item.contextList.length > 0) {
-                    item.header = createFileListHeader(item.contextList, item.title)
+                    item.header = createFileListHeader(item.contextList, item.rootFolderTitle)
                 }
                 mynahUI.updateChatAnswerWithMessageId(tabID, item.messageId, {
                     ...(item.body !== undefined ? { body: item.body } : {}),

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -98,6 +98,41 @@ export const createMynahUI = (
         welcomeCount += 1
     }
 
+    /**
+     * Creates a file list header from context list
+     * @param contextList List of file contexts
+     * @param title Title for the root folder
+     * @returns Header object with file list
+     */
+    const createFileListHeader = (contextList: any[], title?: string) => {
+        return {
+            fileList: {
+                fileTreeTitle: '',
+                filePaths: contextList.map((file) => file.relativeFilePath),
+                rootFolderTitle: title,
+                flatList: true,
+                collapsed: true,
+                hideFileCount: true,
+                details: Object.fromEntries(
+                    contextList.map((file) => [
+                        file.relativeFilePath,
+                        {
+                            label: file.lineRanges
+                                .map((range: { first: number; second: number }) =>
+                                    range.first === -1 || range.second === -1
+                                        ? ''
+                                        : `line ${range.first} - ${range.second}`
+                                )
+                                .join(', '),
+                            description: file.relativeFilePath,
+                            clickable: true,
+                        },
+                    ])
+                ),
+            },
+        }
+    }
+
     // Adding the first tab as CWC tab
     tabsStorage.addTab({
         id: 'tab-1',
@@ -342,8 +377,11 @@ export const createMynahUI = (
         sendMessageToExtension: (message) => {
             ideApi.postMessage(message)
         },
-        onChatAnswerUpdated: (tabID: string, item: ChatItem) => {
+        onChatAnswerUpdated: (tabID: string, item: CWCChatItem) => {
             if (item.messageId !== undefined) {
+                if (item.contextList !== undefined && item.contextList.length > 0) {
+                    item.header = createFileListHeader(item.contextList, item.title)
+                }
                 mynahUI.updateChatAnswerWithMessageId(tabID, item.messageId, {
                     ...(item.body !== undefined ? { body: item.body } : {}),
                     ...(item.buttons !== undefined ? { buttons: item.buttons } : {}),
@@ -405,32 +443,7 @@ export const createMynahUI = (
             }
 
             if (item.contextList !== undefined && item.contextList.length > 0) {
-                item.header = {
-                    fileList: {
-                        fileTreeTitle: '',
-                        filePaths: item.contextList.map((file) => file.relativeFilePath),
-                        rootFolderTitle: item.title,
-                        flatList: true,
-                        collapsed: true,
-                        hideFileCount: true,
-                        details: Object.fromEntries(
-                            item.contextList.map((file) => [
-                                file.relativeFilePath,
-                                {
-                                    label: file.lineRanges
-                                        .map((range) =>
-                                            range.first === -1 || range.second === -1
-                                                ? ''
-                                                : `line ${range.first} - ${range.second}`
-                                        )
-                                        .join(', '),
-                                    description: file.relativeFilePath,
-                                    clickable: true,
-                                },
-                            ])
-                        ),
-                    },
-                }
+                item.header = createFileListHeader(item.contextList, item.title)
             }
 
             if (

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -33,6 +33,7 @@ export class ChatSession {
      * _messageIdToUpdate = messageId of a chat message to be updated, used for reducing consecutive tool messages
      */
     private _readFiles: DocumentReference[] = []
+    private _readFolders: DocumentReference[] = []
     private _toolUseWithError: ToolUseWithError | undefined
     private _showDiffOnFileWrite: boolean = false
     private _context: PromptMessage['context']
@@ -43,6 +44,7 @@ export class ChatSession {
      */
     localHistoryHydrated: boolean = false
     private _messageIdToUpdate: string | undefined
+    private _messageIdToUpdateListDirectory: string | undefined
 
     contexts: Map<string, { first: number; second: number }[]> = new Map()
     // TODO: doesn't handle the edge case when two files share the same relativePath string but from different root
@@ -57,6 +59,14 @@ export class ChatSession {
 
     public setMessageIdToUpdate(messageId: string | undefined) {
         this._messageIdToUpdate = messageId
+    }
+
+    public get messageIdToUpdateListDirectory(): string | undefined {
+        return this._messageIdToUpdateListDirectory
+    }
+
+    public setMessageIdToUpdateListDirectory(messageId: string | undefined) {
+        this._messageIdToUpdateListDirectory = messageId
     }
 
     public get pairProgrammingModeOn(): boolean {
@@ -107,6 +117,9 @@ export class ChatSession {
     public get readFiles(): DocumentReference[] {
         return this._readFiles
     }
+    public get readFolders(): DocumentReference[] {
+        return this._readFolders
+    }
     public get showDiffOnFileWrite(): boolean {
         return this._showDiffOnFileWrite
     }
@@ -118,6 +131,12 @@ export class ChatSession {
     }
     public clearListOfReadFiles() {
         this._readFiles = []
+    }
+    public setReadFolders(folder: DocumentReference) {
+        this._readFolders.push(folder)
+    }
+    public clearListOfReadFolders() {
+        this._readFolders = []
     }
     async chatIam(chatRequest: SendMessageRequest): Promise<SendMessageCommandOutput> {
         const client = await createQDeveloperStreamingClient()

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -716,9 +716,18 @@ export class ChatController {
                         try {
                             await ToolUtils.validate(tool)
 
-                            const chatStream = new ChatStream(this.messenger, tabID, triggerID, toolUse, {
-                                requiresAcceptance: false,
-                            })
+                            const chatStream = new ChatStream(
+                                this.messenger,
+                                tabID,
+                                triggerID,
+                                { ...toolUse, toolUseId: `${toolUse.toolUseId}-output` },
+                                session,
+                                undefined,
+                                false,
+                                {
+                                    requiresAcceptance: false,
+                                }
+                            )
                             if (tool.type === ToolType.FsWrite && toolUse.toolUseId) {
                                 const backup = await tool.tool.getBackup()
                                 session.setFsWriteBackup(toolUse.toolUseId, backup)

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1178,6 +1178,7 @@ export class ChatController {
     private async processPromptMessageAsNewThread(message: PromptMessage) {
         const session = this.sessionStorage.getSession(message.tabID)
         session.clearListOfReadFiles()
+        session.clearListOfReadFolders()
         session.setShowDiffOnFileWrite(false)
         this.editorContextExtractor
             .extractContextForTrigger('ChatMessage')

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -720,7 +720,7 @@ export class ChatController {
                                 this.messenger,
                                 tabID,
                                 triggerID,
-                                { ...toolUse, toolUseId: `${toolUse.toolUseId}-output` },
+                                toolUse,
                                 session,
                                 undefined,
                                 false,

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -670,7 +670,10 @@ export class Messenger {
                         fullWidth: false,
                         padding: true,
                         codeBlockActions: undefined,
-                        title: 'Reading Files',
+                        title:
+                            session.readFiles.length > 1
+                                ? `Files Read ${session.readFiles.length} files`
+                                : `File Read 1 file`,
                     },
                     tabID
                 )

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -622,7 +622,7 @@ export class Messenger {
                     fullWidth: false,
                     padding: false,
                     codeBlockActions: undefined,
-                    title,
+                    rootFolderTitle: title,
                 },
                 tabID
             )

--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -9,6 +9,8 @@ import { Messenger } from '../controllers/chat/messenger/messenger'
 import { ToolUse } from '@amzn/codewhisperer-streaming'
 import { CommandValidation } from './executeBash'
 import { Change } from 'diff'
+import { ChatSession } from '../clients/chat/v0/chat'
+import { ToolType } from './toolUtils'
 
 /**
  * A writable stream that feeds each chunk/line to the chat UI.
@@ -22,28 +24,49 @@ export class ChatStream extends Writable {
         private readonly tabID: string,
         private readonly triggerID: string,
         private readonly toolUse: ToolUse | undefined,
+        private readonly session: ChatSession,
+        private readonly messageIdToUpdate: string | undefined,
+        // emitEvent decides to show the read toolMessage to the user.
+        private readonly emitEvent: boolean,
         private readonly validation: CommandValidation,
         private readonly changeList?: Change[],
         private readonly logger = getLogger('chatStream')
     ) {
         super()
-        this.logger.debug(`ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}`)
-        this.messenger.sendInitalStream(tabID, triggerID)
+        this.logger.debug(
+            `ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}, session: ${session.readFiles}, emitEvent to mynahUI: ${emitEvent}`
+        )
+        if (toolUse?.name === ToolType.FsRead && emitEvent) {
+            if (!messageIdToUpdate) {
+                // If messageIdToUpdate is undefined, we need to first create an empty message
+                // with messageId so it can be updated later
+                this.messenger.sendInitialToolMessage(tabID, triggerID, toolUse?.toolUseId)
+            }
+        } else if (!(toolUse?.name === ToolType.FsRead)) {
+            this.messenger.sendInitalStream(tabID, triggerID)
+        }
     }
 
     override _write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
-        const text = chunk.toString()
-        this.accumulatedLogs += text
-        this.logger.debug(`ChatStream received chunk: ${text}`)
-        this.messenger.sendPartialToolLog(
-            this.accumulatedLogs,
-            this.tabID,
-            this.triggerID,
-            this.toolUse,
-            this.validation,
-            this.changeList
-        )
-        callback()
+        try {
+            const text = chunk.toString()
+            this.accumulatedLogs += text
+            this.logger.debug(`ChatStream received chunk: ${text}, emitEvent to mynahUI: ${this.emitEvent}`)
+            this.messenger.sendPartialToolLog(
+                this.accumulatedLogs,
+                this.tabID,
+                this.triggerID,
+                this.toolUse,
+                this.session,
+                this.messageIdToUpdate,
+                this.validation,
+                this.changeList
+            )
+            callback()
+        } catch (error) {
+            this.logger.error(`Error in ChatStream.write: ${error}`)
+            callback(error instanceof Error ? error : new Error(String(error)))
+        }
     }
 
     override _final(callback: (error?: Error | null) => void): void {

--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -10,7 +10,6 @@ import { ToolUse } from '@amzn/codewhisperer-streaming'
 import { CommandValidation } from './executeBash'
 import { Change } from 'diff'
 import { ChatSession } from '../clients/chat/v0/chat'
-import { ToolType } from './toolUtils'
 
 /**
  * A writable stream that feeds each chunk/line to the chat UI.
@@ -26,7 +25,7 @@ export class ChatStream extends Writable {
         private readonly toolUse: ToolUse | undefined,
         private readonly session: ChatSession,
         private readonly messageIdToUpdate: string | undefined,
-        // emitEvent decides to show the read toolMessage to the user.
+        // emitEvent decides to show the streaming message or read/list directory tool message to the user.
         private readonly emitEvent: boolean,
         private readonly validation: CommandValidation,
         private readonly changeList?: Change[],
@@ -36,15 +35,13 @@ export class ChatStream extends Writable {
         this.logger.debug(
             `ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}, session: ${session.readFiles}, emitEvent to mynahUI: ${emitEvent}`
         )
-        if (toolUse?.name === ToolType.FsRead && emitEvent) {
-            if (!messageIdToUpdate) {
-                // If messageIdToUpdate is undefined, we need to first create an empty message
-                // with messageId so it can be updated later
-                this.messenger.sendInitialToolMessage(tabID, triggerID, toolUse?.toolUseId)
-            }
-        } else if (!(toolUse?.name === ToolType.FsRead)) {
-            this.messenger.sendInitalStream(tabID, triggerID)
+        if (!emitEvent) {
+            return
         }
+        // If messageIdToUpdate is undefined, we need to first create an empty message with messageId so it can be updated later
+        messageIdToUpdate
+            ? this.messenger.sendInitalStream(tabID, triggerID)
+            : this.messenger.sendInitialToolMessage(tabID, triggerID, toolUse?.toolUseId)
     }
 
     override _write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {

--- a/packages/core/src/codewhispererChat/tools/fsRead.ts
+++ b/packages/core/src/codewhispererChat/tools/fsRead.ts
@@ -7,7 +7,6 @@ import { getLogger } from '../../shared/logger/logger'
 import fs from '../../shared/fs/fs'
 import { InvokeOutput, OutputKind, sanitizePath } from './toolShared'
 import { Writable } from 'stream'
-import path from 'path'
 
 export interface FsReadParams {
     path: string
@@ -48,23 +47,7 @@ export class FsRead {
     }
 
     public queueDescription(updates: Writable): void {
-        const fileName = path.basename(this.fsPath)
-        const fileUri = vscode.Uri.file(this.fsPath)
-        updates.write(`Reading file: [${fileName}](${fileUri}), `)
-
-        const [start, end] = this.readRange ?? []
-
-        if (start && end) {
-            updates.write(`from line ${start} to ${end}`)
-        } else if (start) {
-            if (start > 0) {
-                updates.write(`from line ${start} to end of file`)
-            } else {
-                updates.write(`${start} line from the end of file to end of file`)
-            }
-        } else {
-            updates.write('all lines')
-        }
+        updates.write('')
         updates.end()
     }
 

--- a/packages/core/src/codewhispererChat/tools/listDirectory.ts
+++ b/packages/core/src/codewhispererChat/tools/listDirectory.ts
@@ -51,12 +51,12 @@ export class ListDirectory {
     public queueDescription(updates: Writable): void {
         const fileName = path.basename(this.fsPath)
         if (this.maxDepth === undefined) {
-            updates.write(`Listing directory recursively: ${fileName}`)
+            updates.write(`Analyzing directories recursively: ${fileName}`)
         } else if (this.maxDepth === 0) {
-            updates.write(`Listing directory: ${fileName}`)
+            updates.write(`Analyzing directory: ${fileName}`)
         } else {
             const level = this.maxDepth > 1 ? 'levels' : 'level'
-            updates.write(`Listing directory: ${fileName} limited to ${this.maxDepth} subfolder ${level}`)
+            updates.write(`Analyzing directory: ${fileName} limited to ${this.maxDepth} subfolder ${level}`)
         }
         updates.end()
     }

--- a/packages/core/src/codewhispererChat/view/connector/connector.ts
+++ b/packages/core/src/codewhispererChat/view/connector/connector.ts
@@ -401,6 +401,10 @@ export class ChatMessage extends UiMessage {
     }
 }
 
+export class ToolMessage extends ChatMessage {
+    override type = 'toolMessage'
+}
+
 export interface FollowUp {
     readonly type: string
     readonly pillText: string
@@ -452,6 +456,10 @@ export class AppToWebViewMessageDispatcher {
     }
 
     public sendChatMessage(message: ChatMessage) {
+        this.appsToWebViewMessagePublisher.publish(message)
+    }
+
+    public sendToolMessage(message: ToolMessage) {
         this.appsToWebViewMessagePublisher.publish(message)
     }
 


### PR DESCRIPTION
## Problem
- We show read tool message for each file read which is occupying the entire chat with these messages which is not super important.

## Solution
- Group all the read tool messaged under ContextList.
![image](https://github.com/user-attachments/assets/194e4ca1-7645-4419-8b9b-b5ac9a58279f)



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
