### PR TITLE
telemetry(chat): agentic chat metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.312",
+                "@aws-toolkits/telemetry": "^1.0.313",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -10806,9 +10806,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.312",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.312.tgz",
-            "integrity": "sha512-Ufr24XeVrkBrsyUZyGRXprclkGsF/5O16IXP0dW7LC2DMqFyMuvmcHhIkQDN9D8ydnsHdutj/ZxTyvpkHpXQJw==",
+            "version": "1.0.313",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.313.tgz",
+            "integrity": "sha512-GHlx2AoUfUuadXjZqMlQmpayVhnH1r6Ndbm7jOXvp80j3cwHqUdOgD/7gqK4mYKuxNBhEFC9yB5ieqmaH1lMuQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.312",
+        "@aws-toolkits/telemetry": "^1.0.313",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -832,7 +832,7 @@ export class ChatController {
             case 'run-shell-command':
             case 'generic-tool-execution':
                 await this.processToolUseMessage(message)
-                if (message.action.id === 'run-shell-command') {
+                if (message.action.id === 'run-shell-command' && message.action.text === 'Run') {
                     this.telemetryHelper.recordInteractionWithAgenticChat(
                         AgenticChatInteractionType.RunCommand,
                         message

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -834,7 +834,7 @@ export class ChatController {
                 await this.processToolUseMessage(message)
                 if (message.action.id === 'run-shell-command') {
                     this.telemetryHelper.recordInteractionWithAgenticChat(
-                        AgenticChatInteractionType.AcceptCommand,
+                        AgenticChatInteractionType.RunCommand,
                         message
                     )
                 }

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -509,7 +509,7 @@ export class Messenger {
                 this.telemetryHelper.setResponseStreamTotalTime(tabID)
 
                 const responseCode = response?.$metadata.httpStatusCode ?? 0
-                const promptAnswer = {
+                this.telemetryHelper.recordAddMessage(triggerPayload, {
                     followUpCount: followUps.length,
                     suggestionCount: relatedSuggestions.length,
                     tabID: tabID,
@@ -518,13 +518,7 @@ export class Messenger {
                     responseCode,
                     codeReferenceCount: codeReference.length,
                     totalNumberOfCodeBlocksInResponse: await this.countTotalNumberOfCodeBlocks(message),
-                }
-
-                this.telemetryHelper.recordAddMessage(triggerPayload, promptAnswer)
-
-                if (message.length) {
-                    this.telemetryHelper.recordMessageReceived(triggerPayload, promptAnswer)
-                }
+                })
             })
     }
 

--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -198,6 +198,18 @@ export enum ChatTriggerType {
     InlineChatMessage = 'InlineChatMessage',
 }
 
+export enum AgenticChatInteractionType {
+    RejectDiff = 'RejectDiff',
+    GeneratedDiff = 'GeneratedDiff',
+    AcceptCommand = 'AcceptCommand',
+    GeneratedCommand = 'GeneratedCommand',
+    StopChat = 'StopChat',
+}
+
+export interface AcceptResponseMessage {
+    tabID: string
+}
+
 export interface TriggerPayload {
     readonly query: string | undefined
     readonly codeSelection: Selection | undefined

--- a/packages/core/src/codewhispererChat/controllers/chat/model.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/model.ts
@@ -201,7 +201,7 @@ export enum ChatTriggerType {
 export enum AgenticChatInteractionType {
     RejectDiff = 'RejectDiff',
     GeneratedDiff = 'GeneratedDiff',
-    AcceptCommand = 'AcceptCommand',
+    RunCommand = 'RunCommand',
     GeneratedCommand = 'GeneratedCommand',
     StopChat = 'StopChat',
 }

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -230,24 +230,6 @@ export class CWCTelemetryHelper {
         })
     }
 
-    public recordMessageReceived(triggerPayload: TriggerPayload, message: PromptAnswer) {
-        telemetry.amazonq_messageReceived.emit({
-            result: 'Succeeded',
-            cwsprChatConversationId: this.getConversationId(message.tabID) ?? '',
-            cwsprChatMessageId: message.messageID,
-            cwsprChatTimeToFirstChunk: this.getResponseStreamTimeToFirstChunk(message.tabID),
-            cwsprChatTimeBetweenChunks: JSON.stringify(
-                this.getTimeBetweenChunks(message.tabID, this.responseStreamTimeForChunks)
-            ),
-            cwsprChatRequestLength: triggerPayload.message.length,
-            cwsprChatResponseLength: message.messageLength,
-            cwsprChatConversationType: 'Chat',
-            cwsprChatResponseCode: message.responseCode,
-            cwsprChatFullResponseLatency: this.responseStreamTotalTime.get(message.tabID) ?? 0,
-            credentialStartUrl: AuthUtil.instance.startUrl,
-        })
-    }
-
     public recordInteractWithMessage(
         message:
             | AcceptDiff

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -30,6 +30,9 @@ import {
     TriggerPayload,
     AdditionalContextLengths,
     AdditionalContextInfo,
+    StopResponseMessage,
+    AgenticChatInteractionType,
+    AcceptResponseMessage,
 } from './model'
 import { TriggerEvent, TriggerEventsStorage } from '../../storages/triggerEvents'
 import globals from '../../../shared/extensionGlobals'
@@ -44,6 +47,7 @@ import { undefinedIfEmpty } from '../../../shared/utilities/textUtilities'
 import { AdditionalContextPrompt } from '../../../amazonq/lsp/types'
 import { getUserPromptsDirectory, promptFileExtension } from '../../constants'
 import { isInDirectory } from '../../../shared/filesystemUtilities'
+import { CustomFormActionMessage } from '../../view/connector/connector'
 
 export function logSendTelemetryEventFailure(error: any) {
     let requestId: string | undefined
@@ -211,6 +215,37 @@ export class CWCTelemetryHelper {
 
     private recordFeedbackResult(feedbackResult: Result) {
         telemetry.feedback_result.emit({ result: feedbackResult })
+    }
+
+    public recordInteractionWithAgenticChat(
+        interactionType: AgenticChatInteractionType,
+        message: AcceptResponseMessage | CustomFormActionMessage | StopResponseMessage
+    ) {
+        telemetry.amazonq_interactWithAgenticChat.emit({
+            cwsprAgenticChatInteractionType: interactionType,
+            result: 'Succeeded',
+            cwsprChatConversationId: this.getConversationId(message.tabID ?? '') ?? '',
+            cwsprChatConversationType: 'Chat',
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+
+    public recordMessageReceived(triggerPayload: TriggerPayload, message: PromptAnswer) {
+        telemetry.amazonq_messageReceived.emit({
+            result: 'Succeeded',
+            cwsprChatConversationId: this.getConversationId(message.tabID) ?? '',
+            cwsprChatMessageId: message.messageID,
+            cwsprChatTimeToFirstChunk: this.getResponseStreamTimeToFirstChunk(message.tabID),
+            cwsprChatTimeBetweenChunks: JSON.stringify(
+                this.getTimeBetweenChunks(message.tabID, this.responseStreamTimeForChunks)
+            ),
+            cwsprChatRequestLength: triggerPayload.message.length,
+            cwsprChatResponseLength: message.messageLength,
+            cwsprChatConversationType: 'Chat',
+            cwsprChatResponseCode: message.responseCode,
+            cwsprChatFullResponseLatency: this.responseStreamTotalTime.get(message.tabID) ?? 0,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
     }
 
     public recordInteractWithMessage(

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -232,7 +232,7 @@
         {
             "name": "cwsprAgenticChatInteractionType",
             "type": "string",
-            "allowedValues": ["RejectDiff", "GeneratedDiff", "AcceptCommand", "GeneratedCommand", "StopChat"],
+            "allowedValues": ["RejectDiff", "GeneratedDiff", "RunCommand", "GeneratedCommand", "StopChat"],
             "description": "Type of interaction with agentic chat messages"
         }
     ],
@@ -570,43 +570,6 @@
                 },
                 {
                     "type": "cwsprChatConversationType"
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "amazonq_messageReceived",
-            "description": "When a user receives a message",
-            "metadata": [
-                {
-                    "type": "cwsprChatConversationId"
-                },
-                {
-                    "type": "cwsprChatConversationType"
-                },
-                {
-                    "type": "cwsprChatFullResponseLatency"
-                },
-                {
-                    "type": "cwsprChatMessageId"
-                },
-                {
-                    "type": "cwsprChatRequestLength"
-                },
-                {
-                    "type": "cwsprChatResponseCode"
-                },
-                {
-                    "type": "cwsprChatResponseLength"
-                },
-                {
-                    "type": "cwsprChatTimeBetweenChunks"
-                },
-                {
-                    "type": "cwsprChatTimeToFirstChunk"
                 },
                 {
                     "type": "credentialStartUrl",

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -228,6 +228,12 @@
             "name": "executedCount",
             "type": "int",
             "description": "The number of executed operations"
+        },
+        {
+            "name": "cwsprAgenticChatInteractionType",
+            "type": "string",
+            "allowedValues": ["RejectDiff", "GeneratedDiff", "AcceptCommand", "GeneratedCommand", "StopChat"],
+            "description": "Type of interaction with agentic chat messages"
         }
     ],
     "metrics": [
@@ -551,6 +557,62 @@
         {
             "name": "amazonq_closeChat",
             "description": "When chat panel is closed"
+        },
+        {
+            "name": "amazonq_interactWithAgenticChat",
+            "description": "When a user interacts with a message in the agentic chat",
+            "metadata": [
+                {
+                    "type": "cwsprAgenticChatInteractionType"
+                },
+                {
+                    "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "cwsprChatConversationType"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_messageReceived",
+            "description": "When a user receives a message",
+            "metadata": [
+                {
+                    "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "cwsprChatConversationType"
+                },
+                {
+                    "type": "cwsprChatFullResponseLatency"
+                },
+                {
+                    "type": "cwsprChatMessageId"
+                },
+                {
+                    "type": "cwsprChatRequestLength"
+                },
+                {
+                    "type": "cwsprChatResponseCode"
+                },
+                {
+                    "type": "cwsprChatResponseLength"
+                },
+                {
+                    "type": "cwsprChatTimeBetweenChunks"
+                },
+                {
+                    "type": "cwsprChatTimeToFirstChunk"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
         },
         {
             "name": "amazonq_startConversation",

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -228,12 +228,6 @@
             "name": "executedCount",
             "type": "int",
             "description": "The number of executed operations"
-        },
-        {
-            "name": "cwsprAgenticChatInteractionType",
-            "type": "string",
-            "allowedValues": ["RejectDiff", "GeneratedDiff", "RunCommand", "GeneratedCommand", "StopChat"],
-            "description": "Type of interaction with agentic chat messages"
         }
     ],
     "metrics": [
@@ -557,25 +551,6 @@
         {
             "name": "amazonq_closeChat",
             "description": "When chat panel is closed"
-        },
-        {
-            "name": "amazonq_interactWithAgenticChat",
-            "description": "When a user interacts with a message in the agentic chat",
-            "metadata": [
-                {
-                    "type": "cwsprAgenticChatInteractionType"
-                },
-                {
-                    "type": "cwsprChatConversationId"
-                },
-                {
-                    "type": "cwsprChatConversationType"
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                }
-            ]
         },
         {
             "name": "amazonq_startConversation",


### PR DESCRIPTION
## Problem
- currently no metrics for agentic chat

## Solution
Emit telemetry events when:
- message shown to user (message sent from user already exists)
- diff was generated
- user rejected diff
- command was generated
- user accepted command
- user pressed stop button
- upstreamed metric to aws-toolkit-common: https://github.com/aws/aws-toolkit-common/pull/1010

#### TODO:
- additional telemetry events for: user interrupts Q while generating, thumbs up/down
- see when user pressed stop (ex: chat, command execution, etc)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
