### PR TITLE
feat(amazon lsp): add copyToClipboard implementation

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -23,12 +23,12 @@ import {
     insertToCursorPositionNotificationType,
 } from '@aws/language-server-runtimes/protocol'
 import { v4 as uuidv4 } from 'uuid'
-import { window } from 'vscode'
+import * as vscode from 'vscode'
 import { Disposable, LanguageClient, Position, State, TextDocumentIdentifier } from 'vscode-languageclient'
 import * as jose from 'jose'
 import { AmazonQChatViewProvider } from './webviewProvider'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
-import { AmazonQPromptSettings } from 'aws-core-vscode/shared'
+import { AmazonQPromptSettings, messages } from 'aws-core-vscode/shared'
 
 export function registerLanguageServerEventListener(languageClient: LanguageClient, provider: AmazonQChatViewProvider) {
     languageClient.onDidChangeState(({ oldState, newState }) => {
@@ -62,11 +62,15 @@ export function registerMessageListeners(
 
         switch (message.command) {
             case COPY_TO_CLIPBOARD:
-                // TODO see what we need to hook this up
                 languageClient.info('[VSCode Client] Copy to clipboard event received')
+                try {
+                    await messages.copyToClipboard(message.params.code)
+                } catch (e) {
+                    languageClient.error(`[VSCode Client] Failed to copy to clipboard: ${(e as Error).message}`)
+                }
                 break
             case INSERT_TO_CURSOR_POSITION: {
-                const editor = window.activeTextEditor
+                const editor = vscode.window.activeTextEditor
                 let textDocument: TextDocumentIdentifier | undefined = undefined
                 let cursorPosition: Position | undefined = undefined
                 if (editor) {
@@ -119,8 +123,8 @@ export function registerMessageListeners(
                 )
 
                 const editor =
-                    window.activeTextEditor ||
-                    window.visibleTextEditors.find((editor) => editor.document.languageId !== 'Log')
+                    vscode.window.activeTextEditor ||
+                    vscode.window.visibleTextEditors.find((editor) => editor.document.languageId !== 'Log')
                 if (editor) {
                     message.params.cursorPosition = [editor.selection.active]
                     message.params.textDocument = { uri: editor.document.uri.toString() }

--- a/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
@@ -4,7 +4,6 @@
  */
 
 import * as sinon from 'sinon'
-import * as vscode from 'vscode'
 import { LanguageClient } from 'vscode-languageclient'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { registerMessageListeners } from '../../../../../src/lsp/chat/messages'


### PR DESCRIPTION
## Problem
There was no implementation for the `copyToClipboard` message received from LSP for Amazon Q. The functionality did work because of the [MynahUI implementation](https://github.com/aws/mynah-ui/blob/b56a4b1df828eaa22515ef0f5af211eec24a5f89/src/helper/chat-item.ts#L36C1-L37C1), but for UI consistency to consider edge cases with webview clipboard, we decided to handle it explicitly.

## Solution
Call the `copyToClipboard` function and add unit tests

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
