### PR TITLE
fix(chat): Send back throttling error message

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -754,6 +754,20 @@ export class Messenger {
     }
 
     private showChatExceptionMessage(e: ChatException, tabID: string, requestID: string | undefined) {
+        const title = 'An error occurred while processing your request.'
+        // TODO: once the server sends the correct exception back, fix this
+        if (e.statusCode && e.statusCode === '500') {
+            // Send throttling message
+            this.dispatcher.sendErrorMessage(
+                new ErrorMessage(
+                    title,
+                    'We are experiencing heavy traffic, please try again shortly.'.trimEnd().trimStart(),
+                    tabID
+                )
+            )
+            return
+        }
+
         let message = 'This error is reported to the team automatically. We will attempt to fix it as soon as possible.'
         if (e.errorMessage !== undefined) {
             message += `\n\nDetails: ${e.errorMessage}`
@@ -769,9 +783,7 @@ export class Messenger {
             message += `\n\nRequest ID: ${requestID}`
         }
 
-        this.dispatcher.sendErrorMessage(
-            new ErrorMessage('An error occurred while processing your request.', message.trimEnd().trimStart(), tabID)
-        )
+        this.dispatcher.sendErrorMessage(new ErrorMessage(title, message.trimEnd().trimStart(), tabID))
     }
 
     public sendOpenSettingsMessage(triggerId: string, tabID: string) {


### PR DESCRIPTION
## Problem
- When throttling happens today, we receive ISE from the server 

## Solution
- Send back appropriate customer facing throttling error message


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
