### PR TITLE
fix(chat): disable prompt during loop

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -125,6 +125,7 @@ export class Connector extends BaseConnector {
                 padding: messageData.padding ?? undefined,
                 fullWidth: messageData.fullWidth ?? undefined,
                 codeBlockActions: messageData.codeBlockActions ?? undefined,
+                rootFolderTitle: messageData.rootFolderTitle ?? undefined,
             }
 
             if (messageData.relatedSuggestions !== undefined) {
@@ -257,14 +258,15 @@ export class Connector extends BaseConnector {
         }
 
         if (messageData.type === 'asyncEventProgressMessage') {
-            const enableStopAction = true
+            const enableStopAction = false
+            const isPromptInputDisabled = true
             this.onAsyncEventProgress(
                 messageData.tabID,
                 messageData.inProgress,
                 messageData.message ?? undefined,
                 messageData.messageId ?? undefined,
                 enableStopAction,
-                false
+                isPromptInputDisabled
             )
             return
         }

--- a/packages/core/src/amazonq/webview/ui/connector.ts
+++ b/packages/core/src/amazonq/webview/ui/connector.ts
@@ -66,6 +66,7 @@ export interface CWCChatItem extends ChatItem {
     codeBlockLanguage?: string
     contextList?: Context[]
     title?: string
+    rootFolderTitle?: string
 }
 
 export interface Context {

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -409,7 +409,7 @@ export const createMynahUI = (
                     fileList: {
                         fileTreeTitle: '',
                         filePaths: item.contextList.map((file) => file.relativeFilePath),
-                        rootFolderTitle: item.title,
+                        rootFolderTitle: item.rootFolderTitle,
                         flatList: true,
                         collapsed: true,
                         hideFileCount: true,

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1484,7 +1484,7 @@ export class ChatController {
         let response: MessengerResponseType | undefined = undefined
         session.createNewTokenSource()
         try {
-            if (!session.context) {
+            if (!session.context && triggerPayload.context.length) {
                 // Only show context for the first message in the loop
                 this.messenger.sendContextMessage(tabID, triggerID, triggerPayload.documentReferences)
                 session.setContext(triggerPayload.context)

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -130,7 +130,7 @@ export class Messenger {
             new ChatMessage(
                 {
                     message: '',
-                    messageType: 'answer',
+                    messageType: 'answer-stream',
                     followUps: undefined,
                     followUpsHeader: undefined,
                     relatedSuggestions: undefined,
@@ -139,7 +139,8 @@ export class Messenger {
                     userIntent: undefined,
                     codeBlockLanguage: undefined,
                     contextList: mergedRelevantDocuments,
-                    title: 'Context',
+                    title: '',
+                    rootFolderTitle: 'Context',
                     buttons: undefined,
                     fileList: undefined,
                     canBeVoted: false,
@@ -452,11 +453,16 @@ export class Messenger {
                     )
                 }
 
+                const agenticLoopEnded = !eventCounts.has('toolUseEvent')
+                if (agenticLoopEnded) {
+                    // Reset context for the next request
+                    session.setContext(undefined)
+                }
                 this.dispatcher.sendChatMessage(
                     new ChatMessage(
                         {
                             message: undefined,
-                            messageType: 'answer',
+                            messageType: agenticLoopEnded ? 'answer' : 'answer-stream',
                             followUps: followUps,
                             followUpsHeader: undefined,
                             relatedSuggestions: undefined,
@@ -480,11 +486,6 @@ export class Messenger {
                             toolUse.input !== '' && { toolUses: [{ ...toolUse }] }),
                     },
                 })
-                const agenticLoopEnded = !eventCounts.has('toolUseEvent')
-                if (agenticLoopEnded) {
-                    // Reset context for the next request
-                    session.setContext(undefined)
-                }
 
                 getLogger().info(
                     `All events received. requestId=%s counts=%s`,

--- a/packages/core/src/codewhispererChat/view/connector/connector.ts
+++ b/packages/core/src/codewhispererChat/view/connector/connector.ts
@@ -352,6 +352,7 @@ export interface ChatMessageProps {
     readonly fullWidth?: boolean
     readonly padding?: boolean
     readonly codeBlockActions?: CodeBlockActions | null
+    readonly rootFolderTitle?: string
 }
 
 export class ChatMessage extends UiMessage {
@@ -375,6 +376,7 @@ export class ChatMessage extends UiMessage {
     readonly padding?: boolean
     readonly codeBlockActions?: CodeBlockActions | null
     readonly canBeVoted?: boolean = false
+    readonly rootFolderTitle?: string
     override type = 'chatMessage'
 
     constructor(props: ChatMessageProps, tabID: string) {
@@ -398,6 +400,7 @@ export class ChatMessage extends UiMessage {
         this.fullWidth = props.fullWidth
         this.padding = props.padding
         this.codeBlockActions = props.codeBlockActions
+        this.rootFolderTitle = props.rootFolderTitle
     }
 }
 


### PR DESCRIPTION
## Problem
Chat input prompt should be disabled during the agentic loop


## Solution
- Disable chat prompt
- Removed stop button for now


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
