### PR TITLE
fix(chat): handle JSON.parse error gracefully

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -261,12 +261,11 @@ export class Messenger {
                     }
 
                     if (cwChatEvent.toolUseEvent?.stop) {
-                        toolUse.input = JSON.parse(toolUseInput)
-                        toolUse.toolUseId = cwChatEvent.toolUseEvent.toolUseId ?? ''
-                        toolUse.name = cwChatEvent.toolUseEvent.name ?? ''
-
                         let toolError = undefined
                         try {
+                            toolUse.toolUseId = cwChatEvent.toolUseEvent.toolUseId ?? ''
+                            toolUse.name = cwChatEvent.toolUseEvent.name ?? ''
+                            toolUse.input = JSON.parse(toolUseInput)
                             const availableToolsNames = (session.pairProgrammingModeOn ? tools : noWriteTools).map(
                                 (item) => item.toolSpecification?.name
                             )


### PR DESCRIPTION
## Problem
- JSON.parse error will break the agentic loop

## Solution
- handle JSON.parse error gracefully


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
