### PR TITLE
fix(chat): Prune history if it's too large, ignore log window as active file

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/chatRequest/converter.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/chatRequest/converter.ts
@@ -145,6 +145,12 @@ export function triggerPayloadToChatRequest(triggerPayload: TriggerPayload): { c
                 },
             }
         }
+
+        if (document.relativeFilePath === 'amazonwebservices.amazon-q-vscode.Amazon Q Logs') {
+            getLogger().debug('Active file is Amazon Q Logs, filter it out in the chat request')
+            document = undefined
+            cursorState = undefined
+        }
     }
 
     // service will throw validation exception if string is empty

--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -33,7 +33,7 @@ export class ChatStream extends Writable {
     ) {
         super()
         this.logger.debug(
-            `ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}, session: ${session.readFiles}, emitEvent to mynahUI: ${emitEvent}`
+            `ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}, emitEvent to mynahUI: ${emitEvent}`
         )
         if (!emitEvent) {
             return


### PR DESCRIPTION
## Problem
```
An error occurred while processing your request.This error is reported to the team automatically. We will attempt to fix it as soon as possible.Details: Input is too long.
```
- A bug where status code is not being populated in error message
- A bug where output log window can be considered as active file which can cause waste of tokens
- A bug where toolUse JSON.parse is not being handled correctly

## Solution
- Prune history if it's too large
- Fix status code bug in error message
- Fix active file bug
- Fix JSON.parse handling

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
