### PR TITLE
fix(chat): Add ToolUse to history even if input is missing

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -518,9 +518,7 @@ export class Messenger {
                         messageId: messageID,
                         content: message,
                         references: codeReference,
-                        ...(toolUse &&
-                            toolUse.input !== undefined &&
-                            toolUse.input !== '' && { toolUses: [{ ...toolUse }] }),
+                        ...(toolUse && { toolUses: [{ ...toolUse }] }),
                     },
                 })
 


### PR DESCRIPTION
## Problem
- Add ToolUse to history even if input is missing
    - It may be missing in case when we cannot parse the input

## Solution
- Still add the toolUse to history to allow LLM to auto-correct itself


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
