### PR TITLE
feat(amazonq): handle context command and open file for chat with lsp

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -32,6 +32,11 @@ import {
     ShowSaveFileDialogParams,
     LSPErrorCodes,
     tabBarActionRequestType,
+    ShowDocumentParams,
+    ShowDocumentResult,
+    ShowDocumentRequest,
+    contextCommandsNotificationType,
+    ContextCommandParams,
 } from '@aws/language-server-runtimes/protocol'
 import { v4 as uuidv4 } from 'uuid'
 import * as vscode from 'vscode'
@@ -285,6 +290,23 @@ export function registerMessageListeners(
         return {
             targetUri: targetUri.toString(),
         }
+    })
+
+    languageClient.onRequest<ShowDocumentParams, ShowDocumentResult>(
+        ShowDocumentRequest.method,
+        async (params: ShowDocumentParams): Promise<ShowDocumentParams | ResponseError<ShowDocumentResult>> => {
+            const uri = vscode.Uri.parse(params.uri)
+            const doc = await vscode.workspace.openTextDocument(uri)
+            await vscode.window.showTextDocument(doc, { preview: false })
+            return params
+        }
+    )
+
+    languageClient.onNotification(contextCommandsNotificationType.method, (params: ContextCommandParams) => {
+        void provider.webview?.postMessage({
+            command: contextCommandsNotificationType.method,
+            params: params,
+        })
     })
 }
 

--- a/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
@@ -27,6 +27,7 @@ describe('registerMessageListeners', () => {
             error: errorStub,
             sendNotification: sandbox.stub(),
             onRequest: sandbox.stub(),
+            onNotification: sandbox.stub(),
         } as unknown as LanguageClient
 
         provider = {


### PR DESCRIPTION
## Problem
for agentic chat with language server, we need client to handle open files and update context command

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
