### PR TITLE
deps(amazonq): mynah-ui 4.30.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11940,9 +11940,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.30.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.30.0.tgz",
-            "integrity": "sha512-ZUje97UxfhrxWoT8P4qKs3qRUq0c92gwFNxR6c4szpRZeEchPTqDP/HIX5KE6AEIeMFyiHx/qgDjmuNIc3kZyw==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.30.1.tgz",
+            "integrity": "sha512-ZBtvmHYjlJXzIUCeDmNu1cFfJyO86S/+UCuM/LFbAV5mf4Qm1o8i0Gmpw/4ngKx3ZXdFGnVT1Iq2bCGSYhuoSw==",
             "hasInstallScript": true,
             "dependencies": {
                 "escape-html": "^1.0.3",
@@ -26739,7 +26739,7 @@
                 "@aws-sdk/s3-request-presigner": "<3.731.0",
                 "@aws-sdk/smithy-client": "<3.731.0",
                 "@aws-sdk/util-arn-parser": "<3.731.0",
-                "@aws/mynah-ui": "^4.30.0",
+                "@aws/mynah-ui": "^4.30.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/fetch-http-handler": "^5.0.1",

--- a/packages/amazonq/.changes/next-release/Bug Fix-9d840c3e-80a2-45a0-961f-8441b2339860.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-9d840c3e-80a2-45a0-961f-8441b2339860.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: code blocks in responses flicker, switching tabs during answer streaming makes expand button disappear"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-e8dc0bd0-b232-429c-b16a-f3bf993b19b4.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-e8dc0bd0-b232-429c-b16a-f3bf993b19b4.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: tab bar buttons disappear when closing non-active tab"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-ee90e4d2-aa78-403f-8b58-1464c6419778.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-ee90e4d2-aa78-403f-8b58-1464c6419778.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q Chat: chat history list does not truncate markdown"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -524,7 +524,7 @@
         "@aws-sdk/s3-request-presigner": "<3.731.0",
         "@aws-sdk/smithy-client": "<3.731.0",
         "@aws-sdk/util-arn-parser": "<3.731.0",
-        "@aws/mynah-ui": "^4.30.0",
+        "@aws/mynah-ui": "^4.30.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/fetch-http-handler": "^5.0.1",


### PR DESCRIPTION
## Problem
from mynah-ui changelog:
- Fixed bug where tab bar buttons would disappear when closing a non-active tab 
- Fixed bug where markdown in detailed list descriptions could mess up layout through newlines
- Fixed issues with code blocks
  - Code block max-height is no longer breaking inline codes
  - Fixed issue where switching tabs while streaming makes expand buttons disappear on code blocks
  - Fixed issue where while streaming, expand code block button blinks
  - Code block action icons and show more resource link icons are now properly visible

## Solution
Update to latest mynah-ui: [changelog](https://github.com/aws/mynah-ui/releases/tag/v4.30.1)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
