### PR TITLE
style(chat): smaller headers, fix no-padding

### DIFF
--- a/packages/core/resources/css/amazonq-webview.css
+++ b/packages/core/resources/css/amazonq-webview.css
@@ -116,8 +116,19 @@ body.vscode-high-contrast:not(.vscode-high-contrast-light) {
 
 body .mynah-card-body h1 {
     --mynah-line-height: 1.5rem;
+    font-size: 1.25em;
+}
+
+body .mynah-card-body h2,
+body .mynah-card-body h3,
+body .mynah-card-body h4 {
+    font-size: 1em;
 }
 
 div.mynah-card.padding-large {
     padding: var(--mynah-sizing-4) var(--mynah-sizing-3);
+}
+
+div.mynah-chat-items-container .mynah-chat-item-card.no-padding > .mynah-card {
+    padding: 0;
 }


### PR DESCRIPTION
## Problem
- Markdown headers are too large 
- `no-padding` from mynah-ui is not working

Before:
![image](https://github.com/user-attachments/assets/f0996f84-6ae8-4747-8e1b-d6d9ada4c213)
![image](https://github.com/user-attachments/assets/caddda94-f6d8-4bfd-9a5e-d49f0633c529)



## Solution
- Override the font size for h1-h4
- Override the padding for any card under `no-padding`

After:
![image](https://github.com/user-attachments/assets/9373ab02-2912-48fd-af2b-2a1e72375d84)
![image](https://github.com/user-attachments/assets/a606188e-0c2e-430e-b979-2187ba6c8bf6)



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
