### PR TITLE
fix(chat): Add session context for the agentic loop

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -774,7 +774,7 @@ export class ChatController {
                         toolResults: toolResults,
                         profile: AuthUtil.instance.regionProfileManager.activeRegionProfile,
                         origin: Origin.IDE,
-                        context: [],
+                        context: session.context ?? [],
                         relevantTextDocuments: [],
                         additionalContents: [],
                         documentReferences: [],

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -257,11 +257,7 @@ export class Messenger {
                     }
 
                     const cwChatEvent: cwChatResponseStream = chatEvent
-                    if (
-                        cwChatEvent.toolUseEvent?.input !== undefined &&
-                        cwChatEvent.toolUseEvent.input.length > 0 &&
-                        !cwChatEvent.toolUseEvent.stop
-                    ) {
+                    if (cwChatEvent.toolUseEvent?.input !== undefined && cwChatEvent.toolUseEvent.input.length > 0) {
                         toolUseInput += cwChatEvent.toolUseEvent.input
                     }
 


### PR DESCRIPTION
## Problem
- Session context is missing for the follow ups in the agentic loop
- Bug in parsing toolUseInput which causes JSON.parse error

## Solution
- Add session context for the agentic loop
- Fixed the bug in parsing toolUseInput


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
