### PR TITLE
fix(chat): Set valid tooluse Input when parsing fails

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -273,8 +273,8 @@ export class Messenger {
                                 toolUse.input = JSON.parse(toolUseInput)
                             } catch (error: any) {
                                 getLogger().error(`JSON parse error for toolUseInput: ${toolUseInput}`)
-                                // set toolUse.input to the raw value
-                                toolUse.input = toolUseInput
+                                // set toolUse.input to be empty valid json object
+                                toolUse.input = {}
                                 error.message = `Tool input has invalid JSON format: ${error.message}`
                                 // throw it out to allow the error to be handled in the catch block
                                 throw error


### PR DESCRIPTION
## Problem
-  Set valid tooluse Input when parsing fails

## Solution
- Server side cannot handle the raw string

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
