### PR TITLE
style(chat): undo padding change

### DIFF
--- a/packages/core/resources/css/amazonq-webview.css
+++ b/packages/core/resources/css/amazonq-webview.css
@@ -128,7 +128,3 @@ body .mynah-card-body h4 {
 div.mynah-card.padding-large {
     padding: var(--mynah-sizing-4) var(--mynah-sizing-3);
 }
-
-div.mynah-chat-items-container .mynah-chat-item-card.no-padding > .mynah-card {
-    padding: 0;
-}


### PR DESCRIPTION
## Problem

Padding override is not needed anymore


## Solution

Revert padding change since it looks like it was already fixed in mynah-ui


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
