### PR TITLE
fix(chat): Reduce maxToolResponseSize from 800K to 200K

### DIFF
--- a/packages/core/src/codewhispererChat/tools/toolShared.ts
+++ b/packages/core/src/codewhispererChat/tools/toolShared.ts
@@ -6,7 +6,7 @@
 import path from 'path'
 import fs from '../../shared/fs/fs'
 
-export const maxToolResponseSize = 800_000
+export const maxToolResponseSize = 200_000
 
 export enum OutputKind {
     Text = 'text',

--- a/packages/core/src/codewhispererChat/tools/tool_index.json
+++ b/packages/core/src/codewhispererChat/tools/tool_index.json
@@ -10,7 +10,7 @@
                     "type": "string"
                 },
                 "readRange": {
-                    "description": "Optional parameter when reading files.\n * If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[startLine, -1]` shows all lines from `startLine` to the end of the file.",
+                    "description": "Optional parameter when reading files.\n * If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[startLine, -1]` shows all lines from `startLine` to the end of the file. If the whole file is too large, try reading 4000 lines at once, for example: after reading [1, 4000], read [4000, 8000] next and repeat.",
                     "items": {
                         "type": "integer"
                     },
@@ -26,6 +26,10 @@
         "inputSchema": {
             "type": "object",
             "properties": {
+                "explanation": {
+                    "description": "One sentence explanation as to why this tool is being used, and how it contributes to the goal.",
+                    "type": "string"
+                },
                 "command": {
                     "type": "string",
                     "enum": ["create", "strReplace", "insert", "append"],

--- a/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
@@ -162,7 +162,7 @@ describe('ToolUtils', function () {
             const output: InvokeOutput = {
                 output: {
                     kind: OutputKind.Text,
-                    content: 'a'.repeat(700_000),
+                    content: 'a'.repeat(150_000),
                 },
             }
             assert.doesNotThrow(() => ToolUtils.validateOutput(output))
@@ -171,12 +171,12 @@ describe('ToolUtils', function () {
             const output: InvokeOutput = {
                 output: {
                     kind: OutputKind.Text,
-                    content: 'a'.repeat(900_000), // 900,000 characters
+                    content: 'a'.repeat(200_001), // 200,001 characters
                 },
             }
             assert.throws(() => ToolUtils.validateOutput(output), {
                 name: 'Error',
-                message: 'Tool output exceeds maximum character limit of 800000',
+                message: 'Tool output exceeds maximum character limit of 200000',
             })
         })
     })


### PR DESCRIPTION
## Problem
- Large repo can cause result of listDirectory to contain more than 500K characters


## Solution
- Reduce maxToolResponseSize from 800K to 200K
- Updated fsRead to read every 4000 lines if the file is too big
- Updated fsWrite to include explanation optional parameter


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
