### PR TITLE
Revert "fix(amazonq): "failed to run command""

### DIFF
--- a/packages/amazonq/src/lsp/chat/commands.ts
+++ b/packages/amazonq/src/lsp/chat/commands.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode'
 import { Commands, globals } from 'aws-core-vscode/shared'
 import { window } from 'vscode'
 import { AmazonQChatViewProvider } from './webviewProvider'
@@ -73,6 +74,6 @@ function registerGenericCommand(commandName: string, genericCommand: string, pro
  * Instead, we just create our own as a temporary solution
  */
 async function focusAmazonQPanel() {
-    await Commands.tryExecute('aws.amazonq.AmazonQChatView.focus')
-    await Commands.tryExecute('aws.amazonq.AmazonCommonAuth.focus')
+    await vscode.commands.executeCommand('aws.amazonq.AmazonQChatView.focus')
+    await vscode.commands.executeCommand('aws.amazonq.AmazonCommonAuth.focus')
 }

--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -42,7 +42,7 @@ import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { AuthController } from '../../../amazonq/auth/controller'
 import { getLogger } from '../../../shared/logger/logger'
 import { submitFeedback } from '../../../feedback/vue/submitFeedback'
-import { Commands, placeholder } from '../../../shared/vscode/commands2'
+import { placeholder } from '../../../shared/vscode/commands2'
 import { EditorContentController } from '../../../amazonq/commons/controllers/contentController'
 import { openUrl } from '../../../shared/utilities/vsCodeUtils'
 import { checkForDevFile, getPathsFromZipFilePath } from '../../../amazonq/util/files'
@@ -579,7 +579,7 @@ export class FeatureDevController {
                         open
                     )
                     if (resp === open) {
-                        await Commands.tryExecute('aws.amazonq.AmazonQChatView.focus')
+                        await vscode.commands.executeCommand('aws.amazonq.AmazonQChatView.focus')
                         // TODO add focusing on the specific tab once that's implemented
                     }
                 }

--- a/packages/core/src/codewhispererChat/commands/registerCommands.ts
+++ b/packages/core/src/codewhispererChat/commands/registerCommands.ts
@@ -7,6 +7,7 @@ import { commandPalette } from '../../codewhisperer/commands/types'
 import { CodeScanIssue } from '../../codewhisperer/models/model'
 import { Commands, VsCodeCommandArg, placeholder } from '../../shared/vscode/commands2'
 import { ChatControllerMessagePublishers } from '../controllers/chat/controller'
+import vscode from 'vscode'
 
 /**
  * Opens the Amazon Q panel, showing the correct View that should
@@ -24,8 +25,8 @@ export const focusAmazonQPanel = Commands.declare(
          * So when we try to focus the following Views, only one will show depending
          * on the context.
          */
-        await Commands.tryExecute('aws.amazonq.AmazonQChatView.focus')
-        await Commands.tryExecute('aws.amazonq.AmazonCommonAuth.focus')
+        await vscode.commands.executeCommand('aws.amazonq.AmazonQChatView.focus')
+        await vscode.commands.executeCommand('aws.amazonq.AmazonCommonAuth.focus')
     }
 )
 


### PR DESCRIPTION
This is preventing users from seeing the sign in page when clicking sign in. This is because `tryExecute` only works for commands created via the `Commands` utilities, but these are vscode generated commands and are never registered.