### PR TITLE
fix(childprocess): noisy "memory threshold" logs

### DIFF
--- a/packages/core/src/shared/utilities/collectionUtils.ts
+++ b/packages/core/src/shared/utilities/collectionUtils.ts
@@ -588,4 +588,8 @@ export class CircularBuffer {
     contains(value: number): boolean {
         return this.buffer.has(value)
     }
+
+    clear(): void {
+        this.buffer.clear()
+    }
 }

--- a/packages/core/src/shared/utilities/collectionUtils.ts
+++ b/packages/core/src/shared/utilities/collectionUtils.ts
@@ -568,7 +568,7 @@ export function isPresent<T>(value: T | undefined): value is T {
 }
 
 export class CircularBuffer {
-    private buffer = new Map<number, boolean>()
+    private buffer = new Set<number>()
     private maxSize: number
 
     constructor(size: number) {
@@ -577,12 +577,12 @@ export class CircularBuffer {
 
     add(value: number): void {
         if (this.buffer.size >= this.maxSize) {
-            // Map iterates its keys in insertion-order.
-            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+            // Set iterates its keys in insertion-order.
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
             const firstKey = this.buffer.keys().next().value
             this.buffer.delete(firstKey)
         }
-        this.buffer.set(value, true)
+        this.buffer.add(value)
     }
 
     contains(value: number): boolean {

--- a/packages/core/src/shared/utilities/collectionUtils.ts
+++ b/packages/core/src/shared/utilities/collectionUtils.ts
@@ -566,3 +566,26 @@ export function createCollectionFromPages<T>(...pages: T[]): AsyncCollection<T> 
 export function isPresent<T>(value: T | undefined): value is T {
     return value !== undefined
 }
+
+export class CircularBuffer {
+    private buffer = new Map<number, boolean>()
+    private maxSize: number
+
+    constructor(size: number) {
+        this.maxSize = size
+    }
+
+    add(value: number): void {
+        if (this.buffer.size >= this.maxSize) {
+            // Map iterates its keys in insertion-order.
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+            const firstKey = this.buffer.keys().next().value
+            this.buffer.delete(firstKey)
+        }
+        this.buffer.set(value, true)
+    }
+
+    contains(value: number): boolean {
+        return this.buffer.has(value)
+    }
+}

--- a/packages/core/src/shared/utilities/processUtils.ts
+++ b/packages/core/src/shared/utilities/processUtils.ts
@@ -8,6 +8,7 @@ import * as crossSpawn from 'cross-spawn'
 import * as logger from '../logger/logger'
 import { Timeout, CancellationError, waitUntil } from './timeoutUtils'
 import { PollingSet } from './pollingSet'
+import { CircularBuffer } from './collectionUtils'
 
 export interface RunParameterContext {
     /** Reports an error parsed from the stdin/stdout streams. */
@@ -73,6 +74,7 @@ export class ChildProcessTracker {
         cpu: 50,
     }
     static readonly logger = logger.getLogger('childProcess')
+    static readonly #loggedPids = new CircularBuffer(1000)
     #processByPid: Map<number, ChildProcess> = new Map<number, ChildProcess>()
     #pids: PollingSet<number>
 
@@ -100,18 +102,25 @@ export class ChildProcessTracker {
 
     private async checkProcessUsage(pid: number): Promise<void> {
         if (!this.#pids.has(pid)) {
-            ChildProcessTracker.logger.warn(`Missing process with id ${pid}`)
+            ChildProcessTracker.logOnce(pid, `Missing process with id ${pid}`)
             return
         }
         const stats = this.getUsage(pid)
         if (stats) {
             ChildProcessTracker.logger.debug(`Process ${pid} usage: %O`, stats)
             if (stats.memory > ChildProcessTracker.thresholds.memory) {
-                ChildProcessTracker.logger.warn(`Process ${pid} exceeded memory threshold: ${stats.memory}`)
+                ChildProcessTracker.logOnce(pid, `Process ${pid} exceeded memory threshold: ${stats.memory}`)
             }
             if (stats.cpu > ChildProcessTracker.thresholds.cpu) {
-                ChildProcessTracker.logger.warn(`Process ${pid} exceeded cpu threshold: ${stats.cpu}`)
+                ChildProcessTracker.logOnce(pid, `Process ${pid} exceeded cpu threshold: ${stats.cpu}`)
             }
+        }
+    }
+
+    public static logOnce(pid: number, msg: string) {
+        if (!ChildProcessTracker.#loggedPids.contains(pid)) {
+            ChildProcessTracker.#loggedPids.add(pid)
+            ChildProcessTracker.logger.warn(msg)
         }
     }
 
@@ -147,7 +156,7 @@ export class ChildProcessTracker {
             // isWin() leads to circular dependency.
             return process.platform === 'win32' ? getWindowsUsage() : getUnixUsage()
         } catch (e) {
-            ChildProcessTracker.logger.warn(`Failed to get process stats for ${pid}: ${e}`)
+            ChildProcessTracker.logOnce(pid, `Failed to get process stats for ${pid}: ${e}`)
             return { cpu: 0, memory: 0 }
         }
 

--- a/packages/core/src/shared/utilities/processUtils.ts
+++ b/packages/core/src/shared/utilities/processUtils.ts
@@ -74,7 +74,7 @@ export class ChildProcessTracker {
         cpu: 50,
     }
     static readonly logger = logger.getLogger('childProcess')
-    static readonly #loggedPids = new CircularBuffer(1000)
+    static readonly loggedPids = new CircularBuffer(1000)
     #processByPid: Map<number, ChildProcess> = new Map<number, ChildProcess>()
     #pids: PollingSet<number>
 
@@ -118,8 +118,8 @@ export class ChildProcessTracker {
     }
 
     public static logOnce(pid: number, msg: string) {
-        if (!ChildProcessTracker.#loggedPids.contains(pid)) {
-            ChildProcessTracker.#loggedPids.add(pid)
+        if (!ChildProcessTracker.loggedPids.contains(pid)) {
+            ChildProcessTracker.loggedPids.add(pid)
             ChildProcessTracker.logger.warn(msg)
         }
     }

--- a/packages/core/src/test/shared/utilities/processUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/processUtils.test.ts
@@ -393,6 +393,10 @@ describe('ChildProcessTracker', function () {
         usageMock = sinon.stub(ChildProcessTracker.prototype, 'getUsage')
     })
 
+    beforeEach(function () {
+        ChildProcessTracker.loggedPids.clear()
+    })
+
     afterEach(function () {
         tracker.clear()
         usageMock.reset()
@@ -463,6 +467,7 @@ describe('ChildProcessTracker', function () {
         await clock.tickAsync(ChildProcessTracker.pollingInterval)
         assertLogsContain('exceeded cpu threshold', false, 'warn')
 
+        ChildProcessTracker.loggedPids.clear()
         usageMock.returns(highMemory)
         await clock.tickAsync(ChildProcessTracker.pollingInterval)
         assertLogsContain('exceeded memory threshold', false, 'warn')


### PR DESCRIPTION
## Problem
"memory threshold" message logged multiple times for a the same PID:

    2025-04-11 ... Process 23662 exceeded memory threshold: 506986496
    2025-04-11 ... Process 23662 exceeded memory threshold: 507019264
    2025-04-11 ... Process 23662 exceeded memory threshold: 507052032
    2025-04-11 ... Process 23662 exceeded memory threshold: 507084800

This is noisy in the logs.

## Solution
Only log "memory threshold" once per PID.







---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
