### PR TITLE
fix(amazonq): make code fix's line number or file to be accurate

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-42b2c2f0-e40e-4f97-842b-cb7ead1a010b.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-42b2c2f0-e40e-4f97-842b-cb7ead1a010b.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "fix bug where code fix line number or file was not accurate"
+	"description": "Code fix line number or file is sometimes not accurate"
 }

--- a/packages/amazonq/.changes/next-release/Bug Fix-42b2c2f0-e40e-4f97-842b-cb7ead1a010b.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-42b2c2f0-e40e-4f97-842b-cb7ead1a010b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "fix bug where code fix line number or file was not accurate"
+}

--- a/packages/core/src/codewhisperer/commands/startCodeFixGeneration.ts
+++ b/packages/core/src/codewhisperer/commands/startCodeFixGeneration.ts
@@ -20,6 +20,7 @@ import { TelemetryHelper } from '../util/telemetryHelper'
 import { tempDirPath } from '../../shared/filesystemUtilities'
 import { CodeWhispererSettings } from '../util/codewhispererSettings'
 import { AuthUtil } from '../util/authUtil'
+import { saveDocumentIfDirty } from '../../shared/utilities/textDocumentUtilities'
 
 export async function startCodeFixGeneration(
     client: DefaultCodeWhispererClient,
@@ -44,6 +45,9 @@ export async function startCodeFixGeneration(
          * Step 1: Generate zip
          */
         throwIfCancelled()
+
+        // Save the file if it has unsaved changes to ensure the latest content is included in the zip
+        await saveDocumentIfDirty(filePath)
         const admZip = new AdmZip()
         admZip.addLocalFile(filePath)
 

--- a/packages/core/src/codewhisperer/service/securityIssueProvider.ts
+++ b/packages/core/src/codewhisperer/service/securityIssueProvider.ts
@@ -46,12 +46,14 @@ export class SecurityIssueProvider {
                 ...group,
                 issues: group.issues
                     .filter((issue) => {
-                        const range = new vscode.Range(
-                            issue.startLine,
-                            event.document.lineAt(issue.startLine)?.range.start.character ?? 0,
-                            issue.endLine,
-                            event.document.lineAt(issue.endLine - 1)?.range.end.character ?? 0
-                        )
+                        // event document is the new document after deleting lines, but issue.startLine and endLines are not
+                        let range
+                        if (issue.startLine === issue.endLine) {
+                            range = new vscode.Range(issue.startLine, 0, issue.endLine + 1, 0)
+                        } else {
+                            range = new vscode.Range(issue.startLine, 0, issue.endLine, 0)
+                        }
+
                         const intersection = changedRange.intersection(range)
                         return !(intersection && (/\S/.test(changedText) || changedText === ''))
                     })

--- a/packages/core/src/codewhisperer/service/securityIssueProvider.ts
+++ b/packages/core/src/codewhisperer/service/securityIssueProvider.ts
@@ -46,7 +46,6 @@ export class SecurityIssueProvider {
                 ...group,
                 issues: group.issues
                     .filter((issue) => {
-                        // event document is the new document after deleting lines, but issue.startLine and endLines are not
                         let range
                         if (issue.startLine === issue.endLine) {
                             range = new vscode.Range(issue.startLine, 0, issue.endLine + 1, 0)

--- a/packages/core/src/codewhisperer/service/securityIssueProvider.ts
+++ b/packages/core/src/codewhisperer/service/securityIssueProvider.ts
@@ -46,12 +46,12 @@ export class SecurityIssueProvider {
                 ...group,
                 issues: group.issues
                     .filter((issue) => {
-                        let range
-                        if (issue.startLine === issue.endLine) {
-                            range = new vscode.Range(issue.startLine, 0, issue.endLine + 1, 0)
-                        } else {
-                            range = new vscode.Range(issue.startLine, 0, issue.endLine, 0)
-                        }
+                        const range = new vscode.Range(
+                            issue.startLine,
+                            0,
+                            issue.startLine === issue.endLine ? issue.endLine + 1 : issue.endLine,
+                            0
+                        )
 
                         const intersection = changedRange.intersection(range)
                         return !(intersection && (/\S/.test(changedText) || changedText === ''))


### PR DESCRIPTION
## Problem

1. `document.lineAt` would error due to line out of bounds.
2. File uploaded for codeFix is not the same as the one in editor

## Solution

1. Remove `document.lineAt` logic 
2. Ensure dirty file is saved before zipping.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
