### PR TITLE
Fix broken keyPath to ssh-keygen

### DIFF
--- a/packages/core/src/awsService/ec2/sshKeyPair.ts
+++ b/packages/core/src/awsService/ec2/sshKeyPair.ts
@@ -81,7 +81,7 @@ export class SshKeyPair {
         }
         return await tryRun(
             'ssh-keygen',
-            ['-t', keyType, '-N', '', '-q', '-f', keyPath],
+            ['-t', keyType, '-N', '', '-q', '-f', concat('"', keyPath, '"')],
             'yes',
             /^(?!.*Unknown key type).*/i,
             {


### PR DESCRIPTION
## Problem

When keyPath contains spaces, ex. `/Users/username/Library/Application Support/Code/User/globalStorage/amazonwebservices.aws-toolkit-vscode/aws-ec2-key` the ssh-keygen command fails with "Too many arguments", and doesn't get caught by the "Unknown key type" failure check. 

This results in log output like

[error] aws.ec2.openRemoteConnection: Error: Unable to connect to target instance <id> on region <region>. Testing SSM connection to instance failed: Warning: Permanently added 'aws-ec2-<id>' (ED25519) to the list of known hosts.
no such identity: /Users/username/Library/Application Support/Code/User/globalStorage/amazonwebservices.aws-toolkit-vscode/aws-ec2-key: No such file or directory
ec2-user@aws-ec2-<id>: Permission denied (publickey,gssapi-keyex,gssapi-with-mic). [EC2SSMTestConnect]

## Workaround

Manually run the command with a double quoted path to create the key in this path.

## Solution

Double quote the path in the command arg

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
