### PR TITLE
fix(chat): Adding conditional check for Read and List tool execution

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -459,6 +459,7 @@
     "AWS.amazonq.executeBash.reject": "Reject",
     "AWS.amazonq.chat.directive.pairProgrammingModeOn": "You are using **pair programming mode**: Q can now list files, preview code diffs and allow you to run shell commands.",
     "AWS.amazonq.chat.directive.pairProgrammingModeOff": "You turned off **pair programming mode**. Q will not include code diffs or run commands in the chat.",
+    "AWS.amazonq.chat.directive.permission.readAndList": "I need permission to read files and list directories outside the workspace.",
     "AWS.amazonq.chat.directive.runCommandToProceed": "Run the command to proceed.",
     "AWS.toolkit.lambda.walkthrough.quickpickTitle": "Application Builder Walkthrough",
     "AWS.toolkit.lambda.walkthrough.title": "Get started building your application",

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -833,6 +833,9 @@ export class Messenger {
             }
         } else if (toolUse?.name === ToolType.ListDirectory || toolUse?.name === ToolType.FsRead) {
             if (validation.requiresAcceptance) {
+                /** For Read and List Directory tools
+                 * requiredAcceptance = false, we use messageID = toolID and we keep on updating this messageID
+                 * requiredAcceptance = true, IDE sends messageID != toolID, some default value, as this overlaps with previous message. */
                 messageID = 'toolUse'
                 const buttons: ChatItemButton[] = [
                     {

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -376,7 +376,11 @@ export class Messenger {
                                     changeList,
                                     explanation
                                 )
-                                await ToolUtils.queueDescription(tool, chatStream)
+                                await ToolUtils.queueDescription(
+                                    tool,
+                                    chatStream,
+                                    chatStream.validation.requiresAcceptance
+                                )
                                 if (session.messageIdToUpdate === undefined && tool.type === ToolType.FsRead) {
                                     // Store the first messageId in a chain of tool uses
                                     session.setMessageIdToUpdate(toolUse.toolUseId)

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -748,13 +748,17 @@ export class Messenger {
         }
 
         // Handle read tool and list directory messages
-        if (toolUse?.name === ToolType.FsRead || toolUse?.name === ToolType.ListDirectory) {
+        if (
+            (toolUse?.name === ToolType.FsRead || toolUse?.name === ToolType.ListDirectory) &&
+            !validation.requiresAcceptance
+        ) {
             return this.sendReadAndListDirToolMessage(toolUse, session, tabID, triggerID, messageIdToUpdate)
         }
 
         // Handle file write tool, execute bash tool and bash command output log messages
         const buttons: ChatItemButton[] = []
         let header: ChatItemHeader | undefined = undefined
+        let messageID: string = toolUse?.toolUseId ?? ''
         if (toolUse?.name === ToolType.ExecuteBash && message.startsWith('```shell')) {
             if (validation.requiresAcceptance) {
                 const buttons: ChatItemButton[] = [
@@ -825,6 +829,7 @@ export class Messenger {
             }
         } else if (toolUse?.name === ToolType.ListDirectory || toolUse?.name === ToolType.FsRead) {
             if (validation.requiresAcceptance) {
+                messageID = 'toolUse'
                 const buttons: ChatItemButton[] = [
                     {
                         id: 'confirm-tool-use',
@@ -840,7 +845,6 @@ export class Messenger {
                     },
                 ]
                 header = {
-                    body: 'shell',
                     buttons,
                 }
             }
@@ -859,7 +863,7 @@ export class Messenger {
                     followUpsHeader: undefined,
                     relatedSuggestions: undefined,
                     triggerID,
-                    messageID: toolUse?.toolUseId ?? '',
+                    messageID,
                     userIntent: undefined,
                     codeBlockLanguage: undefined,
                     contextList: undefined,

--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -29,7 +29,7 @@ export class ChatStream extends Writable {
         private readonly messageIdToUpdate: string | undefined,
         // emitEvent decides to show the streaming message or read/list directory tool message to the user.
         private readonly emitEvent: boolean,
-        private readonly validation: CommandValidation,
+        readonly validation: CommandValidation,
         private readonly isReadorList: boolean,
         private readonly changeList?: Change[],
         private readonly explanation?: string,
@@ -45,7 +45,13 @@ export class ChatStream extends Writable {
         if (this.explanation) {
             this.messenger.sendDirectiveMessage(tabID, triggerID, this.explanation)
         }
-        if (validation.requiresAcceptance && this.toolUse?.name === 'executeBash') {
+        if (validation.requiresAcceptance && isReadorList) {
+            this.messenger.sendDirectiveMessage(
+                tabID,
+                triggerID,
+                i18n('AWS.amazonq.chat.directive.permission.readAndList')
+            )
+        } else if (validation.requiresAcceptance && this.toolUse?.name === 'executeBash') {
             this.messenger.sendDirectiveMessage(
                 tabID,
                 triggerID,

--- a/packages/core/src/codewhispererChat/tools/fsRead.ts
+++ b/packages/core/src/codewhispererChat/tools/fsRead.ts
@@ -9,7 +9,6 @@ import { Writable } from 'stream'
 import { InvokeOutput, OutputKind, sanitizePath, CommandValidation, fsReadToolResponseSize } from './toolShared'
 import { isInDirectory } from '../../shared/filesystemUtilities'
 import path from 'path'
-import { ChatStream } from './chatStream'
 
 export interface FsReadParams {
     path: string
@@ -49,8 +48,8 @@ export class FsRead {
         this.logger.debug(`Validation succeeded for path: ${this.fsPath}`)
     }
 
-    public queueDescription(updates: ChatStream): void {
-        if (updates.validation.requiresAcceptance) {
+    public queueDescription(updates: Writable, requiresAcceptance: boolean): void {
+        if (requiresAcceptance) {
             const fileName = path.basename(this.fsPath)
             const fileUri = vscode.Uri.file(this.fsPath)
             updates.write(`Reading file: [${fileName}](${fileUri}), `)

--- a/packages/core/src/codewhispererChat/tools/listDirectory.ts
+++ b/packages/core/src/codewhispererChat/tools/listDirectory.ts
@@ -10,7 +10,6 @@ import { Writable } from 'stream'
 import path from 'path'
 import { InvokeOutput, OutputKind, sanitizePath, CommandValidation } from './toolShared'
 import { isInDirectory } from '../../shared/filesystemUtilities'
-import { ChatStream } from './chatStream'
 
 export interface ListDirectoryParams {
     path: string
@@ -50,8 +49,8 @@ export class ListDirectory {
         }
     }
 
-    public queueDescription(updates: ChatStream): void {
-        if (updates.validation.requiresAcceptance) {
+    public queueDescription(updates: Writable, requiresAcceptance: boolean): void {
+        if (requiresAcceptance) {
             const fileName = path.basename(this.fsPath)
             if (this.maxDepth === undefined) {
                 updates.write(`Analyzing directories recursively: ${fileName}`)

--- a/packages/core/src/codewhispererChat/tools/listDirectory.ts
+++ b/packages/core/src/codewhispererChat/tools/listDirectory.ts
@@ -10,6 +10,7 @@ import { Writable } from 'stream'
 import path from 'path'
 import { InvokeOutput, OutputKind, sanitizePath, CommandValidation } from './toolShared'
 import { isInDirectory } from '../../shared/filesystemUtilities'
+import { ChatStream } from './chatStream'
 
 export interface ListDirectoryParams {
     path: string
@@ -49,16 +50,21 @@ export class ListDirectory {
         }
     }
 
-    public queueDescription(updates: Writable): void {
-        const fileName = path.basename(this.fsPath)
-        if (this.maxDepth === undefined) {
-            updates.write(`Analyzing directories recursively: ${fileName}`)
-        } else if (this.maxDepth === 0) {
-            updates.write(`Analyzing directory: ${fileName}`)
+    public queueDescription(updates: ChatStream): void {
+        if (updates.validation.requiresAcceptance) {
+            const fileName = path.basename(this.fsPath)
+            if (this.maxDepth === undefined) {
+                updates.write(`Analyzing directories recursively: ${fileName}`)
+            } else if (this.maxDepth === 0) {
+                updates.write(`Analyzing directory: ${fileName}`)
+            } else {
+                const level = this.maxDepth > 1 ? 'levels' : 'level'
+                updates.write(`Analyzing directory: ${fileName} limited to ${this.maxDepth} subfolder ${level}`)
+            }
         } else {
-            const level = this.maxDepth > 1 ? 'levels' : 'level'
-            updates.write(`Analyzing directory: ${fileName} limited to ${this.maxDepth} subfolder ${level}`)
+            updates.write('')
         }
+
         updates.end()
     }
 

--- a/packages/core/src/codewhispererChat/tools/toolUtils.ts
+++ b/packages/core/src/codewhispererChat/tools/toolUtils.ts
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as vscode from 'vscode'
 import { Writable } from 'stream'
 import { FsRead, FsReadParams } from './fsRead'
 import { FsWrite, FsWriteParams } from './fsWrite'
@@ -14,7 +15,7 @@ import {
     fsReadToolResponseSize,
 } from './toolShared'
 import { ListDirectory, ListDirectoryParams } from './listDirectory'
-import * as vscode from 'vscode'
+import { ChatStream } from './chatStream'
 
 export enum ToolType {
     FsRead = 'fsRead',
@@ -95,7 +96,7 @@ export class ToolUtils {
         }
     }
 
-    static async queueDescription(tool: Tool, updates: Writable): Promise<void> {
+    static async queueDescription(tool: Tool, updates: ChatStream): Promise<void> {
         switch (tool.type) {
             case ToolType.FsRead:
                 tool.tool.queueDescription(updates)

--- a/packages/core/src/codewhispererChat/tools/toolUtils.ts
+++ b/packages/core/src/codewhispererChat/tools/toolUtils.ts
@@ -15,7 +15,6 @@ import {
     fsReadToolResponseSize,
 } from './toolShared'
 import { ListDirectory, ListDirectoryParams } from './listDirectory'
-import { ChatStream } from './chatStream'
 
 export enum ToolType {
     FsRead = 'fsRead',
@@ -96,10 +95,10 @@ export class ToolUtils {
         }
     }
 
-    static async queueDescription(tool: Tool, updates: ChatStream): Promise<void> {
+    static async queueDescription(tool: Tool, updates: Writable, requiresAcceptance: boolean): Promise<void> {
         switch (tool.type) {
             case ToolType.FsRead:
-                tool.tool.queueDescription(updates)
+                tool.tool.queueDescription(updates, requiresAcceptance)
                 break
             case ToolType.FsWrite:
                 await tool.tool.queueDescription(updates)
@@ -108,7 +107,7 @@ export class ToolUtils {
                 tool.tool.queueDescription(updates)
                 break
             case ToolType.ListDirectory:
-                tool.tool.queueDescription(updates)
+                tool.tool.queueDescription(updates, requiresAcceptance)
                 break
         }
     }

--- a/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
@@ -22,7 +22,6 @@ import { ToolUse } from '@amzn/codewhisperer-streaming'
 import path from 'path'
 import fs from '../../../shared/fs/fs'
 import { ListDirectory } from '../../../codewhispererChat/tools/listDirectory'
-import { ChatStream } from '../../../codewhispererChat/tools/chatStream'
 
 describe('ToolUtils', function () {
     let sandbox: sinon.SinonSandbox
@@ -31,7 +30,6 @@ describe('ToolUtils', function () {
     let mockExecuteBash: sinon.SinonStubbedInstance<ExecuteBash>
     let mockListDirectory: sinon.SinonStubbedInstance<ListDirectory>
     let mockWritable: sinon.SinonStubbedInstance<Writable>
-    let mockChatStream: sinon.SinonStubbedInstance<ChatStream>
 
     beforeEach(function () {
         sandbox = sinon.createSandbox()
@@ -42,7 +40,6 @@ describe('ToolUtils', function () {
         mockWritable = {
             write: sandbox.stub(),
         } as unknown as sinon.SinonStubbedInstance<Writable>
-        mockChatStream = sandbox.createStubInstance(ChatStream)
         ;(mockFsRead.requiresAcceptance as sinon.SinonStub).returns({ requiresAcceptance: false })
         ;(mockListDirectory.requiresAcceptance as sinon.SinonStub).returns({ requiresAcceptance: false })
     })
@@ -237,30 +234,30 @@ describe('ToolUtils', function () {
         // TODO: Adding "void" to the following tests for the current implementation but in the next followup PR I will fix this issue.
         it('delegates to FsRead tool queueDescription method', function () {
             const tool: Tool = { type: ToolType.FsRead, tool: mockFsRead as unknown as FsRead }
-            void ToolUtils.queueDescription(tool, mockWritable as unknown as ChatStream)
+            void ToolUtils.queueDescription(tool, mockWritable as unknown as Writable, false)
 
-            assert(mockFsRead.queueDescription.calledOnceWith(mockChatStream))
+            assert(mockFsRead.queueDescription.calledOnceWith(mockWritable, false))
         })
 
         it('delegates to FsWrite tool queueDescription method', function () {
             const tool: Tool = { type: ToolType.FsWrite, tool: mockFsWrite as unknown as FsWrite }
-            void ToolUtils.queueDescription(tool, mockWritable as unknown as ChatStream)
+            void ToolUtils.queueDescription(tool, mockWritable as unknown as Writable, false)
 
             assert(mockFsWrite.queueDescription.calledOnceWith(mockWritable))
         })
 
         it('delegates to ExecuteBash tool queueDescription method', function () {
             const tool: Tool = { type: ToolType.ExecuteBash, tool: mockExecuteBash as unknown as ExecuteBash }
-            void ToolUtils.queueDescription(tool, mockWritable as unknown as ChatStream)
+            void ToolUtils.queueDescription(tool, mockWritable as unknown as Writable, false)
 
             assert(mockExecuteBash.queueDescription.calledOnceWith(mockWritable))
         })
 
         it('delegates to ListDirectory tool queueDescription method', function () {
             const tool: Tool = { type: ToolType.ListDirectory, tool: mockListDirectory as unknown as ListDirectory }
-            void ToolUtils.queueDescription(tool, mockWritable as unknown as ChatStream)
+            void ToolUtils.queueDescription(tool, mockWritable as unknown as Writable, false)
 
-            assert(mockListDirectory.queueDescription.calledOnceWith(mockChatStream))
+            assert(mockListDirectory.queueDescription.calledOnceWith(mockWritable, false))
         })
     })
 

--- a/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/toolShared.test.ts
@@ -22,6 +22,7 @@ import { ToolUse } from '@amzn/codewhisperer-streaming'
 import path from 'path'
 import fs from '../../../shared/fs/fs'
 import { ListDirectory } from '../../../codewhispererChat/tools/listDirectory'
+import { ChatStream } from '../../../codewhispererChat/tools/chatStream'
 
 describe('ToolUtils', function () {
     let sandbox: sinon.SinonSandbox
@@ -30,6 +31,7 @@ describe('ToolUtils', function () {
     let mockExecuteBash: sinon.SinonStubbedInstance<ExecuteBash>
     let mockListDirectory: sinon.SinonStubbedInstance<ListDirectory>
     let mockWritable: sinon.SinonStubbedInstance<Writable>
+    let mockChatStream: sinon.SinonStubbedInstance<ChatStream>
 
     beforeEach(function () {
         sandbox = sinon.createSandbox()
@@ -40,6 +42,7 @@ describe('ToolUtils', function () {
         mockWritable = {
             write: sandbox.stub(),
         } as unknown as sinon.SinonStubbedInstance<Writable>
+        mockChatStream = sandbox.createStubInstance(ChatStream)
         ;(mockFsRead.requiresAcceptance as sinon.SinonStub).returns({ requiresAcceptance: false })
         ;(mockListDirectory.requiresAcceptance as sinon.SinonStub).returns({ requiresAcceptance: false })
     })
@@ -234,30 +237,30 @@ describe('ToolUtils', function () {
         // TODO: Adding "void" to the following tests for the current implementation but in the next followup PR I will fix this issue.
         it('delegates to FsRead tool queueDescription method', function () {
             const tool: Tool = { type: ToolType.FsRead, tool: mockFsRead as unknown as FsRead }
-            void ToolUtils.queueDescription(tool, mockWritable as unknown as Writable)
+            void ToolUtils.queueDescription(tool, mockWritable as unknown as ChatStream)
 
-            assert(mockFsRead.queueDescription.calledOnceWith(mockWritable))
+            assert(mockFsRead.queueDescription.calledOnceWith(mockChatStream))
         })
 
         it('delegates to FsWrite tool queueDescription method', function () {
             const tool: Tool = { type: ToolType.FsWrite, tool: mockFsWrite as unknown as FsWrite }
-            void ToolUtils.queueDescription(tool, mockWritable as unknown as Writable)
+            void ToolUtils.queueDescription(tool, mockWritable as unknown as ChatStream)
 
             assert(mockFsWrite.queueDescription.calledOnceWith(mockWritable))
         })
 
         it('delegates to ExecuteBash tool queueDescription method', function () {
             const tool: Tool = { type: ToolType.ExecuteBash, tool: mockExecuteBash as unknown as ExecuteBash }
-            void ToolUtils.queueDescription(tool, mockWritable as unknown as Writable)
+            void ToolUtils.queueDescription(tool, mockWritable as unknown as ChatStream)
 
             assert(mockExecuteBash.queueDescription.calledOnceWith(mockWritable))
         })
 
         it('delegates to ListDirectory tool queueDescription method', function () {
             const tool: Tool = { type: ToolType.ListDirectory, tool: mockListDirectory as unknown as ListDirectory }
-            void ToolUtils.queueDescription(tool, mockWritable as unknown as Writable)
+            void ToolUtils.queueDescription(tool, mockWritable as unknown as ChatStream)
 
-            assert(mockListDirectory.queueDescription.calledOnceWith(mockWritable))
+            assert(mockListDirectory.queueDescription.calledOnceWith(mockChatStream))
         })
     })
 


### PR DESCRIPTION


## Problem
- Reading Tool and List Directory tool requires users acceptance if IDE wants to perform operation outside of workspace.

## Solution
- This problem is fixed as part of this PR
![image](https://github.com/user-attachments/assets/ad2811a6-7dca-4f21-b1f5-4c7809ec58e9)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
