### PR TITLE
feat(amazonq): Add region profile manager functionality

### DIFF
--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -328,11 +328,11 @@ export class RegionProfileManager {
         }
     }
 
-    requireProfileSelection(): boolean {
+    requireProfileSelection() {
         if (AuthUtil.instance.isBuilderIdConnection()) {
             return false
         }
-        return Boolean(AuthUtil.instance.isIdcConnection() && this.activeRegionProfile === undefined)
+        return AuthUtil.instance.isIdcConnection() && this.activeRegionProfile === undefined
     }
 
     async createQClient(region: string, endpoint: string): Promise<CodeWhispererUserClient> {


### PR DESCRIPTION
## Problem
The [first version](https://github.com/aws/aws-toolkit-vscode/pull/6958) of migration of all auth for vscode to Flare using the identity server did not support the recently introduced RegionProfileManager

## Solution
These code changes bring back the RegionProfileManager functionality, in the new auth setup. Integration tests and unit tests to be fixed after all references are updated in a follow-up PR to keep the changes manageable. **CI is expected to fail**.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
