### PR TITLE
telemetry(chat): differentiate chat vs agenticChat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.313",
+                "@aws-toolkits/telemetry": "^1.0.314",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -10806,9 +10806,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.313",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.313.tgz",
-            "integrity": "sha512-GHlx2AoUfUuadXjZqMlQmpayVhnH1r6Ndbm7jOXvp80j3cwHqUdOgD/7gqK4mYKuxNBhEFC9yB5ieqmaH1lMuQ==",
+            "version": "1.0.314",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.314.tgz",
+            "integrity": "sha512-9Utwv6Z1TO477+l67Y35OhPzWWOFEetj8qcyQ9bBXnJmq0fVGTyvx1RH/OxmcGW42iAIovA9a3ck4oou02rbeQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.313",
+        "@aws-toolkits/telemetry": "^1.0.314",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -414,6 +414,11 @@ export class ChatController {
 
     private async processStopResponseMessage(message: StopResponseMessage) {
         const session = this.sessionStorage.getSession(message.tabID)
+
+        if (session.agenticLoopInProgress === true) {
+            this.telemetryHelper.recordInteractionWithAgenticChat(AgenticChatInteractionType.StopChat, message)
+        }
+
         session.tokenSource.cancel()
         session.setAgenticLoopInProgress(false)
         session.setToolUseWithError(undefined)
@@ -428,7 +433,6 @@ export class ChatController {
         }
 
         this.messenger.sendEmptyMessage(message.tabID, '', undefined)
-        this.telemetryHelper.recordInteractionWithAgenticChat(AgenticChatInteractionType.StopChat, message)
     }
 
     private async processTriggerTabIDReceived(message: TriggerTabIDReceived) {

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -225,7 +225,7 @@ export class CWCTelemetryHelper {
             cwsprAgenticChatInteractionType: interactionType,
             result: 'Succeeded',
             cwsprChatConversationId: this.getConversationId(message.tabID ?? '') ?? '',
-            cwsprChatConversationType: 'Chat',
+            cwsprChatConversationType: 'AgenticChat',
             credentialStartUrl: AuthUtil.instance.startUrl,
         })
     }
@@ -543,7 +543,7 @@ export class CWCTelemetryHelper {
             cwsprChatFullDisplayLatency: fullDisplayLatency,
             cwsprChatRequestLength: triggerPayload.message.length,
             cwsprChatResponseLength: message.messageLength,
-            cwsprChatConversationType: 'Chat',
+            cwsprChatConversationType: triggerPayload.origin ? 'AgenticChat' : 'Chat',
             credentialStartUrl: AuthUtil.instance.startUrl,
             codewhispererCustomizationArn: triggerPayload.customization.arn,
             cwsprChatHasProjectContext: hasProjectLevelContext,


### PR DESCRIPTION
## Problem
- differentiate `Chat` vs `AgenticChat` for cwsprChatConversationType
- stop button functionality changed so event is being incorrectly emitted

## Solution
- emit `AgenticChat` for cwsprChatConversationType
- correctly emit event when user clicks stop button
- https://github.com/aws/aws-toolkit-common/pull/1012 


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
