### PR TITLE
fix(chat): Ignore directories and files that are not relevant to the code analysis in listDirectory

### DIFF
--- a/packages/core/src/codewhispererChat/constants.ts
+++ b/packages/core/src/codewhispererChat/constants.ts
@@ -55,3 +55,115 @@ export const defaultContextLengths: ContextLengths = {
 }
 
 export const defaultStreamingResponseTimeoutInMs = 180_000
+
+export const ignoredDirectoriesAndFiles = [
+    // Dependency directories
+    'node_modules',
+    '.venv',
+    'venv',
+    'bower_components',
+    'jspm_packages',
+    // Build outputs
+    'dist',
+    'build',
+    'out',
+    'target',
+    '.gradle',
+    '.pytest_cache',
+    '.tox',
+    '__snapshots__',
+    // Compiled files
+    '*.class',
+    '*.o',
+    '*.a',
+    '*.so',
+    '*.pyc',
+    '__pycache__',
+    '*.exe',
+    '*.dll',
+    // Package files
+    '*.jar',
+    '*.gem',
+    '*.vsix',
+    '*.zip',
+    '*.tar.gz',
+    '*.rar',
+    // IDE and editor files
+    '.idea/',
+    '.vscode/',
+    '*.sublime-*',
+    '*.swp',
+    '*.swo',
+    '.project',
+    '.classpath',
+    '*.iml',
+    // Log files
+    '*.log',
+    'logs/',
+    'npm-debug.log*',
+    // Coverage and test reports
+    'coverage/',
+    '.nyc_output/',
+    'test-results/',
+    '.test-reports/',
+    // Cache directories
+    '.cache/',
+    '.sass-cache/',
+    '.eslintcache',
+    '.parcel-cache',
+    // Environment and local configuration
+    '.env',
+    '.env.local',
+    '*.env.*',
+    '*.local.json',
+    '*.local.yml',
+    'config.local.*',
+    '.npmrc',
+    '.yarnrc',
+    '.dockerignore',
+    // OS specific files
+    '.DS_Store',
+    'Thumbs.db',
+    'desktop.ini',
+    // Temporary files
+    'tmp/',
+    'temp/',
+    '*.tmp',
+    '*.bak',
+    '*.bk',
+    // Generated documentation
+    'docs/_build/',
+    'site/',
+    'public/',
+    // Database files
+    '*.sqlite',
+    '*.db',
+    // Secrets and credentials
+    '*.pem',
+    '*.key',
+    'id_rsa',
+    'id_dsa',
+    '*.pfx',
+    '*.p12',
+    'credentials.json',
+    '*_credentials.*',
+    'aws-credentials.*',
+    'secrets.*',
+    // Version Control Directories
+    '.git/',
+    '.svn/',
+    '.hg/',
+    '.bzr/',
+    // Generated Code
+    '*.generated.*',
+    '*.auto.*',
+    '*.g.*',
+    // Cloud Provider Specific
+    '.terraform/',
+    '.serverless/',
+    'cdk.out/',
+    '.aws-sam/',
+    '.amplify/',
+    // Mobile Development
+    'Pods/',
+]

--- a/packages/core/src/codewhispererChat/constants.ts
+++ b/packages/core/src/codewhispererChat/constants.ts
@@ -59,111 +59,13 @@ export const defaultStreamingResponseTimeoutInMs = 180_000
 export const ignoredDirectoriesAndFiles = [
     // Dependency directories
     'node_modules',
-    '.venv',
-    'venv',
-    'bower_components',
-    'jspm_packages',
     // Build outputs
     'dist',
     'build',
     'out',
-    'target',
-    '.gradle',
-    '.pytest_cache',
-    '.tox',
-    '__snapshots__',
-    // Compiled files
-    '*.class',
-    '*.o',
-    '*.a',
-    '*.so',
-    '*.pyc',
-    '__pycache__',
-    '*.exe',
-    '*.dll',
-    // Package files
-    '*.jar',
-    '*.gem',
-    '*.vsix',
-    '*.zip',
-    '*.tar.gz',
-    '*.rar',
-    // IDE and editor files
+    // IDE and editor directories
     '.idea/',
     '.vscode/',
-    '*.sublime-*',
-    '*.swp',
-    '*.swo',
-    '.project',
-    '.classpath',
-    '*.iml',
-    // Log files
-    '*.log',
-    'logs/',
-    'npm-debug.log*',
-    // Coverage and test reports
-    'coverage/',
-    '.nyc_output/',
-    'test-results/',
-    '.test-reports/',
-    // Cache directories
-    '.cache/',
-    '.sass-cache/',
-    '.eslintcache',
-    '.parcel-cache',
-    // Environment and local configuration
-    '.env',
-    '.env.local',
-    '*.env.*',
-    '*.local.json',
-    '*.local.yml',
-    'config.local.*',
-    '.npmrc',
-    '.yarnrc',
-    '.dockerignore',
     // OS specific files
     '.DS_Store',
-    'Thumbs.db',
-    'desktop.ini',
-    // Temporary files
-    'tmp/',
-    'temp/',
-    '*.tmp',
-    '*.bak',
-    '*.bk',
-    // Generated documentation
-    'docs/_build/',
-    'site/',
-    'public/',
-    // Database files
-    '*.sqlite',
-    '*.db',
-    // Secrets and credentials
-    '*.pem',
-    '*.key',
-    'id_rsa',
-    'id_dsa',
-    '*.pfx',
-    '*.p12',
-    'credentials.json',
-    '*_credentials.*',
-    'aws-credentials.*',
-    'secrets.*',
-    // Version Control Directories
-    '.git/',
-    '.svn/',
-    '.hg/',
-    '.bzr/',
-    // Generated Code
-    '*.generated.*',
-    '*.auto.*',
-    '*.g.*',
-    // Cloud Provider Specific
-    '.terraform/',
-    '.serverless/',
-    'cdk.out/',
-    '.aws-sam/',
-    '.amplify/',
-    // Mobile Development
-    'Pods/',
 ]

--- a/packages/core/src/codewhispererChat/constants.ts
+++ b/packages/core/src/codewhispererChat/constants.ts
@@ -63,9 +63,6 @@ export const ignoredDirectoriesAndFiles = [
     'dist',
     'build',
     'out',
-    // IDE and editor directories
-    '.idea/',
-    '.vscode/',
     // OS specific files
     '.DS_Store',
 ]

--- a/packages/core/src/codewhispererChat/tools/tool_index.json
+++ b/packages/core/src/codewhispererChat/tools/tool_index.json
@@ -83,7 +83,7 @@
     },
     "listDirectory": {
         "name": "listDirectory",
-        "description": "List the contents of a directory and its subdirectories, it will filter out build outputs such as `build/`, `out/` and `dist` and dependency directory such as `node_modules/` and IDE directories such as `.idea/`, `.vscode/`.\n * Use this tool for discovery, before using more targeted tools like fsRead.\n *Useful to try to understand the file structure before diving deeper into specific files.\n *Can be used to explore the codebase.\n *Results clearly distinguish between files, directories or symlinks with [F], [D] and [L] prefixes.",
+        "description": "List the contents of a directory and its subdirectories, it will filter out build outputs such as `build/`, `out/` and `dist` and dependency directory such as `node_modules/`.\n * Use this tool for discovery, before using more targeted tools like fsRead.\n *Useful to try to understand the file structure before diving deeper into specific files.\n *Can be used to explore the codebase.\n *Results clearly distinguish between files, directories or symlinks with [F], [D] and [L] prefixes.",
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/packages/core/src/codewhispererChat/tools/tool_index.json
+++ b/packages/core/src/codewhispererChat/tools/tool_index.json
@@ -83,7 +83,7 @@
     },
     "listDirectory": {
         "name": "listDirectory",
-        "description": "List the contents of a directory and its subdirectories.\n * Use this tool for discovery, before using more targeted tools like fsRead.\n *Useful to try to understand the file structure before diving deeper into specific files.\n *Can be used to explore the codebase.\n *Results clearly distinguish between files, directories or symlinks with [FILE], [DIR] and [LINK] prefixes.",
+        "description": "List the contents of a directory and its subdirectories, it will filter out build and artifacts directories and files such as `node_modules/`, `build/`, `.git/` or `*.log`.\n * Use this tool for discovery, before using more targeted tools like fsRead.\n *Useful to try to understand the file structure before diving deeper into specific files.\n *Can be used to explore the codebase.\n *Results clearly distinguish between files, directories or symlinks with [F], [D] and [L] prefixes.",
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/packages/core/src/codewhispererChat/tools/tool_index.json
+++ b/packages/core/src/codewhispererChat/tools/tool_index.json
@@ -83,7 +83,7 @@
     },
     "listDirectory": {
         "name": "listDirectory",
-        "description": "List the contents of a directory and its subdirectories, it will filter out build and artifacts directories and files such as `node_modules/`, `build/`, `.git/` or `*.log`.\n * Use this tool for discovery, before using more targeted tools like fsRead.\n *Useful to try to understand the file structure before diving deeper into specific files.\n *Can be used to explore the codebase.\n *Results clearly distinguish between files, directories or symlinks with [F], [D] and [L] prefixes.",
+        "description": "List the contents of a directory and its subdirectories, it will filter out build outputs such as `build/`, `out/` and `dist` and dependency directory such as `node_modules/` and IDE directories such as `.idea/`, `.vscode/`.\n * Use this tool for discovery, before using more targeted tools like fsRead.\n *Useful to try to understand the file structure before diving deeper into specific files.\n *Can be used to explore the codebase.\n *Results clearly distinguish between files, directories or symlinks with [F], [D] and [L] prefixes.",
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/packages/core/src/test/codewhispererChat/tools/listDirectory.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/listDirectory.test.ts
@@ -43,9 +43,9 @@ describe('ListDirectory Tool', () => {
         const result = await listDirectory.invoke(process.stdout)
 
         const lines = result.output.content.split('\n')
-        const hasFileA = lines.some((line: string | string[]) => line.includes('[FILE] ') && line.includes('fileA.txt'))
+        const hasFileA = lines.some((line: string | string[]) => line.includes('[F] ') && line.includes('fileA.txt'))
         const hasSubfolder = lines.some(
-            (line: string | string[]) => line.includes('[DIR] ') && line.includes('subfolder')
+            (line: string | string[]) => line.includes('[D] ') && line.includes('subfolder')
         )
 
         assert.ok(hasFileA, 'Should list fileA.txt in the directory output')
@@ -62,15 +62,33 @@ describe('ListDirectory Tool', () => {
         const result = await listDirectory.invoke(process.stdout)
 
         const lines = result.output.content.split('\n')
-        const hasFileA = lines.some((line: string | string[]) => line.includes('[FILE] ') && line.includes('fileA.txt'))
+        const hasFileA = lines.some((line: string | string[]) => line.includes('[F] ') && line.includes('fileA.txt'))
         const hasSubfolder = lines.some(
-            (line: string | string[]) => line.includes('[DIR] ') && line.includes('subfolder')
+            (line: string | string[]) => line.includes('[D] ') && line.includes('subfolder')
         )
-        const hasFileB = lines.some((line: string | string[]) => line.includes('[FILE] ') && line.includes('fileB.md'))
+        const hasFileB = lines.some((line: string | string[]) => line.includes('[F] ') && line.includes('fileB.md'))
 
         assert.ok(hasFileA, 'Should list fileA.txt in the directory output')
         assert.ok(hasSubfolder, 'Should list the subfolder in the directory output')
         assert.ok(hasFileB, 'Should list fileB.md in the subfolder in the directory output')
+    })
+
+    it('lists directory contents with ignored pattern', async () => {
+        await testFolder.mkdir('node_modules')
+        await testFolder.write(path.join('node_modules', 'fileC.md'), '# fileC')
+
+        const listDirectory = new ListDirectory({ path: testFolder.path })
+        await listDirectory.validate()
+        const result = await listDirectory.invoke(process.stdout)
+
+        const lines = result.output.content.split('\n')
+        const hasNodeModules = lines.some(
+            (line: string | string[]) => line.includes('[D] ') && line.includes('node_modules')
+        )
+        const hasFileC = lines.some((line: string | string[]) => line.includes('[F] ') && line.includes('fileC.md'))
+
+        assert.ok(!hasNodeModules, 'Should not list node_modules in the directory output')
+        assert.ok(!hasFileC, 'Should not list fileC.md under node_modules in the directory output')
     })
 
     it('throws error if path does not exist', async () => {

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -14,6 +14,7 @@ import {
     findStringInDirectory,
     getWorkspaceFoldersByPrefixes,
     getWorkspaceRelativePath,
+    shouldIgnoreDirAndFile,
 } from '../../../shared/utilities/workspaceUtils'
 import { getTestWorkspaceFolder } from '../../integrationTestsUtilities'
 import globals from '../../../shared/extensionGlobals'
@@ -588,6 +589,38 @@ describe('workspaceUtils', () => {
                 ] satisfies typeof result,
                 result
             )
+        })
+    })
+
+    describe('shouldIgnoreDirAndFile', function () {
+        it('handles exact matches', function () {
+            assert.strictEqual(shouldIgnoreDirAndFile('node_modules', vscode.FileType.Directory), true)
+            assert.strictEqual(shouldIgnoreDirAndFile('.env', vscode.FileType.File), true)
+            assert.strictEqual(shouldIgnoreDirAndFile('random_file.txt', vscode.FileType.File), false)
+        })
+
+        it('handles directory patterns with trailing slash', function () {
+            assert.strictEqual(shouldIgnoreDirAndFile('.idea', vscode.FileType.Directory), true)
+            assert.strictEqual(shouldIgnoreDirAndFile('logs', vscode.FileType.Directory), true)
+            assert.strictEqual(shouldIgnoreDirAndFile('.idea', vscode.FileType.File), false)
+        })
+
+        it('handles wildcard patterns at the start', function () {
+            assert.strictEqual(shouldIgnoreDirAndFile('example.class', vscode.FileType.File), true)
+            assert.strictEqual(shouldIgnoreDirAndFile('test.log', vscode.FileType.File), true)
+            assert.strictEqual(shouldIgnoreDirAndFile('class.example', vscode.FileType.File), false)
+        })
+
+        it('handles wildcard patterns at the end', function () {
+            assert.strictEqual(shouldIgnoreDirAndFile('npm-debug.log123', vscode.FileType.File), true)
+            assert.strictEqual(shouldIgnoreDirAndFile('npm-debug.txt', vscode.FileType.File), false)
+        })
+
+        it('handles complex wildcard patterns', function () {
+            assert.strictEqual(shouldIgnoreDirAndFile('test.env.local', vscode.FileType.File), true)
+            assert.strictEqual(shouldIgnoreDirAndFile('my_credentials.json', vscode.FileType.File), true)
+            assert.strictEqual(shouldIgnoreDirAndFile('config.local.json', vscode.FileType.File), true)
+            assert.strictEqual(shouldIgnoreDirAndFile('random.txt', vscode.FileType.File), false)
         })
     })
 

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -595,7 +595,6 @@ describe('workspaceUtils', () => {
     describe('shouldIgnoreDirAndFile', function () {
         it('handles exact matches', function () {
             assert.strictEqual(shouldIgnoreDirAndFile('node_modules', vscode.FileType.Directory), true)
-            assert.strictEqual(shouldIgnoreDirAndFile('.env', vscode.FileType.File), true)
             assert.strictEqual(shouldIgnoreDirAndFile('random_file.txt', vscode.FileType.File), false)
         })
 
@@ -603,24 +602,6 @@ describe('workspaceUtils', () => {
             assert.strictEqual(shouldIgnoreDirAndFile('.idea', vscode.FileType.Directory), true)
             assert.strictEqual(shouldIgnoreDirAndFile('logs', vscode.FileType.Directory), true)
             assert.strictEqual(shouldIgnoreDirAndFile('.idea', vscode.FileType.File), false)
-        })
-
-        it('handles wildcard patterns at the start', function () {
-            assert.strictEqual(shouldIgnoreDirAndFile('example.class', vscode.FileType.File), true)
-            assert.strictEqual(shouldIgnoreDirAndFile('test.log', vscode.FileType.File), true)
-            assert.strictEqual(shouldIgnoreDirAndFile('class.example', vscode.FileType.File), false)
-        })
-
-        it('handles wildcard patterns at the end', function () {
-            assert.strictEqual(shouldIgnoreDirAndFile('npm-debug.log123', vscode.FileType.File), true)
-            assert.strictEqual(shouldIgnoreDirAndFile('npm-debug.txt', vscode.FileType.File), false)
-        })
-
-        it('handles complex wildcard patterns', function () {
-            assert.strictEqual(shouldIgnoreDirAndFile('test.env.local', vscode.FileType.File), true)
-            assert.strictEqual(shouldIgnoreDirAndFile('my_credentials.json', vscode.FileType.File), true)
-            assert.strictEqual(shouldIgnoreDirAndFile('config.local.json', vscode.FileType.File), true)
-            assert.strictEqual(shouldIgnoreDirAndFile('random.txt', vscode.FileType.File), false)
         })
     })
 

--- a/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/packages/core/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -597,12 +597,6 @@ describe('workspaceUtils', () => {
             assert.strictEqual(shouldIgnoreDirAndFile('node_modules', vscode.FileType.Directory), true)
             assert.strictEqual(shouldIgnoreDirAndFile('random_file.txt', vscode.FileType.File), false)
         })
-
-        it('handles directory patterns with trailing slash', function () {
-            assert.strictEqual(shouldIgnoreDirAndFile('.idea', vscode.FileType.Directory), true)
-            assert.strictEqual(shouldIgnoreDirAndFile('logs', vscode.FileType.Directory), true)
-            assert.strictEqual(shouldIgnoreDirAndFile('.idea', vscode.FileType.File), false)
-        })
     })
 
     describe('findStringInDirectory', function () {


### PR DESCRIPTION
## Problem
- ListDirectory tool will include all directories and files in the result which is not necessary and does not help LLM understand the structure better 

## Solution
- Ignore directories and files that are not relevant to the code analysis in listDirectory


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
