### PR TITLE
fix(lsp): verify that nodejs runs before starting LSP client

### DIFF
--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -50,7 +50,7 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
     ) {
         this.webview = webviewView.webview
 
-        const lspDir = Uri.parse(LanguageServerResolver.defaultDir)
+        const lspDir = Uri.parse(LanguageServerResolver.defaultDir())
         webviewView.webview.options = {
             enableScripts: true,
             enableCommandUris: true,

--- a/packages/amazonq/test/unit/amazonq/lsp/lspClient.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/lspClient.test.ts
@@ -4,8 +4,8 @@
  */
 import * as sinon from 'sinon'
 import assert from 'assert'
-import { globals } from 'aws-core-vscode/shared'
-import { LspClient } from 'aws-core-vscode/amazonq'
+import { globals, getNodeExecutableName } from 'aws-core-vscode/shared'
+import { LspClient, lspClient as lspClientModule } from 'aws-core-vscode/amazonq'
 
 describe('Amazon Q LSP client', function () {
     let lspClient: LspClient
@@ -48,6 +48,22 @@ describe('Amazon Q LSP client', function () {
         const sample = 'hello'
         const encryptedSample = await lspClient.encrypt(sample)
         assert.ok(!encryptedSample.includes('hello'))
+    })
+
+    it('validates node executable + lsp bundle', async () => {
+        await assert.rejects(async () => {
+            await lspClientModule.activate(globals.context, {
+                // Mimic the `LspResolution<ResourcePaths>` type.
+                node: 'node.bogus.exe',
+                lsp: 'fake/lsp.js',
+            })
+        }, /.*failed to run basic .*node.*exitcode.*node\.bogus\.exe.*/)
+        await assert.rejects(async () => {
+            await lspClientModule.activate(globals.context, {
+                node: getNodeExecutableName(),
+                lsp: 'fake/lsp.js',
+            })
+        }, /.*failed to run .*exitcode.*node.*lsp\.js/)
     })
 
     afterEach(() => {

--- a/packages/core/src/amazonq/index.ts
+++ b/packages/core/src/amazonq/index.ts
@@ -17,6 +17,7 @@ export {
 } from './onboardingPage/walkthrough'
 export { LspController } from './lsp/lspController'
 export { LspClient } from './lsp/lspClient'
+export * as lspClient from './lsp/lspClient'
 export { api } from './extApi'
 export { AmazonQChatViewProvider } from './webview/webView'
 export { init as cwChatAppInit } from '../codewhispererChat/app'

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -47,7 +47,7 @@ import { ChildProcess } from '../../shared/utilities/processUtils'
 const localize = nls.loadMessageBundle()
 
 const key = crypto.randomBytes(32)
-const logger = getLogger('amazonqLsp')
+const logger = getLogger('amazonqLsp.lspClient')
 
 /**
  * LspClient manages the API call between VS Code extension and LSP server
@@ -83,7 +83,7 @@ export class LspClient {
             const resp = await this.client?.sendRequest(BuildIndexRequestType, encryptedRequest)
             return resp
         } catch (e) {
-            logger.error(`LspClient: buildIndex error: ${e}`)
+            logger.error(`buildIndex error: ${e}`)
             return undefined
         }
     }
@@ -98,7 +98,7 @@ export class LspClient {
             const resp = await this.client?.sendRequest(QueryVectorIndexRequestType, encryptedRequest)
             return resp
         } catch (e) {
-            logger.error(`LspClient: queryVectorIndex error: ${e}`)
+            logger.error(`queryVectorIndex error: ${e}`)
             return []
         }
     }
@@ -114,7 +114,7 @@ export class LspClient {
             const resp: any = await this.client?.sendRequest(QueryInlineProjectContextRequestType, encrypted)
             return resp
         } catch (e) {
-            logger.error(`LspClient: queryInlineProjectContext error: ${e}`)
+            logger.error(`queryInlineProjectContext error: ${e}`)
             throw e
         }
     }
@@ -135,7 +135,7 @@ export class LspClient {
             const resp = await this.client?.sendRequest(UpdateIndexV2RequestType, encryptedRequest)
             return resp
         } catch (e) {
-            logger.error(`LspClient: updateIndex error: ${e}`)
+            logger.error(`updateIndex error: ${e}`)
             return undefined
         }
     }
@@ -147,7 +147,7 @@ export class LspClient {
             const resp: any = await this.client?.sendRequest(QueryRepomapIndexRequestType, await this.encrypt(request))
             return resp
         } catch (e) {
-            logger.error(`LspClient: QueryRepomapIndex error: ${e}`)
+            logger.error(`QueryRepomapIndex error: ${e}`)
             throw e
         }
     }
@@ -160,7 +160,7 @@ export class LspClient {
             )
             return resp
         } catch (e) {
-            logger.error(`LspClient: queryInlineProjectContext error: ${e}`)
+            logger.error(`queryInlineProjectContext error: ${e}`)
             throw e
         }
     }
@@ -177,7 +177,7 @@ export class LspClient {
             )
             return resp
         } catch (e) {
-            logger.error(`LspClient: getContextCommandItems error: ${e}`)
+            logger.error(`getContextCommandItems error: ${e}`)
             throw e
         }
     }
@@ -193,7 +193,7 @@ export class LspClient {
             )
             return resp || []
         } catch (e) {
-            logger.error(`LspClient: getContextCommandPrompt error: ${e}`)
+            logger.error(`getContextCommandPrompt error: ${e}`)
             throw e
         }
     }
@@ -207,7 +207,7 @@ export class LspClient {
             )
             return resp
         } catch (e) {
-            logger.error(`LspClient: getIndexSequenceNumber error: ${e}`)
+            logger.error(`getIndexSequenceNumber error: ${e}`)
             throw e
         }
     }
@@ -235,9 +235,9 @@ async function validateNodeExe(nodePath: string, lsp: string, args: string[]) {
     const r = await proc.run()
     const ok = r.exitCode === 0 && r.stdout.includes('ok')
     if (!ok) {
-        const msg = `amazonqLsp: failed to run basic "node -e" test (exitcode=${r.exitCode}): ${proc}`
+        const msg = `failed to run basic "node -e" test (exitcode=${r.exitCode}): ${proc}`
         logger.error(msg)
-        throw new ToolkitError(msg)
+        throw new ToolkitError(`amazonqLsp: ${msg}`)
     }
 
     // Check that we can start `node …/lsp.js --stdio …`.
@@ -416,7 +416,7 @@ export async function activate(extensionContext: ExtensionContext, resourcePaths
             toDispose.push(disposableFunc)
         },
         (reason) => {
-            logger.error('LspClient.instance.client.onReady() failed: %O', reason)
+            logger.error('client.onReady() failed: %O', reason)
         }
     )
 }

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -235,7 +235,7 @@ async function validateNodeExe(nodePath: string) {
     const r = await proc.run()
     const ok = r.exitCode === 0 && r.stdout.includes('ok')
     if (!ok) {
-        throw new ToolkitError(`amazonqLsp: failed to run node (exitcode=${r.exitCode}): "${resourcePaths.node}"`)
+        throw new ToolkitError(`amazonqLsp: failed to run node (exitcode=${r.exitCode}): "${nodePath}"`)
     }
 }
 

--- a/packages/core/src/amazonq/webview/generators/webViewContent.ts
+++ b/packages/core/src/amazonq/webview/generators/webViewContent.ts
@@ -9,7 +9,6 @@ import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { FeatureConfigProvider, FeatureContext } from '../../../shared/featureConfig'
 import globals from '../../../shared/extensionGlobals'
 import { isSageMaker } from '../../../shared/extensionUtilities'
-import { RegionProfile } from '../../../codewhisperer/models/model'
 import { AmazonQPromptSettings } from '../../../shared/settings'
 
 export class WebViewContentGenerator {
@@ -90,10 +89,10 @@ export class WebViewContentGenerator {
         // only show profile card when the two conditions
         //  1. profile count >= 2
         //  2. not default (fallback) which has empty arn
-        let regionProfile: RegionProfile | undefined = AuthUtil.instance.regionProfileManager.activeRegionProfile
-        if (AuthUtil.instance.regionProfileManager.profiles.length === 1) {
-            regionProfile = undefined
-        }
+        const regionProfile =
+            AuthUtil.instance.regionProfileManager.profiles.length === 1
+                ? undefined
+                : AuthUtil.instance.regionProfileManager.activeRegionProfile
 
         const regionProfileString: string = JSON.stringify(regionProfile)
         const authState = (await AuthUtil.instance.getChatAuthState()).amazonQ
@@ -104,7 +103,7 @@ export class WebViewContentGenerator {
         <script type="text/javascript">
             const init = () => {
                 createMynahUI(
-                    acquireVsCodeApi(), 
+                    acquireVsCodeApi(),
                     ${authState === 'connected'},
                     ${featureConfigsString},
                     ${welcomeLoadCount},

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -14,6 +14,7 @@ export type LogTopic =
     | 'lsp'
     | 'amazonqWorkspaceLsp'
     | 'amazonqLsp'
+    | 'amazonqLsp.lspClient'
     | 'chat'
     | 'stepfunctions'
     | 'unknown'

--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -54,10 +54,19 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, 
         const deletedVersions = await cleanLspDownloads(manifest.versions, nodePath.dirname(assetDirectory))
         this.logger.debug(`cleaning old LSP versions deleted ${deletedVersions.length} versions`)
 
-        return {
+        const r = {
             ...installationResult,
+            // Example:
+            // ```
+            // resourcePaths = {
+            //     lsp = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/aws-lsp-codewhisperer.js'
+            //     node = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/node'
+            //     ui = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/clients/amazonq-ui.js'
+            // }
+            // ```
             resourcePaths: this.resourcePaths(assetDirectory),
         }
+        return r
     }
 
     protected abstract postInstall(assetDirectory: string): Promise<void>

--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -47,25 +47,40 @@ export class LanguageServerResolver {
 
             const serverResolvers: StageResolver<LspResult>[] = [
                 {
+                    // 1: Use the current local ("cached") LSP server bundle, if any.
                     resolve: async () => await this.getLocalServer(cacheDirectory, latestVersion, targetContents),
                     telemetryMetadata: { id: this.lsName, languageServerLocation: 'cache' },
                 },
                 {
+                    // 2: Download the latest LSP server bundle.
                     resolve: async () => await this.fetchRemoteServer(cacheDirectory, latestVersion, targetContents),
                     telemetryMetadata: { id: this.lsName, languageServerLocation: 'remote' },
                 },
                 {
+                    // 3: If the download fails, try an older, cached version.
                     resolve: async () => await this.getFallbackServer(latestVersion),
                     telemetryMetadata: { id: this.lsName, languageServerLocation: 'fallback' },
                 },
             ]
 
-            return await tryStageResolvers('getServer', serverResolvers, getServerVersion)
+            /**
+             * Example:
+             * ```
+             * LspResult {
+             *   assetDirectory = "<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0"
+             *   location = 'cache'
+             *   version = '3.3.0'
+             * }
+             * ```
+             */
+            const resolved = await tryStageResolvers('getServer', serverResolvers, getServerVersion)
+            return resolved
         } finally {
             logger.info(`Finished setting up LSP server`)
         }
     }
 
+    /** Finds an older, cached version of the LSP server bundle. */
     private async getFallbackServer(latestVersion: LspVersion): Promise<LspResult> {
         const fallbackDirectory = await this.getFallbackDir(latestVersion.serverVersion)
         if (!fallbackDirectory) {
@@ -96,6 +111,7 @@ export class LanguageServerResolver {
         return timeout
     }
 
+    /** Downloads the latest LSP server bundle. */
     private async fetchRemoteServer(
         cacheDirectory: string,
         latestVersion: LspVersion,
@@ -117,6 +133,7 @@ export class LanguageServerResolver {
         }
     }
 
+    /** Gets the current local ("cached") LSP server bundle. */
     private async getLocalServer(
         cacheDirectory: string,
         latestVersion: LspVersion,
@@ -417,13 +434,17 @@ export class LanguageServerResolver {
         return version.targets.find((x) => x.arch === arch && x.platform === platform)
     }
 
-    // lazy calls to `getApplicationSupportFolder()` to avoid failure on windows.
-    public static get defaultDir() {
+    /**
+     * Gets platform-specific "cache" dir ("$LOCALAPPDATA/aws/…" or "~/.cache/aws/…").
+     *
+     * Lazy-calls `getCacheDir()` to avoid failure on Windows.
+     */
+    public static defaultDir() {
         return path.join(fs.getCacheDir(), `aws/toolkits/language-servers`)
     }
 
     defaultDownloadFolder() {
-        return path.join(LanguageServerResolver.defaultDir, `${this.lsName}`)
+        return path.join(LanguageServerResolver.defaultDir(), `${this.lsName}`)
     }
 
     private getDownloadDirectory(version: string) {

--- a/packages/core/src/shared/lsp/types.ts
+++ b/packages/core/src/shared/lsp/types.ts
@@ -9,17 +9,48 @@ import { LanguageServerLocation, ManifestLocation } from '../telemetry/telemetry
 export const logger = getLogger('lsp')
 
 export interface LspResult {
+    /** Example: `"cache"` */
     location: LanguageServerLocation
+    /** Example: `"3.3.0"` */
     version: string
+    /** Example: `"<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0"` */
     assetDirectory: string
 }
 
+/**
+ * Example:
+ * ```
+ * resourcePaths = {
+ *     lsp = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/aws-lsp-codewhisperer.js'
+ *     node = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/node'
+ *     ui = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/clients/amazonq-ui.js'
+ * }
+ * ```
+ */
 export interface ResourcePaths {
+    /**
+     * Path to `.js` bundle to be executed by `node`.
+     * Example: `"<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/aws-lsp-codewhisperer.js"`
+     */
     lsp: string
+    /**
+     * Path to `node` (or `node.exe`) executable/binary.
+     * Example: `"<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/node"`
+     */
     node: string
 }
 
 export interface LspResolution<T extends ResourcePaths> extends LspResult {
+    /**
+     * Example:
+     * ```
+     * resourcePaths = {
+     *     lsp = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/aws-lsp-codewhisperer.js'
+     *     node = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/node'
+     *     ui = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/clients/amazonq-ui.js'
+     * }
+     * ```
+     */
     resourcePaths: T
 }
 


### PR DESCRIPTION
## Problem
When lsp fetch/install/start fails it does not mention the download path, which could help with troubleshooting. #6972

    [info] using amazonqWorkspaceLsp service configuration: default
    [info] lsp: Failed to download latest "AmazonQ-Workspace" manifest. Falling back to local manifest.
    [info] lsp: Finished setting up LSP server
    [info] [Error] Starting client failed
    [info] Error: write EPIPE

## Solution
- Validate that `node` can actually run, before passing it to `LspClient`.
- Add more logging.

Also captured by telemetry:

```
2025-04-16 08:24:51.738 [debug] telemetry: languageServer_setup {
  Metadata: {
    missingFields: 'id',
    metricId: '8da91a4b-ee00-4115-9b9e-796b5357402c',
    traceId: '8569c16e-d319-486e-a6f3-d4ee91698468',
    languageServerSetupStage: 'all',
    duration: '1417',
    result: 'Failed',
    reason: 'Error',
    reasonDesc: 'amazonqLsp: failed to run basic "node -e" test (exitcode=-2): [/Users/x/x/x/aws/x/x/x/x/x -e console.log("ok " + process.version)]',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'Milliseconds',
  Passive: true
}
```




---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
