### PR TITLE
fix(chat): Updating spinner text to thinking

### DIFF
--- a/packages/core/src/amazonq/webview/ui/texts/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/texts/constants.ts
@@ -25,7 +25,7 @@ export const uiComponentsTexts = {
     copyToClipboard: 'Copied to clipboard',
     noMoreTabsTooltip: 'You can only open ten conversation tabs at a time.',
     codeSuggestionWithReferenceTitle: 'Some suggestions contain code with references.',
-    spinnerText: 'Generating your answer...',
+    spinnerText: 'Thinking...',
     changeAccepted: 'Change accepted',
     changeRejected: 'Change rejected',
     acceptChange: 'Accept change',


### PR DESCRIPTION
## Problem
Currently the spinner text on waiting for LLM responses displays `Generating your Answer` which is not reflective of new features.

## Solution
- Updated it to `Thinking`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
