### PR TITLE
telemetry(chat): request id and error message in error metric

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -542,7 +542,13 @@ export class Messenger {
 
                 followUps = []
                 relatedSuggestions = []
-                this.telemetryHelper.recordMessageResponseError(triggerPayload, tabID, errorInfo.statusCode ?? 0)
+                this.telemetryHelper.recordMessageResponseError(
+                    triggerPayload,
+                    tabID,
+                    errorInfo.statusCode ?? 0,
+                    errorInfo.requestId,
+                    errorInfo.errorMessage
+                )
             })
             .finally(async () => {
                 if (session.sessionIdentifier && !this.isTriggerCancelled(triggerID)) {


### PR DESCRIPTION
## Problem
- do not have `requestID` and `errorMessage` in amazonq_messageResponseError

## Solution
- emit amazonq_messageResponseError event with `requestID` and `errorMessage`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
