### PR TITLE
refactor(amazonq): Pass mynah references to ui handlers

### DIFF
--- a/packages/core/src/amazonq/commons/types.ts
+++ b/packages/core/src/amazonq/commons/types.ts
@@ -166,4 +166,9 @@ export enum MetricDataResult {
     LlmFailure = 'LLMFailure',
 }
 
+/**
+ * Note: Passing a reference around allows us to lazily inject mynah UI into
+ * connectors and handlers. This is done to supported "hybrid chat", which
+ * injects mynah UI _after_ the connector has already been created
+ */
 export type MynahUIRef = { mynahUI: MynahUI | undefined }

--- a/packages/core/src/amazonq/commons/types.ts
+++ b/packages/core/src/amazonq/commons/types.ts
@@ -11,6 +11,7 @@ import { DiffTreeFileInfo } from '../webview/ui/diffTree/types'
 import { Messenger } from './connector/baseMessenger'
 import { FeatureClient } from '../client/client'
 import { TelemetryHelper } from '../util/telemetryHelper'
+import { MynahUI } from '@aws/mynah-ui'
 
 export enum FollowUpTypes {
     // UnitTestGeneration
@@ -164,3 +165,5 @@ export enum MetricDataResult {
     Error = 'Error',
     LlmFailure = 'LLMFailure',
 }
+
+export type MynahUIRef = { mynahUI: MynahUI | undefined }

--- a/packages/core/src/amazonq/webview/ui/followUps/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/followUps/handler.ts
@@ -8,21 +8,21 @@ import { Connector } from '../connector'
 import { TabsStorage } from '../storages/tabsStorage'
 import { WelcomeFollowupType } from '../apps/amazonqCommonsConnector'
 import { AuthFollowUpType } from './generator'
-import { FollowUpTypes } from '../../../commons/types'
+import { FollowUpTypes, MynahUIRef } from '../../../commons/types'
 
 export interface FollowUpInteractionHandlerProps {
-    mynahUI: MynahUI
+    mynahUIRef: MynahUIRef
     connector: Connector
     tabsStorage: TabsStorage
 }
 
 export class FollowUpInteractionHandler {
-    private mynahUI: MynahUI
+    private mynahUIRef: MynahUIRef
     private connector: Connector
     private tabsStorage: TabsStorage
 
     constructor(props: FollowUpInteractionHandlerProps) {
-        this.mynahUI = props.mynahUI
+        this.mynahUIRef = props.mynahUIRef
         this.connector = props.connector
         this.tabsStorage = props.tabsStorage
     }
@@ -41,6 +41,11 @@ export class FollowUpInteractionHandler {
             this.connector.help(tabID)
             return
         }
+
+        if (!this.mynahUI) {
+            return
+        }
+
         // we need to check if there is a prompt
         // which will cause an api call
         // then we can set the loading state to true
@@ -70,7 +75,7 @@ export class FollowUpInteractionHandler {
         }
 
         const addChatItem = (tabID: string, messageId: string, options: any[]) => {
-            this.mynahUI.addChatItem(tabID, {
+            this.mynahUI?.addChatItem(tabID, {
                 type: ChatItemType.ANSWER_PART,
                 messageId,
                 followUp: {
@@ -150,7 +155,7 @@ export class FollowUpInteractionHandler {
 
     public onWelcomeFollowUpClicked(tabID: string, welcomeFollowUpType: WelcomeFollowupType) {
         if (welcomeFollowUpType === 'continue-to-chat') {
-            this.mynahUI.addChatItem(tabID, {
+            this.mynahUI?.addChatItem(tabID, {
                 type: ChatItemType.ANSWER,
                 body: 'Ok, please write your question below.',
             })
@@ -158,5 +163,9 @@ export class FollowUpInteractionHandler {
             this.connector.onUpdateTabType(tabID)
             return
         }
+    }
+
+    private get mynahUI(): MynahUI | undefined {
+        return this.mynahUIRef.mynahUI
     }
 }

--- a/packages/core/src/amazonq/webview/ui/messages/controller.ts
+++ b/packages/core/src/amazonq/webview/ui/messages/controller.ts
@@ -8,9 +8,10 @@ import { Connector } from '../connector'
 import { TabType, TabsStorage } from '../storages/tabsStorage'
 import { TabDataGenerator } from '../tabs/generator'
 import { uiComponentsTexts } from '../texts/constants'
+import { MynahUIRef } from '../../../commons/types'
 
 export interface MessageControllerProps {
-    mynahUI: MynahUI
+    mynahUIRef: MynahUIRef
     connector: Connector
     tabsStorage: TabsStorage
     isFeatureDevEnabled: boolean
@@ -22,13 +23,13 @@ export interface MessageControllerProps {
 }
 
 export class MessageController {
-    private mynahUI: MynahUI
+    private mynahUIRef: MynahUIRef
     private connector: Connector
     private tabsStorage: TabsStorage
     private tabDataGenerator: TabDataGenerator
 
     constructor(props: MessageControllerProps) {
-        this.mynahUI = props.mynahUI
+        this.mynahUIRef = props.mynahUIRef
         this.connector = props.connector
         this.tabsStorage = props.tabsStorage
         this.tabDataGenerator = new TabDataGenerator({
@@ -43,6 +44,10 @@ export class MessageController {
 
     public sendSelectedCodeToTab(message: ChatItem, command: string = ''): string | undefined {
         const selectedTab = { ...this.tabsStorage.getSelectedTab() }
+        if (!this.mynahUI) {
+            return
+        }
+
         if (
             selectedTab?.id === undefined ||
             selectedTab?.type === undefined ||
@@ -76,6 +81,9 @@ export class MessageController {
 
     public sendMessageToTab(message: ChatItem, tabType: TabType, command: string = ''): string | undefined {
         const selectedTab = this.tabsStorage.getSelectedTab()
+        if (!this.mynahUI) {
+            return
+        }
 
         if (
             selectedTab !== undefined &&
@@ -140,5 +148,9 @@ export class MessageController {
 
             return newTabID
         }
+    }
+
+    private get mynahUI(): MynahUI | undefined {
+        return this.mynahUIRef.mynahUI
     }
 }

--- a/packages/core/src/amazonq/webview/ui/messages/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/messages/handler.ts
@@ -6,20 +6,21 @@
 import { ChatItemType, ChatPrompt, MynahUI } from '@aws/mynah-ui'
 import { Connector } from '../connector'
 import { TabsStorage } from '../storages/tabsStorage'
+import { MynahUIRef } from '../../../commons/types'
 
 export interface TextMessageHandlerProps {
-    mynahUI: MynahUI
+    mynahUIRef: MynahUIRef
     connector: Connector
     tabsStorage: TabsStorage
 }
 
 export class TextMessageHandler {
-    private mynahUI: MynahUI
+    private mynahUIRef: MynahUIRef
     private connector: Connector
     private tabsStorage: TabsStorage
 
     constructor(props: TextMessageHandlerProps) {
-        this.mynahUI = props.mynahUI
+        this.mynahUIRef = props.mynahUIRef
         this.connector = props.connector
         this.tabsStorage = props.tabsStorage
     }
@@ -29,6 +30,10 @@ export class TextMessageHandler {
         this.tabsStorage.updateTabTypeFromUnknown(tabID, 'cwc')
         this.tabsStorage.resetTabTimer(tabID)
         this.connector.onUpdateTabType(tabID)
+        if (!this.mynahUI) {
+            return
+        }
+
         this.mynahUI.addChatItem(tabID, {
             type: ChatItemType.PROMPT,
             body: chatPrompt.escapedPrompt,
@@ -49,5 +54,9 @@ export class TextMessageHandler {
                 chatContext: chatPrompt.context,
             })
             .then(() => {})
+    }
+
+    private get mynahUI(): MynahUI | undefined {
+        return this.mynahUIRef.mynahUI
     }
 }

--- a/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
@@ -344,7 +344,7 @@ export class QuickActionHandler {
     }
 
     private handleClearCommand(tabID: string) {
-        this.mynahUI.updateStore(tabID, {
+        this.mynahUI?.updateStore(tabID, {
             chatItems: [],
         })
         this.connector.clearChat(tabID)

--- a/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
@@ -8,9 +8,10 @@ import { TabDataGenerator } from '../tabs/generator'
 import { Connector } from '../connector'
 import { TabsStorage, TabType } from '../storages/tabsStorage'
 import { uiComponentsTexts } from '../texts/constants'
+import { MynahUIRef } from '../../../commons/types'
 
 export interface QuickActionsHandlerProps {
-    mynahUI: MynahUI
+    mynahUIRef: { mynahUI: MynahUI | undefined }
     connector: Connector
     tabsStorage: TabsStorage
     isFeatureDevEnabled: boolean
@@ -30,7 +31,7 @@ export interface HandleCommandProps {
     taskName?: string
 }
 export class QuickActionHandler {
-    private mynahUI: MynahUI
+    private mynahUIRef: MynahUIRef
     private connector: Connector
     private tabsStorage: TabsStorage
     private tabDataGenerator: TabDataGenerator
@@ -41,7 +42,7 @@ export class QuickActionHandler {
     private isDocEnabled: boolean
 
     constructor(props: QuickActionsHandlerProps) {
-        this.mynahUI = props.mynahUI
+        this.mynahUIRef = props.mynahUIRef
         this.connector = props.connector
         this.tabsStorage = props.tabsStorage
         this.isDocEnabled = props.isDocEnabled
@@ -104,7 +105,7 @@ export class QuickActionHandler {
     }
 
     private handleScanCommand(tabID: string, eventId: string | undefined) {
-        if (!this.isScanEnabled) {
+        if (!this.isScanEnabled || !this.mynahUI) {
             return
         }
         let scanTabId: string | undefined = undefined
@@ -158,7 +159,7 @@ export class QuickActionHandler {
     }
 
     private handleTestCommand(chatPrompt: ChatPrompt, tabID: string, eventId: string | undefined) {
-        if (!this.isTestEnabled) {
+        if (!this.isTestEnabled || !this.mynahUI) {
             return
         }
         const testTabId = this.tabsStorage.getTabs().find((tab) => tab.type === 'testgen')?.id
@@ -207,7 +208,7 @@ export class QuickActionHandler {
     }
 
     private handleCommand(props: HandleCommandProps) {
-        if (!props.isEnabled) {
+        if (!props.isEnabled || !this.mynahUI) {
             return
         }
 
@@ -244,7 +245,7 @@ export class QuickActionHandler {
 
             const addInformationCard = (tabId: string) => {
                 if (props.tabType === 'featuredev') {
-                    this.mynahUI.addChatItem(tabId, {
+                    this.mynahUI?.addChatItem(tabId, {
                         type: ChatItemType.ANSWER,
                         informationCard: {
                             title: 'Feature development',
@@ -286,7 +287,7 @@ export class QuickActionHandler {
     }
 
     private handleGumbyCommand(tabID: string, eventId: string | undefined) {
-        if (!this.isGumbyEnabled) {
+        if (!this.isGumbyEnabled || !this.mynahUI) {
             return
         }
 
@@ -356,5 +357,9 @@ export class QuickActionHandler {
         }
 
         this.connector.help(tabID)
+    }
+
+    private get mynahUI(): MynahUI | undefined {
+        return this.mynahUIRef.mynahUI
     }
 }


### PR DESCRIPTION
## Problem
- Flare's hybrid chat injects MynahUI reference after chat connector creation

## Solution
- Implement delayed resolution so that onces MynahUI is injected everything dynamically resolves

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
