### PR TITLE
fix(amazonq): validate customization on profile change

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-a6e9ce99-842b-4d64-b9b0-967383d7acb9.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-a6e9ce99-842b-4d64-b9b0-967383d7acb9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Users might be bound to a customization which they dont have access with the selected profile and it causes service throwing 403 when using inline suggestion and chat features"
+}

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -344,9 +344,9 @@ export async function activate(context: ExtContext): Promise<void> {
         ),
         vscode.commands.registerCommand('aws.amazonq.openEditorAtRange', openEditorAtRange),
         auth.regionProfileManager.onDidChangeRegionProfile(() => {
-            // validate user's still has access to the selected customization
+            // Validate user still has access to the selected customization.
             const selectedCustomization = getSelectedCustomization()
-            // no need to validate base customization which has empty arn
+            // No need to validate base customization which has empty arn
             if (selectedCustomization.arn.length > 0) {
                 getAvailableCustomizationsList()
                     .then(async (customizations) => {
@@ -357,7 +357,8 @@ export async function activate(context: ExtContext): Promise<void> {
                     })
                     .catch((e) => {
                         getLogger().error(
-                            `encounter error while validating selected customization on profile change: ${(e as Error).message}`
+                            `encounter error while validating selected customization on profile change: %s`,
+                            (e as Error).message
                         )
                     })
             }

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -349,10 +349,10 @@ export async function activate(context: ExtContext): Promise<void> {
             // no need to validate base customization which has empty arn
             if (selectedCustomization.arn.length > 0) {
                 getAvailableCustomizationsList()
-                    .then((customizations) => {
+                    .then(async (customizations) => {
                         const r = customizations.find((it) => it.arn === selectedCustomization.arn)
                         if (!r) {
-                            void switchToBaseCustomizationAndNotify().then()
+                            await switchToBaseCustomizationAndNotify()
                         }
                     })
                     .catch((e) => {

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -346,7 +346,7 @@ export async function activate(context: ExtContext): Promise<void> {
         auth.regionProfileManager.onDidChangeRegionProfile(() => {
             // Validate user still has access to the selected customization.
             const selectedCustomization = getSelectedCustomization()
-            // No need to validate base customization which has empty arn
+            // No need to validate base customization which has empty arn.
             if (selectedCustomization.arn.length > 0) {
                 getAvailableCustomizationsList()
                     .then(async (customizations) => {

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -72,7 +72,12 @@ import { AuthUtil } from './util/authUtil'
 import { ImportAdderProvider } from './service/importAdderProvider'
 import { TelemetryHelper } from './util/telemetryHelper'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
-import { notifyNewCustomizations } from './util/customizationUtil'
+import {
+    getAvailableCustomizationsList,
+    getSelectedCustomization,
+    notifyNewCustomizations,
+    switchToBaseCustomizationAndNotify,
+} from './util/customizationUtil'
 import { CodeWhispererCommandBackend, CodeWhispererCommandDeclarations } from './commands/gettingStartedPageCommands'
 import { SecurityIssueHoverProvider } from './service/securityIssueHoverProvider'
 import { SecurityIssueCodeActionProvider } from './service/securityIssueCodeActionProvider'
@@ -337,7 +342,26 @@ export async function activate(context: ExtContext): Promise<void> {
             [...CodeWhispererConstants.securityScanLanguageIds],
             SecurityIssueCodeActionProvider.instance
         ),
-        vscode.commands.registerCommand('aws.amazonq.openEditorAtRange', openEditorAtRange)
+        vscode.commands.registerCommand('aws.amazonq.openEditorAtRange', openEditorAtRange),
+        auth.regionProfileManager.onDidChangeRegionProfile(() => {
+            // validate user's still has access to the selected customization
+            const selectedCustomization = getSelectedCustomization()
+            // no need to validate base customization which has empty arn
+            if (selectedCustomization.arn.length > 0) {
+                getAvailableCustomizationsList()
+                    .then((customizations) => {
+                        const r = customizations.find((it) => it.arn === selectedCustomization.arn)
+                        if (!r) {
+                            void switchToBaseCustomizationAndNotify().then()
+                        }
+                    })
+                    .catch((e) => {
+                        getLogger().error(
+                            `encounter error while validating selected customization on profile change: ${(e as Error).message}`
+                        )
+                    })
+            }
+        })
     )
 
     // run the auth startup code with context for telemetry


### PR DESCRIPTION
## Problem
- Before
customization is bound to a specific idc instance

- After
customization is bound to a specific Q profile and an idc instance can have multi profiles

therefore each Q profile will have access to different sets of customization

## Solution
We need to validate if the selected customization is accessible from the user's selected profile, otherwise will get
```
*An error occurred while processing your request.*
This error is reported to the team automatically. We will attempt to fix it as soon as possible.
Details: The provided profile ARN and customization ARN is mismatched. (Service: CodeWhispererRuntime, Status Code: 403, 
```

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
