### PR TITLE
fix(chat): Add Undo clickable button and string change

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -394,7 +394,7 @@ export class Connector extends BaseConnector {
                 if (answer.header) {
                     answer.header.status = {
                         icon: 'cancel' as MynahIconsType,
-                        text: 'Rejected',
+                        text: 'Change discarded',
                         status: 'error',
                     }
                     answer.header.buttons = []

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -53,8 +53,6 @@ import {
     MynahIconsType,
     DetailedList,
     MynahUIDataModel,
-    MynahIcons,
-    Status,
 } from '@aws/mynah-ui'
 import { Database } from '../../../../shared/db/chatDb/chatDb'
 import { TabType } from '../../../../amazonq/webview/ui/storages/tabsStorage'

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -810,25 +810,12 @@ export class Messenger {
                 {
                     id: 'reject-code-diff',
                     status: 'clear',
-                    icon: 'cancel' as MynahIconsType,
+                    icon: 'revert' as MynahIconsType,
+                    text: 'Undo',
                 },
             ]
-            const status: {
-                icon?: MynahIcons | MynahIconsType
-                status?: {
-                    status?: Status
-                    icon?: MynahIcons | MynahIconsType
-                    text?: string
-                }
-            } = {
-                status: {
-                    text: 'Accepted',
-                    status: 'success',
-                },
-            }
             header = {
                 buttons,
-                ...status,
                 fileList,
             }
         } else if (toolUse?.name === ToolType.ListDirectory || toolUse?.name === ToolType.FsRead) {


### PR DESCRIPTION
## Problem
The Ux design does not meet the requirement

## Solution
Make the undo a clickable button and change the string when user reject the generated code
![image](https://github.com/user-attachments/assets/53bf59e8-ffc6-45ba-9944-236e4e3bae69)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
