### PR TITLE
fix(chat): When user reject executing command, it should not send messages to LLM

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -394,7 +394,7 @@ export class Connector extends BaseConnector {
                 if (answer.header) {
                     answer.header.status = {
                         icon: 'cancel' as MynahIconsType,
-                        text: 'Rejected',
+                        text: 'Change discarded',
                         status: 'error',
                     }
                     answer.header.buttons = []

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -928,11 +928,22 @@ export class ChatController {
             case 'reject-shell-command':
             case 'reject-tool-use':
                 await this.rejectShellCommand(message)
-                await this.processToolUseMessage(message)
+                if (message.tabID) {
+                    await this.sendCommandRejectMessage(message.tabID)
+                }
+                if (message.triggerId) {
+                    ConversationTracker.getInstance().markTriggerCompleted(message.triggerId)
+                }
                 break
             default:
                 getLogger().warn(`Unhandled action: ${message.action.id}`)
         }
+    }
+
+    private async sendCommandRejectMessage(tabID: string) {
+        const session = this.sessionStorage.getSession(tabID)
+        session.setAgenticLoopInProgress(false)
+        this.messenger.sendDirectiveMessage(tabID, '', 'Command Rejected')
     }
 
     private async restoreBackup(message: CustomFormActionMessage) {

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1662,7 +1662,26 @@ export class ChatController {
 
             await this.messenger.sendAIResponse(response, session, tabID, triggerID, triggerPayload)
         } catch (e: any) {
-            this.telemetryHelper.recordMessageResponseError(triggerPayload, tabID, getHttpStatusCode(e) ?? 0)
+            let errorMessage: string
+            let requestID: string | undefined
+
+            if (e instanceof CodeWhispererStreamingServiceException) {
+                errorMessage = e.message
+                requestID = e.$metadata.requestId
+            } else {
+                errorMessage = 'Error is not CodeWhispererStreamingServiceException. '
+                if (e instanceof Error || e?.message) {
+                    errorMessage += `Error message is: ${e.message}`
+                }
+            }
+
+            this.telemetryHelper.recordMessageResponseError(
+                triggerPayload,
+                tabID,
+                getHttpStatusCode(e) ?? 0,
+                requestID,
+                errorMessage
+            )
             // clears session, record telemetry before this call
             this.processException(e, tabID)
         }

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -894,6 +894,8 @@ export class ChatController {
                 currentToolUse.name === ToolType.ListDirectory)
         ) {
             session.toolUseWithError.error = new Error('Tool use was rejected by the user.')
+            session.setToolUseWithError(undefined)
+            this.messenger.sendAsyncEventProgress(message.tabID!, false, undefined)
         } else {
             getLogger().error(
                 `toolUse name: ${currentToolUse!.name} of toolUseWithError in the stored session doesn't match when click shell command reject button.`

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -53,8 +53,6 @@ import {
     MynahIconsType,
     DetailedList,
     MynahUIDataModel,
-    MynahIcons,
-    Status,
 } from '@aws/mynah-ui'
 import { Database } from '../../../../shared/db/chatDb/chatDb'
 import { TabType } from '../../../../amazonq/webview/ui/storages/tabsStorage'
@@ -810,25 +808,12 @@ export class Messenger {
                 {
                     id: 'reject-code-diff',
                     status: 'clear',
-                    icon: 'cancel' as MynahIconsType,
+                    icon: 'revert' as MynahIconsType,
+                    text: 'Undo',
                 },
             ]
-            const status: {
-                icon?: MynahIcons | MynahIconsType
-                status?: {
-                    status?: Status
-                    icon?: MynahIcons | MynahIconsType
-                    text?: string
-                }
-            } = {
-                status: {
-                    text: 'Accepted',
-                    status: 'success',
-                },
-            }
             header = {
                 buttons,
-                ...status,
                 fileList,
             }
         } else if (toolUse?.name === ToolType.ListDirectory || toolUse?.name === ToolType.FsRead) {

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -540,7 +540,13 @@ export class Messenger {
 
                 followUps = []
                 relatedSuggestions = []
-                this.telemetryHelper.recordMessageResponseError(triggerPayload, tabID, errorInfo.statusCode ?? 0)
+                this.telemetryHelper.recordMessageResponseError(
+                    triggerPayload,
+                    tabID,
+                    errorInfo.statusCode ?? 0,
+                    errorInfo.requestId,
+                    errorInfo.errorMessage
+                )
             })
             .finally(async () => {
                 if (session.sessionIdentifier && !this.isTriggerCancelled(triggerID)) {


### PR DESCRIPTION
## Problem
Right now, when user reject executing command, chat would send the reject message to LLM and LLM would response. The loop would still continue
<img width="428" alt="Screenshot 2025-04-15 at 11 36 15 AM" src="https://github.com/user-attachments/assets/cd5d1c03-271a-416e-9c9e-d62068a82020" />
## Solution
<img width="428" alt="Screenshot 2025-04-15 at 11 44 57 AM" src="https://github.com/user-attachments/assets/66a6a05a-444d-4e90-bce1-c1bfb2ffa217" />




---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
