### PR TITLE
fix(chat): Add more fsWrite validation and validate before diff view

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -330,6 +330,8 @@ export class Messenger {
                                         )
                                         explanation = input.explanation
                                     }
+                                    // validate the fsWrite tool input before showing the diff view
+                                    await tool.tool.validate()
                                     session.setShowDiffOnFileWrite(true)
                                     changeList = await tool.tool.getDiffChanges()
                                 }

--- a/packages/core/src/test/codewhispererChat/tools/fsWrite.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/fsWrite.test.ts
@@ -66,39 +66,6 @@ describe('FsWrite Tool', function () {
 
             assert.deepStrictEqual(output, expectedOutput)
         })
-
-        it('uses newStr when fileText is not provided', async function () {
-            const filePath = path.join(testFolder.path, 'file2.txt')
-
-            const params: CreateParams = {
-                command: 'create',
-                newStr: 'Hello World',
-                path: filePath,
-            }
-            const fsWrite = new FsWrite(params)
-            const output = await fsWrite.invoke(process.stdout)
-
-            const content = await fs.readFileText(filePath)
-            assert.strictEqual(content, 'Hello World')
-
-            assert.deepStrictEqual(output, expectedOutput)
-        })
-
-        it('creates an empty file when no content is provided', async function () {
-            const filePath = path.join(testFolder.path, 'file3.txt')
-
-            const params: CreateParams = {
-                command: 'create',
-                path: filePath,
-            }
-            const fsWrite = new FsWrite(params)
-            const output = await fsWrite.invoke(process.stdout)
-
-            const content = await fs.readFileText(filePath)
-            assert.strictEqual(content, '')
-
-            assert.deepStrictEqual(output, expectedOutput)
-        })
     })
 
     describe('handleStrReplace', async function () {


### PR DESCRIPTION
## Problem
- Sometimes the fsWrite input is invalid causing the diff view to show 0 changes

## Solution
- Add more fsWrite validation and validate before diff view


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
