### PR TITLE
fix(chat): Fixing bug in read files and in accepting permissions

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1286,6 +1286,16 @@ export class ChatController {
             this.processException(e, message.tabID)
         }
     }
+    private sessionCleanUp(session: ChatSession) {
+        // Create a fresh token for this new conversation
+        session.createNewTokenSource()
+        session.setAgenticLoopInProgress(true)
+        session.clearListOfReadFiles()
+        session.clearListOfReadFolders()
+        session.setShowDiffOnFileWrite(false)
+        session.setMessageIdToUpdate(undefined)
+        session.setMessageIdToUpdateListDirectory(undefined)
+    }
 
     private async processPromptMessageAsNewThread(message: PromptMessage) {
         const session = this.sessionStorage.getSession(message.tabID)
@@ -1293,13 +1303,7 @@ export class ChatController {
         if (session.agenticLoopInProgress) {
             session.disposeTokenSource()
         }
-
-        // Create a fresh token for this new conversation
-        session.createNewTokenSource()
-        session.setAgenticLoopInProgress(true)
-        session.clearListOfReadFiles()
-        session.clearListOfReadFolders()
-        session.setShowDiffOnFileWrite(false)
+        this.sessionCleanUp(session)
         this.editorContextExtractor
             .extractContextForTrigger('ChatMessage')
             .then(async (context) => {

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -844,7 +844,9 @@ export class Messenger {
                 ]
                 header = {
                     buttons,
+                    body: message,
                 }
+                message = ''
             }
         }
 


### PR DESCRIPTION
## Problem
- Message should be provided as part of header body but right now its passed as body directly.
![image](https://github.com/user-attachments/assets/d5e6fbf9-a642-48f1-b18c-46c110364704)
- In existing IDE experience, If user asks a second question in the same chat tab, IDE overrides the first workflow read files with second workflow read files because `session.setMessageIdToUpdate` is unchanged(not defined to undefined after completion of first request.)


## Solution
- Fixed in this as passing as part of header body.
![image](https://github.com/user-attachments/assets/49e6d328-1869-4d83-85ba-ecc3066f608f)
- Cleaning the `session.setMessageIdToUpdate` value so for second request IDE won't update the first request read fileTree.
![image](https://github.com/user-attachments/assets/1574aae9-c353-4793-a682-61388ed36faa)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
