### PR TITLE
feat(amazonq): Chat history provided through flare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10831,18 +10831,16 @@
             }
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.49",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.49.tgz",
-            "integrity": "sha512-GJMxZiDuV4zXGh4RBGDEobVH0CvgmFT3O3ZxYfmVGq3JvNhnKXXNYFNzWDUvF8aUUJZJGv4u4OyHitm8TSjrBg==",
+            "version": "0.2.58",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.58.tgz",
+            "integrity": "sha512-gb1oLKACFpmDKkzSdDAqMdpo63m+Kul4B/uVNNO1IFN4+wEP7zPVgmd1dLDPlLKHrxsAEQDxoYDaYVyQ+yJKqQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.9.3",
                 "@aws-crypto/sha256-js": "^5.2.0",
                 "@aws-sdk/client-cognito-identity": "^3.758.0",
-                "@aws/language-server-runtimes-types": "^0.1.6",
+                "@aws/language-server-runtimes-types": "^0.1.13",
                 "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
                 "@opentelemetry/resources": "^1.30.1",
                 "@opentelemetry/sdk-metrics": "^1.30.1",
                 "@opentelemetry/sdk-node": "^0.57.2",
@@ -10855,7 +10853,7 @@
                 "aws-sdk": "^2.1692.0",
                 "axios": "^1.8.4",
                 "hpagent": "^1.2.0",
-                "jose": "^5.9.6",
+                "jose": "^6.0.10",
                 "mac-ca": "^3.1.1",
                 "rxjs": "^7.8.2",
                 "vscode-languageserver": "^9.0.1",
@@ -10867,9 +10865,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.10.tgz",
-            "integrity": "sha512-SIzwtSKG0IFrQFDREVdIIzpMOCVbcV45Nk/LufXIux523KlNSvxpQViIIQThqO4KmoyOZZ3ZWsUELdzpxc//iQ==",
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.13.tgz",
+            "integrity": "sha512-+FJREN6qyNcOwbu0fxAKt0QUh6x10xg2a9fLL722yVisXV0p4ElgHuXssOWhwALJrmy47DF7bRunZYNpFR9mqw==",
             "dev": true,
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -11893,9 +11891,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes/node_modules/jose": {
-            "version": "5.9.6",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
-            "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.10.tgz",
+            "integrity": "sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==",
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -26795,8 +26793,8 @@
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
                 "@aws/chat-client-ui-types": "^0.1.12",
-                "@aws/language-server-runtimes": "^0.2.49",
-                "@aws/language-server-runtimes-types": "^0.1.10",
+                "@aws/language-server-runtimes": "^0.2.58",
+                "@aws/language-server-runtimes-types": "^0.1.13",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",
@@ -27956,16 +27954,6 @@
                 "aws-crt": {
                     "optional": true
                 }
-            }
-        },
-        "packages/core/node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.10.tgz",
-            "integrity": "sha512-SIzwtSKG0IFrQFDREVdIIzpMOCVbcV45Nk/LufXIux523KlNSvxpQViIIQThqO4KmoyOZZ3ZWsUELdzpxc//iQ==",
-            "dev": true,
-            "dependencies": {
-                "vscode-languageserver-textdocument": "^1.0.12",
-                "vscode-languageserver-types": "^3.17.5"
             }
         },
         "packages/core/node_modules/@smithy/fetch-http-handler": {

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -186,13 +186,9 @@ export function registerMessageListeners(
                 break
             }
             case listConversationsRequestType.method:
-                await resolveChatResponse(listConversationsRequestType.method, message.params, languageClient, webview)
-                break
             case conversationClickRequestType.method:
-                await resolveChatResponse(conversationClickRequestType.method, message.params, languageClient, webview)
-                break
             case tabBarActionRequestType.method:
-                await resolveChatResponse(tabBarActionRequestType.method, message.params, languageClient, webview)
+                await resolveChatResponse(message.command, message.params, languageClient, webview)
                 break
             case followUpClickNotificationType.method:
                 if (!isValidAuthFollowUpType(message.params.followUp.type)) {

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -186,13 +186,13 @@ export function registerMessageListeners(
                 break
             }
             case listConversationsRequestType.method:
-                await handleRequest(languageClient, message.params, webview, listConversationsRequestType.method)
+                await resolveChatResponse(listConversationsRequestType.method, message.params, languageClient, webview)
                 break
             case conversationClickRequestType.method:
-                await handleRequest(languageClient, message.params, webview, conversationClickRequestType.method)
+                await resolveChatResponse(conversationClickRequestType.method, message.params, languageClient, webview)
                 break
             case tabBarActionRequestType.method:
-                await handleRequest(languageClient, message.params, webview, tabBarActionRequestType.method)
+                await resolveChatResponse(tabBarActionRequestType.method, message.params, languageClient, webview)
                 break
             case followUpClickNotificationType.method:
                 if (!isValidAuthFollowUpType(message.params.followUp.type)) {
@@ -364,11 +364,11 @@ async function handleCompleteResult<T>(
     disposable.dispose()
 }
 
-async function handleRequest(
-    languageClient: LanguageClient,
+async function resolveChatResponse(
+    requestMethod: string,
     params: any,
-    webview: vscode.Webview | undefined,
-    requestMethod: string
+    languageClient: LanguageClient,
+    webview: vscode.Webview | undefined
 ) {
     const result = await languageClient.sendRequest(requestMethod, params)
     void webview?.postMessage({

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -49,8 +49,9 @@ export function registerLanguageServerEventListener(languageClient: LanguageClie
 
     const chatOptions = languageClient.initializeResult?.awsServerCapabilities?.chatOptions
 
-    // Enable the history feature flag
+    // Enable the history/export feature flags
     chatOptions.history = true
+    chatOptions.export = true
 
     provider.onDidResolveWebview(() => {
         void provider.webview?.postMessage({

--- a/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/chat/messages.test.ts
@@ -26,6 +26,7 @@ describe('registerMessageListeners', () => {
             info: sandbox.stub(),
             error: errorStub,
             sendNotification: sandbox.stub(),
+            onRequest: sandbox.stub(),
         } as unknown as LanguageClient
 
         provider = {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -441,8 +441,8 @@
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
         "@aws/chat-client-ui-types": "^0.1.12",
-        "@aws/language-server-runtimes": "^0.2.49",
-        "@aws/language-server-runtimes-types": "^0.1.10",
+        "@aws/language-server-runtimes": "^0.2.58",
+        "@aws/language-server-runtimes-types": "^0.1.13",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",


### PR DESCRIPTION
## Problem
- In order to enable chat history in Flare the: listConversationsRequestType, conversationClickRequestType, tabBarActionRequestType events need to be implemented

## Solution
- Handle listConversationsRequestType, conversationClickRequestType, tabBarActionRequestType events



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
