### PR TITLE
fix(lsp): manifest resolver always reports "Failed to download"

### DIFF
--- a/packages/amazonq/src/lsp/activation.ts
+++ b/packages/amazonq/src/lsp/activation.ts
@@ -6,7 +6,7 @@
 import vscode from 'vscode'
 import { startLanguageServer } from './client'
 import { AmazonQLspInstaller } from './lspInstaller'
-import { lspSetupStage, ToolkitError } from 'aws-core-vscode/shared'
+import { lspSetupStage, ToolkitError, messages } from 'aws-core-vscode/shared'
 
 export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     try {
@@ -16,6 +16,6 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
         })
     } catch (err) {
         const e = err as ToolkitError
-        void vscode.window.showInformationMessage(`Unable to launch amazonq language server: ${e.message}`)
+        void messages.showViewLogsMessage(`Failed to launch Amazon Q language server: ${e.message}`)
     }
 }

--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -98,11 +98,11 @@ export class LspController {
     }
 
     async buildIndex(buildIndexConfig: BuildIndexConfig) {
-        this.logger.info(`LspController: Starting to build index of project`)
+        this.logger.info(`Starting to build index of project`)
         const start = performance.now()
         const projPaths = (vscode.workspace.workspaceFolders ?? []).map((folder) => folder.uri.fsPath)
         if (projPaths.length === 0) {
-            this.logger.info(`LspController: Skipping building index. No projects found in workspace`)
+            this.logger.info(`Skipping building index. No projects found in workspace`)
             return
         }
         projPaths.sort()
@@ -119,12 +119,12 @@ export class LspController {
                 (accumulator, currentFile) => accumulator + currentFile.fileSizeBytes,
                 0
             )
-            this.logger.info(`LspController: Found ${files.length} files in current project ${projPaths}`)
+            this.logger.info(`Found ${files.length} files in current project ${projPaths}`)
             const config = buildIndexConfig.isVectorIndexEnabled ? 'all' : 'default'
             const r = files.map((f) => f.fileUri.fsPath)
             const resp = await LspClient.instance.buildIndex(r, projRoot, config)
             if (resp) {
-                this.logger.debug(`LspController: Finish building index of project`)
+                this.logger.debug(`Finish building index of project`)
                 const usage = await LspClient.instance.getLspServerUsage()
                 telemetry.amazonq_indexWorkspace.emit({
                     duration: performance.now() - start,
@@ -137,7 +137,7 @@ export class LspController {
                     credentialStartUrl: buildIndexConfig.startUrl,
                 })
             } else {
-                this.logger.error(`LspController: Failed to build index of project`)
+                this.logger.error(`Failed to build index of project`)
                 telemetry.amazonq_indexWorkspace.emit({
                     duration: performance.now() - start,
                     result: 'Failed',
@@ -149,7 +149,7 @@ export class LspController {
             }
         } catch (error) {
             // TODO: use telemetry.run()
-            this.logger.error(`LspController: Failed to build index of project`)
+            this.logger.error(`Failed to build index of project`)
             telemetry.amazonq_indexWorkspace.emit({
                 duration: performance.now() - start,
                 result: 'Failed',
@@ -166,7 +166,7 @@ export class LspController {
 
     async trySetupLsp(context: vscode.ExtensionContext, buildIndexConfig: BuildIndexConfig) {
         if (isCloud9() || isWeb() || isAmazonInternalOs()) {
-            this.logger.warn('LspController: Skipping LSP setup. LSP is not compatible with the current environment. ')
+            this.logger.warn('Skipping LSP setup. LSP is not compatible with the current environment. ')
             // do not do anything if in Cloud9 or Web mode or in AL2 (AL2 does not support node v18+)
             return
         }
@@ -181,7 +181,7 @@ export class LspController {
                         const usage = await LspClient.instance.getLspServerUsage()
                         if (usage) {
                             this.logger.info(
-                                `LspController: LSP server CPU ${usage.cpuUsage}%, LSP server Memory ${
+                                `LSP server CPU ${usage.cpuUsage}%, LSP server Memory ${
                                     usage.memoryUsage / (1024 * 1024)
                                 }MB  `
                             )
@@ -190,7 +190,7 @@ export class LspController {
                     30 * 60 * 1000
                 )
             } catch (e) {
-                this.logger.error(`LspController: LSP failed to activate ${e}`)
+                this.logger.error(`LSP failed to activate ${e}`)
             }
         })
     }
@@ -207,7 +207,7 @@ export class LspController {
             return
         }
         this._contextCommandSymbolsUpdated = true
-        getLogger().debug(`LspController: Start adding symbols to context picker menu`)
+        getLogger().debug(`Start adding symbols to context picker menu`)
         try {
             const indexSeqNum = await LspClient.instance.getIndexSequenceNumber()
             await LspClient.instance.updateIndex([], 'context_command_symbol_update')
@@ -223,7 +223,7 @@ export class LspController {
                 { interval: 1000, timeout: 60_000, truthy: true }
             )
         } catch (err) {
-            getLogger().error(`LspController: Failed to find symbols`)
+            this.logger.error(`Failed to find symbols`)
         }
     }
 
@@ -231,7 +231,7 @@ export class LspController {
         await lspSetupStage('all', async () => {
             const installResult = await new WorkspaceLspInstaller().resolve()
             await lspSetupStage('launch', async () => activateLsp(context, installResult.resourcePaths))
-            this.logger.info('LspController: LSP activated')
+            this.logger.info('LSP activated')
         })
     }
 }

--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -52,7 +52,9 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, 
         await this.postInstall(assetDirectory)
 
         const deletedVersions = await cleanLspDownloads(manifest.versions, nodePath.dirname(assetDirectory))
-        this.logger.debug(`cleaning old LSP versions deleted ${deletedVersions.length} versions`)
+        if (deletedVersions.length > 0) {
+            this.logger.debug(`cleaning old LSP versions: deleted ${deletedVersions.length} versions`)
+        }
 
         const r = {
             ...installationResult,

--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -73,7 +73,7 @@ export class LanguageServerResolver {
          * ```
          */
         const resolved = await tryStageResolvers('getServer', serverResolvers, getServerVersion)
-        logger.info('Finished updating "%s" LSP server: %O', this.lsName, resolved.assetDirectory)
+        logger.info('Finished preparing "%s" LSP server: %O', this.lsName, resolved.assetDirectory)
         return resolved
     }
 
@@ -144,11 +144,7 @@ export class LanguageServerResolver {
             }
         } else {
             // Delete the cached directory since it's invalid
-            if (await fs.existsDir(cacheDirectory)) {
-                await fs.delete(cacheDirectory, {
-                    recursive: true,
-                })
-            }
+            await fs.delete(cacheDirectory, { force: true, recursive: true })
             throw new ToolkitError('Failed to retrieve server from cache', { code: 'InvalidCache' })
         }
     }

--- a/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/packages/core/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -68,9 +68,9 @@ export class HttpResourceFetcher implements ResourceFetcher<Response> {
         if (response.status === 304) {
             // Explanation: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
             contents = undefined
-            this.logger.verbose(`E-Tag, ${eTagResponse}, matched. No content downloaded from: ${this.url}`)
+            this.logger.verbose(`E-Tag matched (${eTagResponse}). Download skipped: ${this.url}`)
         } else {
-            this.logger.verbose(`No E-Tag match. Downloaded content from: ${this.logText()}`)
+            this.logger.verbose(`E-Tag not matched. Downloaded: ${this.logText()}`)
         }
 
         return { content: contents, eTag: eTagResponse }

--- a/packages/core/src/shared/utilities/processUtils.ts
+++ b/packages/core/src/shared/utilities/processUtils.ts
@@ -513,9 +513,10 @@ export class ChildProcess {
      * Gets a string representation of the process invocation.
      *
      * @param noparams Omit parameters in the result (to protect sensitive info).
+     * @param nostatus Omit "(not started)" note.
      */
-    public toString(noparams = false): string {
-        const pid = this.pid() > 0 ? `PID ${this.pid()}:` : '(not started)'
+    public toString(noparams = false, nostatus = false): string {
+        const pid = this.pid() > 0 ? `PID ${this.pid()}:` : nostatus ? '' : '(not started)'
         return `${pid} [${this.#command} ${noparams ? '...' : this.#args.join(' ')}]`
     }
 }


### PR DESCRIPTION
continues https://github.com/aws/aws-toolkit-vscode/pull/7043

## Problem:
Manifest resolver always reports:

    Failed to download latest "…" manifest. Falling back to local manifest.

## Solution:
- In `fetchRemoteManifest()`, if the ETag indicates no new manifest is needed, return the local manifest instead of throwing an error
- Fix other ambiguous/misleading log messages.



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
