### PR TITLE
feat(core): Store codewhisperer customization in global state as single value and consume new authUtil

### DIFF
--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -98,10 +98,7 @@ export const getSelectedCustomization = (): Customization => {
         return baseCustomization
     }
 
-    const selectedCustomization = globals.globalState.tryGet<Customization>(
-        'CODEWHISPERER_SELECTED_CUSTOMIZATION',
-        Object
-    )
+    const selectedCustomization = globals.globalState.getCodewhispererCustomization(AuthUtil.instance.profileName)
 
     if (selectedCustomization && selectedCustomization.name !== '') {
         return selectedCustomization

--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -139,25 +139,15 @@ export const getPersistedCustomizations = (): Customization[] => {
     if (!AuthUtil.instance.isIdcConnection()) {
         return []
     }
-    const persistedCustomizationsObj = globals.globalState.tryGet<{ [label: string]: Customization[] }>(
-        'CODEWHISPERER_PERSISTED_CUSTOMIZATIONS',
-        Object,
-        {}
-    )
-    return persistedCustomizationsObj[AuthUtil.instance.profileName] || []
+    return globals.globalState.getCodewhispererPersistedCustomization(AuthUtil.instance.profileName)
 }
 
 export const setPersistedCustomizations = async (customizations: Customization[]) => {
     if (!AuthUtil.instance.isIdcConnection()) {
         return
     }
-    const persistedCustomizationsObj = globals.globalState.tryGet<{ [label: string]: Customization[] }>(
-        'CODEWHISPERER_PERSISTED_CUSTOMIZATIONS',
-        Object,
-        {}
-    )
-    persistedCustomizationsObj[AuthUtil.instance.profileName] = customizations
-    await globals.globalState.update('CODEWHISPERER_PERSISTED_CUSTOMIZATIONS', persistedCustomizationsObj)
+
+    await globals.globalState.update('CODEWHISPERER_PERSISTED_CUSTOMIZATIONS', customizations)
 }
 
 export const getNewCustomizationsAvailable = () => {

--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -98,7 +98,7 @@ export const getSelectedCustomization = (): Customization => {
         return baseCustomization
     }
 
-    const selectedCustomization = globals.globalState.getCodewhispererCustomization(AuthUtil.instance.profileName)
+    const selectedCustomization = globals.globalState.getAmazonQCustomization(AuthUtil.instance.profileName)
 
     if (selectedCustomization && selectedCustomization.name !== '') {
         return selectedCustomization
@@ -139,7 +139,7 @@ export const getPersistedCustomizations = (): Customization[] => {
     if (!AuthUtil.instance.isIdcConnection()) {
         return []
     }
-    return globals.globalState.getCodewhispererPersistedCustomization(AuthUtil.instance.profileName)
+    return globals.globalState.getAmazonQCachedCustomization(AuthUtil.instance.profileName)
 }
 
 export const setPersistedCustomizations = async (customizations: Customization[]) => {

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -229,7 +229,7 @@ export class GlobalState implements vscode.Memento {
     }
 
     /**
-     * Get the codewhisperer customerization. If legacy (map of customizations) store the
+     * Get the codewhisperer customization. If legacy (map of customizations) store the
      * customization with label of profile name
      *
      * @param profileName name of profile, only used in case legacy customization is found
@@ -244,6 +244,32 @@ export class GlobalState implements vscode.Memento {
             const selectedCustomization = result[profileName]
             this.tryUpdate('CODEWHISPERER_SELECTED_CUSTOMIZATION', selectedCustomization)
             return selectedCustomization
+        } else {
+            return result
+        }
+    }
+
+    /**
+     * Get the codewhisperer persisted customizations. If legacy (map of customizations) store the
+     * customizations with label of profile name
+     *
+     * @param profileName name of profile, only used in case legacy customization is found
+     * @returns array of codewhisperer persisted customizations, or empty array if not found.
+     * If legacy, return the codewhisperer persisted customizations for the auth profile name
+     */
+    getCodewhispererPersistedCCustomization(profileName: string): Customization[] {
+        const result = this.tryGet<Customization[]>('CODEWHISPERER_PERSISTED_CUSTOMIZATIONS', Array, [])
+
+        // Legacy migration for old customization map of type { [label: string]: Customization[] }
+        if (result.length === 0) {
+            const customizations = this.tryGet<{ [label: string]: Customization[] }>(
+                'CODEWHISPERER_PERSISTED_CUSTOMIZATIONS',
+                Object,
+                {}
+            )
+            const persistedCustomizationsArray = customizations[profileName] || []
+            this.tryUpdate('CODEWHISPERER_PERSISTED_CUSTOMIZATIONS', persistedCustomizationsArray)
+            return persistedCustomizationsArray
         } else {
             return result
         }

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -229,14 +229,14 @@ export class GlobalState implements vscode.Memento {
     }
 
     /**
-     * Get the codewhisperer customization. If legacy (map of customizations) store the
+     * Get the Amazon Q customization. If legacy (map of customizations) store the
      * customization with label of profile name
      *
      * @param profileName name of profile, only used in case legacy customization is found
-     * @returns codewhisperer customization, or undefined if not found.
-     * If legacy, return the codewhisperer customization for the auth profile name
+     * @returns Amazon Q customization, or undefined if not found.
+     * If legacy, return the Amazon Q customization for the auth profile name
      */
-    getCodewhispererCustomization(profileName: string): Customization | undefined {
+    getAmazonQCustomization(profileName: string): Customization | undefined {
         const result = this.tryGet('CODEWHISPERER_SELECTED_CUSTOMIZATION', Object, undefined)
 
         // Legacy migration for old customization map of type { [label: string]: Customization[] }
@@ -250,14 +250,14 @@ export class GlobalState implements vscode.Memento {
     }
 
     /**
-     * Get the codewhisperer persisted customizations. If legacy (map of customizations) store the
+     * Get the Amazon Q cached customizations. If legacy (map of customizations) store the
      * customizations with label of profile name
      *
      * @param profileName name of profile, only used in case legacy customization is found
-     * @returns array of codewhisperer persisted customizations, or empty array if not found.
-     * If legacy, return the codewhisperer persisted customizations for the auth profile name
+     * @returns array of Amazon Q cached customizations, or empty array if not found.
+     * If legacy, return the Amazon Q persisted customizations for the auth profile name
      */
-    getCodewhispererPersistedCCustomization(profileName: string): Customization[] {
+    getAmazonQCachedCustomization(profileName: string): Customization[] {
         const result = this.tryGet<Customization[]>('CODEWHISPERER_PERSISTED_CUSTOMIZATIONS', Array, [])
 
         // Legacy migration for old customization map of type { [label: string]: Customization[] }
@@ -267,9 +267,9 @@ export class GlobalState implements vscode.Memento {
                 Object,
                 {}
             )
-            const persistedCustomizationsArray = customizations[profileName] || []
-            this.tryUpdate('CODEWHISPERER_PERSISTED_CUSTOMIZATIONS', persistedCustomizationsArray)
-            return persistedCustomizationsArray
+            const cachedCustomizationsArray = customizations[profileName] || []
+            this.tryUpdate('CODEWHISPERER_PERSISTED_CUSTOMIZATIONS', cachedCustomizationsArray)
+            return cachedCustomizationsArray
         } else {
             return result
         }


### PR DESCRIPTION
## Problem
With the old VSCode auth, customization was stored in global state (indexed by connection ID). With the new auth from the Flare identity server, this no longer applies since there is only a single connection

## Solution
* Consume the new AuthUtil in the customizationUtil
* Change `CODEWHISPERER_SELECTED_CUSTOMIZATION` in the global state to be a single value instead of a map

## Follow-up
Investigate if it's possible to hook up the customization to the Q profile from the new Region Manager, so customizations are persisted between different logins

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
