### PR TITLE
telemetry(chat): see if message is apart of agentic loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.314",
+                "@aws-toolkits/telemetry": "^1.0.315",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -10806,9 +10806,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.314",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.314.tgz",
-            "integrity": "sha512-9Utwv6Z1TO477+l67Y35OhPzWWOFEetj8qcyQ9bBXnJmq0fVGTyvx1RH/OxmcGW42iAIovA9a3ck4oou02rbeQ==",
+            "version": "1.0.315",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.315.tgz",
+            "integrity": "sha512-BJniCka+nGWpLokN1sn4oXes7Rvq6V6Fr1qZlCHI/j1mOqQEWYPnOKd+HdLcuqHWQKr3o5znnBlg0CmY+7kdNg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.314",
+        "@aws-toolkits/telemetry": "^1.0.315",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -627,7 +627,11 @@ export class CWCTelemetryHelper {
             cwsprChatActiveEditorImportCount: triggerPayload.codeQuery?.fullyQualifiedNames?.used?.length,
             cwsprChatResponseCode: responseCode,
             cwsprChatRequestLength: triggerPayload.message?.length ?? 0,
-            cwsprChatConversationType: triggerPayload.origin ? 'AgenticChat' : 'Chat',
+            cwsprChatConversationType: triggerPayload.origin
+                ? triggerPayload.toolResults
+                    ? 'AgenticChatWithToolUse'
+                    : 'AgenticChat'
+                : 'Chat',
             credentialStartUrl: AuthUtil.instance.startUrl,
             requestId: requestID,
             reasonDesc: getTelemetryReasonDesc(errorReason),

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -543,7 +543,11 @@ export class CWCTelemetryHelper {
             cwsprChatFullDisplayLatency: fullDisplayLatency,
             cwsprChatRequestLength: triggerPayload.message.length,
             cwsprChatResponseLength: message.messageLength,
-            cwsprChatConversationType: triggerPayload.origin ? 'AgenticChat' : 'Chat',
+            cwsprChatConversationType: triggerPayload.origin
+                ? triggerPayload.toolResults
+                    ? 'AgenticChatWithToolUse'
+                    : 'AgenticChat'
+                : 'Chat',
             credentialStartUrl: AuthUtil.instance.startUrl,
             codewhispererCustomizationArn: triggerPayload.customization.arn,
             cwsprChatHasProjectContext: hasProjectLevelContext,


### PR DESCRIPTION
## Problem
- want to differentiate between a message without tool use (ex: what time is it) and a message with tool use (ex: write a docstring for my function)

## Solution
- for both successful messages and messages that resulted in error, see if this message was apart of an agentic loop. 
- An agentic loop is when the LLM asks to run a tool and the LLM receives the results back of running the tool.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
