### PR TITLE
fix(amazonq): quick action handler should add to tab storage

### DIFF
--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -210,6 +210,7 @@ export class WebviewUIHandler {
                     isScanEnabled: this.isScanEnabled,
                     isTestEnabled: this.isTestEnabled,
                     isDocEnabled: this.isDocEnabled,
+                    hybridChat,
                     disabledCommands,
                 })
 
@@ -659,8 +660,11 @@ export class WebviewUIHandler {
             },
             onTabAdd: (tabID: string) => {
                 if (hybridChat) {
-                    // hybrid chat doesn't support the welcome page
-                    this.connector?.onTabAdd(tabID)
+                    /**
+                     * hybrid chat doesn't support the welcome page
+                     * tabs are already added by the quick action handler
+                     * so theres nothing we have to do here
+                     */
                     return
                 }
                 /**
@@ -1038,6 +1042,7 @@ export class WebviewUIHandler {
             isScanEnabled: this.isScanEnabled,
             isTestEnabled: this.isTestEnabled,
             isDocEnabled: this.isDocEnabled,
+            hybridChat,
         })
         this.textMessageHandler = new TextMessageHandler({
             mynahUIRef: this.mynahUIRef,

--- a/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
@@ -19,6 +19,7 @@ export interface QuickActionsHandlerProps {
     isScanEnabled: boolean
     isTestEnabled: boolean
     isDocEnabled: boolean
+    hybridChat?: boolean
     disabledCommands?: string[]
 }
 
@@ -40,6 +41,7 @@ export class QuickActionHandler {
     private isScanEnabled: boolean
     private isTestEnabled: boolean
     private isDocEnabled: boolean
+    private isHybridChatEnabled: boolean
 
     constructor(props: QuickActionsHandlerProps) {
         this.mynahUIRef = props.mynahUIRef
@@ -58,6 +60,7 @@ export class QuickActionHandler {
         this.isGumbyEnabled = props.isGumbyEnabled
         this.isScanEnabled = props.isScanEnabled
         this.isTestEnabled = props.isTestEnabled
+        this.isHybridChatEnabled = props.hybridChat ?? false
     }
 
     /**
@@ -123,14 +126,8 @@ export class QuickActionHandler {
             return
         }
 
-        let affectedTabId: string | undefined = tabID
         // if there is no scan tab, open a new one
-        const currentTabType = this.tabsStorage.getTab(affectedTabId)?.type
-        if (currentTabType !== 'unknown' && currentTabType !== 'welcome') {
-            affectedTabId = this.mynahUI.updateStore('', {
-                loadingChat: true,
-            })
-        }
+        const affectedTabId: string | undefined = this.addTab(tabID)
 
         if (affectedTabId === undefined) {
             this.mynahUI.notify({
@@ -172,14 +169,8 @@ export class QuickActionHandler {
             return
         }
 
-        let affectedTabId: string | undefined = tabID
         // if there is no test tab, open a new one
-        const currentTabType = this.tabsStorage.getTab(affectedTabId)?.type
-        if (currentTabType !== 'unknown' && currentTabType !== 'welcome') {
-            affectedTabId = this.mynahUI.updateStore('', {
-                loadingChat: true,
-            })
-        }
+        const affectedTabId: string | undefined = this.addTab(tabID)
 
         if (affectedTabId === undefined) {
             this.mynahUI.notify({
@@ -212,12 +203,10 @@ export class QuickActionHandler {
             return
         }
 
-        let affectedTabId: string | undefined = props.tabID
         const realPromptText = props.chatPrompt?.escapedPrompt?.trim() ?? ''
-        const currentTabType = this.tabsStorage.getTab(affectedTabId)?.type
-        if (currentTabType !== 'unknown' && currentTabType !== 'welcome') {
-            affectedTabId = this.mynahUI.updateStore('', {})
-        }
+
+        const affectedTabId = this.addTab(props.tabID)
+
         if (affectedTabId === undefined) {
             this.mynahUI.notify({
                 content: uiComponentsTexts.noMoreTabsTooltip,
@@ -305,15 +294,8 @@ export class QuickActionHandler {
             return
         }
 
-        let affectedTabId: string | undefined = tabID
         // if there is no gumby tab, open a new one
-        const currentTabType = this.tabsStorage.getTab(affectedTabId)?.type
-        if (currentTabType !== 'unknown' && currentTabType !== 'welcome') {
-            affectedTabId = this.mynahUI.updateStore('', {
-                loadingChat: true,
-                cancelButtonWhenLoading: false,
-            })
-        }
+        const affectedTabId: string | undefined = this.addTab(tabID)
 
         if (affectedTabId === undefined) {
             this.mynahUI.notify({
@@ -341,6 +323,33 @@ export class QuickActionHandler {
 
             this.connector.transform(affectedTabId)
         }
+    }
+
+    private addTab(affectedTabId: string | undefined) {
+        if (!affectedTabId || !this.mynahUI) {
+            return
+        }
+
+        const currTab = this.mynahUI.getAllTabs()[affectedTabId]
+        const currTabWasUsed =
+            (currTab.store?.chatItems?.filter((item) => item.type === ChatItemType.PROMPT).length ?? 0) > 0
+        if (currTabWasUsed) {
+            affectedTabId = this.mynahUI.updateStore('', {
+                loadingChat: true,
+                cancelButtonWhenLoading: false,
+            })
+        }
+
+        if (affectedTabId && this.isHybridChatEnabled) {
+            this.tabsStorage.addTab({
+                id: affectedTabId,
+                type: 'unknown',
+                status: 'free',
+                isSelected: true,
+            })
+        }
+
+        return affectedTabId
     }
 
     private handleClearCommand(tabID: string) {


### PR DESCRIPTION
## Problem
currently tabs get added to the tabs storage when the onTabAdd handler gets called.

In hybrid chat, the onTabAdd handler will never get called, because it first needs to be in the tabsStorage, which doesn't happen because the onTabAdd handler hasn't been called

## Solution
in hybrid chat mode just add new tabs directly to the tabs storage


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
