### PR TITLE
feat(amazonq): sync developer profiles to flare chat panel

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -59,6 +59,9 @@ export async function startLanguageServer(
                     clientId: crypto.randomUUID(),
                 },
                 awsClientCapabilities: {
+                    q: {
+                        developerProfiles: true,
+                    },
                     window: {
                         notifications: true,
                     },


### PR DESCRIPTION
## Problem
- developer profiles are only synced to our local agents (/dev, /doc, etc). Now that the main chat panel is served by flare we need to update the profile information when it becomes available so that flare is using the correct profile for the request

## Solution
- send profile information to flare on the initial request + subsequent changes to the active profile
- refresh the webview if the profile changes 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
