### PR TITLE
fix(chat): Fixing issue with opening the file for read files.

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -357,7 +357,6 @@ export class Connector extends BaseConnector {
         if (
             !this.onChatAnswerUpdated ||
             ![
-                'accept-code-diff',
                 'reject-code-diff',
                 'run-shell-command',
                 'reject-shell-command',
@@ -379,17 +378,6 @@ export class Connector extends BaseConnector {
             header: currentChatItem?.header ? { ...currentChatItem.header } : {},
         }
         switch (action.id) {
-            case 'accept-code-diff':
-                if (answer.header) {
-                    answer.header.status = {
-                        icon: 'ok' as MynahIconsType,
-                        text: 'Accepted',
-                        status: 'success',
-                    }
-                    answer.header.buttons = []
-                    answer.body = ' '
-                }
-                break
             case 'reject-code-diff':
                 if (answer.header) {
                     answer.header.status = {

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -24,22 +24,27 @@ export type ToolUseWithError = {
     error: Error | undefined
 }
 
+type OperationType = 'read' | 'write' | 'listDir'
+
+interface FileOperation {
+    type: OperationType
+    filePaths: DocumentReference[]
+}
+
 export class ChatSession {
     private sessionId: string
     /**
-     * _readFiles = list of files read from the project to gather context before generating response.
      * _showDiffOnFileWrite = Controls whether to show diff view (true) or file context view (false) to the user
      * _context = Additional context to be passed to the LLM for generating the response
      * _messageIdToUpdate = messageId of a chat message to be updated, used for reducing consecutive tool messages
      */
-    private _readFiles: DocumentReference[] = []
-    private _readFolders: DocumentReference[] = []
     private _toolUseWithError: ToolUseWithError | undefined
     private _showDiffOnFileWrite: boolean = false
     private _context: PromptMessage['context']
     private _pairProgrammingModeOn: boolean = true
     private _fsWriteBackups: Map<string, FsWriteBackup> = new Map()
     private _agenticLoopInProgress: boolean = false
+    private _messageOperations: Map<string, FileOperation> = new Map()
 
     /**
      * True if messages from local history have been sent to session.
@@ -144,29 +149,11 @@ export class ChatSession {
     public setSessionID(id: string) {
         this.sessionId = id
     }
-    public get readFiles(): DocumentReference[] {
-        return this._readFiles
-    }
-    public get readFolders(): DocumentReference[] {
-        return this._readFolders
-    }
     public get showDiffOnFileWrite(): boolean {
         return this._showDiffOnFileWrite
     }
     public setShowDiffOnFileWrite(value: boolean) {
         this._showDiffOnFileWrite = value
-    }
-    public addToReadFiles(filePath: DocumentReference) {
-        this._readFiles.push(filePath)
-    }
-    public clearListOfReadFiles() {
-        this._readFiles = []
-    }
-    public setReadFolders(folder: DocumentReference) {
-        this._readFolders.push(folder)
-    }
-    public clearListOfReadFolders() {
-        this._readFolders = []
     }
     async chatIam(chatRequest: SendMessageRequest): Promise<SendMessageCommandOutput> {
         const client = await createQDeveloperStreamingClient()
@@ -195,5 +182,57 @@ export class ChatSession {
         UserWrittenCodeTracker.instance.onQFeatureInvoked()
 
         return response
+    }
+
+    /**
+     * Adds a file operation for a specific message
+     * @param messageId The ID of the message
+     * @param type The type of operation ('read' or 'write')
+     * @param filePaths Array of DocumentReference involved in the operation
+     */
+    public addMessageOperation(messageId: string, type: OperationType, filePaths: DocumentReference[]) {
+        this._messageOperations.set(messageId, { type, filePaths })
+    }
+
+    /**
+     * Gets the file operation details for a specific message
+     * @param messageId The ID of the message
+     * @returns The file operation details or undefined if not found
+     */
+    public getMessageOperation(messageId: string): FileOperation | undefined {
+        return this._messageOperations.get(messageId)
+    }
+
+    /**
+     * Gets all file paths along with line ranges associated with a message
+     * @param messageId The ID of the message
+     * @returns Array of DocumentReference or empty array if message ID not found
+     */
+    public getFilePathsByMessageId(messageId: string): DocumentReference[] {
+        return this._messageOperations.get(messageId)?.filePaths || []
+    }
+
+    /**
+     * Gets the operation type for a specific message
+     * @param messageId The ID of the message
+     * @returns The operation type or undefined if message ID not found
+     */
+    public getOperationTypeByMessageId(messageId: string): OperationType | undefined {
+        return this._messageOperations.get(messageId)?.type
+    }
+
+    /**
+     * Clears the operation for a specific message
+     * @param messageId The ID of the message
+     */
+    public clearMessageOperation(messageId: string) {
+        this._messageOperations.delete(messageId)
+    }
+
+    /**
+     * Clears all message operations
+     */
+    public clearAllMessageOperations() {
+        this._messageOperations.clear()
     }
 }

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -37,6 +37,7 @@ export class ChatSession {
      * _showDiffOnFileWrite = Controls whether to show diff view (true) or file context view (false) to the user
      * _context = Additional context to be passed to the LLM for generating the response
      * _messageIdToUpdate = messageId of a chat message to be updated, used for reducing consecutive tool messages
+     * _messageOperations = Maps messageId to filePaths which helps to open the read files and to open the code diff accordingly.
      */
     private _toolUseWithError: ToolUseWithError | undefined
     private _showDiffOnFileWrite: boolean = false
@@ -187,7 +188,7 @@ export class ChatSession {
     /**
      * Adds a file operation for a specific message
      * @param messageId The ID of the message
-     * @param type The type of operation ('read' or 'write')
+     * @param type The type of operation ('read' or 'listDir' or 'write')
      * @param filePaths Array of DocumentReference involved in the operation
      */
     public addMessageOperation(messageId: string, type: OperationType, filePaths: DocumentReference[]) {
@@ -219,20 +220,5 @@ export class ChatSession {
      */
     public getOperationTypeByMessageId(messageId: string): OperationType | undefined {
         return this._messageOperations.get(messageId)?.type
-    }
-
-    /**
-     * Clears the operation for a specific message
-     * @param messageId The ID of the message
-     */
-    public clearMessageOperation(messageId: string) {
-        this._messageOperations.delete(messageId)
-    }
-
-    /**
-     * Clears all message operations
-     */
-    public clearAllMessageOperations() {
-        this._messageOperations.clear()
     }
 }

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -1317,7 +1317,7 @@ export class ChatController {
             this.processException(e, message.tabID)
         }
     }
-    private sessionCleanUp(session: ChatSession) {
+    private initialCleanUp(session: ChatSession) {
         // Create a fresh token for this new conversation
         session.createNewTokenSource()
         session.setAgenticLoopInProgress(true)
@@ -1332,7 +1332,7 @@ export class ChatController {
         if (session.agenticLoopInProgress) {
             session.disposeTokenSource()
         }
-        this.sessionCleanUp(session)
+        this.initialCleanUp(session)
         this.editorContextExtractor
             .extractContextForTrigger('ChatMessage')
             .then(async (context) => {

--- a/packages/core/src/codewhispererChat/tools/chatStream.ts
+++ b/packages/core/src/codewhispererChat/tools/chatStream.ts
@@ -37,7 +37,7 @@ export class ChatStream extends Writable {
     ) {
         super()
         this.logger.debug(
-            `ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}, readFiles: ${session.readFiles}, emitEvent to mynahUI: ${emitEvent}`
+            `ChatStream created for tabID: ${tabID}, triggerID: ${triggerID}, emitEvent to mynahUI: ${emitEvent}`
         )
         if (!emitEvent) {
             return


### PR DESCRIPTION
## Problem
- If user clicks on filePath(example: `util.py`) in read files, in existing user experience nothing happens. Ideally we need to open the file in the editor.
![image](https://github.com/user-attachments/assets/6afbe884-9e84-4683-a6f5-ea139ed97f00)


## Solution
- Fixed this issue by maintaining a map between `messageID to filePath`, so IDE can display the files according to the use click on specific messageId.
**Demo:**

https://github.com/user-attachments/assets/b78d8de1-970f-4e0f-ac09-a0e93d5bd73c


- Refactored some parts of legacy code.

### TODO:
- Refactor the code diff part of code which is not related to this PR.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
