### PR TITLE
fix(amazonq): improve lsp cleanup logic

### DIFF
--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -51,7 +51,11 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, 
 
         await this.postInstall(assetDirectory)
 
-        const deletedVersions = await cleanLspDownloads(manifest.versions, nodePath.dirname(assetDirectory))
+        const deletedVersions = await cleanLspDownloads(
+            installationResult.version,
+            manifest.versions,
+            nodePath.dirname(assetDirectory)
+        )
         this.logger.debug(`cleaning old LSP versions deleted ${deletedVersions.length} versions`)
 
         return {

--- a/packages/core/src/test/shared/lsp/utils/cleanup.test.ts
+++ b/packages/core/src/test/shared/lsp/utils/cleanup.test.ts
@@ -68,7 +68,7 @@ describe('cleanLSPDownloads', function () {
     it('handles case where less than 2 versions are not delisted', async function () {
         await fakeInstallVersions(['1.0.0', '1.0.1', '1.1.1', '2.1.1'], installationDir.fsPath)
         const deleted = await cleanLspDownloads(
-            '',
+            '1.0.1',
             [
                 { serverVersion: '1.1.1', isDelisted: true, targets: [] },
                 { serverVersion: '2.1.1', isDelisted: true, targets: [] },

--- a/packages/core/src/test/shared/lsp/utils/cleanup.test.ts
+++ b/packages/core/src/test/shared/lsp/utils/cleanup.test.ts
@@ -41,7 +41,7 @@ describe('cleanLSPDownloads', function () {
 
     it('keeps two newest versions', async function () {
         await fakeInstallVersions(['1.0.0', '1.0.1', '1.1.1', '2.1.1'], installationDir.fsPath)
-        const deleted = await cleanLspDownloads([], installationDir.fsPath)
+        const deleted = await cleanLspDownloads('2.1.1', [], installationDir.fsPath)
 
         const result = (await fs.readdir(installationDir.fsPath)).map(([filename, _filetype], _index) => filename)
         assert.strictEqual(result.length, 2)
@@ -53,6 +53,7 @@ describe('cleanLSPDownloads', function () {
     it('deletes delisted versions', async function () {
         await fakeInstallVersions(['1.0.0', '1.0.1', '1.1.1', '2.1.1'], installationDir.fsPath)
         const deleted = await cleanLspDownloads(
+            '2.1.1',
             [{ serverVersion: '1.1.1', isDelisted: true, targets: [] }],
             installationDir.fsPath
         )
@@ -67,6 +68,7 @@ describe('cleanLSPDownloads', function () {
     it('handles case where less than 2 versions are not delisted', async function () {
         await fakeInstallVersions(['1.0.0', '1.0.1', '1.1.1', '2.1.1'], installationDir.fsPath)
         const deleted = await cleanLspDownloads(
+            '',
             [
                 { serverVersion: '1.1.1', isDelisted: true, targets: [] },
                 { serverVersion: '2.1.1', isDelisted: true, targets: [] },
@@ -83,7 +85,7 @@ describe('cleanLSPDownloads', function () {
 
     it('handles case where less than 2 versions exist', async function () {
         await fakeInstallVersions(['1.0.0'], installationDir.fsPath)
-        const deleted = await cleanLspDownloads([], installationDir.fsPath)
+        const deleted = await cleanLspDownloads('1.0.0', [], installationDir.fsPath)
 
         const result = (await fs.readdir(installationDir.fsPath)).map(([filename, _filetype], _index) => filename)
         assert.strictEqual(result.length, 1)
@@ -93,6 +95,7 @@ describe('cleanLSPDownloads', function () {
     it('does not install delisted version when no other option exists', async function () {
         await fakeInstallVersions(['1.0.0'], installationDir.fsPath)
         const deleted = await cleanLspDownloads(
+            '1.0.0',
             [{ serverVersion: '1.0.0', isDelisted: true, targets: [] }],
             installationDir.fsPath
         )
@@ -105,6 +108,7 @@ describe('cleanLSPDownloads', function () {
     it('ignores invalid versions', async function () {
         await fakeInstallVersions(['1.0.0', '.DS_STORE'], installationDir.fsPath)
         const deleted = await cleanLspDownloads(
+            '1.0.0',
             [{ serverVersion: '1.0.0', isDelisted: true, targets: [] }],
             installationDir.fsPath
         )


### PR DESCRIPTION
## Problem
When switching between different manifests, a newly downloaded version might chronologically be older than all previously downloaded versions, even though it's marked as the latest version in its own manifest. This is why we are getting the EPIPE error when trying out the alpha manifest. The cleanup deletes the language server right after it was downloaded

## Solution
In such cases, we skip the cleanup process to preserve this version. Otherwise we will get an EPIPE error. At this point the version that was downloaded shouldn't be delisted, so we don't want to make sure its not removed

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
