### PR TITLE
refactor(amazonq): cleanup remove customization feature flag

### DIFF
--- a/packages/core/src/codewhisperer/ui/statusBarMenu.ts
+++ b/packages/core/src/codewhisperer/ui/statusBarMenu.ts
@@ -77,9 +77,7 @@ function getAmazonQCodeWhispererNodes() {
 
         // Amazon Q + others
         createSeparator('Other Features'),
-        ...(AuthUtil.instance.isValidEnterpriseSsoInUse() && AuthUtil.instance.isCustomizationFeatureEnabled
-            ? [createSelectCustomization()]
-            : []),
+        ...(AuthUtil.instance.isValidEnterpriseSsoInUse() ? [createSelectCustomization()] : []),
         switchToAmazonQNode(),
     ]
 }

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -77,25 +77,10 @@ export class AuthUtil {
     protected static readonly logIfChanged = onceChanged((s: string) => getLogger().info(s))
 
     private reauthenticatePromptShown: boolean = false
-    private _isCustomizationFeatureEnabled: boolean = false
 
     // user should only see that screen once.
     // TODO: move to memento
     public hasAlreadySeenMigrationAuthScreen: boolean = false
-
-    public get isCustomizationFeatureEnabled(): boolean {
-        return this._isCustomizationFeatureEnabled
-    }
-
-    // This boolean controls whether the Select Customization node will be visible. A change to this value
-    // means that the old UX was wrong and must refresh the devTool tree.
-    public set isCustomizationFeatureEnabled(value: boolean) {
-        if (this._isCustomizationFeatureEnabled === value) {
-            return
-        }
-        this._isCustomizationFeatureEnabled = value
-        void Commands.tryExecute('aws.amazonq.refreshStatusBar')
-    }
 
     public readonly secondaryAuth = getSecondaryAuth(
         this.auth,

--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -33,10 +33,7 @@ export async function notifyNewCustomizations() {
     let availableCustomizations: Customization[] = []
     try {
         availableCustomizations = await getAvailableCustomizationsList()
-        AuthUtil.instance.isCustomizationFeatureEnabled = true
     } catch (error) {
-        // On receiving any error, we will disable the customization feature
-        AuthUtil.instance.isCustomizationFeatureEnabled = false
         await setSelectedCustomization(baseCustomization)
         getLogger().error(`Failed to fetch customizations: %O`, error)
         return
@@ -94,11 +91,7 @@ export const baseCustomization = {
  * @returns customization selected by users, `baseCustomization` if none is selected
  */
 export const getSelectedCustomization = (): Customization => {
-    if (
-        !AuthUtil.instance.isCustomizationFeatureEnabled ||
-        !AuthUtil.instance.isValidEnterpriseSsoInUse() ||
-        !AuthUtil.instance.conn
-    ) {
+    if (!AuthUtil.instance.isValidEnterpriseSsoInUse() || !AuthUtil.instance.conn) {
         return baseCustomization
     }
 

--- a/packages/core/src/test/amazonq/customizationUtil.test.ts
+++ b/packages/core/src/test/amazonq/customizationUtil.test.ts
@@ -49,7 +49,6 @@ describe('CodeWhisperer-customizationUtils', function () {
 
         sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
         sinon.stub(AuthUtil.instance, 'isConnected').returns(true)
-        sinon.stub(AuthUtil.instance, 'isCustomizationFeatureEnabled').value(true)
         sinon.stub(AuthUtil.instance, 'conn').value(ssoConn)
 
         await resetCodeWhispererGlobalVariables()

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -476,7 +476,6 @@ describe('CodeWhisperer-basicCommands', function () {
             sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
             sinon.stub(AuthUtil.instance, 'isConnected').returns(true)
             sinon.stub(AuthUtil.instance, 'isValidEnterpriseSsoInUse').returns(true)
-            sinon.stub(AuthUtil.instance, 'isCustomizationFeatureEnabled').value(true)
             await CodeScansState.instance.setScansEnabled(false)
 
             getTestWindow().onDidShowQuickPick(async (e) => {


### PR DESCRIPTION
## Problem
the feature flag is for Gated Preview, and customization is already GA

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
