### PR TITLE
telemetry(chat): metric for distribution of tools 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.315",
+                "@aws-toolkits/telemetry": "^1.0.316",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -10806,9 +10806,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.315",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.315.tgz",
-            "integrity": "sha512-BJniCka+nGWpLokN1sn4oXes7Rvq6V6Fr1qZlCHI/j1mOqQEWYPnOKd+HdLcuqHWQKr3o5znnBlg0CmY+7kdNg==",
+            "version": "1.0.316",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.316.tgz",
+            "integrity": "sha512-zyzubs7fnCLPqdNtfHdmmNXVWrwIWJHIr6LJqdvUtNfdGmN8PWxq/NdBgCP9QcPVZusuK7SHha1knl8vhped/w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.315",
+        "@aws-toolkits/telemetry": "^1.0.316",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -435,6 +435,8 @@ export class Messenger {
                                         { tabID }
                                     )
                                 }
+
+                                this.telemetryHelper.recordToolUseSuggested(toolUse, messageID)
                             } else {
                                 throw new Error('Tool not found')
                             }

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as path from 'path'
-import { UserIntent } from '@amzn/codewhisperer-streaming'
+import { ToolUse, UserIntent } from '@amzn/codewhisperer-streaming'
 import {
     AmazonqAddMessage,
     AmazonqInteractWithMessage,
@@ -215,6 +215,17 @@ export class CWCTelemetryHelper {
 
     private recordFeedbackResult(feedbackResult: Result) {
         telemetry.feedback_result.emit({ result: feedbackResult })
+    }
+
+    public recordToolUseSuggested(toolUse: ToolUse, messageId: string) {
+        telemetry.amazonq_toolUseSuggested.emit({
+            result: 'Succeeded',
+            cwsprChatConversationId: messageId,
+            cwsprChatConversationType: 'AgenticChatWithToolUse',
+            credentialStartUrl: AuthUtil.instance.startUrl,
+            cwsprToolName: toolUse.name ?? '',
+            cwsprToolUseId: toolUse.toolUseId ?? '',
+        })
     }
 
     public recordInteractionWithAgenticChat(


### PR DESCRIPTION
## Problem
- Want to see the distribution of tools that LLM either used directly (no acceptance needed) or suggested (user acceptance required)


## Solution
- Emit metric `toolUseSuggested` after LLM invokes any tool
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
