### PR TITLE
fix(chat): Improve fsRead truncation handling

### DIFF
--- a/packages/core/src/codewhispererChat/tools/fsRead.ts
+++ b/packages/core/src/codewhispererChat/tools/fsRead.ts
@@ -139,23 +139,29 @@ export class FsRead {
     }
 
     private createOutput(content: string): InvokeOutput {
+        let truncated = false
         if (content.length > fsReadToolResponseSize) {
+            truncated = true
             this.logger.info(
                 `The file is too large, truncating output to the first ${fsReadToolResponseSize} characters.`
             )
             content = this.truncateContent(content)
         }
+        const outputJson = {
+            content: content,
+            truncated: truncated,
+        }
         return {
             output: {
-                kind: OutputKind.Text,
-                content: content,
+                kind: OutputKind.Json,
+                content: outputJson,
             },
         }
     }
 
     private truncateContent(content: string): string {
         if (content.length > fsReadToolResponseSize) {
-            return content.substring(0, fsReadToolResponseSize)
+            return content.substring(0, fsReadToolResponseSize - 3) + '...'
         }
         return content
     }

--- a/packages/core/src/codewhispererChat/tools/tool_index.json
+++ b/packages/core/src/codewhispererChat/tools/tool_index.json
@@ -1,7 +1,7 @@
 {
     "fsRead": {
         "name": "fsRead",
-        "description": "A tool for reading a file.\n * This tool returns the contents of a file, and the optional `readRange` determines what range of lines will be read from the specified file.\n * If the file exceeds 200K characters, this tool will only read the first 200K characters of the file.",
+        "description": "A tool for reading a file.\n * This tool returns the contents of a file, and the optional `readRange` determines what range of lines will be read from the specified file.\n * If the file exceeds 200K characters, this tool will only read the first 200K characters of the file with `truncated = true` in the output.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -10,7 +10,7 @@
                     "type": "string"
                 },
                 "readRange": {
-                    "description": "Optional parameter when reading files.\n * If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start.\n * Setting `[startLine, -1]` shows all lines from `startLine` to the end of the file.",
+                    "description": "Optional parameter when reading files.\n * If none is given, the full file or the first 200K characters is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start.\n * Setting `[startLine, -1]` shows all lines from `startLine` to the end of the file.",
                     "items": {
                         "type": "integer"
                     },

--- a/packages/core/src/test/codewhispererChat/tools/fsRead.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/fsRead.test.ts
@@ -34,8 +34,8 @@ describe('FsRead Tool', () => {
         await fsRead.validate()
         const result = await fsRead.invoke(process.stdout)
 
-        assert.strictEqual(result.output.kind, 'text', 'Output kind should be "text"')
-        assert.strictEqual(result.output.content, fileContent, 'File content should match exactly')
+        assert.strictEqual(result.output.kind, 'json', 'Output kind should be "json"')
+        assert.strictEqual(result.output.content.content, fileContent, 'File content should match exactly')
     })
 
     it('truncate output if too large', async () => {
@@ -44,12 +44,13 @@ describe('FsRead Tool', () => {
         const fsRead = new FsRead({ path: filePath })
         await fsRead.validate()
         const result = await fsRead.invoke(process.stdout)
-        assert.strictEqual(result.output.kind, 'text', 'Output kind should be "text"')
+        assert.strictEqual(result.output.kind, 'json', 'Output kind should be "json"')
         assert.strictEqual(
-            result.output.content.length,
+            result.output.content.content.length,
             fsReadToolResponseSize,
             'Output should be truncated to the max size'
         )
+        assert.ok(result.output.content.truncated, 'Output should be truncated to the max size')
     })
 
     it('reads partial lines of a file', async () => {
@@ -60,8 +61,8 @@ describe('FsRead Tool', () => {
         await fsRead.validate()
         const result = await fsRead.invoke(process.stdout)
 
-        assert.strictEqual(result.output.kind, 'text')
-        assert.strictEqual(result.output.content, 'B\nC\nD')
+        assert.strictEqual(result.output.kind, 'json')
+        assert.strictEqual(result.output.content.content, 'B\nC\nD')
     })
 
     it('throws error if path does not exist', async () => {
@@ -81,8 +82,8 @@ describe('FsRead Tool', () => {
 
         await fsRead.validate()
         const result = await fsRead.invoke(process.stdout)
-        assert.strictEqual(result.output.kind, 'text')
-        assert.strictEqual(result.output.content, '')
+        assert.strictEqual(result.output.kind, 'json')
+        assert.strictEqual(result.output.content.content, '')
     })
 
     it('should require acceptance if fsPath is outside the workspace', () => {


### PR DESCRIPTION
## Problem
- LLM sometimes gets confused when reading a large file that are truncated

## Solution
- Improve fsRead truncation handling

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
