### PR TITLE
telemetry(chat): try catch for telemetry to not break tool execution

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -218,27 +218,39 @@ export class CWCTelemetryHelper {
     }
 
     public recordToolUseSuggested(toolUse: ToolUse, messageId: string) {
-        telemetry.amazonq_toolUseSuggested.emit({
-            result: 'Succeeded',
-            cwsprChatConversationId: messageId,
-            cwsprChatConversationType: 'AgenticChatWithToolUse',
-            credentialStartUrl: AuthUtil.instance.startUrl,
-            cwsprToolName: toolUse.name ?? '',
-            cwsprToolUseId: toolUse.toolUseId ?? '',
-        })
+        try {
+            telemetry.amazonq_toolUseSuggested.run((span) => {
+                span.record({
+                    result: 'Succeeded',
+                    cwsprChatConversationId: messageId,
+                    cwsprChatConversationType: 'AgenticChatWithToolUse',
+                    credentialStartUrl: AuthUtil.instance.startUrl,
+                    cwsprToolName: toolUse.name ?? '',
+                    cwsprToolUseId: toolUse.toolUseId ?? '',
+                })
+            })
+        } catch (e: any) {
+            getLogger().info('Unable to record amazonq_toolUseSuggested telemetry')
+        }
     }
 
     public recordInteractionWithAgenticChat(
         interactionType: AgenticChatInteractionType,
         message: AcceptResponseMessage | CustomFormActionMessage | StopResponseMessage
     ) {
-        telemetry.amazonq_interactWithAgenticChat.emit({
-            cwsprAgenticChatInteractionType: interactionType,
-            result: 'Succeeded',
-            cwsprChatConversationId: this.getConversationId(message.tabID ?? '') ?? '',
-            cwsprChatConversationType: 'AgenticChat',
-            credentialStartUrl: AuthUtil.instance.startUrl,
-        })
+        try {
+            telemetry.amazonq_interactWithAgenticChat.run((span) => {
+                span.record({
+                    cwsprAgenticChatInteractionType: interactionType,
+                    result: 'Succeeded',
+                    cwsprChatConversationId: this.getConversationId(message.tabID ?? '') ?? '',
+                    cwsprChatConversationType: 'AgenticChat',
+                    credentialStartUrl: AuthUtil.instance.startUrl,
+                })
+            })
+        } catch (e: any) {
+            getLogger().info('Unable to record amazonq_interactWithAgenticChat telemetry')
+        }
     }
 
     public recordInteractWithMessage(

--- a/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -230,7 +230,7 @@ export class CWCTelemetryHelper {
                 })
             })
         } catch (e: any) {
-            getLogger().info('Unable to record amazonq_toolUseSuggested telemetry')
+            getLogger().error('Unable to record amazonq_toolUseSuggested telemetry')
         }
     }
 
@@ -249,7 +249,7 @@ export class CWCTelemetryHelper {
                 })
             })
         } catch (e: any) {
-            getLogger().info('Unable to record amazonq_interactWithAgenticChat telemetry')
+            getLogger().error('Unable to record amazonq_interactWithAgenticChat telemetry')
         }
     }
 


### PR DESCRIPTION
## Problem
- `error: TypeError: Cannot read properties of undefined (reading 'emit') `
- telemetry can throw an error and break tool execution

## Solution
- use `run` instead of emit
- add try catch

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
