### PR TITLE
fix(amazonq): Previous and subsequent cells are used as context for completion in a Jupyter notebook

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-9b0e6490-39a8-445f-9d67-9d762de7421c.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-9b0e6490-39a8-445f-9d67-9d762de7421c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Previous and subsequent cells are used as context for completion in a Jupyter notebook"
+}

--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -214,78 +214,41 @@ describe('editorContext', function () {
     })
 
     describe('extractPrefixCellsContext', function () {
-        it('Should extract content from cells in reverse order up to maxLength', function () {
+        it('Should extract content from cells in reverse order up to maxLength from prefix cells', function () {
             const mockCells = [
                 createNotebookCell(createMockDocument('First cell content')),
                 createNotebookCell(createMockDocument('Second cell content')),
                 createNotebookCell(createMockDocument('Third cell content')),
             ]
 
-            const result = EditorContext.extractPrefixCellsContext(mockCells, 100, 'python')
+            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', false)
             assert.strictEqual(result, 'First cell content\nSecond cell content\nThird cell content\n')
         })
 
-        it('Should respect maxLength parameter', function () {
+        it('Should extract content from cells in reverse order up to maxLength from suffix cells', function () {
+            const mockCells = [
+                createNotebookCell(createMockDocument('First cell content')),
+                createNotebookCell(createMockDocument('Second cell content')),
+                createNotebookCell(createMockDocument('Third cell content')),
+            ]
+
+            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', true)
+            assert.strictEqual(result, 'First cell content\nSecond cell content\nThird cell content\n')
+        })
+
+        it('Should respect maxLength parameter from prefix cells', function () {
             const mockCells = [
                 createNotebookCell(createMockDocument('First')),
                 createNotebookCell(createMockDocument('Second')),
                 createNotebookCell(createMockDocument('Third')),
                 createNotebookCell(createMockDocument('Fourth')),
             ]
-
-            const result = EditorContext.extractPrefixCellsContext(mockCells, 15, 'python')
+            // Should only include part of second cell and the last two cells
+            const result = EditorContext.extractCellsSliceContext(mockCells, 15, 'python', false)
             assert.strictEqual(result, 'd\nThird\nFourth\n')
         })
 
-        it('Should handle empty cells array', function () {
-            const result = EditorContext.extractPrefixCellsContext([], 100, '')
-            assert.strictEqual(result, '')
-        })
-
-        it('Should add python comments to markdown cells', function () {
-            const mockCells = [
-                createNotebookCell(createMockDocument('# Heading\nThis is markdown'), vscode.NotebookCellKind.Markup),
-                createNotebookCell(createMockDocument('def example():\n    return "test"')),
-            ]
-            const result = EditorContext.extractPrefixCellsContext(mockCells, 100, 'python')
-            assert.strictEqual(result, '# # Heading\n# This is markdown\ndef example():\n    return "test"\n')
-        })
-
-        it('Should add java comments to markdown and python cells when language is java', function () {
-            const mockCells = [
-                createNotebookCell(createMockDocument('# Heading\nThis is markdown'), vscode.NotebookCellKind.Markup),
-                createNotebookCell(createMockDocument('def example():\n    return "test"')),
-            ]
-            const result = EditorContext.extractPrefixCellsContext(mockCells, 100, 'java')
-            assert.strictEqual(result, '// # Heading\n// This is markdown\n// def example():\n//     return "test"\n')
-        })
-
-        it('Should handle code cells with different languages', function () {
-            const mockCells = [
-                createNotebookCell(
-                    createMockDocument('println(1 + 1);', 'somefile.ipynb', 'java'),
-                    vscode.NotebookCellKind.Code
-                ),
-                createNotebookCell(createMockDocument('def example():\n    return "test"')),
-            ]
-            const result = EditorContext.extractPrefixCellsContext(mockCells, 100, 'python')
-            assert.strictEqual(result, '# println(1 + 1);\ndef example():\n    return "test"\n')
-        })
-    })
-
-    describe('extractSuffixCellsContext', function () {
-        it('Should extract content from cells in order up to maxLength', function () {
-            const mockCells = [
-                createNotebookCell(createMockDocument('First cell content')),
-                createNotebookCell(createMockDocument('Second cell content')),
-                createNotebookCell(createMockDocument('Third cell content')),
-            ]
-
-            const result = EditorContext.extractSuffixCellsContext(mockCells, 100, 'python')
-            assert.strictEqual(result, 'First cell content\nSecond cell content\nThird cell content\n')
-        })
-
-        it('Should respect maxLength parameter', function () {
+        it('Should respect maxLength parameter from suffix cells', function () {
             const mockCells = [
                 createNotebookCell(createMockDocument('First')),
                 createNotebookCell(createMockDocument('Second')),
@@ -294,39 +257,59 @@ describe('editorContext', function () {
             ]
 
             // Should only include first cell and part of second cell
-            const result = EditorContext.extractSuffixCellsContext(mockCells, 15, 'plaintext')
+            const result = EditorContext.extractCellsSliceContext(mockCells, 15, 'python', true)
             assert.strictEqual(result, 'First\nSecond\nTh')
         })
 
-        it('Should handle empty cells array', function () {
-            const result = EditorContext.extractSuffixCellsContext([], 100, 'plaintext')
+        it('Should handle empty cells array from prefix cells', function () {
+            const result = EditorContext.extractCellsSliceContext([], 100, 'python', false)
             assert.strictEqual(result, '')
         })
 
-        it('Should add python comments to markdown cells', function () {
+        it('Should handle empty cells array from suffix cells', function () {
+            const result = EditorContext.extractCellsSliceContext([], 100, 'python', true)
+            assert.strictEqual(result, '')
+        })
+
+        it('Should add python comments to markdown prefix cells', function () {
             const mockCells = [
                 createNotebookCell(createMockDocument('# Heading\nThis is markdown'), vscode.NotebookCellKind.Markup),
                 createNotebookCell(createMockDocument('def example():\n    return "test"')),
             ]
-
-            const result = EditorContext.extractSuffixCellsContext(mockCells, 100, 'python')
+            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', false)
             assert.strictEqual(result, '# # Heading\n# This is markdown\ndef example():\n    return "test"\n')
         })
 
-        it('Should add java comments to markdown cells', function () {
+        it('Should add python comments to markdown suffix cells', function () {
             const mockCells = [
                 createNotebookCell(createMockDocument('# Heading\nThis is markdown'), vscode.NotebookCellKind.Markup),
-                createNotebookCell(
-                    createMockDocument('println(1 + 1);', 'somefile.ipynb', 'java'),
-                    vscode.NotebookCellKind.Code
-                ),
+                createNotebookCell(createMockDocument('def example():\n    return "test"')),
             ]
 
-            const result = EditorContext.extractSuffixCellsContext(mockCells, 100, 'java')
+            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', true)
+            assert.strictEqual(result, '# # Heading\n# This is markdown\ndef example():\n    return "test"\n')
+        })
+
+        it('Should add java comments to markdown and python prefix cells when language is java', function () {
+            const mockCells = [
+                createNotebookCell(createMockDocument('# Heading\nThis is markdown'), vscode.NotebookCellKind.Markup),
+                createNotebookCell(createMockDocument('def example():\n    return "test"')),
+            ]
+            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'java', false)
+            assert.strictEqual(result, '// # Heading\n// This is markdown\n// def example():\n//     return "test"\n')
+        })
+
+        it('Should add java comments to markdown and python suffix cells when language is java', function () {
+            const mockCells = [
+                createNotebookCell(createMockDocument('# Heading\nThis is markdown'), vscode.NotebookCellKind.Markup),
+                createNotebookCell(createMockDocument('println(1 + 1);', 'somefile.ipynb', 'java')),
+            ]
+
+            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'java', true)
             assert.strictEqual(result, '// # Heading\n// This is markdown\nprintln(1 + 1);\n')
         })
 
-        it('Should handle code cells with different languages', function () {
+        it('Should handle code prefix cells with different languages', function () {
             const mockCells = [
                 createNotebookCell(
                     createMockDocument('println(1 + 1);', 'somefile.ipynb', 'java'),
@@ -334,7 +317,19 @@ describe('editorContext', function () {
                 ),
                 createNotebookCell(createMockDocument('def example():\n    return "test"')),
             ]
-            const result = EditorContext.extractSuffixCellsContext(mockCells, 100, 'python')
+            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', false)
+            assert.strictEqual(result, '# println(1 + 1);\ndef example():\n    return "test"\n')
+        })
+
+        it('Should handle code suffix cells with different languages', function () {
+            const mockCells = [
+                createNotebookCell(
+                    createMockDocument('println(1 + 1);', 'somefile.ipynb', 'java'),
+                    vscode.NotebookCellKind.Code
+                ),
+                createNotebookCell(createMockDocument('def example():\n    return "test"')),
+            ]
+            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', true)
             assert.strictEqual(result, '# println(1 + 1);\ndef example():\n    return "test"\n')
         })
     })

--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -213,7 +213,7 @@ describe('editorContext', function () {
         })
     })
 
-    describe('extractPrefixCellsContext', function () {
+    describe('extractCellsSliceContext', function () {
         it('Should extract content from cells in reverse order up to maxLength from prefix cells', function () {
             const mockCells = [
                 createNotebookCell(createMockDocument('First cell content')),

--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -86,7 +86,7 @@ describe('editorContext', function () {
             assert.deepStrictEqual(actual, expected)
         })
 
-        it('Should include context from other cells when in a notebook', async function () {
+        it('in a notebook, includes context from other cells', async function () {
             const cells: vscode.NotebookCellData[] = [
                 new vscode.NotebookCellData(vscode.NotebookCellKind.Markup, 'Previous cell', 'python'),
                 new vscode.NotebookCellData(
@@ -175,7 +175,7 @@ describe('editorContext', function () {
         })
     })
 
-    describe('extractSingleCellContext', function () {
+    describe('getNotebookCellContext', function () {
         it('Should return cell text for python code cells when language is python', function () {
             const mockCodeCell = createNotebookCell(createMockDocument('def example():\n    return "test"'))
             const result = EditorContext.extractSingleCellContext(mockCodeCell, 'python')

--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -213,7 +213,7 @@ describe('editorContext', function () {
         })
     })
 
-    describe('extractCellsSliceContext', function () {
+    describe('getNotebookCellsSliceContext', function () {
         it('Should extract content from cells in reverse order up to maxLength from prefix cells', function () {
             const mockCells = [
                 createNotebookCell(createMockDocument('First cell content')),
@@ -221,7 +221,7 @@ describe('editorContext', function () {
                 createNotebookCell(createMockDocument('Third cell content')),
             ]
 
-            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', false)
+            const result = EditorContext.getNotebookCellsSliceContext(mockCells, 100, 'python', false)
             assert.strictEqual(result, 'First cell content\nSecond cell content\nThird cell content\n')
         })
 
@@ -232,7 +232,7 @@ describe('editorContext', function () {
                 createNotebookCell(createMockDocument('Third cell content')),
             ]
 
-            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', true)
+            const result = EditorContext.getNotebookCellsSliceContext(mockCells, 100, 'python', true)
             assert.strictEqual(result, 'First cell content\nSecond cell content\nThird cell content\n')
         })
 
@@ -244,7 +244,7 @@ describe('editorContext', function () {
                 createNotebookCell(createMockDocument('Fourth')),
             ]
             // Should only include part of second cell and the last two cells
-            const result = EditorContext.extractCellsSliceContext(mockCells, 15, 'python', false)
+            const result = EditorContext.getNotebookCellsSliceContext(mockCells, 15, 'python', false)
             assert.strictEqual(result, 'd\nThird\nFourth\n')
         })
 
@@ -257,17 +257,17 @@ describe('editorContext', function () {
             ]
 
             // Should only include first cell and part of second cell
-            const result = EditorContext.extractCellsSliceContext(mockCells, 15, 'python', true)
+            const result = EditorContext.getNotebookCellsSliceContext(mockCells, 15, 'python', true)
             assert.strictEqual(result, 'First\nSecond\nTh')
         })
 
         it('Should handle empty cells array from prefix cells', function () {
-            const result = EditorContext.extractCellsSliceContext([], 100, 'python', false)
+            const result = EditorContext.getNotebookCellsSliceContext([], 100, 'python', false)
             assert.strictEqual(result, '')
         })
 
         it('Should handle empty cells array from suffix cells', function () {
-            const result = EditorContext.extractCellsSliceContext([], 100, 'python', true)
+            const result = EditorContext.getNotebookCellsSliceContext([], 100, 'python', true)
             assert.strictEqual(result, '')
         })
 
@@ -276,7 +276,7 @@ describe('editorContext', function () {
                 createNotebookCell(createMockDocument('# Heading\nThis is markdown'), vscode.NotebookCellKind.Markup),
                 createNotebookCell(createMockDocument('def example():\n    return "test"')),
             ]
-            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', false)
+            const result = EditorContext.getNotebookCellsSliceContext(mockCells, 100, 'python', false)
             assert.strictEqual(result, '# # Heading\n# This is markdown\ndef example():\n    return "test"\n')
         })
 
@@ -286,7 +286,7 @@ describe('editorContext', function () {
                 createNotebookCell(createMockDocument('def example():\n    return "test"')),
             ]
 
-            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', true)
+            const result = EditorContext.getNotebookCellsSliceContext(mockCells, 100, 'python', true)
             assert.strictEqual(result, '# # Heading\n# This is markdown\ndef example():\n    return "test"\n')
         })
 
@@ -295,7 +295,7 @@ describe('editorContext', function () {
                 createNotebookCell(createMockDocument('# Heading\nThis is markdown'), vscode.NotebookCellKind.Markup),
                 createNotebookCell(createMockDocument('def example():\n    return "test"')),
             ]
-            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'java', false)
+            const result = EditorContext.getNotebookCellsSliceContext(mockCells, 100, 'java', false)
             assert.strictEqual(result, '// # Heading\n// This is markdown\n// def example():\n//     return "test"\n')
         })
 
@@ -305,7 +305,7 @@ describe('editorContext', function () {
                 createNotebookCell(createMockDocument('println(1 + 1);', 'somefile.ipynb', 'java')),
             ]
 
-            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'java', true)
+            const result = EditorContext.getNotebookCellsSliceContext(mockCells, 100, 'java', true)
             assert.strictEqual(result, '// # Heading\n// This is markdown\nprintln(1 + 1);\n')
         })
 
@@ -317,7 +317,7 @@ describe('editorContext', function () {
                 ),
                 createNotebookCell(createMockDocument('def example():\n    return "test"')),
             ]
-            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', false)
+            const result = EditorContext.getNotebookCellsSliceContext(mockCells, 100, 'python', false)
             assert.strictEqual(result, '# println(1 + 1);\ndef example():\n    return "test"\n')
         })
 
@@ -329,7 +329,7 @@ describe('editorContext', function () {
                 ),
                 createNotebookCell(createMockDocument('def example():\n    return "test"')),
             ]
-            const result = EditorContext.extractCellsSliceContext(mockCells, 100, 'python', true)
+            const result = EditorContext.getNotebookCellsSliceContext(mockCells, 100, 'python', true)
             assert.strictEqual(result, '# println(1 + 1);\ndef example():\n    return "test"\n')
         })
     })

--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -178,19 +178,19 @@ describe('editorContext', function () {
     describe('getNotebookCellContext', function () {
         it('Should return cell text for python code cells when language is python', function () {
             const mockCodeCell = createNotebookCell(createMockDocument('def example():\n    return "test"'))
-            const result = EditorContext.extractSingleCellContext(mockCodeCell, 'python')
+            const result = EditorContext.getNotebookCellContext(mockCodeCell, 'python')
             assert.strictEqual(result, 'def example():\n    return "test"')
         })
 
         it('Should return java comments for python code cells when language is java', function () {
             const mockCodeCell = createNotebookCell(createMockDocument('def example():\n    return "test"'))
-            const result = EditorContext.extractSingleCellContext(mockCodeCell, 'java')
+            const result = EditorContext.getNotebookCellContext(mockCodeCell, 'java')
             assert.strictEqual(result, '// def example():\n//     return "test"')
         })
 
         it('Should return python comments for java code cells when language is python', function () {
             const mockCodeCell = createNotebookCell(createMockDocument('println(1 + 1);', 'somefile.ipynb', 'java'))
-            const result = EditorContext.extractSingleCellContext(mockCodeCell, 'python')
+            const result = EditorContext.getNotebookCellContext(mockCodeCell, 'python')
             assert.strictEqual(result, '# println(1 + 1);')
         })
 
@@ -199,7 +199,7 @@ describe('editorContext', function () {
                 createMockDocument('# Heading\nThis is a markdown cell'),
                 vscode.NotebookCellKind.Markup
             )
-            const result = EditorContext.extractSingleCellContext(mockMarkdownCell, 'python')
+            const result = EditorContext.getNotebookCellContext(mockMarkdownCell, 'python')
             assert.strictEqual(result, '# # Heading\n# This is a markdown cell')
         })
 
@@ -208,7 +208,7 @@ describe('editorContext', function () {
                 createMockDocument('# Heading\nThis is a markdown cell'),
                 vscode.NotebookCellKind.Markup
             )
-            const result = EditorContext.extractSingleCellContext(mockMarkdownCell, 'java')
+            const result = EditorContext.getNotebookCellContext(mockMarkdownCell, 'java')
             assert.strictEqual(result, '// # Heading\n// This is a markdown cell')
         })
     })

--- a/packages/amazonq/test/unit/codewhisperer/util/runtimeLanguageContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/runtimeLanguageContext.test.ts
@@ -333,6 +333,40 @@ describe('runtimeLanguageContext', function () {
         }
     })
 
+    describe('getSingleLineCommentPrefix', function () {
+        it('should return the correct comment prefix for supported languages', function () {
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('java'), '// ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('javascript'), '// ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('jsonc'), '// ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('kotlin'), '// ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('lua'), '-- ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('python'), '# ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('ruby'), '# ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('sql'), '-- ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('tf'), '# ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('typescript'), '// ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('vue'), '')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('yaml'), '# ')
+        })
+
+        it('should normalize language ID before getting comment prefix', function () {
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('hcl'), '# ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('javascriptreact'), '// ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('shellscript'), '# ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('typescriptreact'), '// ')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('yml'), '# ')
+        })
+
+        it('should return empty string for unsupported languages', function () {
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('nonexistent'), '')
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix(undefined), '')
+        })
+
+        it('should return empty string for plaintext', function () {
+            assert.strictEqual(languageContext.getSingleLineCommentPrefix('plaintext'), '')
+        })
+    })
+
     // for now we will only jsx mapped to javascript, tsx mapped to typescript, all other language should remain the same
     describe('test covertCwsprRequest', function () {
         const leftFileContent = 'left'

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -38,7 +38,7 @@ function getEnclosingNotebook(editor: vscode.TextEditor): vscode.NotebookDocumen
     )
 }
 
-export function extractNotebookContext(
+export function getNotebookContext(
     notebook: vscode.NotebookDocument,
     editor: vscode.TextEditor,
     languageName: string,
@@ -75,7 +75,7 @@ export function extractNotebookContext(
     return { caretLeftFileContext, caretRightFileContext }
 }
 
-export function extractSingleCellContext(cell: vscode.NotebookCell, referenceLanguage?: string): string {
+export function getNotebookCellContext(cell: vscode.NotebookCell, referenceLanguage?: string): string {
     // Extract the text verbatim if the cell is code and the cell has the same language.
     // Otherwise, add the correct comment string for the refeference language
     const cellText = cell.document.getText()
@@ -110,7 +110,7 @@ export function getNotebookCellsSliceContext(
         cells = cells.reverse()
     }
     cells.some((cell) => {
-        let cellText = addNewlineIfMissing(extractSingleCellContext(cell, referenceLanguage))
+        let cellText = addNewlineIfMissing(getNotebookCellContext(cell, referenceLanguage))
         if (cellText.length > 0) {
             if (cellText.length >= maxLength) {
                 if (fromStart) {
@@ -162,7 +162,7 @@ export function extractContextForCodeWhisperer(editor: vscode.TextEditor): codew
     if (editor.document.uri.scheme === 'vscode-notebook-cell') {
         const notebook = getEnclosingNotebook(editor)
         if (notebook) {
-            ;({ caretLeftFileContext, caretRightFileContext } = extractNotebookContext(
+            ;({ caretLeftFileContext, caretRightFileContext } = getNotebookContext(
                 notebook,
                 editor,
                 languageName,

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -25,11 +25,6 @@ import { predictionTracker } from '../nextEditPrediction/activation'
 
 let tabSize: number = getTabSizeSetting()
 
-const languageCommentChars: Record<string, string> = {
-    python: '# ',
-    java: '// ',
-}
-
 function getEnclosingNotebook(editor: vscode.TextEditor): vscode.NotebookDocument | undefined {
     // For notebook cells, find the existing notebook with a cell that matches the current editor.
     return vscode.workspace.notebookDocuments.find(
@@ -77,14 +72,14 @@ export function getNotebookContext(
 
 export function getNotebookCellContext(cell: vscode.NotebookCell, referenceLanguage?: string): string {
     // Extract the text verbatim if the cell is code and the cell has the same language.
-    // Otherwise, add the correct comment string for the refeference language
+    // Otherwise, add the correct comment string for the reference language
     const cellText = cell.document.getText()
     if (
         cell.kind === vscode.NotebookCellKind.Markup ||
         (runtimeLanguageContext.normalizeLanguage(cell.document.languageId) ?? cell.document.languageId) !==
             referenceLanguage
     ) {
-        const commentPrefix = (referenceLanguage && languageCommentChars[referenceLanguage]) ?? ''
+        const commentPrefix = runtimeLanguageContext.getSingleLineCommentPrefix(referenceLanguage)
         if (commentPrefix === '') {
             return cellText
         }

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -30,7 +30,7 @@ const languageCommentChars: Record<string, string> = {
     java: '// ',
 }
 
-export function extractSingleCellContext(cell: vscode.NotebookCell, referenceLanguage?: string): string {
+export function getNotebookCellContext(cell: vscode.NotebookCell, referenceLanguage?: string): string {
     // Extract the text verbatim if the cell is code and the cell has the same language.
     // Otherwise, add the correct comment string for the refeference language
     const cellText = cell.document.getText()
@@ -52,7 +52,7 @@ export function extractSingleCellContext(cell: vscode.NotebookCell, referenceLan
     return cellText
 }
 
-export function extractCellsSliceContext(
+export function getNotebookCellsSliceContext(
     cells: vscode.NotebookCell[],
     maxLength: number,
     referenceLanguage: string,

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -110,7 +110,7 @@ export function getNotebookCellsSliceContext(
         cells = cells.reverse()
     }
     cells.some((cell) => {
-        let cellText = addNewlineIfMissing(getNotebookCellContext(cell, referenceLanguage))
+        const cellText = addNewlineIfMissing(getNotebookCellContext(cell, referenceLanguage))
         if (cellText.length > 0) {
             if (cellText.length >= maxLength) {
                 if (fromStart) {

--- a/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -58,6 +58,13 @@ export class RuntimeLanguageContext {
      */
     private supportedLanguageExtensionMap: ConstantMap<string, CodewhispererLanguage>
 
+    /**
+     * A map storing single-line comment prefixes for different languages
+     * Key: CodewhispererLanguage
+     * Value: Comment prefix string
+     */
+    private languageSingleLineCommentPrefixMap: ConstantMap<CodewhispererLanguage, string>
+
     constructor() {
         this.supportedLanguageMap = createConstantMap<
             CodeWhispererConstants.PlatformLanguageId | CodewhispererLanguage,
@@ -146,6 +153,39 @@ export class RuntimeLanguageContext {
             psm1: 'powershell',
             r: 'r',
         })
+        this.languageSingleLineCommentPrefixMap = createConstantMap<CodewhispererLanguage, string>({
+            c: '// ',
+            cpp: '// ',
+            csharp: '// ',
+            dart: '// ',
+            go: '// ',
+            hcl: '# ',
+            java: '// ',
+            javascript: '// ',
+            json: '// ',
+            jsonc: '// ',
+            jsx: '// ',
+            kotlin: '// ',
+            lua: '-- ',
+            php: '// ',
+            plaintext: '',
+            powershell: '# ',
+            python: '# ',
+            r: '# ',
+            ruby: '# ',
+            rust: '// ',
+            scala: '// ',
+            shell: '# ',
+            sql: '-- ',
+            swift: '// ',
+            systemVerilog: '// ',
+            tf: '# ',
+            tsx: '// ',
+            typescript: '// ',
+            vue: '', // vue lacks a single-line comment prefix
+            yaml: '# ',
+            yml: '# ',
+        })
     }
 
     /**
@@ -157,6 +197,16 @@ export class RuntimeLanguageContext {
      */
     public normalizeLanguage(languageId?: string): CodewhispererLanguage | undefined {
         return this.supportedLanguageMap.get(languageId)
+    }
+
+    /**
+     * Get the comment prefix for a given language
+     * @param language The language to get comment prefix for
+     * @returns The comment prefix string, or empty string if not found
+     */
+    public getSingleLineCommentPrefix(language?: string): string {
+        const normalizedLanguage = this.normalizeLanguage(language)
+        return normalizedLanguage ? (this.languageSingleLineCommentPrefixMap.get(normalizedLanguage) ?? '') : ''
     }
 
     /**


### PR DESCRIPTION
## Problem
VS Code treats each cell in a notebook as a separate editor.  As a result, when building the left- and right-contexts for the completion from the current editor, we were limited to just the current cell, which might be very small and/or reference variables and functions defined in other cells.  That meant that completions never used the context of other cells when making suggestions, and were often _very_ generic. https://github.com/aws/aws-toolkit-vscode/issues/7031

## Solution
The `extractContextForCodeWhisperer` function now checks if it is being called in a cell in a Jupyter notebook.  If so, it collects the surrounding cells to use as context, respecting the maximum context length.  During this process, Markdown cells have each line prefixed with a language-specific comment character.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
