### PR TITLE
fix(chat): tooltip for pair programmer

### DIFF
--- a/packages/core/src/amazonq/webview/ui/tabs/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/generator.ts
@@ -115,7 +115,8 @@ Enter \`/\` to view quick actions. Use \`@\` to add saved prompts, files, folder
                           {
                               type: 'switch',
                               id: 'pair-programmer-mode',
-                              tooltip: 'Enable or disable Pair Programmer',
+                              tooltip: 'Turn off for read only responses',
+                              alternateTooltip: 'Turn on to allow Q to run commands and generate code diffs',
                               value: 'true',
                               icon: 'code-block',
                           },


### PR DESCRIPTION
## Problem
- we want different tooltip when pair programmer is on vs off

## Solution
<img width="442" alt="Screenshot 2025-04-17 at 1 30 54 PM" src="https://github.com/user-attachments/assets/fdda5d12-c3ef-4a89-9731-4c13e401e45f" />
<img width="436" alt="Screenshot 2025-04-17 at 1 31 00 PM" src="https://github.com/user-attachments/assets/28e76bfe-9293-4cb1-be2f-23d51ed75f73" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).


- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
