### PR TITLE
fix(amazonq): enable local workspace server through flare

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -72,25 +72,23 @@ export async function startLanguageServer(
     const clientOptions: LanguageClientOptions = {
         // Register the server for json documents
         documentSelector,
-        // TODO uncomment this when local indexing is in agent chat server manifest and
-        // starting the workspace context doesn't generate known errors: https://github.com/aws/language-servers/pull/982/files
-        // middleware: {
-        //     workspace: {
-        //         configuration: async (params, token, next) => {
-        //             const config = await next(params, token)
-        //             if (params.items[0].section === 'aws.q') {
-        //                 return [
-        //                     {
-        //                         projectContext: {
-        //                             enableLocalIndexing: true,
-        //                         },
-        //                     },
-        //                 ]
-        //             }
-        //             return config
-        //         },
-        //     },
-        // },
+        middleware: {
+            workspace: {
+                configuration: async (params, token, next) => {
+                    const config = await next(params, token)
+                    if (params.items[0].section === 'aws.q') {
+                        return [
+                            {
+                                projectContext: {
+                                    enableLocalIndexing: true,
+                                },
+                            },
+                        ]
+                    }
+                    return config
+                },
+            },
+        },
         initializationOptions: {
             aws: {
                 clientInfo: {

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -72,6 +72,25 @@ export async function startLanguageServer(
     const clientOptions: LanguageClientOptions = {
         // Register the server for json documents
         documentSelector,
+        // TODO uncomment this when local indexing is in agent chat server manifest and
+        // starting the workspace context doesn't generate known errors: https://github.com/aws/language-servers/pull/982/files
+        // middleware: {
+        //     workspace: {
+        //         configuration: async (params, token, next) => {
+        //             const config = await next(params, token)
+        //             if (params.items[0].section === 'aws.q') {
+        //                 return [
+        //                     {
+        //                         projectContext: {
+        //                             enableLocalIndexing: true,
+        //                         },
+        //                     },
+        //                 ]
+        //             }
+        //             return config
+        //         },
+        //     },
+        // },
         initializationOptions: {
             aws: {
                 clientInfo: {


### PR DESCRIPTION
## Problem
local workspace context has been added to flare and its needed for falcon changes 

## Solution
we don't have `aws.q` settings in vscode so we have to use the language server middleware to send back the settings

Once local workspace context is fully working and in the manifest I'll uncomment

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
