### PR TITLE
feat(chat): undo all file changes

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -457,6 +457,7 @@
     "AWS.amazonq.opensettings:": "Open settings",
     "AWS.amazonq.executeBash.run": "Run",
     "AWS.amazonq.executeBash.reject": "Reject",
+    "AWS.amazonq.fsWrite.undoAll": "Undo all changes",
     "AWS.amazonq.chat.directive.pairProgrammingModeOn": "You are using **pair programming**: Q can now list files, preview code diffs and allow you to run shell commands.",
     "AWS.amazonq.chat.directive.pairProgrammingModeOff": "You turned off **pair programming**. Q will not include code diffs or run commands in the chat.",
     "AWS.amazonq.chat.directive.permission.readAndList": "I need permission to read files and list directories outside the workspace.",

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -46,6 +46,8 @@ export class ChatSession {
     private _fsWriteBackups: Map<string, FsWriteBackup> = new Map()
     private _agenticLoopInProgress: boolean = false
     private _messageOperations: Map<string, FileOperation> = new Map()
+    private _fsWriteGroupsForUndoAll: Map<string, Set<string>> = new Map()
+    private _currentFsWriteIdForUndoAll: string | undefined
 
     /**
      * True if messages from local history have been sent to session.
@@ -220,5 +222,41 @@ export class ChatSession {
      */
     public getOperationTypeByMessageId(messageId: string): OperationType | undefined {
         return this._messageOperations.get(messageId)?.type
+    }
+
+    /**
+     * Gets the fsWrite groups for undo all operations
+     * @returns Map where key is the first fsWriteId in a group and value is a Set of all fsWriteIds in that group
+     */
+    public get fsWriteGroupsForUndoAll(): Map<string, Set<string>> {
+        return this._fsWriteGroupsForUndoAll
+    }
+
+    /**
+     * Adds a single fsWriteId to a group for undo all operations
+     * @param groupId The first fsWriteId in the group (used as key)
+     * @param fsWriteId A single fsWriteId to add to the group
+     */
+    public addToFsWriteGroupForUndoAll(groupId: string, fsWriteId: string): void {
+        if (!this._fsWriteGroupsForUndoAll.has(groupId)) {
+            this._fsWriteGroupsForUndoAll.set(groupId, new Set<string>())
+        }
+        this._fsWriteGroupsForUndoAll.get(groupId)?.add(fsWriteId)
+    }
+
+    /**
+     * Gets the current fsWriteId for undo all operations
+     * @returns The first fsWriteId in the current undo all group, or undefined if not set
+     */
+    public get currentFsWriteIdForUndoAll(): string | undefined {
+        return this._currentFsWriteIdForUndoAll
+    }
+
+    /**
+     * Sets the current fsWriteId for undo all operations
+     * @param fsWriteId The first fsWriteId in the current undo all group
+     */
+    public setCurrentFsWriteIdForUndoAll(fsWriteId: string | undefined): void {
+        this._currentFsWriteIdForUndoAll = fsWriteId
     }
 }

--- a/packages/core/src/codewhispererChat/view/connector/connector.ts
+++ b/packages/core/src/codewhispererChat/view/connector/connector.ts
@@ -276,6 +276,7 @@ export class CustomFormActionMessage extends UiMessage {
         formItemValues?: Record<string, string> | undefined
     }
     readonly triggerId: string
+    readonly messageId?: string
 
     constructor(
         tabID: string,
@@ -284,11 +285,13 @@ export class CustomFormActionMessage extends UiMessage {
             text?: string | undefined
             formItemValues?: Record<string, string> | undefined
         },
-        triggerId: string
+        triggerId: string,
+        messageId?: string
     ) {
         super(tabID)
         this.action = action
         this.triggerId = triggerId
+        this.messageId = messageId
     }
 }
 


### PR DESCRIPTION
## Problem
File changes have to be reverted one at a time.

## Solution
Implement a button to revert all changes (grouped by consecutive fsWrite tool executions).


https://github.com/user-attachments/assets/fe2a74f6-363c-42f4-82e3-e0df7168e062




---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
