### PR TITLE
fix(amazonq): Remove `strReplace` from command enum

### DIFF
--- a/packages/core/src/codewhispererChat/tools/tool_index.json
+++ b/packages/core/src/codewhispererChat/tools/tool_index.json
@@ -32,7 +32,7 @@
                 },
                 "command": {
                     "type": "string",
-                    "enum": ["create", "strReplace", "insert", "append"],
+                    "enum": ["create", "insert", "append"],
                     "description": "The commands to run. Allowed options are: `create`, `strReplace`, `insert`, `append`."
                 },
                 "fileText": {


### PR DESCRIPTION
## Problem
- `fsWrite` tool tends to favor doing line-by-line replaces which causes an increase in latency

## Solution

- Remove `strReplace` from the enum array in the command property of the tool spec. This gives better multi-line replace performance. It encourages the LLM to favor `create` and `insert`. By not removing it elsewhere, the LLM can still use the `strReplace` tool if needed.

## Testing
- Manually tested fix
- Latency comparison:

|     | Build with strReplace | Build without strReplace |
| -------- | ------- |  ------- |
| renaming a single function |  16s  |  17s |
| translate comments (multi-line replace +19 -20) |  98s  | 20s |


### Without `strReplace`
    


https://github.com/user-attachments/assets/efbbe2c3-a94b-4d38-8c5c-176faa5b461f

---


- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
