### PR TITLE
fix(amazonq): duplicate messages in flare chat

### DIFF
--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -6,11 +6,11 @@
 import {
     EventEmitter,
     CancellationToken,
-    Webview,
     WebviewView,
     WebviewViewProvider,
     WebviewViewResolveContext,
     Uri,
+    Webview,
 } from 'vscode'
 import * as path from 'path'
 import {
@@ -28,7 +28,8 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
     private readonly onDidResolveWebviewEmitter = new EventEmitter<void>()
     public readonly onDidResolveWebview = this.onDidResolveWebviewEmitter.event
 
-    webview: Webview | undefined
+    webviewView?: WebviewView
+    webview?: Webview
 
     connectorAdapterPath?: string
     uiPath?: string
@@ -40,8 +41,6 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
         context: WebviewViewResolveContext,
         _token: CancellationToken
     ) {
-        this.webview = webviewView.webview
-
         const lspDir = Uri.parse(LanguageServerResolver.defaultDir())
         const dist = Uri.joinPath(globals.context.extensionUri, 'dist')
         webviewView.webview.options = {
@@ -63,7 +62,16 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
 
         webviewView.webview.html = await this.getWebviewContent()
 
+        this.webviewView = webviewView
+        this.webview = this.webviewView.webview
+
         this.onDidResolveWebviewEmitter.fire()
+        globals.context.subscriptions.push(
+            this.webviewView.onDidDispose(() => {
+                this.webviewView = undefined
+                this.webview = undefined
+            })
+        )
         performance.mark(amazonqMark.open)
     }
 


### PR DESCRIPTION
## Problem
when the flare chat panel refreshes on log in/log out, the message listener never gets disposed of, causing the next webview instantiation to have two message listeners that are forwarding messages to the ui

## Solution
dispose of the message listener when the webview gets disposed

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
