### PR TITLE
fix(chat): UX fixes for agentic chat

### DIFF
--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -178,6 +178,9 @@ export const createMynahUI = (
     let messageController: MessageController
 
     function getCodeBlockActions(messageData: any) {
+        if (!messageData.codeBlockActions) {
+            return {}
+        }
         // Show ViewDiff and AcceptDiff for allowedCommands in CWC
         const isEnabled = featureConfigs.get('ViewDiffInChat')?.variation === 'TREATMENT'
         const tab = tabsStorage.getTab(messageData?.tabID || '')
@@ -202,6 +205,17 @@ export const createMynahUI = (
                     icon: MynahIcons.EYE,
                     data: messageData,
                 },
+            }
+        }
+        if (
+            tab?.type === 'cwc' &&
+            messageData.codeBlockActions['insert-to-cursor'] === null &&
+            messageData.codeBlockActions['copy'] === null
+        ) {
+            return {
+                'insert-to-cursor': undefined,
+                // eslint-disable-next-line prettier/prettier
+                copy: undefined,
             }
         }
         // Show only "Copy" option for codeblocks in Q Test Tab

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -207,16 +207,14 @@ export const createMynahUI = (
                 },
             }
         }
-        if (
-            tab?.type === 'cwc' &&
-            messageData.codeBlockActions['insert-to-cursor'] === null &&
-            messageData.codeBlockActions['copy'] === null
-        ) {
-            return {
+        if (tab?.type === 'cwc' && messageData.codeBlockActions['insert-to-cursor'] === null) {
+            const actions: Record<string, undefined> = {
                 'insert-to-cursor': undefined,
-                // eslint-disable-next-line prettier/prettier
-                copy: undefined,
             }
+            if (messageData.codeBlockActions['copy'] === null) {
+                actions.copy = undefined
+            }
+            return actions
         }
         // Show only "Copy" option for codeblocks in Q Test Tab
         if (tab?.type === 'testgen') {

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -21,6 +21,7 @@ import {
     SelectTabMessage,
     ChatItemHeader,
     ToolMessage,
+    ChatMessageType,
 } from '../../../view/connector/connector'
 import { EditorContextCommandType } from '../../../commands/registerCommands'
 import { ChatResponseStream as qdevChatResponseStream } from '@amzn/amazon-q-developer-streaming-client'
@@ -71,6 +72,7 @@ import { ConversationTracker } from '../../../storages/conversationTracker'
 import { waitTimeout, Timeout } from '../../../../shared/utilities/timeoutUtils'
 import { FsReadParams } from '../../../tools/fsRead'
 import { ListDirectoryParams } from '../../../tools/listDirectory'
+import { fs } from '../../../../shared/fs/fs'
 
 export type StaticTextResponseType = 'quick-action-help' | 'onboarding-help' | 'transform' | 'help'
 
@@ -193,12 +195,16 @@ export class Messenger {
         return codeBlocks.length
     }
 
-    public handleFileReadOrListOperation = (session: ChatSession, toolUse: ToolUse, tool: Tool) => {
+    public handleFileReadOrListOperation = async (session: ChatSession, toolUse: ToolUse, tool: Tool) => {
         const messageIdToUpdate =
             tool.type === ToolType.FsRead ? session.messageIdToUpdate : session.messageIdToUpdateListDirectory
         const messageId = messageIdToUpdate ?? toolUse?.toolUseId ?? ''
         const operationType = tool.type === ToolType.FsRead ? 'read' : 'listDir'
         const input = toolUse.input as unknown as FsReadParams | ListDirectoryParams
+        const fileExists = await fs.exists(input.path)
+        if (!fileExists) {
+            return messageIdToUpdate
+        }
         const existingPaths = session.getFilePathsByMessageId(messageId)
 
         // Check if path already exists in the list
@@ -359,7 +365,7 @@ export class Messenger {
                                     changeList = await tool.tool.getDiffChanges()
                                 }
                                 if (isReadOrList) {
-                                    messageIdToUpdate = this.handleFileReadOrListOperation(session, toolUse, tool)
+                                    messageIdToUpdate = await this.handleFileReadOrListOperation(session, toolUse, tool)
                                 }
                                 const validation = ToolUtils.requiresAcceptance(tool)
                                 const chatStream = new ChatStream(
@@ -768,8 +774,10 @@ export class Messenger {
         const buttons: ChatItemButton[] = []
         let header: ChatItemHeader | undefined = undefined
         let messageID: string = toolUse?.toolUseId ?? ''
+        let messageType: ChatMessageType = 'answer-part'
         if (toolUse?.name === ToolType.ExecuteBash && message.startsWith('```shell')) {
             if (validation.requiresAcceptance) {
+                messageType = 'answer'
                 const buttons: ChatItemButton[] = [
                     {
                         id: 'reject-shell-command',
@@ -796,6 +804,7 @@ export class Messenger {
             if (this.isTriggerCancelled(triggerID)) {
                 return
             }
+            messageType = 'answer'
             const input = toolUse.input as unknown as FsWriteParams
             const fileName = path.basename(input.path)
             const changes = getDiffLinesFromChanges(changeList)
@@ -829,6 +838,7 @@ export class Messenger {
                  * requiredAcceptance = false, we use messageID = toolID and we keep on updating this messageID
                  * requiredAcceptance = true, IDE sends messageID != toolID, some default value, as this overlaps with previous message. */
                 messageID = 'toolUse'
+                messageType = 'answer'
                 const buttons: ChatItemButton[] = [
                     {
                         id: 'confirm-tool-use',
@@ -858,8 +868,8 @@ export class Messenger {
         this.dispatcher.sendChatMessage(
             new ChatMessage(
                 {
-                    message: message,
-                    messageType: toolUse?.name === ToolType.FsWrite ? 'answer' : 'answer-part',
+                    message,
+                    messageType,
                     followUps: undefined,
                     followUpsHeader: undefined,
                     relatedSuggestions: undefined,

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -54,6 +54,7 @@ import {
     MynahIconsType,
     DetailedList,
     MynahUIDataModel,
+    CodeBlockActions,
 } from '@aws/mynah-ui'
 import { Database } from '../../../../shared/db/chatDb/chatDb'
 import { TabType } from '../../../../amazonq/webview/ui/storages/tabsStorage'
@@ -477,7 +478,11 @@ export class Messenger {
                         if (this.isTriggerCancelled(triggerID)) {
                             return
                         }
-
+                        let codeBlockActions: CodeBlockActions | null = {}
+                        if (session.pairProgrammingModeOn) {
+                            // eslint-disable-next-line unicorn/no-null
+                            codeBlockActions = { 'insert-to-cursor': null }
+                        }
                         this.dispatcher.sendChatMessage(
                             new ChatMessage(
                                 {
@@ -492,6 +497,7 @@ export class Messenger {
                                     userIntent: triggerPayload.userIntent,
                                     codeBlockLanguage: codeBlockLanguage,
                                     contextList: undefined,
+                                    codeBlockActions,
                                 },
                                 tabID
                             )

--- a/packages/core/src/codewhispererChat/tools/fsRead.ts
+++ b/packages/core/src/codewhispererChat/tools/fsRead.ts
@@ -52,21 +52,20 @@ export class FsRead {
         if (requiresAcceptance) {
             const fileName = path.basename(this.fsPath)
             const fileUri = vscode.Uri.file(this.fsPath)
-            updates.write(`Reading file: [${fileName}](${fileUri}), `)
-
             const [start, end] = this.readRange ?? []
-
+            let readMessage = ''
             if (start && end) {
-                updates.write(`from line ${start} to ${end}`)
+                readMessage += `from line ${start} to ${end}`
             } else if (start) {
                 if (start > 0) {
-                    updates.write(`from line ${start} to end of file`)
+                    readMessage += `from line ${start} to end of file`
                 } else {
-                    updates.write(`${start} line from the end of file to end of file`)
+                    readMessage += `${start} line from the end of file to end of file`
                 }
             } else {
-                updates.write('all lines')
+                readMessage += 'all lines'
             }
+            updates.write(`Reading file: [${fileName}](${fileUri}), ${readMessage}`)
         } else {
             updates.write('')
         }


### PR DESCRIPTION
## Problem
- IDE requests permission twice when accessing files outside workspace
![image](https://github.com/user-attachments/assets/a74fd330-91ca-417c-98e9-11b0cab2d4b6)
- Users can see insert at cursor and copy buttons for bash commands.
- UX stying: No borders for 
  - Read and List directory files/folder outside of the workspace
  - Code diff view UX
  - Execute bash command UX
- `Insert at cursor` option is available if pair programming mode is enabled.


## Solution
- Fixed issue issue of showing reading files twice.
![image](https://github.com/user-attachments/assets/a57e4004-bf18-4d09-978c-8bbc1dda98da)
- Fixed issue of showing insert at cursor and copy buttons for bash commands.
- Added borders for mentioned UX.
- User can see only `Copy` option (remove `Insert at cursor` option) if pair programming mode is enabled.
![image](https://github.com/user-attachments/assets/548a949e-61f4-4c53-b736-3d0c9c12e5c5)
![image](https://github.com/user-attachments/assets/5622a673-673e-4eb0-ad6a-26cd7a815dcf)
- If user turn off pair programming mode, IDE shows both `Insert at cursor` and `Copy` options.
![image](https://github.com/user-attachments/assets/de8d8622-e080-489d-92ee-6d4aac8c2b5d)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
