### PR TITLE
fix(chat): fix for history overload issue

### DIFF
--- a/packages/core/src/codewhispererChat/constants.ts
+++ b/packages/core/src/codewhispererChat/constants.ts
@@ -56,6 +56,8 @@ export const defaultContextLengths: ContextLengths = {
 
 export const defaultStreamingResponseTimeoutInMs = 180_000
 
+export const maxHistoryMessages = 100
+
 export const ignoredDirectoriesAndFiles = [
     // Dependency directories
     'node_modules',

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -92,6 +92,7 @@ import {
     additionalContentInnerContextLimit,
     workspaceChunkMaxSize,
     defaultContextLengths,
+    maxHistoryMessages,
 } from '../../constants'
 import { ChatSession } from '../../clients/chat/v0/chat'
 import { amazonQTabSuffix } from '../../../shared/constants'
@@ -1601,7 +1602,7 @@ export class ChatController {
         //  Do not include chatHistory for requests going to Mynah
         request.conversationState.history = request.conversationState.currentMessage?.userInputMessage?.userIntent
             ? []
-            : this.chatHistoryDb.getMessages(tabID).map((chat) => messageToChatMessage(chat))
+            : this.chatHistoryDb.getMessages(tabID, maxHistoryMessages).map((chat) => messageToChatMessage(chat))
         request.conversationState.conversationId = session.sessionIdentifier
 
         triggerPayload.documentReferences = this.mergeRelevantTextDocuments(triggerPayload.relevantTextDocuments)


### PR DESCRIPTION
## Problem
Overtime chat history added to request is exceeding 100 messages limit causing errors.

## Solution
- Limiting history to 100 messages max per request.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
