### PR TITLE
fix(chat): Fix unwanted destructive warning for the commands which not in the destructive commands list

### DIFF
--- a/packages/core/src/codewhispererChat/tools/executeBash.ts
+++ b/packages/core/src/codewhispererChat/tools/executeBash.ts
@@ -200,13 +200,13 @@ export class ExecuteBash {
                         }
                         const workspaceFolders = vscode.workspace.workspaceFolders
                         if (!workspaceFolders || workspaceFolders.length === 0) {
-                            return { requiresAcceptance: true, warning: destructiveCommandWarningMessage }
+                            return { requiresAcceptance: true }
                         }
                         const isInWorkspace = workspaceFolders.some((folder) =>
                             isInDirectory(folder.uri.fsPath, fullPath)
                         )
                         if (!isInWorkspace) {
-                            return { requiresAcceptance: true, warning: destructiveCommandWarningMessage }
+                            return { requiresAcceptance: true }
                         }
                     }
                 }


### PR DESCRIPTION
## Problem
Right now, when user run the commands outside the workspace, it would have destructive warning
![image](https://github.com/user-attachments/assets/0191a655-6a9a-428c-a6ca-bd790610f1fa)

## Solution

https://github.com/user-attachments/assets/38752309-0cc9-4994-82a1-67148cfae17d




---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
