### PR TITLE
telemetry(amazonq): correct auth_userState telemetry 

### DIFF
--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -112,6 +112,11 @@ async function getAuthState(): Promise<Omit<AuthUserState, 'source'>> {
         getLogger().error(`Current Amazon Q connection is not SSO, type is: %s`, currConn?.type)
     }
 
+    // Pending profile selection state means users already log in with Sso service
+    if (authState === 'pendingProfileSelection') {
+        authState = 'connected'
+    }
+
     return {
         authStatus:
             authState === 'connected' || authState === 'expired' || authState === 'connectedWithNetworkError'


### PR DESCRIPTION
We introduced a new auth state `pendingProfileSelection`, however the current code path will determine the connectivity to be `disconnected` and thus we observe a drastic drop of `connected` users and increase of `disconnected`.

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
