### PR TITLE
fix(amazonq): Restore toolUse explanations when restoring tabs

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/tabBarController.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/tabBarController.ts
@@ -90,7 +90,7 @@ export class TabBarController {
                 selectedTab.conversations.flatMap((conv: Conversation) =>
                     conv.messages
                         .filter((message) => message.shouldDisplayMessage !== false)
-                        .map((message) => messageToChatItem(message))
+                        .flatMap((message) => messageToChatItem(message))
                 ),
                 exportTab
             )

--- a/packages/core/src/shared/db/chatDb/util.ts
+++ b/packages/core/src/shared/db/chatDb/util.ts
@@ -84,13 +84,31 @@ export function messageToChatMessage(msg: Message): ChatMessage {
 /**
  * Converts Message to MynahUI Chat Item
  */
-export function messageToChatItem(msg: Message): ChatItem {
-    return {
-        body: msg.body,
-        type: msg.type as ChatItemType,
-        codeReference: msg.codeReference,
-        relatedContent: msg.relatedContent && msg.relatedContent?.content.length > 0 ? msg.relatedContent : undefined,
+export function messageToChatItem(msg: Message): ChatItem[] {
+    const chatItems: ChatItem[] = [
+        {
+            body: msg.body,
+            type: msg.type as ChatItemType,
+            codeReference: msg.codeReference,
+            relatedContent:
+                msg.relatedContent && msg.relatedContent?.content.length > 0 ? msg.relatedContent : undefined,
+        },
+    ]
+    // Check if there are any toolUses with explanations that should be displayed as directive messages
+    if (msg.toolUses && msg.toolUses.length > 0) {
+        for (const toolUse of msg.toolUses) {
+            if (toolUse.input && typeof toolUse.input === 'object') {
+                const input = toolUse.input as any
+                if (input.explanation) {
+                    chatItems.push({
+                        body: input.explanation,
+                        type: 'directive' as ChatItemType,
+                    })
+                }
+            }
+        }
     }
+    return chatItems
 }
 
 /**


### PR DESCRIPTION
## Problem
When tabs are restored, directive messages stored in the explanation field of toolUses are not being displayed.

## Solution
Restore toolUse explanations when restoring tabs

## Testing
Tested manually



Uploading Screen Recording 2025-04-18 at 4.15.40 PM.mov…


---




- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
