### PR TITLE
feat(amazonq): add pair programming card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10833,12 +10833,12 @@
             }
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.12.tgz",
-            "integrity": "sha512-2yfRwElcJOwJ8dBR8aLcWAy9HlULRluaVCerCHXV+LstiIvkS0cd92l248Y+RQlKAvbGZXpnEzUOrlkNWVa80Q==",
+            "version": "0.1.22",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.22.tgz",
+            "integrity": "sha512-vn+UKnh9hgZN1LCMONgeZE8WWxivWXaHQq+oG9wpbFhaTXn/nNBTQ9ON7S2fvMqo0g0Np/6hirxZy5ROcWnB9Q==",
             "dev": true,
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.10"
+                "@aws/language-server-runtimes-types": "^0.1.19"
             }
         },
         "node_modules/@aws/language-server-runtimes": {
@@ -10876,9 +10876,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.13.tgz",
-            "integrity": "sha512-+FJREN6qyNcOwbu0fxAKt0QUh6x10xg2a9fLL722yVisXV0p4ElgHuXssOWhwALJrmy47DF7bRunZYNpFR9mqw==",
+            "version": "0.1.19",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.19.tgz",
+            "integrity": "sha512-c81J3G3N6JP5A6g70xTpK/XPS1YWwviQBn307Rk3S5fSiALT8INeHM+IPDg9AuONU6w378RJjzQy3+PE0gJvsw==",
             "dev": true,
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -26804,7 +26804,7 @@
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
                 "@aws/chat-client": "^0.1.4",
-                "@aws/chat-client-ui-types": "^0.1.12",
+                "@aws/chat-client-ui-types": "^0.1.22",
                 "@aws/language-server-runtimes": "^0.2.58",
                 "@aws/language-server-runtimes-types": "^0.1.13",
                 "@cspotcode/source-map-support": "^0.8.1",

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -131,6 +131,10 @@
                         "amazonQChatDisclaimer": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "amazonQChatPairProgramming": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -12,6 +12,8 @@ import {
     AuthFollowUpType,
     DISCLAIMER_ACKNOWLEDGED,
     UiMessageResultParams,
+    CHAT_PROMPT_OPTION_ACKNOWLEDGED,
+    ChatPromptOptionAcknowledgedMessage,
 } from '@aws/chat-client-ui-types'
 import {
     ChatResult,
@@ -144,6 +146,15 @@ export function registerMessageListeners(
             }
             case DISCLAIMER_ACKNOWLEDGED: {
                 void AmazonQPromptSettings.instance.update('amazonQChatDisclaimer', true)
+                break
+            }
+            case CHAT_PROMPT_OPTION_ACKNOWLEDGED: {
+                const acknowledgedMessage = message as ChatPromptOptionAcknowledgedMessage
+                switch (acknowledgedMessage.params.messageId) {
+                    case 'programmerModeCardId': {
+                        void AmazonQPromptSettings.instance.disablePrompt('amazonQChatPairProgramming')
+                    }
+                }
                 break
             }
             case chatRequestType.method: {

--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -96,6 +96,8 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
         const isSMUS = isSageMaker('SMUS')
         const disabledCommands = isSM ? `['/dev', '/transform', '/test', '/review', '/doc']` : '[]'
         const disclaimerAcknowledged = !AmazonQPromptSettings.instance.isPromptEnabled('amazonQChatDisclaimer')
+        const pairProgrammingAcknowledged =
+            !AmazonQPromptSettings.instance.isPromptEnabled('amazonQChatPairProgramming')
         const welcomeCount = globals.globalState.tryGet('aws.amazonq.welcomeChatShowCount', Number, 0)
 
         // only show profile card when the two conditions
@@ -144,7 +146,7 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
                     const vscodeApi = acquireVsCodeApi()
                     const hybridChatConnector = new HybridChatAdapter(${(await AuthUtil.instance.getChatAuthState()).amazonQ === 'connected'},${featureConfigData},${welcomeCount},${disclaimerAcknowledged},${regionProfileString},${disabledCommands},${isSMUS},${isSM},vscodeApi.postMessage)
                     const commands = [hybridChatConnector.initialQuickActions[0]]
-                    amazonQChat.createChat(vscodeApi, {disclaimerAcknowledged: ${disclaimerAcknowledged}, quickActionCommands: commands}, hybridChatConnector);
+                    amazonQChat.createChat(vscodeApi, {disclaimerAcknowledged: ${disclaimerAcknowledged}, pairProgrammingAcknowledged: ${pairProgrammingAcknowledged}, quickActionCommands: commands}, hybridChatConnector);
                 }
             </script>
         </body>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -442,7 +442,7 @@
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
         "@aws/chat-client": "^0.1.4",
-        "@aws/chat-client-ui-types": "^0.1.12",
+        "@aws/chat-client-ui-types": "^0.1.22",
         "@aws/language-server-runtimes": "^0.2.58",
         "@aws/language-server-runtimes-types": "^0.1.13",
         "@cspotcode/source-map-support": "^0.8.1",

--- a/packages/core/src/shared/settings-amazonq.gen.ts
+++ b/packages/core/src/shared/settings-amazonq.gen.ts
@@ -21,7 +21,8 @@ export const amazonqSettings = {
         "ssoCacheError": {},
         "amazonQLspManifestMessage": {},
         "amazonQWorkspaceLspManifestMessage": {},
-        "amazonQChatDisclaimer": {}
+        "amazonQChatDisclaimer": {},
+        "amazonQChatPairProgramming": {}
     },
     "amazonQ.showCodeWithReferences": {},
     "amazonQ.allowFeatureDevelopmentToRunCodeAndTests": {},


### PR DESCRIPTION
## Problem
agentic chat should have a pair programming card that appears at the top of chat

## Solution
implement it with the following behaviors:
1. If the pair programming card was dismissed in a previous session, never show it again
2. Continue showing the pair programming card in new basic chat tabs until you click the "X" to dismiss it. Once the "X" is pressed it will never be shown for future tabs in the current chat-client session or future sessions
3. If you have multiple basic chat tabs open and click X on one of them it only closes the programmer mode card for that single tab

depends on: https://github.com/aws/language-servers/pull/1023

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
