### PR TITLE
fix(amazonq): temporarily disable q developer profiles

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -127,7 +127,7 @@ export async function startLanguageServer(
                 },
                 awsClientCapabilities: {
                     q: {
-                        developerProfiles: true,
+                        developerProfiles: false,
                     },
                     window: {
                         notifications: true,


### PR DESCRIPTION
## Problem
q developer profiles are being fetched by VSCode + flare on the same token causing requests to be throttled

## Solution
temporary disable profile fetching. The real solution will need to be implemented in flare, which should disable profile fetching by default for VSCode?

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
