### PR TITLE
feat(amazonq): handle stop response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10833,12 +10833,12 @@
             }
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.22",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.22.tgz",
-            "integrity": "sha512-vn+UKnh9hgZN1LCMONgeZE8WWxivWXaHQq+oG9wpbFhaTXn/nNBTQ9ON7S2fvMqo0g0Np/6hirxZy5ROcWnB9Q==",
+            "version": "0.1.25",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.25.tgz",
+            "integrity": "sha512-sxSookCLlhfsamse3x9AkvCei7SSUYDOklAe1O2jiUOYSN79M5JlVVRZShoqiOCHds7bb9nSaz+DMWIwEK1+2w==",
             "dev": true,
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.19"
+                "@aws/language-server-runtimes-types": "^0.1.21"
             }
         },
         "node_modules/@aws/language-server-runtimes": {
@@ -10876,9 +10876,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.19.tgz",
-            "integrity": "sha512-c81J3G3N6JP5A6g70xTpK/XPS1YWwviQBn307Rk3S5fSiALT8INeHM+IPDg9AuONU6w378RJjzQy3+PE0gJvsw==",
+            "version": "0.1.21",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.21.tgz",
+            "integrity": "sha512-03C3dz4MvMyKg4UAgHMNNw675OQJkDq+7TPXUPaiasqPF946ywTDD9xoNPaVOQI+YTtC7Re4vhPRfBzyad3MOg==",
             "dev": true,
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -26804,7 +26804,7 @@
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
                 "@aws/chat-client": "^0.1.4",
-                "@aws/chat-client-ui-types": "^0.1.22",
+                "@aws/chat-client-ui-types": "^0.1.24",
                 "@aws/language-server-runtimes": "^0.2.58",
                 "@aws/language-server-runtimes-types": "^0.1.13",
                 "@cspotcode/source-map-support": "^0.8.1",

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -198,7 +198,7 @@ export function registerMessageListeners(
                 const partialResultToken = uuidv4()
                 let lastPartialResult: ChatResult | undefined
                 const cancellationToken = new CancellationTokenSource()
-                chatStreamTokens.set(message.params.tabId, cancellationToken)
+                chatStreamTokens.set(chatParams.tabId, cancellationToken)
 
                 const chatDisposable = languageClient.onProgress(
                     chatRequestType,
@@ -259,6 +259,8 @@ export function registerMessageListeners(
                         chatParams.tabId,
                         chatDisposable
                     )
+                } finally {
+                    chatStreamTokens.delete(chatParams.tabId)
                 }
                 break
             }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -442,7 +442,7 @@
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
         "@aws/chat-client": "^0.1.4",
-        "@aws/chat-client-ui-types": "^0.1.22",
+        "@aws/chat-client-ui-types": "^0.1.24",
         "@aws/language-server-runtimes": "^0.2.58",
         "@aws/language-server-runtimes-types": "^0.1.13",
         "@cspotcode/source-map-support": "^0.8.1",


### PR DESCRIPTION
## Problem
agentic chat has stop response disabled

## Solution
make it so that when its clicked the token is disposed off and the UI unlocks
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
