### PR TITLE
feat(amazonq): emit flare telemetry events

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -56,6 +56,7 @@ import { AmazonQChatViewProvider } from './webviewProvider'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { AmazonQPromptSettings, messages, openUrl } from 'aws-core-vscode/shared'
 import { DefaultAmazonQAppInitContext, messageDispatcher, EditorContentController } from 'aws-core-vscode/amazonq'
+import { telemetry, TelemetryBase } from 'aws-core-vscode/telemetry'
 
 export function registerLanguageServerEventListener(languageClient: LanguageClient, provider: AmazonQChatViewProvider) {
     languageClient.info(
@@ -78,7 +79,11 @@ export function registerLanguageServerEventListener(languageClient: LanguageClie
     })
 
     languageClient.onTelemetry((e) => {
-        languageClient.info(`[VSCode Client] Received telemetry event from server ${JSON.stringify(e)}`)
+        const telemetryName: string = e.name
+
+        if (telemetryName in telemetry) {
+            telemetry[telemetryName as keyof TelemetryBase].emit(e.data)
+        }
     })
 }
 


### PR DESCRIPTION
## Problem
telemetry events forwarded to flare aren't emitted 

## Solution
emit them

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
