### PR TITLE
feat(amazonq): option to show diff in reverse order

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -54,7 +54,7 @@ import { Disposable, LanguageClient, Position, TextDocumentIdentifier } from 'vs
 import * as jose from 'jose'
 import { AmazonQChatViewProvider } from './webviewProvider'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
-import { AmazonQPromptSettings, messages, openUrl } from 'aws-core-vscode/shared'
+import { amazonQDiffScheme, AmazonQPromptSettings, messages, openUrl } from 'aws-core-vscode/shared'
 import { DefaultAmazonQAppInitContext, messageDispatcher, EditorContentController } from 'aws-core-vscode/amazonq'
 
 export function registerLanguageServerEventListener(languageClient: LanguageClient, provider: AmazonQChatViewProvider) {
@@ -427,13 +427,17 @@ export function registerMessageListeners(
             new vscode.Position(0, 0),
             new vscode.Position(doc.lineCount - 1, doc.lineAt(doc.lineCount - 1).text.length)
         )
-        await edc.viewDiff({
-            context: {
-                activeFileContext: { filePath: params.originalFileUri },
-                focusAreaContext: { selectionInsideExtendedCodeBlock: entireDocumentSelection },
+        await edc.viewDiff(
+            {
+                context: {
+                    activeFileContext: { filePath: params.originalFileUri },
+                    focusAreaContext: { selectionInsideExtendedCodeBlock: entireDocumentSelection },
+                },
+                code: params.fileContent,
             },
-            code: params.fileContent,
-        })
+            amazonQDiffScheme,
+            true
+        )
     })
 }
 

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -420,14 +420,14 @@ export function registerMessageListeners(
     })
 
     languageClient.onNotification(openFileDiffNotificationType.method, async (params: OpenFileDiffParams) => {
-        const edc = new EditorContentController()
+        const ecc = new EditorContentController()
         const uri = params.originalFileUri
         const doc = await vscode.workspace.openTextDocument(uri)
         const entireDocumentSelection = new vscode.Selection(
             new vscode.Position(0, 0),
             new vscode.Position(doc.lineCount - 1, doc.lineAt(doc.lineCount - 1).text.length)
         )
-        await edc.viewDiff(
+        await ecc.viewDiff(
             {
                 context: {
                     activeFileContext: { filePath: params.originalFileUri },

--- a/packages/core/src/amazonq/commons/controllers/contentController.ts
+++ b/packages/core/src/amazonq/commons/controllers/contentController.ts
@@ -156,7 +156,7 @@ export class EditorContentController {
      *
      * @param message the message from Amazon Q chat
      */
-    public async viewDiff(message: any, scheme: string = amazonQDiffScheme) {
+    public async viewDiff(message: any, scheme: string = amazonQDiffScheme, reverseOrder = false) {
         const errorNotification = 'Unable to Open Diff.'
         const { filePath, selection } = extractFileAndCodeSelectionFromMessage(message)
 
@@ -170,8 +170,7 @@ export class EditorContentController {
                 const disposable = vscode.workspace.registerTextDocumentContentProvider(scheme, contentProvider)
                 await vscode.commands.executeCommand(
                     'vscode.diff',
-                    originalFileUri,
-                    uri,
+                    ...(reverseOrder ? [uri, originalFileUri] : [originalFileUri, uri]),
                     `${path.basename(filePath)} ${amazonQTabSuffix}`
                 )
 


### PR DESCRIPTION
## Problem
Sometimes we need to show the diff in reverse order (left/right flipped).


## Solution
Add a flag to show the diff in reverse order. Right now we will always do this in the lsp diff handler to avoid the need to create a temporary file.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
