### PR TITLE
fix(amazonq): diff not appearing for new files

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -452,7 +452,7 @@ export function registerMessageListeners(
                     activeFileContext: { filePath: params.originalFileUri },
                     focusAreaContext: { selectionInsideExtendedCodeBlock: entireDocumentSelection },
                 },
-                code: params.fileContent,
+                code: params.fileContent ?? '',
             },
             amazonQDiffScheme,
             true

--- a/packages/core/src/amazonq/commons/controllers/contentController.ts
+++ b/packages/core/src/amazonq/commons/controllers/contentController.ts
@@ -161,7 +161,7 @@ export class EditorContentController {
         const { filePath, selection } = extractFileAndCodeSelectionFromMessage(message)
 
         try {
-            if (filePath && message?.code?.trim().length > 0 && selection) {
+            if (filePath && message?.code !== undefined && selection) {
                 const originalFileUri = vscode.Uri.file(filePath)
                 const uri = await createTempFileForDiff(originalFileUri, message, selection, scheme)
 


### PR DESCRIPTION
## Problem
Clicking on diff for newly created files did not open diff


## Solution
Allow opening diffs for empty string


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
