### PR TITLE
fix(amazonq): show empty response when token was cancelled

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -249,11 +249,16 @@ export function registerMessageListeners(
                 } catch (e) {
                     languageClient.info(`Error occurred during chat request: ${e}`)
                     // Use the last partial result if available, append error message
+                    let body = ''
+                    if (!cancellationToken.token.isCancellationRequested) {
+                        body = lastPartialResult?.body
+                            ? `${lastPartialResult.body}\n\n ❌ Error: Request failed to complete`
+                            : '❌ An error occurred while processing your request'
+                    }
+
                     const errorResult: ChatResult = {
                         ...lastPartialResult,
-                        body: lastPartialResult?.body
-                            ? `${lastPartialResult.body}\n\n ❌ Error: Request failed to complete`
-                            : '❌ An error occurred while processing your request',
+                        body,
                     }
 
                     await handleCompleteResult<ChatResult>(


### PR DESCRIPTION
## Problem
in some cases when tools are cancelled on the flare side, a cancellation error will hit our catch and log "❌ Error: Request failed to complete"

## Solution
when the token was canceled don't log anything


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
