### PR TITLE
fix(amazonq): revert 7060 show customization across profiles

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-2a696d00-e8c8-44a4-ab2c-2204b4d8e31d.json
+++ b/packages/amazonq/.changes/next-release/Feature-2a696d00-e8c8-44a4-ab2c-2204b4d8e31d.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "Support selecting customizations across all Q profiles with automatic profile switching for enterprise users"
-}

--- a/packages/amazonq/test/unit/codewhisperer/region/regionProfileManager.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/region/regionProfileManager.test.ts
@@ -65,7 +65,7 @@ describe('RegionProfileManager', function () {
             const mockClient = {
                 listAvailableProfiles: listProfilesStub,
             }
-            const createClientStub = sinon.stub(sut, '_createQClient').resolves(mockClient)
+            const createClientStub = sinon.stub(sut, 'createQClient').resolves(mockClient)
 
             const r = await sut.listRegionProfile()
 
@@ -234,65 +234,13 @@ describe('RegionProfileManager', function () {
     })
 
     describe('createQClient', function () {
-        it(`should configure the endpoint and region from a profile`, async function () {
-            await setupConnection('idc')
-
-            const iadClient = await sut.createQClient({
-                name: 'foo',
-                region: 'us-east-1',
-                arn: 'arn',
-                description: 'description',
-            })
-
-            assert.deepStrictEqual(iadClient.config.region, 'us-east-1')
-            assert.deepStrictEqual(iadClient.endpoint.href, 'https://q.us-east-1.amazonaws.com/')
-
-            const fraClient = await sut.createQClient({
-                name: 'bar',
-                region: 'eu-central-1',
-                arn: 'arn',
-                description: 'description',
-            })
-
-            assert.deepStrictEqual(fraClient.config.region, 'eu-central-1')
-            assert.deepStrictEqual(fraClient.endpoint.href, 'https://q.eu-central-1.amazonaws.com/')
-        })
-
-        it(`should throw if the region is not supported or recognizable by Q`, async function () {
-            await setupConnection('idc')
-
-            await assert.rejects(
-                async () => {
-                    await sut.createQClient({
-                        name: 'foo',
-                        region: 'ap-east-1',
-                        arn: 'arn',
-                        description: 'description',
-                    })
-                },
-                { message: /trying to initiatize Q client with unrecognizable region/ }
-            )
-
-            await assert.rejects(
-                async () => {
-                    await sut.createQClient({
-                        name: 'foo',
-                        region: 'unknown-somewhere',
-                        arn: 'arn',
-                        description: 'description',
-                    })
-                },
-                { message: /trying to initiatize Q client with unrecognizable region/ }
-            )
-        })
-
         it(`should configure the endpoint and region correspondingly`, async function () {
             await setupConnection('idc')
             await sut.switchRegionProfile(profileFoo, 'user')
             assert.deepStrictEqual(sut.activeRegionProfile, profileFoo)
             const conn = authUtil.conn as SsoConnection
 
-            const client = await sut._createQClient('eu-central-1', 'https://amazon.com/', conn)
+            const client = await sut.createQClient('eu-central-1', 'https://amazon.com/', conn)
 
             assert.deepStrictEqual(client.config.region, 'eu-central-1')
             assert.deepStrictEqual(client.endpoint.href, 'https://amazon.com/')

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -72,7 +72,12 @@ import { AuthUtil } from './util/authUtil'
 import { ImportAdderProvider } from './service/importAdderProvider'
 import { TelemetryHelper } from './util/telemetryHelper'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
-import { notifyNewCustomizations, onProfileChangedListener } from './util/customizationUtil'
+import {
+    getAvailableCustomizationsList,
+    getSelectedCustomization,
+    notifyNewCustomizations,
+    switchToBaseCustomizationAndNotify,
+} from './util/customizationUtil'
 import { CodeWhispererCommandBackend, CodeWhispererCommandDeclarations } from './commands/gettingStartedPageCommands'
 import { SecurityIssueHoverProvider } from './service/securityIssueHoverProvider'
 import { SecurityIssueCodeActionProvider } from './service/securityIssueCodeActionProvider'
@@ -338,7 +343,26 @@ export async function activate(context: ExtContext): Promise<void> {
             SecurityIssueCodeActionProvider.instance
         ),
         vscode.commands.registerCommand('aws.amazonq.openEditorAtRange', openEditorAtRange),
-        auth.regionProfileManager.onDidChangeRegionProfile(onProfileChangedListener)
+        auth.regionProfileManager.onDidChangeRegionProfile(() => {
+            // Validate user still has access to the selected customization.
+            const selectedCustomization = getSelectedCustomization()
+            // No need to validate base customization which has empty arn.
+            if (selectedCustomization.arn.length > 0) {
+                getAvailableCustomizationsList()
+                    .then(async (customizations) => {
+                        const r = customizations.find((it) => it.arn === selectedCustomization.arn)
+                        if (!r) {
+                            await switchToBaseCustomizationAndNotify()
+                        }
+                    })
+                    .catch((e) => {
+                        getLogger().error(
+                            `encounter error while validating selected customization on profile change: %s`,
+                            (e as Error).message
+                        )
+                    })
+            }
+        })
     )
 
     // run the auth startup code with context for telemetry

--- a/packages/core/src/codewhisperer/client/codewhisperer.ts
+++ b/packages/core/src/codewhisperer/client/codewhisperer.ts
@@ -7,17 +7,19 @@ import { AWSError, Credentials, Service } from 'aws-sdk'
 import globals from '../../shared/extensionGlobals'
 import * as CodeWhispererClient from './codewhispererclient'
 import * as CodeWhispererUserClient from './codewhispereruserclient'
-import { SendTelemetryEventRequest } from './codewhispereruserclient'
+import { ListAvailableCustomizationsResponse, SendTelemetryEventRequest } from './codewhispereruserclient'
 import { ServiceOptions } from '../../shared/awsClientBuilder'
 import { hasVendedIamCredentials } from '../../auth/auth'
 import { CodeWhispererSettings } from '../util/codewhispererSettings'
 import { PromiseResult } from 'aws-sdk/lib/request'
 import { AuthUtil } from '../util/authUtil'
 import { isSsoConnection } from '../../auth/connection'
+import { pageableToCollection } from '../../shared/utilities/collectionUtils'
 import apiConfig = require('./service-2.json')
 import userApiConfig = require('./user-service-2.json')
 import { session } from '../util/codeWhispererSession'
 import { getLogger } from '../../shared/logger/logger'
+import { indent } from '../../shared/utilities/textUtilities'
 import { getClientId, getOptOutPreference, getOperatingSystem } from '../../shared/telemetry/util'
 import { extensionVersion, getServiceEnvVarConfig } from '../../shared/vscode/env'
 import { DevSettings } from '../../shared/settings'
@@ -215,6 +217,28 @@ export class DefaultCodeWhispererClient {
         return (await this.createSdkClient())
             .listCodeScanFindings(request as CodeWhispererClient.ListCodeScanFindingsRequest)
             .promise()
+    }
+
+    public async listAvailableCustomizations(): Promise<ListAvailableCustomizationsResponse[]> {
+        const client = await this.createUserSdkClient()
+        const profile = AuthUtil.instance.regionProfileManager.activeRegionProfile
+        const requester = async (request: CodeWhispererUserClient.ListAvailableCustomizationsRequest) =>
+            client.listAvailableCustomizations(request).promise()
+        return pageableToCollection(requester, { profileArn: profile?.arn }, 'nextToken')
+            .promise()
+            .then((resps) => {
+                let logStr = 'amazonq: listAvailableCustomizations API request:'
+                for (const resp of resps) {
+                    const requestId = resp.$response.requestId
+                    logStr += `\n${indent('RequestID: ', 4)}${requestId},\n${indent('Customizations:', 4)}`
+                    for (const [index, c] of resp.customizations.entries()) {
+                        const entry = `${index.toString().padStart(2, '0')}: ${c.name?.trim()}`
+                        logStr += `\n${indent(entry, 8)}`
+                    }
+                }
+                getLogger().debug(logStr)
+                return resps
+            })
     }
 
     public async sendTelemetryEvent(request: SendTelemetryEventRequest) {

--- a/packages/core/src/codewhisperer/index.ts
+++ b/packages/core/src/codewhisperer/index.ts
@@ -99,13 +99,7 @@ export * as diagnosticsProvider from './service/diagnosticsProvider'
 export * from './ui/codeWhispererNodes'
 export { SecurityScanError, SecurityScanTimedOutError } from '../codewhisperer/models/errors'
 export * as CodeWhispererConstants from '../codewhisperer/models/constants'
-export {
-    getSelectedCustomization,
-    setSelectedCustomization,
-    baseCustomization,
-    onProfileChangedListener,
-    CustomizationProvider,
-} from './util/customizationUtil'
+export { getSelectedCustomization, setSelectedCustomization, baseCustomization } from './util/customizationUtil'
 export { Container } from './service/serviceContainer'
 export * from './util/gitUtil'
 export * from './ui/prompters'

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -47,17 +47,12 @@ const endpoints = createConstantMap({
  * 'update' -> plugin auto select the profile on users' behalf as there is only 1 profile
  * 'reload' -> on plugin restart, plugin will try to reload previous selected profile
  */
-export type ProfileSwitchIntent = 'user' | 'auth' | 'update' | 'reload' | 'customization'
-
-export type ProfileChangedEvent = {
-    profile: RegionProfile | undefined
-    intent: ProfileSwitchIntent
-}
+export type ProfileSwitchIntent = 'user' | 'auth' | 'update' | 'reload'
 
 export class RegionProfileManager {
     private static logger = getLogger()
     private _activeRegionProfile: RegionProfile | undefined
-    private _onDidChangeRegionProfile = new vscode.EventEmitter<ProfileChangedEvent>()
+    private _onDidChangeRegionProfile = new vscode.EventEmitter<RegionProfile | undefined>()
     public readonly onDidChangeRegionProfile = this._onDidChangeRegionProfile.event
 
     // Store the last API results (for UI propuse) so we don't need to call service again if doesn't require "latest" result
@@ -117,7 +112,7 @@ export class RegionProfileManager {
         }
         const availableProfiles: RegionProfile[] = []
         for (const [region, endpoint] of endpoints.entries()) {
-            const client = await this._createQClient(region, endpoint, conn as SsoConnection)
+            const client = await this.createQClient(region, endpoint, conn as SsoConnection)
             const requester = async (request: CodeWhispererUserClient.ListAvailableProfilesRequest) =>
                 client.listAvailableProfiles(request).promise()
             const request: CodeWhispererUserClient.ListAvailableProfilesRequest = {}
@@ -167,7 +162,7 @@ export class RegionProfileManager {
         const ssoConn = this.connectionProvider() as SsoConnection
 
         // only prompt to users when users switch from A profile to B profile
-        if (source !== 'customization' && this.activeRegionProfile !== undefined && regionProfile !== undefined) {
+        if (this.activeRegionProfile !== undefined && regionProfile !== undefined) {
             const response = await showConfirmationMessage({
                 prompt: localize(
                     'AWS.amazonq.profile.confirmation',
@@ -209,16 +204,13 @@ export class RegionProfileManager {
             })
         }
 
-        await this._switchRegionProfile(regionProfile, source)
+        await this._switchRegionProfile(regionProfile)
     }
 
-    private async _switchRegionProfile(regionProfile: RegionProfile | undefined, source: ProfileSwitchIntent) {
+    private async _switchRegionProfile(regionProfile: RegionProfile | undefined) {
         this._activeRegionProfile = regionProfile
 
-        this._onDidChangeRegionProfile.fire({
-            profile: regionProfile,
-            intent: source,
-        })
+        this._onDidChangeRegionProfile.fire(regionProfile)
         // dont show if it's a default (fallback)
         if (regionProfile && this.profiles.length > 1) {
             void vscode.window.showInformationMessage(`You are using the ${regionProfile.name} profile for Q.`).then()
@@ -351,21 +343,7 @@ export class RegionProfileManager {
         }
     }
 
-    // TODO: Should maintain sdk client in a better way
-    async createQClient(profile: RegionProfile): Promise<CodeWhispererUserClient> {
-        const conn = this.connectionProvider()
-        if (conn === undefined || !isSsoConnection(conn)) {
-            throw new Error('No valid SSO connection')
-        }
-        const endpoint = endpoints.get(profile.region)
-        if (!endpoint) {
-            throw new Error(`trying to initiatize Q client with unrecognizable region ${profile.region}`)
-        }
-        return this._createQClient(profile.region, endpoint, conn)
-    }
-
-    // Visible for testing only, do not use this directly, please use createQClient(profile)
-    async _createQClient(region: string, endpoint: string, conn: SsoConnection): Promise<CodeWhispererUserClient> {
+    async createQClient(region: string, endpoint: string, conn: SsoConnection): Promise<CodeWhispererUserClient> {
         const token = (await conn.getToken()).accessToken
         const serviceOption: ServiceOptions = {
             apiConfig: userApiConfig,

--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -10,77 +10,14 @@ import { AuthUtil } from './authUtil'
 import * as vscode from 'vscode'
 import { createCommonButtons } from '../../shared/ui/buttons'
 import { DataQuickPickItem, showQuickPick } from '../../shared/ui/pickerPrompter'
-import CodeWhispererUserClient, { Customization, ResourceArn } from '../client/codewhispereruserclient'
+import { codeWhispererClient } from '../client/codewhisperer'
+import { Customization, ResourceArn } from '../client/codewhispereruserclient'
 import { codicon, getIcon } from '../../shared/icons'
 import { getLogger } from '../../shared/logger/logger'
 import { showMessageWithUrl } from '../../shared/utilities/messages'
 import { parse } from '@aws-sdk/util-arn-parser'
 import { Commands } from '../../shared/vscode/commands2'
-import { RegionProfile, vsCodeState } from '../models/model'
-import { pageableToCollection } from '../../shared/utilities/collectionUtils'
-import { isAwsError } from '../../shared/errors'
-import { ProfileChangedEvent } from '../region/regionProfileManager'
-
-export class CustomizationProvider {
-    readonly region: string
-    constructor(
-        private readonly client: CodeWhispererUserClient,
-        private readonly profile: RegionProfile
-    ) {
-        this.region = profile.region
-    }
-
-    async listAvailableCustomizations(): Promise<Customization[]> {
-        const requester = async (request: CodeWhispererUserClient.ListAvailableCustomizationsRequest) =>
-            this.client.listAvailableCustomizations(request).promise()
-
-        try {
-            const request = { profileArn: this.profile.arn }
-            const customizations = await pageableToCollection(requester, request, 'nextToken', 'customizations')
-                .flatten()
-                .promise()
-
-            return customizations
-        } catch (e) {
-            const logMsg = isAwsError(e) ? `requestId=${e.requestId}; message=${e.message}` : (e as Error).message
-            getLogger().error(`failed to listAvailableCustomizations: ${logMsg}`)
-            return []
-        }
-    }
-
-    static async init(profile: RegionProfile): Promise<CustomizationProvider> {
-        const client = await AuthUtil.instance.regionProfileManager.createQClient(profile)
-        return new CustomizationProvider(client, profile)
-    }
-}
-
-export const onProfileChangedListener: (event: ProfileChangedEvent) => any = async (event) => {
-    // Skip because customization means the following validation has been done
-    if (event.intent === 'customization') {
-        return
-    }
-    const logger = getLogger()
-    if (!event.profile) {
-        await setSelectedCustomization(baseCustomization)
-        return
-    }
-
-    // Validate user still has access to the selected customization.
-    const selectedCustomization = getSelectedCustomization()
-    // No need to validate base customization which has empty arn.
-    if (selectedCustomization.arn.length > 0) {
-        const customizationProvider = await CustomizationProvider.init(event.profile)
-        const customizations = await customizationProvider.listAvailableCustomizations()
-
-        const r = customizations.find((it) => it.arn === selectedCustomization.arn)
-        if (!r) {
-            logger.debug(
-                `profile ${event.profile.name} doesnt have access to customization ${selectedCustomization.name} but has access to ${customizations.map((it) => it.name)}`
-            )
-            await switchToBaseCustomizationAndNotify()
-        }
-    }
-}
+import { vsCodeState } from '../models/model'
 
 /**
  *
@@ -287,6 +224,7 @@ const createCustomizationItems = async () => {
     if (availableCustomizations.length === 0) {
         items.push(createBaseCustomizationItem())
 
+        // TODO: finalize the url string with documentation
         void showMessageWithUrl(
             localize(
                 'AWS.codewhisperer.customization.noCustomizations.description',
@@ -345,12 +283,8 @@ const createBaseCustomizationItem = () => {
     } as DataQuickPickItem<string>
 }
 
-/**
- * When users click "select customizations", we're showing ALL customizations across different profiles.
- * Thus If users select the customization, we also change the profile if the customization is accessible from a different profile.
- */
 const createCustomizationItem = (
-    customization: Customization & { profile: RegionProfile },
+    customization: Customization,
     persistedArns: (ResourceArn | undefined)[],
     shouldPrefixAccountId: boolean
 ) => {
@@ -359,8 +293,8 @@ const createCustomizationItem = (
         ? shouldPrefixAccountId
             ? accountId
                 ? `${customization.name} (${accountId})`
-                : `${customization.name} (${customization.profile.name})`
-            : `${customization.name} (${customization.profile.name})`
+                : `${customization.name}`
+            : customization.name
         : 'unknown'
 
     const isNewCustomization = !persistedArns.includes(customization.arn)
@@ -369,10 +303,6 @@ const createCustomizationItem = (
     return {
         label: label,
         onClick: async () => {
-            const profile = AuthUtil.instance.regionProfileManager.activeRegionProfile
-            if (profile && customization.profile.arn !== profile.arn) {
-                await AuthUtil.instance.regionProfileManager.switchRegionProfile(customization.profile, 'customization')
-            }
             await selectCustomization(customization)
         },
         detail:
@@ -403,28 +333,13 @@ export const selectCustomization = async (customization: Customization) => {
     )
 }
 
-// Return all customizations across different profiles and associate the customization with the source profile
 export const getAvailableCustomizationsList = async () => {
-    const items: (Customization & { profile: RegionProfile })[] = []
-    const profiles: RegionProfile[] = []
-    try {
-        const r = await AuthUtil.instance.regionProfileManager.listRegionProfile()
-        profiles.push(...r)
-    } catch (e) {
-        getLogger().error(`Failed to list customizations because listAvailableProfiles failed %s`, (e as Error).message)
-        return []
-    }
-
-    for (const profile of profiles) {
-        const provider = await CustomizationProvider.init(profile)
-        const customizations = await provider.listAvailableCustomizations()
-
-        for (const c of customizations) {
-            items.push({
-                ...c,
-                profile: profile,
-            })
-        }
+    const items: Customization[] = []
+    const response = await codeWhispererClient.listAvailableCustomizations()
+    for (const customizations of response.map(
+        (listAvailableCustomizationsResponse) => listAvailableCustomizationsResponse.customizations
+    )) {
+        items.push(...customizations)
     }
 
     return items

--- a/packages/core/src/shared/featureConfig.ts
+++ b/packages/core/src/shared/featureConfig.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+    Customization,
     FeatureValue,
     ListFeatureEvaluationsRequest,
     ListFeatureEvaluationsResponse,
@@ -20,7 +21,7 @@ import { getClientId, getOperatingSystem } from './telemetry/util'
 import { extensionVersion } from './vscode/env'
 import { telemetry } from './telemetry/telemetry'
 import { Commands } from './vscode/commands2'
-import { getAvailableCustomizationsList, setSelectedCustomization } from '../codewhisperer/util/customizationUtil'
+import { setSelectedCustomization } from '../codewhisperer/util/customizationUtil'
 
 const localize = nls.loadMessageBundle()
 
@@ -152,7 +153,19 @@ export class FeatureConfigProvider {
                 if (isBuilderIdConnection(AuthUtil.instance.conn)) {
                     this.featureConfigs.delete(Features.customizationArnOverride)
                 } else if (isIdcSsoConnection(AuthUtil.instance.conn)) {
-                    const availableCustomizations = await getAvailableCustomizationsList()
+                    let availableCustomizations: Customization[] = []
+                    try {
+                        const items: Customization[] = []
+                        const response = await client.listAvailableCustomizations()
+                        for (const customizations of response.map(
+                            (listAvailableCustomizationsResponse) => listAvailableCustomizationsResponse.customizations
+                        )) {
+                            items.push(...customizations)
+                        }
+                        availableCustomizations = items
+                    } catch (e) {
+                        getLogger().debug('amazonq: Failed to list available customizations')
+                    }
 
                     // If customizationArn from A/B is not available in listAvailableCustomizations response, don't use this value
                     const targetCustomization = availableCustomizations?.find((c) => c.arn === customizationArnOverride)
@@ -163,16 +176,6 @@ export class FeatureConfigProvider {
                         this.featureConfigs.delete(Features.customizationArnOverride)
                     } else {
                         await setSelectedCustomization(targetCustomization, true)
-                        // note that we should also switch profile if either
-                        // 1. user has not selected a profile yet
-                        // 2. user's selected profile is not the same as the one of customizationOverride
-                        const profile = AuthUtil.instance.regionProfileManager.activeRegionProfile
-                        if (!profile || (profile && profile.arn !== targetCustomization.profile.arn)) {
-                            await AuthUtil.instance.regionProfileManager.switchRegionProfile(
-                                targetCustomization.profile,
-                                'customization'
-                            )
-                        }
                     }
 
                     await vscode.commands.executeCommand('aws.amazonq.refreshStatusBar')

--- a/packages/core/src/test/amazonq/customizationUtil.test.ts
+++ b/packages/core/src/test/amazonq/customizationUtil.test.ts
@@ -11,11 +11,9 @@ import {
     AuthUtil,
     baseCustomization,
     Customization,
-    CustomizationProvider,
     FeatureConfigProvider,
     getSelectedCustomization,
     refreshStatusBar,
-    RegionProfileManager,
     setSelectedCustomization,
 } from '../../codewhisperer'
 import { FeatureContext, globals } from '../../shared'
@@ -24,45 +22,6 @@ import { createSsoProfile, createTestAuth } from '../credentials/testUtil'
 import { SsoConnection } from '../../auth'
 
 const enterpriseSsoStartUrl = 'https://enterprise.awsapps.com/start'
-
-describe('customizationProvider', function () {
-    let auth: ReturnType<typeof createTestAuth>
-    let ssoConn: SsoConnection
-    let regionProfileManager: RegionProfileManager
-
-    beforeEach(async () => {
-        auth = createTestAuth(globals.globalState)
-        ssoConn = await auth.createInvalidSsoConnection(
-            createSsoProfile({ startUrl: enterpriseSsoStartUrl, scopes: amazonQScopes })
-        )
-
-        regionProfileManager = new RegionProfileManager(() => ssoConn)
-    })
-
-    afterEach(() => {
-        sinon.restore()
-    })
-
-    it('init should create new instance with client', async function () {
-        const mockAuthUtil = {
-            regionProfileManager: regionProfileManager,
-        }
-        sinon.stub(AuthUtil, 'instance').get(() => mockAuthUtil)
-        const createClientStub = sinon.stub(regionProfileManager, 'createQClient')
-        const mockProfile = {
-            name: 'foo',
-            region: 'us-east-1',
-            arn: 'arn',
-            description: '',
-        }
-
-        const provider = await CustomizationProvider.init(mockProfile)
-        assert(provider instanceof CustomizationProvider)
-        assert(createClientStub.calledOnce)
-        assert(createClientStub.calledWith(mockProfile))
-        assert.strictEqual(provider.region, 'us-east-1')
-    })
-})
 
 describe('CodeWhisperer-customizationUtils', function () {
     let auth: ReturnType<typeof createTestAuth>


### PR DESCRIPTION
Due to throttling issue we already encounter now in PROD, we decided to revert it back and fix the throttling issue first then bring this back afterward.



This reverts commit 70ba83fc066cfe8a1f9f50e5eb73a5e1b51d42f4. #7060 

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
