### PR TITLE
feat(amazonq): workspace indexing should use vscode setting

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -93,7 +93,9 @@ export async function startLanguageServer(
                                 customization,
                                 optOutTelemetry: getOptOutPreference() === 'OPTOUT',
                                 projectContext: {
-                                    enableLocalIndexing: true,
+                                    enableLocalIndexing: vscode.workspace
+                                        .getConfiguration()
+                                        .get('amazonQ.workspaceIndex'),
                                 },
                             },
                         ]


### PR DESCRIPTION
## Problem
workspace indexing is always true

## Solution
use our vscode setting for it. If its disabled then chat will prompt the user to enable it


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
