### PR TITLE
fix(amazonq): forward chat update notification

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -49,6 +49,8 @@ import {
     buttonClickRequestType,
     ButtonClickResult,
     CancellationTokenSource,
+    chatUpdateNotificationType,
+    ChatUpdateParams,
 } from '@aws/language-server-runtimes/protocol'
 import { v4 as uuidv4 } from 'uuid'
 import * as vscode from 'vscode'
@@ -462,6 +464,13 @@ export function registerMessageListeners(
             amazonQDiffScheme,
             true
         )
+    })
+
+    languageClient.onNotification(chatUpdateNotificationType.method, (params: ChatUpdateParams) => {
+        void provider.webview?.postMessage({
+            command: chatUpdateNotificationType.method,
+            params: params,
+        })
     })
 }
 


### PR DESCRIPTION
## Problem
ChatUpdate notifications are not getting forwarded to UI

## Solution
Forward chat update notification

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
