### PR TITLE
fix(amazonq): indicate profile needs to be selected from status bar menu

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-4323842a-bd34-4c49-9a03-12620cce0203.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-4323842a-bd34-4c49-9a03-12620cce0203.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Some users not signaled they needed to select a Region Profile to get features working"
+}

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -28,6 +28,7 @@ import { parse } from '@aws-sdk/util-arn-parser'
 import { isAwsError, ToolkitError } from '../../shared/errors'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { localize } from '../../shared/utilities/vsCodeUtils'
+import { Commands } from '../../shared/vscode/commands2'
 
 // TODO: is there a better way to manage all endpoint strings in one place?
 export const defaultServiceConfig: CodeWhispererConfig = {
@@ -226,6 +227,9 @@ export class RegionProfileManager {
 
         // persist to state
         await this.persistSelectRegionProfile()
+
+        // Force status bar to reflect this change in state
+        await Commands.tryExecute('aws.amazonq.refreshStatusBar')
     }
 
     restoreProfileSelection = once(async () => {

--- a/packages/core/src/codewhisperer/service/inlineCompletionService.ts
+++ b/packages/core/src/codewhisperer/service/inlineCompletionService.ts
@@ -167,6 +167,9 @@ export class InlineCompletionService {
     /** Updates the status bar to represent the latest CW state */
     refreshStatusBar() {
         if (AuthUtil.instance.isConnectionValid()) {
+            if (AuthUtil.instance.requireProfileSelection()) {
+                return this.setState('needsProfile')
+            }
             return this.setState('ok')
         } else if (AuthUtil.instance.isConnectionExpired()) {
             return this.setState('expired')
@@ -193,6 +196,10 @@ export class InlineCompletionService {
                 await this.statusBar.setState('notConnected')
                 break
             }
+            case 'needsProfile': {
+                await this.statusBar.setState('needsProfile')
+                break
+            }
         }
     }
 }
@@ -203,6 +210,7 @@ const states = {
     ok: 'ok',
     expired: 'expired',
     notConnected: 'notConnected',
+    needsProfile: 'needsProfile',
 } as const
 
 export class CodeWhispererStatusBar {
@@ -245,6 +253,7 @@ export class CodeWhispererStatusBar {
                 statusBar.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
                 break
             }
+            case 'needsProfile':
             case 'notConnected':
                 statusBar.text = codicon` ${getIcon('vscode-chrome-close')} ${title}`
                 statusBar.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')

--- a/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
+++ b/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
@@ -21,7 +21,7 @@ import {
     selectRegionProfileCommand,
 } from '../commands/basicCommands'
 import { CodeWhispererCommandDeclarations } from '../commands/gettingStartedPageCommands'
-import { CodeScansState, codeScanState } from '../models/model'
+import { CodeScansState, codeScanState, RegionProfile } from '../models/model'
 import { getNewCustomizationsAvailable, getSelectedCustomization } from '../util/customizationUtil'
 import { cwQuickPickSource } from '../commands/types'
 import { AuthUtil } from '../util/authUtil'
@@ -138,12 +138,16 @@ export function createSelectCustomization(): DataQuickPickItem<'selectCustomizat
     } as DataQuickPickItem<'selectCustomization'>
 }
 
-export function createSelectRegionProfileNode(): DataQuickPickItem<'selectRegionProfile'> {
-    const selectedRegionProfile = AuthUtil.instance.regionProfileManager.activeRegionProfile
+export function createSelectRegionProfileNode(
+    profile: RegionProfile | undefined
+): DataQuickPickItem<'selectRegionProfile'> {
+    const selectedRegionProfile = profile
 
-    const label = 'Change Profile'
+    const label = profile ? 'Change Profile' : '(Required) Select Profile'
     const icon = getIcon('vscode-arrow-swap')
-    const description = selectedRegionProfile ? `Current profile: ${selectedRegionProfile.name}` : ''
+    const description = selectedRegionProfile
+        ? `Current profile: ${selectedRegionProfile.name}`
+        : 'A profile MUST be selected for features to work'
 
     return {
         data: 'selectRegionProfile',
@@ -152,6 +156,7 @@ export function createSelectRegionProfileNode(): DataQuickPickItem<'selectRegion
             await selectRegionProfileCommand.execute(placeholder, cwQuickPickSource)
         },
         description: description,
+        picked: profile === undefined,
     }
 }
 

--- a/packages/core/src/codewhisperer/ui/statusBarMenu.ts
+++ b/packages/core/src/codewhisperer/ui/statusBarMenu.ts
@@ -85,7 +85,14 @@ function getAmazonQCodeWhispererNodes() {
 }
 
 export function getQuickPickItems(): DataQuickPickItem<string>[] {
+    const isUsingEnterpriseSso = AuthUtil.instance.isValidEnterpriseSsoInUse()
+    const regionProfile = AuthUtil.instance.regionProfileManager.activeRegionProfile
+
     const children = [
+        // If the user has signed in but not selected a region, we strongly indicate they need to select
+        // a profile, otherwise features will not work.
+        ...(isUsingEnterpriseSso && !regionProfile ? [createSelectRegionProfileNode(undefined)] : []),
+
         ...getAmazonQCodeWhispererNodes(),
 
         // Generic Nodes
@@ -97,7 +104,7 @@ export function getQuickPickItems(): DataQuickPickItem<string>[] {
         // Add settings and signout
         createSeparator(),
         createSettingsNode(),
-        ...(AuthUtil.instance.isValidEnterpriseSsoInUse() ? [createSelectRegionProfileNode()] : []),
+        ...(isUsingEnterpriseSso && regionProfile ? [createSelectRegionProfileNode(regionProfile)] : []),
         ...(AuthUtil.instance.isConnected() && !hasVendedIamCredentials() && !hasVendedCredentialsFromMetadata()
             ? [createSignout()]
             : []),


### PR DESCRIPTION
## Problem:

Inline suggestion users who upgraded to the new extension version with region profile selection need to select a profile, but are not prompted in a significant way to do so.

If they didn't select a profile, inline suggestions would just stop working for them. There is no obvious hint to the user that to get inline suggestions working again they must select a profile.

## Solution:

If a profile is not selected, show the status bar as not connected. Once the status bar is clicked they will see the top item telling them they must select a profile to get features working. This opens a quick pick of the profiles they can select from.

<img width="1512" alt="Screenshot 2025-04-22 at 3 29 54 PM" src="https://github.com/user-attachments/assets/67524b54-ab1b-4f43-80ee-ba1718ce80c8" />


https://github.com/user-attachments/assets/7115ed56-8faf-486f-beaa-6f09cbca56e7


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
