### PR TITLE
Revert "fix(amazonq): temporarily disable q developer profiles"

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -127,7 +127,7 @@ export async function startLanguageServer(
                 },
                 awsClientCapabilities: {
                     q: {
-                        developerProfiles: false,
+                        developerProfiles: true,
                     },
                     window: {
                         notifications: true,


### PR DESCRIPTION
Reverts aws/aws-toolkit-vscode#7118

We were getting throttled because of https://github.com/aws/aws-toolkit-vscode/pull/7060. That's been reverted so we should be safe to re-enable this