### PR TITLE
feat(amazonq): support dart in Q chat code search

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-1152ddd0-fc0f-4dc4-8cf1-fdc9629a91a3.json
+++ b/packages/amazonq/.changes/next-release/Feature-1152ddd0-fc0f-4dc4-8cf1-fdc9629a91a3.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Support dart in Amazon Q Chat code search"
+}

--- a/packages/core/src/amazonq/lsp/config.ts
+++ b/packages/core/src/amazonq/lsp/config.ts
@@ -16,7 +16,7 @@ export interface LspConfig {
 
 export const defaultAmazonQWorkspaceLspConfig: LspConfig = {
     manifestUrl: 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json',
-    supportedVersions: '0.1.47',
+    supportedVersions: '0.1.51',
     id: 'AmazonQ-Workspace', // used across IDEs for identifying global storage/local disk locations. Do not change.
     suppressPromptPrefix: 'amazonQWorkspace',
     path: undefined,


### PR DESCRIPTION
## Problem
1. dart is not supported in Q Chat code search.

## Solution
1. Support dart in Q chat code search

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
