### PR TITLE
fix(amazonq): simulate refresh of chat

### DIFF
--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -168,7 +168,7 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
 
     async refreshWebview() {
         if (this.webview) {
-            // post a message to the webview telling it to reload refresh
+            // post a message to the webview telling it to reload
             void this.webview?.postMessage({
                 command: 'reload',
             })


### PR DESCRIPTION
## Problem
Reloading the webview directly causes export/history to be missing

## Solution
Add a specialized handler that simulates reloading the webview when a profile changes, rather than actually refresh everything. This is required because the chat-client relies on initializedResult values from the language server that are only sent once

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
