### PR TITLE
fix(amazonq): deny restoreTabMessage/contextCommandData messages from cwc chat

### DIFF
--- a/packages/amazonq/src/lsp/chat/activation.ts
+++ b/packages/amazonq/src/lsp/chat/activation.ts
@@ -45,6 +45,14 @@ export async function activate(languageClient: LanguageClient, encryptionKey: Bu
 
     provider.onDidResolveWebview(() => {
         const disposable = DefaultAmazonQAppInitContext.instance.getAppsToWebViewMessageListener().onMessage((msg) => {
+            /**
+             * codewhispers app handler is still registered because the activation flow hasn't been refactored.
+             * We need to explicitly deny events like restoreTabMessage, otherwise they will be forwarded to the frontend
+             *
+             */
+            if (msg.sender === 'CWChat' && ['restoreTabMessage', 'contextCommandData'].includes(msg.type)) {
+                return
+            }
             provider.webview?.postMessage(msg).then(undefined, (e) => {
                 getLogger().error('webView.postMessage failed: %s', (e as Error).message)
             })


### PR DESCRIPTION
## Problem
cw chat is still registered and sending events to the frontend, in some cases those UI handlers are the same as they are on the chat-client. This causes disruptive behavior to happen like "normal" chat tabs being restored when they shouldn't

## Solution
disable restoreTabMessage, contextCommandData

## TODO
get rid of cw app start up

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
