### PR TITLE
fix(lsp): LSP download timeout message disappears too early

### DIFF
--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -15,9 +15,11 @@ import { lspSetupStage, StageResolver, tryStageResolvers } from './utils/setupSt
 import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
 import { showMessageWithCancel } from '../../shared/utilities/messages'
 import { Timeout } from '../utilities/timeoutUtils'
+import { oneMinute } from '../datetime'
 
-// max timeout for downloading remote LSP assets progress, the lowest possible is 3000, bounded by httpResourceFetcher's waitUntil
-const remoteDownloadTimeout = 5000
+// max timeout for downloading remote LSP assets. Some asserts are large (100+ MB) so this needs to be large for slow connections.
+// Since the user can cancel this one we can let it run very long.
+const remoteDownloadTimeout = oneMinute * 30
 
 export class LanguageServerResolver {
     constructor(


### PR DESCRIPTION
## Problem:

When downloading the LSP artifacts from the manifest, there are some large ones (100+ MB).
For a slow connection this can take 1+ minutes, but our timeout for the "downloading" message
is set to disappear much earlier. So it is still downloading in the background, but the message
has disappeared and the user thinks that the download is done.

## Solution:

Increase the timeout to 30 minutes, which will ensure the downloading message sticks around
while the download is still happening.

## Additional

In another commit this fixes a separate HTTP client bug where it would time out a request if it took longer than 3 seconds.
This caused downloads to be aborted (separate from the download message disappearing). Now it times out after 30 minutes.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
