### PR TITLE
fix(amazonq): Add clarifying comment to telemetry pass through mechanism

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -82,6 +82,7 @@ export function registerLanguageServerEventListener(languageClient: LanguageClie
         })
     })
 
+    // This passes through metric data from LSP events to Toolkit telemetry with all fields from the LSP server
     languageClient.onTelemetry((e) => {
         const telemetryName: string = e.name
 


### PR DESCRIPTION
## Problem
It's not obvious that the LSP language client passes on telemetry events to Toolkits Telemetry

## Solution
Add clarifying comment to the code implementation

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
