### PR TITLE
fix(amazonq): send sso startUrl on token update

### DIFF
--- a/packages/amazonq/src/lsp/auth.ts
+++ b/packages/amazonq/src/lsp/auth.ts
@@ -4,10 +4,12 @@
  */
 
 import {
+    bearerCredentialsUpdateRequestType,
     ConnectionMetadata,
     NotificationType,
     RequestType,
     ResponseMessage,
+    UpdateCredentialsParams,
 } from '@aws/language-server-runtimes/protocol'
 import * as jose from 'jose'
 import * as crypto from 'crypto'
@@ -81,7 +83,7 @@ export class AmazonQLspAuth {
             token,
         })
 
-        await this.client.sendRequest(notificationTypes.updateBearerToken.method, request)
+        await this.client.sendRequest(bearerCredentialsUpdateRequestType.method, request)
 
         this.client.info(`UpdateBearerToken: ${JSON.stringify(request)}`)
     }
@@ -96,7 +98,7 @@ export class AmazonQLspAuth {
         return interval
     }
 
-    private async createUpdateCredentialsRequest(data: any) {
+    private async createUpdateCredentialsRequest(data: any): Promise<UpdateCredentialsParams> {
         const payload = new TextEncoder().encode(JSON.stringify({ data }))
 
         const jwt = await new jose.CompactEncrypt(payload)
@@ -105,6 +107,11 @@ export class AmazonQLspAuth {
 
         return {
             data: jwt,
+            metadata: {
+                sso: {
+                    startUrl: AuthUtil.instance.auth.startUrl,
+                },
+            },
             encrypted: true,
         }
     }

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -10,7 +10,6 @@ import { LanguageClient, LanguageClientOptions, RequestType } from 'vscode-langu
 import { InlineCompletionManager } from '../app/inline/completion'
 import { AmazonQLspAuth, encryptionKey, notificationTypes } from './auth'
 import {
-    ConnectionMetadata,
     CreateFilesParams,
     DeleteFilesParams,
     DidChangeWorkspaceFoldersParams,
@@ -164,14 +163,6 @@ export async function startLanguageServer(
     const auth = new AmazonQLspAuth(client)
 
     return client.onReady().then(async () => {
-        // Request handler for when the server wants to know about the clients auth connnection. Must be registered before the initial auth init call
-        client.onRequest<ConnectionMetadata, Error>(notificationTypes.getConnectionMetadata.method, () => {
-            return {
-                sso: {
-                    startUrl: AuthUtil.instance.auth.startUrl,
-                },
-            }
-        })
         await auth.refreshConnection()
 
         if (Experiments.instance.get('amazonqLSPInline', false)) {


### PR DESCRIPTION
## Problem
race conditions can occur with getConnectionMetadata

## Solution
instead send the start url through the token update. When it's done this way you don't need to [set getConnectionMetadata](https://github.com/aws/language-server-runtimes/blob/5ba754af403a6f35cd771f27efb987c1580ae6b5/runtimes/runtimes/auth/auth.ts#L158)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
