### PR TITLE
feat(lambda): Add checkbox in local invoke webview for debugger

### DIFF
--- a/packages/core/src/lambda/vue/configEditor/samInvokeBackend.ts
+++ b/packages/core/src/lambda/vue/configEditor/samInvokeBackend.ts
@@ -348,14 +348,8 @@ export class SamInvokeWebview extends VueWebview {
      * Validate and execute the provided launch config.
      * TODO: Post validation failures back to webview?
      * @param config Config to invoke
-     * @param source Source of the invoke request
-     * @param useDebugger Whether to invoke with debugger attached
      */
-    public async invokeLaunchConfig(
-        config: AwsSamDebuggerConfiguration,
-        source?: string,
-        useDebugger: boolean = true
-    ): Promise<void> {
+    public async invokeLaunchConfig(config: AwsSamDebuggerConfiguration, source?: string): Promise<void> {
         const finalConfig = finalizeConfig(
             resolveWorkspaceFolderVariable(undefined, config),
             'Editor-Created Debug Config'
@@ -363,10 +357,8 @@ export class SamInvokeWebview extends VueWebview {
         const targetUri = await this.getUriFromLaunchConfig(finalConfig)
         const folder = targetUri ? vscode.workspace.getWorkspaceFolder(targetUri) : undefined
 
-        // Use the existing startDebugging method with the noDebug option
-        await vscode.debug.startDebugging(folder, finalConfig, {
-            noDebug: !useDebugger,
-        })
+        // startDebugging on VS Code goes through the whole resolution chain
+        await vscode.debug.startDebugging(folder, finalConfig)
     }
     public async getLaunchConfigQuickPickItems(
         launchConfig: LaunchConfiguration,

--- a/packages/core/src/lambda/vue/configEditor/samInvokeBackend.ts
+++ b/packages/core/src/lambda/vue/configEditor/samInvokeBackend.ts
@@ -348,8 +348,14 @@ export class SamInvokeWebview extends VueWebview {
      * Validate and execute the provided launch config.
      * TODO: Post validation failures back to webview?
      * @param config Config to invoke
+     * @param source Source of the invoke request
+     * @param useDebugger Whether to invoke with debugger attached
      */
-    public async invokeLaunchConfig(config: AwsSamDebuggerConfiguration, source?: string): Promise<void> {
+    public async invokeLaunchConfig(
+        config: AwsSamDebuggerConfiguration,
+        source?: string,
+        useDebugger: boolean = true
+    ): Promise<void> {
         const finalConfig = finalizeConfig(
             resolveWorkspaceFolderVariable(undefined, config),
             'Editor-Created Debug Config'
@@ -357,8 +363,10 @@ export class SamInvokeWebview extends VueWebview {
         const targetUri = await this.getUriFromLaunchConfig(finalConfig)
         const folder = targetUri ? vscode.workspace.getWorkspaceFolder(targetUri) : undefined
 
-        // startDebugging on VS Code goes through the whole resolution chain
-        await vscode.debug.startDebugging(folder, finalConfig)
+        // Use the existing startDebugging method with the noDebug option
+        await vscode.debug.startDebugging(folder, finalConfig, {
+            noDebug: !useDebugger,
+        })
     }
     public async getLaunchConfigQuickPickItems(
         launchConfig: LaunchConfiguration,

--- a/packages/core/src/lambda/vue/configEditor/samInvokeComponent.vue
+++ b/packages/core/src/lambda/vue/configEditor/samInvokeComponent.vue
@@ -139,6 +139,10 @@
                         </select>
                         <span class="data-view">runtime in data: {{ launchConfig.lambda.runtime }}</span>
                     </div>
+                    <div class="config-item">
+                        <label for="useDebugger">Attach a debugger</label>
+                        <input type="checkbox" id="useDebugger" v-model="useDebugger" name="useDebugger" />
+                    </div>
                 </div>
                 <div class="target-template" v-else-if="launchConfig.invokeTarget.target === 'template'">
                     <div class="config-item">
@@ -195,6 +199,10 @@
                             For invoke the runtime defined in the template is used.
                         </p>
                     </div>
+                    <div class="config-item">
+                        <label for="useDebugger">Attach a debugger</label>
+                        <input type="checkbox" id="useDebugger" v-model="useDebugger" name="useDebugger" />
+                    </div>
                 </div>
                 <div class="target-apigw" v-else-if="launchConfig.invokeTarget.target === 'api'">
                     <button v-on:click.prevent="loadResource">Load resource</button><br />
@@ -228,6 +236,10 @@
                             </option>
                         </select>
                         <span class="data-view">runtime in data: {{ launchConfig.lambda.runtime }}</span>
+                    </div>
+                    <div class="config-item">
+                        <label for="useDebugger">Attach a debugger</label>
+                        <input type="checkbox" id="useDebugger" v-model="useDebugger" name="useDebugger" />
                     </div>
                     <div class="config-item">
                         <label for="path">Path</label>

--- a/packages/core/src/lambda/vue/configEditor/samInvokeFrontend.ts
+++ b/packages/core/src/lambda/vue/configEditor/samInvokeFrontend.ts
@@ -48,6 +48,7 @@ interface SamInvokeVueData {
     showNameInput: boolean
     newTestEventName: string
     resourceData: ResourceData | undefined
+    useDebugger: boolean
 }
 
 function newLaunchConfig(existingConfig?: AwsSamDebuggerConfiguration): AwsSamDebuggerConfigurationLoose {
@@ -112,6 +113,7 @@ function initData() {
     return {
         containerBuild: false,
         skipNewImageCheck: false,
+        useDebugger: true,
         launchConfig: newLaunchConfig(),
         payload: { value: '', errorMsg: '' },
         apiPayload: { value: '', errorMsg: '' },
@@ -170,7 +172,7 @@ export default defineComponent({
 
             const source = this.resourceData?.source
 
-            client.invokeLaunchConfig(config, source).catch((e: Error) => {
+            client.invokeLaunchConfig(config, source, this.useDebugger).catch((e: Error) => {
                 console.error(`invokeLaunchConfig failed: ${e.message}`)
             })
         },

--- a/packages/core/src/lambda/vue/configEditor/samInvokeFrontend.ts
+++ b/packages/core/src/lambda/vue/configEditor/samInvokeFrontend.ts
@@ -172,7 +172,7 @@ export default defineComponent({
 
             const source = this.resourceData?.source
 
-            client.invokeLaunchConfig(config, source, this.useDebugger).catch((e: Error) => {
+            client.invokeLaunchConfig(config, source).catch((e: Error) => {
                 console.error(`invokeLaunchConfig failed: ${e.message}`)
             })
         },
@@ -451,6 +451,7 @@ export default defineComponent({
                           },
                       }
                     : undefined,
+                noDebug: !this.useDebugger,
             }
         },
         clearForm() {

--- a/packages/toolkit/.changes/next-release/Feature-b9357975-bda4-4ec8-a8ea-d955708b7596.json
+++ b/packages/toolkit/.changes/next-release/Feature-b9357975-bda4-4ec8-a8ea-d955708b7596.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "AppBuilder: unchecking the 'Attach a debugger' checkbox in local invoke webview invokes the function without a debugger"
+}


### PR DESCRIPTION
## Problem

## Solution
Add checkbox in local invoke webview so customers can choose to locally invoke with or without debugger

### Note: 
No tests added since the functionality is already tested here: https://github.com/aws/aws-toolkit-vscode/blob/a7732b96982adbbac691f2869db3136c159d80ed/packages/core/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts#L111

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
