### PR TITLE
feat(core): add value length cap to partialClone

### DIFF
--- a/packages/amazonq/test/e2e/inline/inline.test.ts
+++ b/packages/amazonq/test/e2e/inline/inline.test.ts
@@ -122,7 +122,7 @@ describe('Amazon Q Inline', async function () {
             .query({
                 metricName: 'codewhisperer_userTriggerDecision',
             })
-            .map((e) => collectionUtil.partialClone(e, 3, ['credentialStartUrl'], '[omitted]'))
+            .map((e) => collectionUtil.partialClone(e, 3, ['credentialStartUrl'], { replacement: '[omitted]' }))
     }
 
     for (const [name, invokeCompletion] of [

--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -258,7 +258,7 @@ function addLoggingMiddleware(client: SSOOIDCClient) {
                     args.input as unknown as Record<string, unknown>,
                     3,
                     ['clientSecret', 'accessToken', 'refreshToken'],
-                    '[omitted]'
+                    { replacement: '[omitted]' }
                 )
                 getLogger().debug('API request (%s %s): %O', hostname, path, input)
             }
@@ -288,7 +288,7 @@ function addLoggingMiddleware(client: SSOOIDCClient) {
                     result.output as unknown as Record<string, unknown>,
                     3,
                     ['clientSecret', 'accessToken', 'refreshToken'],
-                    '[omitted]'
+                    { replacement: '[omitted]' }
                 )
                 getLogger().debug('API response (%s %s): %O', hostname, path, output)
             }

--- a/packages/core/src/shared/utilities/collectionUtils.ts
+++ b/packages/core/src/shared/utilities/collectionUtils.ts
@@ -305,7 +305,7 @@ export function assign<T extends Record<any, any>, U extends Partial<T>>(data: T
  * @param depth
  * @param omitKeys Omit properties matching these names (at any depth).
  * @param replacement Replacement for object whose fields extend beyond `depth`, and properties matching `omitKeys`.
- * @param maxStringLength truncates string values that exceed this threshold.
+ * @param maxStringLength truncates string values that exceed this threshold (includes values in nested arrays)
  */
 export function partialClone(
     obj: any,
@@ -318,8 +318,10 @@ export function partialClone(
 ): any {
     // Base case: If input is not an object or has no children, return it.
     if (typeof obj !== 'object' || obj === null || 0 === Object.getOwnPropertyNames(obj).length) {
-        const maxLength = options?.maxStringLength
-        return typeof obj === 'string' && maxLength !== undefined ? truncate(obj, maxLength, '...') : obj
+        if (typeof obj === 'string' && options?.maxStringLength) {
+            return truncate(obj, options?.maxStringLength, '...')
+        }
+        return obj
     }
 
     // Create a new object of the same type as the input object.

--- a/packages/core/src/shared/utilities/collectionUtils.ts
+++ b/packages/core/src/shared/utilities/collectionUtils.ts
@@ -305,7 +305,7 @@ export function assign<T extends Record<any, any>, U extends Partial<T>>(data: T
  * @param depth
  * @param omitKeys Omit properties matching these names (at any depth).
  * @param replacement Replacement for object whose fields extend beyond `depth`, and properties matching `omitKeys`.
- * @param maxLength truncates string values that exceed this threshold.
+ * @param maxStringLength truncates string values that exceed this threshold.
  */
 export function partialClone(
     obj: any,
@@ -313,12 +313,12 @@ export function partialClone(
     omitKeys: string[] = [],
     options?: {
         replacement?: any
-        maxLength?: number
+        maxStringLength?: number
     }
 ): any {
     // Base case: If input is not an object or has no children, return it.
     if (typeof obj !== 'object' || obj === null || 0 === Object.getOwnPropertyNames(obj).length) {
-        const maxLength = options?.maxLength
+        const maxLength = options?.maxStringLength
         return typeof obj === 'string' && maxLength !== undefined ? truncate(obj, maxLength, '...') : obj
     }
 

--- a/packages/core/src/shared/utilities/textUtilities.ts
+++ b/packages/core/src/shared/utilities/textUtilities.ts
@@ -10,7 +10,7 @@ import { default as stripAnsi } from 'strip-ansi'
 import { getLogger } from '../logger/logger'
 
 /**
- * Truncates string `s` if it exceeds `n` chars.
+ * Truncates string `s` if it has or exceeds `n` chars.
  *
  * If `n` is negative, truncates at start instead of end.
  *

--- a/packages/core/src/shared/vscode/commands2.ts
+++ b/packages/core/src/shared/vscode/commands2.ts
@@ -653,7 +653,7 @@ async function runCommand<T extends Callback>(fn: T, info: CommandInfo<T>): Prom
 
     logger.debug(
         `command: running ${label} with arguments: %O`,
-        partialClone(args, 3, ['clientSecret', 'accessToken', 'refreshToken', 'tooltip'], '[omitted]')
+        partialClone(args, 3, ['clientSecret', 'accessToken', 'refreshToken', 'tooltip'], { replacement: '[omitted]' })
     )
 
     try {

--- a/packages/core/src/test/shared/utilities/collectionUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/collectionUtils.test.ts
@@ -770,26 +770,36 @@ describe('CollectionUtils', async function () {
 
         it('truncates properties by maxLength', function () {
             const testObj = {
-                a: '1',
-                b: '11',
-                c: '11111',
-                d: {
-                    e: {
-                        a: '11111',
-                        b: '11',
+                strValue: '1',
+                boolValue: true,
+                longString: '11111',
+                nestedObj: {
+                    nestedObjAgain: {
+                        longNestedStr: '11111',
+                        shortNestedStr: '11',
                     },
                 },
+                nestedObj2: {
+                    functionValue: (_: unknown) => {},
+                },
+                nestedObj3: {
+                    myArray: ['1', '11111', '1'],
+                },
+                objInArray: [{ shortString: '11', longString: '11111' }],
             }
             assert.deepStrictEqual(partialClone(testObj, 5, [], { maxStringLength: 2 }), {
-                a: '1',
-                b: '11',
-                c: '11...',
-                d: {
-                    e: {
-                        a: '11...',
-                        b: '11',
+                ...testObj,
+                longString: '11...',
+                nestedObj: {
+                    nestedObjAgain: {
+                        longNestedStr: '11...',
+                        shortNestedStr: '11',
                     },
                 },
+                nestedObj3: {
+                    myArray: ['1', '11...', '1'],
+                },
+                objInArray: [{ shortString: '11', longString: '11...' }],
             })
         })
     })

--- a/packages/core/src/test/shared/utilities/collectionUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/collectionUtils.test.ts
@@ -780,7 +780,7 @@ describe('CollectionUtils', async function () {
                     },
                 },
             }
-            assert.deepStrictEqual(partialClone(testObj, 5, [], { maxLength: 2 }), {
+            assert.deepStrictEqual(partialClone(testObj, 5, [], { maxStringLength: 2 }), {
                 a: '1',
                 b: '11',
                 c: '11...',

--- a/packages/core/src/test/shared/utilities/collectionUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/collectionUtils.test.ts
@@ -710,8 +710,10 @@ describe('CollectionUtils', async function () {
     })
 
     describe('partialClone', function () {
-        it('omits properties by depth', function () {
-            const testObj = {
+        let multipleTypedObj: object
+
+        before(async function () {
+            multipleTypedObj = {
                 a: 34234234234,
                 b: '123456789',
                 c: new Date(2023, 1, 1),
@@ -724,56 +726,69 @@ describe('CollectionUtils', async function () {
                     throw Error()
                 },
             }
+        })
 
-            assert.deepStrictEqual(partialClone(testObj, 1), {
-                ...testObj,
+        it('omits properties by depth', function () {
+            assert.deepStrictEqual(partialClone(multipleTypedObj, 1), {
+                ...multipleTypedObj,
                 d: {},
                 e: {},
             })
-            assert.deepStrictEqual(partialClone(testObj, 0, [], '[replaced]'), '[replaced]')
-            assert.deepStrictEqual(partialClone(testObj, 1, [], '[replaced]'), {
-                ...testObj,
+            assert.deepStrictEqual(partialClone(multipleTypedObj, 0, [], { replacement: '[replaced]' }), '[replaced]')
+            assert.deepStrictEqual(partialClone(multipleTypedObj, 1, [], { replacement: '[replaced]' }), {
+                ...multipleTypedObj,
                 d: '[replaced]',
                 e: '[replaced]',
             })
-            assert.deepStrictEqual(partialClone(testObj, 3), {
-                ...testObj,
+            assert.deepStrictEqual(partialClone(multipleTypedObj, 3), {
+                ...multipleTypedObj,
                 d: { d1: { d2: {} } },
             })
-            assert.deepStrictEqual(partialClone(testObj, 4), testObj)
+            assert.deepStrictEqual(partialClone(multipleTypedObj, 4), multipleTypedObj)
         })
 
         it('omits properties by name', function () {
-            const testObj = {
-                a: 34234234234,
-                b: '123456789',
-                c: new Date(2023, 1, 1),
-                d: { d1: { d2: { d3: 'deep' } } },
+            assert.deepStrictEqual(partialClone(multipleTypedObj, 2, ['c', 'e2'], { replacement: '[replaced]' }), {
+                ...multipleTypedObj,
+                c: '[replaced]',
+                d: { d1: '[replaced]' },
                 e: {
-                    e1: [4, 3, 7],
-                    e2: 'loooooooooo \n nnnnnnnnnnn \n gggggggg \n string',
-                },
-                f: () => {
-                    throw Error()
-                },
-            }
-
-            assert.deepStrictEqual(partialClone(testObj, 2, ['c', 'e2'], '[omitted]'), {
-                ...testObj,
-                c: '[omitted]',
-                d: { d1: '[omitted]' },
-                e: {
-                    e1: '[omitted]',
-                    e2: '[omitted]',
+                    e1: '[replaced]',
+                    e2: '[replaced]',
                 },
             })
-            assert.deepStrictEqual(partialClone(testObj, 3, ['c', 'e2'], '[omitted]'), {
-                ...testObj,
-                c: '[omitted]',
-                d: { d1: { d2: '[omitted]' } },
+            assert.deepStrictEqual(partialClone(multipleTypedObj, 3, ['c', 'e2'], { replacement: '[replaced]' }), {
+                ...multipleTypedObj,
+                c: '[replaced]',
+                d: { d1: { d2: '[replaced]' } },
                 e: {
                     e1: [4, 3, 7],
-                    e2: '[omitted]',
+                    e2: '[replaced]',
+                },
+            })
+        })
+
+        it('truncates properties by maxLength', function () {
+            const testObj = {
+                a: '1',
+                b: '11',
+                c: '11111',
+                d: {
+                    e: {
+                        a: '11111',
+                        b: '11',
+                    },
+                },
+            }
+            assert.deepStrictEqual(partialClone(testObj, 5, [], { maxLength: 2 }), {
+                a: '1',
+                b: '11',
+                c: '11...',
+                d: {
+                    e: {
+                        a: '11...',
+                        b: '11',
+                    },
                 },
             })
         })


### PR DESCRIPTION
## Problem
If we want to log a large json object with giant strings (think whole files), it can make the logs difficult to read. This is especially relevant when the underlying string values are not very important.  

## Solution
- allow the string values to be truncated with `maxStringLength` option. 

## Notes
I am planning to port this utility to Flare to improve the logging experience there, and want this functionality to exist there however I thought this could be useful here too. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
