### PR TITLE
fix(amazonq): fix enterprise users not able to sign in correctly if they have 2+ vscode instances open

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-8290a06f-ee3f-4235-b8af-faedb1bdfbe4.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-8290a06f-ee3f-4235-b8af-faedb1bdfbe4.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix users can not log in successfully with 2+ IDE instnaces open due to throttle error throw by the service"
+}

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -62,13 +62,18 @@ export class RegionProfileManager {
 
     private readonly cache = new (class extends CachedResource<RegionProfile[]> {
         constructor(private readonly profileProvider: () => Promise<RegionProfile[]>) {
-            super('aws.amazonq.regionProfiles.cache', 60000, {
-                resource: {
-                    locked: false,
-                    timestamp: 0,
-                    result: undefined,
+            super(
+                'aws.amazonq.regionProfiles.cache',
+                60000,
+                {
+                    resource: {
+                        locked: false,
+                        timestamp: 0,
+                        result: undefined,
+                    },
                 },
-            })
+                { timeout: 15000, interval: 1500, truthy: true }
+            )
         }
 
         override resourceProvider(): Promise<RegionProfile[]> {

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -126,10 +126,6 @@ export class RegionProfileManager {
 
     constructor(private readonly connectionProvider: () => Connection | undefined) {}
 
-    async resetCache() {
-        await this.cache.releaseLock()
-    }
-
     async getProfiles(): Promise<RegionProfile[]> {
         return this.cache.getResource()
     }

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -373,6 +373,11 @@ export class RegionProfileManager {
         }
     }
 
+    // Should be called on connection changed in case users change to a differnet connection and use the wrong resultset.
+    async clearCache() {
+        await this.cache.clearCache()
+    }
+
     async createQClient(region: string, endpoint: string, conn: SsoConnection): Promise<CodeWhispererUserClient> {
         const token = (await conn.getToken()).accessToken
         const serviceOption: ServiceOptions = {

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -63,9 +63,11 @@ export class RegionProfileManager {
     private readonly cache = new (class extends CachedResource<RegionProfile[]> {
         constructor(private readonly profileProvider: () => Promise<RegionProfile[]>) {
             super('aws.amazonq.regionProfiles.cache', 60000, {
-                locked: false,
-                timestamp: 0,
-                result: undefined,
+                resource: {
+                    locked: false,
+                    timestamp: 0,
+                    result: undefined,
+                },
             })
         }
 

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -29,7 +29,7 @@ import { isAwsError, ToolkitError } from '../../shared/errors'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { Commands } from '../../shared/vscode/commands2'
-import { CachedResource, GlobalStateSchema } from '../../shared/utilities/resourceCache'
+import { CachedResource } from '../../shared/utilities/resourceCache'
 
 // TODO: is there a better way to manage all endpoint strings in one place?
 export const defaultServiceConfig: CodeWhispererConfig = {
@@ -51,10 +51,6 @@ const endpoints = createConstantMap({
  */
 export type ProfileSwitchIntent = 'user' | 'auth' | 'update' | 'reload'
 
-interface RegionProfileGlobalState extends GlobalStateSchema<RegionProfile> {
-    previousSelection: { [label: string]: RegionProfile }
-}
-
 export class RegionProfileManager {
     private static logger = getLogger()
     private _activeRegionProfile: RegionProfile | undefined
@@ -66,7 +62,7 @@ export class RegionProfileManager {
 
     private readonly cache = new (class extends CachedResource<RegionProfile[]> {
         constructor(private readonly profileProvider: () => Promise<RegionProfile[]>) {
-            super('aws.amazonq.regionProfiles', 60000, {
+            super('aws.amazonq.regionProfiles.cache', 60000, {
                 resource: {
                     locked: false,
                     timestamp: 0,
@@ -297,20 +293,13 @@ export class RegionProfileManager {
     }
 
     private loadPersistedRegionProfle(): { [label: string]: RegionProfile } {
-        const previousPersistedState = globals.globalState.tryGet<RegionProfileGlobalState>(
+        const previousPersistedState = globals.globalState.tryGet<{ [label: string]: RegionProfile }>(
             'aws.amazonq.regionProfiles',
             Object,
-            {
-                previousSelection: {},
-                resource: {
-                    locked: false,
-                    result: undefined,
-                    timestamp: 0,
-                },
-            }
+            {}
         )
 
-        return previousPersistedState.previousSelection
+        return previousPersistedState
     }
 
     async persistSelectRegionProfile() {
@@ -322,20 +311,13 @@ export class RegionProfileManager {
         }
 
         // persist connectionId to profileArn
-        const previousPersistedState = globals.globalState.tryGet<RegionProfileGlobalState>(
+        const previousPersistedState = globals.globalState.tryGet<{ [label: string]: RegionProfile }>(
             'aws.amazonq.regionProfiles',
             Object,
-            {
-                previousSelection: {},
-                resource: {
-                    locked: false,
-                    result: undefined,
-                    timestamp: 0,
-                },
-            }
+            {}
         )
 
-        previousPersistedState.previousSelection[conn.id] = this.activeRegionProfile
+        previousPersistedState[conn.id] = this.activeRegionProfile
         await globals.globalState.update('aws.amazonq.regionProfiles', previousPersistedState)
     }
 
@@ -386,23 +368,7 @@ export class RegionProfileManager {
             const updatedProfiles = Object.fromEntries(
                 Object.entries(profiles).filter(([connId, profile]) => profile.arn !== arn)
             )
-            const previousPersistedState = globals.globalState.tryGet<RegionProfileGlobalState>(
-                'aws.amazonq.regionProfiles',
-                Object,
-                {
-                    previousSelection: {},
-                    resource: {
-                        locked: false,
-                        result: undefined,
-                        timestamp: 0,
-                    },
-                }
-            )
-            const toUpdate: RegionProfileGlobalState = {
-                previousSelection: updatedProfiles,
-                resource: previousPersistedState.resource,
-            }
-            await globals.globalState.update('aws.amazonq.regionProfiles', toUpdate)
+            await globals.globalState.update('aws.amazonq.regionProfiles', updatedProfiles)
         }
     }
 

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -143,6 +143,8 @@ export class AuthUtil {
             if (!this.isConnected()) {
                 await this.regionProfileManager.invalidateProfile(this.regionProfileManager.activeRegionProfile?.arn)
             }
+
+            await this.regionProfileManager.clearCache()
         })
 
         this.regionProfileManager.onDidChangeRegionProfile(async () => {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -142,7 +142,6 @@ export class AuthUtil {
 
             if (!this.isConnected()) {
                 await this.regionProfileManager.invalidateProfile(this.regionProfileManager.activeRegionProfile?.arn)
-                await this.regionProfileManager.resetCache()
             }
         })
 

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -142,6 +142,7 @@ export class AuthUtil {
 
             if (!this.isConnected()) {
                 await this.regionProfileManager.invalidateProfile(this.regionProfileManager.activeRegionProfile?.arn)
+                await this.regionProfileManager.resetCache()
             }
         })
 

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -223,7 +223,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
      */
     override async listRegionProfiles(): Promise<RegionProfile[] | string> {
         try {
-            return await AuthUtil.instance.regionProfileManager.listRegionProfile()
+            return await AuthUtil.instance.regionProfileManager.getProfiles()
         } catch (e) {
             const conn = AuthUtil.instance.conn as SsoConnection | undefined
             telemetry.amazonq_didSelectProfile.emit({

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -49,6 +49,7 @@ export type globalKey =
     | 'aws.toolkit.lsp.manifest'
     | 'aws.amazonq.customization.overrideV2'
     | 'aws.amazonq.regionProfiles'
+    | 'aws.amazonq.regionProfiles.cache'
     // Deprecated/legacy names. New keys should start with "aws.".
     | '#sessionCreationDates' // Legacy name from `ssoAccessTokenProvider.ts`.
     | 'CODECATALYST_RECONNECT'

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -18,6 +18,7 @@ export type LogTopic =
     | 'chat'
     | 'stepfunctions'
     | 'unknown'
+    | 'resourceCache'
 
 class ErrorLog {
     constructor(

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -68,7 +68,7 @@ export abstract class CachedResource<V> {
         return latest
     }
 
-    async readResourceAndLock(): Promise<GlobalStateSchema<V> | undefined> {
+    private async readResourceAndLock(): Promise<GlobalStateSchema<V> | undefined> {
         const _acquireLock = async () => {
             const cachedValue = this.readCacheOrDefault()
 
@@ -95,13 +95,6 @@ export abstract class CachedResource<V> {
         )
 
         return lock
-    }
-
-    async releaseLock() {
-        await globals.globalState.update(this.key, {
-            ...this.readCacheOrDefault(),
-            locked: false,
-        })
     }
 
     private async updateCache(cache: GlobalStateSchema<any> | undefined, resource: Resource<any>) {

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -85,7 +85,7 @@ export abstract class CachedResource<V> {
                 )
             }
         } else {
-            logger.debug(`cache miss, pulling latest resource %s`, this.key)
+            logger.info(`cache miss, pulling latest resource %s`, this.key)
         }
 
         /**
@@ -104,14 +104,11 @@ export abstract class CachedResource<V> {
                 timestamp: now(),
                 result: latest,
             }
-            logger.debug(`doen loading latest resource, updating resource cache: %s`, this.key)
+            logger.info(`doen loading latest resource, updating resource cache: %s`, this.key)
             await this.releaseLock(r)
             return latest
         } catch (e) {
-            logger.debug(
-                `encountered unexpected error while loading the latest of resource(%s), releasing resource lock`,
-                this.key
-            )
+            logger.error(`failed to load latest resource, releasing lock: %s`, this.key)
             await this.releaseLock()
             throw e
         }

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -38,6 +38,7 @@ function now() {
  * CacheResource utilizes VSCode global states API to cache resources which are expensive to get so that the result can be shared across multiple VSCode instances.
  *  The first VSCode instance invoking #getResource will hold a lock and make the actual network call/FS read to pull the real response.
  *  When the pull is done, the lock will be released and it then caches the result in the global states. Then the rest of instances can now acquire the lock 1 by 1 and read the resource from the cache.
+ *
  * constructor:
  *  @param key: global state key, which is used for globals.globalState#update, #tryGet etc.
  *  @param expirationInMilli: cache expiration time in milli seconds

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -10,9 +10,9 @@ import { waitUntil } from '../utilities/timeoutUtils'
 
 /**
  * args:
- *  [result]: the actual resource type callers want to use
- *  [locked]: readWriteLock, while the lock is acquired by one process, the other can't access to it until it's released by the previous
- *  [timestamp]: used for determining the resource is stale or not
+ *  @member result: the actual resource type callers want to use
+ *  @member locked: readWriteLock, while the lock is acquired by one process, the other can't access to it until it's released by the previous
+ *  @member timestamp: used for determining the resource is stale or not
  */
 interface Resource<V> {
     result: V | undefined
@@ -35,15 +35,15 @@ function now() {
 }
 
 /**
- * args:
- *  [key]: global state key, which is used for globals.globalState#update, #tryGet etc.
- *  [expirationInMilli]: cache expiration time in milli seconds
- *  [defaultValue]: default value for the cache if the cache doesn't pre-exist in users' FS
- *  [waitUntilOption]: waitUntil option for acquire lock
+ * constructor:
+ *  @param key: global state key, which is used for globals.globalState#update, #tryGet etc.
+ *  @param expirationInMilli: cache expiration time in milli seconds
+ *  @param defaultValue: default value for the cache if the cache doesn't pre-exist in users' FS
+ *  @param waitUntilOption: waitUntil option for acquire lock
  *
  * methods:
- *  #resourceProvider: implementation needs to implement this method to obtain the latest resource either via network calls or FS read
- *  #getResource: obtain the resource from cache or pull the latest from the service if the cache either expires or doesn't exist
+ *  @method resourceProvider: implementation needs to implement this method to obtain the latest resource either via network calls or FS read
+ *  @method getResource: obtain the resource from cache or pull the latest from the service if the cache either expires or doesn't exist
  */
 export abstract class CachedResource<V> {
     constructor(

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -1,0 +1,113 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import globals from '../extensionGlobals'
+import { globalKey } from '../globalState'
+import { getLogger } from '../logger/logger'
+import { waitUntil } from '../utilities/timeoutUtils'
+
+interface WithLock {
+    locked: boolean
+    timestamp: number
+}
+
+interface Resource<V> extends WithLock {
+    result: V | undefined
+}
+
+const logger = getLogger()
+
+function now() {
+    return globals.clock.Date.now()
+}
+
+export abstract class CachedResource<V> {
+    constructor(
+        readonly key: globalKey,
+        readonly expiration: number,
+        private readonly defaultValue: Resource<V>
+    ) {}
+
+    abstract resourceProvider(): Promise<V>
+
+    async getResource(): Promise<V> {
+        const resource = await this.readResourceAndLock()
+        // if cache is still fresh, return
+        if (resource && resource.result) {
+            if (now() - resource.timestamp < this.expiration) {
+                logger.info(`cache hit`)
+                // release the lock
+                await globals.globalState.update(this.key, {
+                    ...resource,
+                    locked: false,
+                })
+                return resource.result
+            } else {
+                logger.info(`cache hit but cached value is stale, invoking service API to pull the latest response`)
+            }
+        }
+
+        // catch and error case?
+        logger.info(`cache miss, invoking service API to pull the latest response`)
+        const latest = await this.resourceProvider()
+
+        // update resource cache and release the lock
+        const toUpdate: Resource<V> = {
+            locked: false,
+            timestamp: now(),
+            result: latest,
+        }
+        await globals.globalState.update(this.key, toUpdate)
+        return latest
+    }
+
+    async readResourceAndLock(): Promise<Resource<V> | undefined> {
+        const _acquireLock = async () => {
+            const cachedValue = this.readCacheOrDefault()
+
+            if (!cachedValue.locked) {
+                await globals.globalState.update(this.key, {
+                    ...cachedValue,
+                    locked: true,
+                })
+
+                return cachedValue
+            }
+
+            return undefined
+        }
+
+        const lock = await waitUntil(
+            async () => {
+                const lock = await _acquireLock()
+                logger.info(`try obtaining cache lock %s`, lock)
+                if (lock) {
+                    return lock
+                }
+            },
+            { timeout: 15000, interval: 1500, truthy: true } // TODO: pass via ctor
+        )
+
+        return lock
+    }
+
+    async releaseLock() {
+        await globals.globalState.update(this.key, {
+            ...this.readCacheOrDefault(),
+            locked: false,
+        })
+    }
+
+    private readCacheOrDefault(): Resource<V> {
+        const cachedValue = globals.globalState.tryGet<Resource<V>>(this.key, Object, {
+            ...this.defaultValue,
+            locked: false,
+            result: undefined,
+            timestamp: 0,
+        })
+
+        return cachedValue
+    }
+}

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -16,7 +16,7 @@ interface Resource<V> {
 
 // GlobalStates schema, which is used for vscode global states deserialization
 // [globals.globalState.tryGet<T>]
-export interface GlobalStateSchema<V> {
+interface GlobalStateSchema<V> {
     resource: Resource<V>
 }
 

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -105,10 +105,8 @@ export abstract class CachedResource<V> {
     }
 
     private async updateCache(cache: GlobalStateSchema<any> | undefined, resource: Resource<any>) {
-        // TODO: undefined?
-
         await globals.globalState.update(this.key, {
-            ...cache,
+            ...(cache ? cache : this.readCacheOrDefault()),
             resource: resource,
         })
     }

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -81,6 +81,7 @@ export abstract class CachedResource<V> {
 
         logger.info(`cache miss, invoking service API to pull the latest response`)
         try {
+            // Make the real network call / FS read to pull the resource
             const latest = await this.resourceProvider()
 
             // Update resource cache and release the lock

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -26,7 +26,7 @@ function now() {
 export abstract class CachedResource<V> {
     constructor(
         readonly key: globalKey,
-        readonly expiration: number,
+        readonly expirationInMilli: number,
         private readonly defaultValue: Resource<V>
     ) {}
 
@@ -36,7 +36,7 @@ export abstract class CachedResource<V> {
         const resource = await this.readResourceAndLock()
         // if cache is still fresh, return
         if (resource && resource.result) {
-            if (now() - resource.timestamp < this.expiration) {
+            if (now() - resource.timestamp < this.expirationInMilli) {
                 logger.info(`cache hit`)
                 // release the lock
                 await globals.globalState.update(this.key, {

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -79,6 +79,12 @@ export abstract class CachedResource<V> {
             }
         }
 
+        /**
+         * Possible paths here
+         *  1. cache doesn't exist.
+         *  2. cache exists but expired.
+         *  3. lock is held by other process and the waiting time is greater than the specified waiting time
+         */
         logger.info(`cache miss, invoking service API to pull the latest response`)
         try {
             // Make the real network call / FS read to pull the resource

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -35,6 +35,9 @@ function now() {
 }
 
 /**
+ * CacheResource utilizes VSCode global states API to cache resources which are expensive to get so that the result can be shared across multiple VSCode instances.
+ *  The first VSCode instance invoking #getResource will hold a lock and make the actual network call/FS read to pull the real response.
+ *  When the pull is done, the lock will be released and it then caches the result in the global states. Then the rest of instances can now acquire the lock 1 by 1 and read the resource from the cache.
  * constructor:
  *  @param key: global state key, which is used for globals.globalState#update, #tryGet etc.
  *  @param expirationInMilli: cache expiration time in milli seconds

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -90,9 +90,14 @@ export abstract class CachedResource<V> {
                 timestamp: now(),
                 result: latest,
             }
+            logger.info(`doen loading the latest of resource(%s), updating resource cache`, this.key)
             await this.updateCache(cachedValue, r)
             return latest
         } catch (e) {
+            logger.info(
+                `encountered unexpected error while loading the latest of resource(%s), releasing resource lock`,
+                this.key
+            )
             await this.releaseLock()
             throw e
         }

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -56,7 +56,7 @@ export abstract class CachedResource<V> {
     abstract resourceProvider(): Promise<V>
 
     async getResource(): Promise<V> {
-        const cachedValue = await this.readResourceAndLock()
+        const cachedValue = await this.tryLoadResourceAndLock()
         const resource = cachedValue?.resource
 
         // If cache is still fresh, return cached result, otherwise pull latest from the service
@@ -99,7 +99,7 @@ export abstract class CachedResource<V> {
     }
 
     // This method will lock the resource so other callers have to wait until the lock is released, otherwise will return undefined if it times out
-    private async readResourceAndLock(): Promise<GlobalStateSchema<V> | undefined> {
+    private async tryLoadResourceAndLock(): Promise<GlobalStateSchema<V> | undefined> {
         const _acquireLock = async () => {
             const cachedValue = this.readCacheOrDefault()
 

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -154,6 +154,11 @@ export abstract class CachedResource<V> {
         }
     }
 
+    async clearCache() {
+        const baseCache = this.readCacheOrDefault()
+        await this.updateResourceCache({ result: undefined, timestamp: 0, locked: false }, baseCache)
+    }
+
     private async updateResourceCache(resource: Partial<Resource<any>>, cache: GlobalStateSchema<any> | undefined) {
         const baseCache = cache ?? this.readCacheOrDefault()
 

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -97,6 +97,13 @@ export abstract class CachedResource<V> {
         return lock
     }
 
+    async releaseLock() {
+        await globals.globalState.update(this.key, {
+            ...this.readCacheOrDefault(),
+            locked: false,
+        })
+    }
+
     private async updateCache(cache: GlobalStateSchema<any> | undefined, resource: Resource<any>) {
         await globals.globalState.update(this.key, {
             ...(cache ? cache : this.readCacheOrDefault()),

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -9,9 +9,10 @@ import { getLogger } from '../logger/logger'
 import { waitUntil } from '../utilities/timeoutUtils'
 
 /**
- * result: the actual resource type callers want to use
- * locked: readWriteLock, while the lock is acquired by one process, the other can't access to it until it's released by the previous
- * timestamp: used for determining the resource is stale or not
+ * args:
+ *  [result]: the actual resource type callers want to use
+ *  [locked]: readWriteLock, while the lock is acquired by one process, the other can't access to it until it's released by the previous
+ *  [timestamp]: used for determining the resource is stale or not
  */
 interface Resource<V> {
     result: V | undefined
@@ -35,14 +36,14 @@ function now() {
 
 /**
  * args:
- *  key: global state key, which is used for globals.globalState#update, #tryGet etc.
- *  expirationInMilli: cache expiration time in milli seconds
- *  defaultValue: default value for the cache if the cache doesn't pre-exist in users' FS
- *  waitUntilOption: waitUntil option for acquire lock
+ *  [key]: global state key, which is used for globals.globalState#update, #tryGet etc.
+ *  [expirationInMilli]: cache expiration time in milli seconds
+ *  [defaultValue]: default value for the cache if the cache doesn't pre-exist in users' FS
+ *  [waitUntilOption]: waitUntil option for acquire lock
  *
  * methods:
- *  resourceProvider(): implementation needs to implement this method to obtain the latest resource either via network calls or FS read
- *  getResource(): obtain the resource from cache or pull the latest from the service if the cache either expires or doesn't exist
+ *  #resourceProvider: implementation needs to implement this method to obtain the latest resource either via network calls or FS read
+ *  #getResource: obtain the resource from cache or pull the latest from the service if the cache either expires or doesn't exist
  */
 export abstract class CachedResource<V> {
     constructor(

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -26,6 +26,17 @@ function now() {
     return globals.clock.Date.now()
 }
 
+/**
+ * args:
+ *  key: global state key, which is used for globals.globalState#update, #tryGet etc.
+ *  expirationInMilli: cache expiration time in milli seconds
+ *  defaultValue: default value for the cache if the cache doesn't pre-exist in users' FS
+ *  waitUntilOption: waitUntil option for acquire lock
+ *
+ * methods:
+ *  resourceProvider(): implementation needs to implement this method to obtain the latest resource either via network calls or FS read
+ *  getResource(): obtain the resource from cache or pull the latest from the service if the cache either expires or doesn't exist
+ */
 export abstract class CachedResource<V> {
     constructor(
         private readonly key: globalKey,
@@ -100,6 +111,7 @@ export abstract class CachedResource<V> {
         return lock
     }
 
+    // TODO: releaseLock and updateCache do similar things, how to improve
     async releaseLock() {
         await globals.globalState.update(this.key, {
             ...this.readCacheOrDefault(),

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -16,7 +16,7 @@ interface Resource<V> {
 
 // GlobalStates schema, which is used for vscode global states deserialization
 // [globals.globalState.tryGet<T>]
-interface GlobalStateSchema<V> {
+export interface GlobalStateSchema<V> {
     resource: Resource<V>
 }
 


### PR DESCRIPTION
## Problem
revision of #7134, this pr aims to address the comment from the previous PR https://github.com/aws/aws-toolkit-vscode/pull/7134#discussion_r2056518840 to extract the logic to a shared module so the diff against 7134 is expected to be large.


after deployment 4/21, service has a strict 1 tps throttling policy and there was no caching for the API call previously.
It will impact users as long as they have multiple ide instances opened as all of them will make list profile call while users attempt to sign in.

## Solution
1. cache the api result for 60 seconds for reuse 
2. use lock to prevent multiple instances trying to call at the same time. Only 1 will make the service call and the rest will wait until it's done and read from the cache.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
