### PR TITLE
feat(amazonq): update mynah version with no style loading option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11781,7 +11781,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.30.1",
+            "version": "4.30.3",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.30.3.tgz",
+            "integrity": "sha512-Xy22dzCaFUqpdSHMpLa8Dsq98DiAUq49dm7Iu8Yj2YZXSCyfKQiYMJOfwU8IoqeNcEney5JRMJpf+/RysWugbA==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {
@@ -26424,7 +26426,7 @@
                 "@aws-sdk/s3-request-presigner": "<3.731.0",
                 "@aws-sdk/smithy-client": "<3.731.0",
                 "@aws-sdk/util-arn-parser": "<3.731.0",
-                "@aws/mynah-ui": "^4.30.1",
+                "@aws/mynah-ui": "^4.30.3",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/fetch-http-handler": "^5.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -526,7 +526,7 @@
         "@aws-sdk/s3-request-presigner": "<3.731.0",
         "@aws-sdk/smithy-client": "<3.731.0",
         "@aws-sdk/util-arn-parser": "<3.731.0",
-        "@aws/mynah-ui": "^4.30.1",
+        "@aws/mynah-ui": "^4.30.3",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/fetch-http-handler": "^5.0.1",

--- a/packages/core/src/amazonq/webview/ui/main.ts
+++ b/packages/core/src/amazonq/webview/ui/main.ts
@@ -1017,7 +1017,7 @@ export class WebviewUIHandler {
              * when in hybrid chat the reference gets resolved later so we
              * don't need to create mynah UI
              */
-            this.mynahUIRef = { mynahUI: new MynahUI(this.mynahUIProps) }
+            this.mynahUIRef = { mynahUI: new MynahUI({ ...this.mynahUIProps, loadStyles: false }) }
         }
 
         /**


### PR DESCRIPTION
## Problem
- UI styles coming from flare and the local instance are conflictin.

## Solution
- Latest production version of mynah-ui has the ability to avoid loading styles. Bumped up mynah-ui version and set `loadStyles` to `false`.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
