### PR TITLE
telemetry(amazonq): bump aws-toolkit-common version to 1.0.317

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.316",
+                "@aws-toolkits/telemetry": "^1.0.317",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -10760,9 +10760,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.316",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.316.tgz",
-            "integrity": "sha512-zyzubs7fnCLPqdNtfHdmmNXVWrwIWJHIr6LJqdvUtNfdGmN8PWxq/NdBgCP9QcPVZusuK7SHha1knl8vhped/w==",
+            "version": "1.0.317",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.317.tgz",
+            "integrity": "sha512-QFLBFfHZjuB2pBd1p0Tn/GMKTYYQu3/nrlj0Co7EkqozvDNDG0nTjxtkXxotbwjrqVD5Sv8i46gEdgsyQ7at3w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.316",
+        "@aws-toolkits/telemetry": "^1.0.317",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -88,11 +88,6 @@
             "description": "CPU used by LSP server as a percentage of all available CPUs on the system"
         },
         {
-            "name": "cwsprChatResponseErrorReason",
-            "type": "string",
-            "description": "Client error reason when processing response stream"
-        },
-        {
             "name": "cwsprChatInteractionTarget",
             "type": "string",
             "description": "Identifies the entity within the message that user interacts with."
@@ -661,56 +656,6 @@
                 },
                 {
                     "type": "amazonqVectorIndexEnabled",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "amazonq_messageResponseError",
-            "description": "When an error has occured in response to a prompt",
-            "metadata": [
-                {
-                    "type": "cwsprChatConversationId",
-                    "required": false
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatTriggerInteraction"
-                },
-                {
-                    "type": "cwsprChatUserIntent",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatHasCodeSnippet",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatProgrammingLanguage",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatActiveEditorTotalCharacters",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatActiveEditorImportCount",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatResponseCode"
-                },
-                {
-                    "type": "cwsprChatRequestLength"
-                },
-                {
-                    "type": "cwsprChatConversationType"
-                },
-                {
-                    "type": "cwsprChatResponseErrorReason",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem
- toolkit commons needs to be updated so that certain telemetry events from flare have `languageServerVersion`

## Solution
- bump aws-toolkit-common version from 1.0.316 to 1.0.317
- proceeding toolkit common pr: https://github.com/aws/aws-toolkit-common/pull/1019

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
