### PR TITLE
fix(amazonq): accept empty body partial result. 

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -516,7 +516,7 @@ async function handlePartialResult<T extends ChatResult>(
             ? await decodeRequest<T>(partialResult, encryptionKey)
             : (partialResult as T)
 
-    if (decryptedMessage.body) {
+    if (decryptedMessage.body !== undefined) {
         void provider.webview?.postMessage({
             command: chatRequestType.method,
             params: decryptedMessage,


### PR DESCRIPTION
## Problem
If the server sends a partial result without a body, we currently ignore it. 

## Solution
- explicitly check for undefined. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
