### PR TITLE
fix(amazonq): Warn user Developer Profile not selected

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-489e72aa-bb0d-4964-bd84-002f25db6b5f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-489e72aa-bb0d-4964-bd84-002f25db6b5f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Toast message to warn users if Developer Profile is not selected"
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -131,6 +131,10 @@
                         "amazonQChatDisclaimer": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "amazonQSelectDeveloperProfile": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -380,6 +380,10 @@ export async function activate(context: ExtContext): Promise<void> {
                     await auth.notifySessionConfiguration()
                 }
             }
+
+            if (auth.requireProfileSelection()) {
+                await auth.notifySelectProfile()
+            }
         },
         { emit: false, functionId: { name: 'activateCwCore' } }
     )

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -95,6 +95,7 @@ import { SecurityIssueTreeViewProvider } from './service/securityIssueTreeViewPr
 import { setContext } from '../shared/vscode/setContext'
 import { syncSecurityIssueWebview } from './views/securityIssue/securityIssueWebview'
 import { detectCommentAboveLine } from '../shared/utilities/commentUtils'
+import { notifySelectDeveloperProfile } from './region/utils'
 
 let localize: nls.LocalizeFunc
 
@@ -382,7 +383,7 @@ export async function activate(context: ExtContext): Promise<void> {
             }
 
             if (auth.requireProfileSelection()) {
-                await auth.notifySelectProfile()
+                await notifySelectDeveloperProfile()
             }
         },
         { emit: false, functionId: { name: 'activateCwCore' } }

--- a/packages/core/src/codewhisperer/commands/types.ts
+++ b/packages/core/src/codewhisperer/commands/types.ts
@@ -18,6 +18,8 @@ export const firstStartUpSource = ExtStartUpSources.firstStartUp
 export const cwEllipsesMenu = 'ellipsesMenu'
 /** Indicates a CodeWhisperer command was executed from the command palette */
 export const commandPalette = 'commandPalette'
+/** Indicates a CodeWhisperer command was executed as a result of a toast message interaction */
+export const toastMessage = 'toastMessage'
 
 /**
  * Indicates what caused the CodeWhisperer command to be executed, since a command can be executed from different "sources"
@@ -35,3 +37,4 @@ export type CodeWhispererSource =
     | typeof firstStartUpSource
     | typeof cwEllipsesMenu
     | typeof commandPalette
+    | typeof toastMessage

--- a/packages/core/src/codewhisperer/region/utils.ts
+++ b/packages/core/src/codewhisperer/region/utils.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+import { AmazonQPromptSettings } from '../../shared/settings'
+import { telemetry } from '../../shared/telemetry/telemetry'
+import vscode from 'vscode'
+import { selectRegionProfileCommand } from '../commands/basicCommands'
+import { placeholder } from '../../shared/vscode/commands2'
+import { toastMessage } from '../commands/types'
+
+/**
+ * Creates a toast message telling the user they need to select a Developer Profile
+ */
+export async function notifySelectDeveloperProfile() {
+    const suppressId = 'amazonQSelectDeveloperProfile'
+    const settings = AmazonQPromptSettings.instance
+    const shouldShow = settings.isPromptEnabled(suppressId)
+    if (!shouldShow) {
+        return
+    }
+
+    const message = localize(
+        'aws.amazonq.profile.mustSelectMessage',
+        'You must select a Q Developer Profile for Amazon Q features to work.'
+    )
+    const selectProfile = 'Select Profile'
+    const dontShowAgain = 'Dont Show Again'
+
+    await telemetry.toolkit_showNotification.run(async () => {
+        telemetry.record({ id: 'mustSelectDeveloperProfileMessage' })
+        void vscode.window.showWarningMessage(message, selectProfile, dontShowAgain).then(async (resp) => {
+            await telemetry.toolkit_invokeAction.run(async () => {
+                if (resp === selectProfile) {
+                    // Show Profile
+                    telemetry.record({ action: 'select' })
+                    void selectRegionProfileCommand.execute(placeholder, toastMessage)
+                } else if (resp === dontShowAgain) {
+                    telemetry.record({ action: 'dontShowAgain' })
+                    await settings.disablePrompt(suppressId)
+                } else {
+                    telemetry.record({ action: 'ignore' })
+                }
+            })
+        })
+    })
+}

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -46,8 +46,7 @@ import { withTelemetryContext } from '../../shared/telemetry/util'
 import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
 import { throttle } from 'lodash'
 import { RegionProfileManager } from '../region/regionProfileManager'
-import { selectRegionProfileCommand } from '../commands/basicCommands'
-import { toastMessage } from '../commands/types'
+
 /** Backwards compatibility for connections w pre-chat scopes */
 export const codeWhispererCoreScopes = [...scopesCodeWhispererCore]
 export const codeWhispererChatScopes = [...codeWhispererCoreScopes, ...scopesCodeWhispererChat]
@@ -406,41 +405,6 @@ export class AuthUtil {
                         telemetry.record({ action: 'dismissSessionExtensionNotification' })
                     }
                     await settings.disablePrompt(suppressId)
-                })
-            })
-        })
-    }
-
-    /** Notify the user they need to select a Developer Profile */
-    public async notifySelectProfile() {
-        const suppressId = 'amazonQSelectDeveloperProfile'
-        const settings = AmazonQPromptSettings.instance
-        const shouldShow = settings.isPromptEnabled(suppressId)
-        if (!shouldShow) {
-            return
-        }
-
-        const message = localize(
-            'aws.amazonq.profile.mustSelectMessage',
-            'You must select a Q Developer Profile for Amazon Q features to work.'
-        )
-        const selectProfile = 'Select Profile'
-        const dontShowAgain = 'Dont Show Again'
-
-        await telemetry.toolkit_showNotification.run(async () => {
-            telemetry.record({ id: 'mustSelectDeveloperProfileMessage' })
-            void vscode.window.showWarningMessage(message, selectProfile, dontShowAgain).then(async (resp) => {
-                await telemetry.toolkit_invokeAction.run(async () => {
-                    if (resp === selectProfile) {
-                        // Show Profile
-                        telemetry.record({ action: 'select' })
-                        void selectRegionProfileCommand.execute(placeholder, toastMessage)
-                    } else if (resp === dontShowAgain) {
-                        telemetry.record({ action: 'dontShowAgain' })
-                        await settings.disablePrompt(suppressId)
-                    } else {
-                        telemetry.record({ action: 'ignore' })
-                    }
                 })
             })
         })

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -411,6 +411,7 @@ export class AuthUtil {
         })
     }
 
+    /** Notify the user they need to select a Developer Profile */
     public async notifySelectProfile() {
         const suppressId = 'amazonQSelectDeveloperProfile'
         const settings = AmazonQPromptSettings.instance
@@ -428,15 +429,17 @@ export class AuthUtil {
 
         await telemetry.toolkit_showNotification.run(async () => {
             telemetry.record({ id: 'mustSelectDeveloperProfileMessage' })
-            void vscode.window.showInformationMessage(message, selectProfile, dontShowAgain).then(async (resp) => {
+            void vscode.window.showWarningMessage(message, selectProfile, dontShowAgain).then(async (resp) => {
                 await telemetry.toolkit_invokeAction.run(async () => {
                     if (resp === selectProfile) {
                         // Show Profile
                         telemetry.record({ action: 'select' })
                         void selectRegionProfileCommand.execute(placeholder, toastMessage)
-                    } else {
-                        telemetry.record({ action: 'dismiss' })
+                    } else if (resp === dontShowAgain) {
+                        telemetry.record({ action: 'dontShowAgain' })
                         await settings.disablePrompt(suppressId)
+                    } else {
+                        telemetry.record({ action: 'ignore' })
                     }
                 })
             })

--- a/packages/core/src/shared/settings-amazonq.gen.ts
+++ b/packages/core/src/shared/settings-amazonq.gen.ts
@@ -21,7 +21,8 @@ export const amazonqSettings = {
         "ssoCacheError": {},
         "amazonQLspManifestMessage": {},
         "amazonQWorkspaceLspManifestMessage": {},
-        "amazonQChatDisclaimer": {}
+        "amazonQChatDisclaimer": {},
+        "amazonQSelectDeveloperProfile": {}
     },
     "amazonQ.showCodeWithReferences": {},
     "amazonQ.allowFeatureDevelopmentToRunCodeAndTests": {},


### PR DESCRIPTION
## Problem:

If a user has not selected Q Developer Profile after signing in, their features will not work.

Some existing users, before the introduction of Q Developer Profiles, who were already signed in had their features stop working because they didn't select a profile.

## Solution:

On startup if we detect the user did not select a profile, then send a warning message that their features will not work until they select one. The message will have a button to allow them to select a profile through quickpick, or entirly ignore the message and not show it again.

<img width="753" alt="Screenshot 2025-04-24 at 5 42 51 PM" src="https://github.com/user-attachments/assets/2429badf-8131-48f8-9ba9-ea81423c9c60" />



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
