### PR TITLE
fix(amazonq): handle response errors from lsp

### DIFF
--- a/packages/amazonq/src/lsp/chat/error.ts
+++ b/packages/amazonq/src/lsp/chat/error.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ChatResult } from '@aws/language-server-runtimes/protocol'
+import { ResponseError } from '@aws/language-server-runtimes/protocol'
+/**
+ * Perform a sanity check that the error we got from the LSP can be safely cast to the expected type.
+ * @param error
+ * @returns
+ */
+export function isValidResponseError(error: unknown): error is ResponseError<ChatResult> & { data: ChatResult } {
+    return (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        typeof error.code === 'number' &&
+        'message' in error &&
+        typeof error.message === 'string' &&
+        'data' in error &&
+        error.data !== undefined
+    )
+}

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -61,6 +61,7 @@ import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { amazonQDiffScheme, AmazonQPromptSettings, messages, openUrl } from 'aws-core-vscode/shared'
 import { DefaultAmazonQAppInitContext, messageDispatcher, EditorContentController } from 'aws-core-vscode/amazonq'
 import { telemetry, TelemetryBase } from 'aws-core-vscode/telemetry'
+import { isValidResponseError } from './error'
 
 export function registerLanguageServerEventListener(languageClient: LanguageClient, provider: AmazonQChatViewProvider) {
     languageClient.info(
@@ -552,23 +553,4 @@ async function resolveChatResponse(
         command: requestMethod,
         params: result,
     })
-}
-
-/**
- * Perform a sanity check that the error we got from the LSP can be safely cast to the expected type.
- * @param error
- * @returns
- */
-function isValidResponseError(error: unknown): error is ResponseError<ChatResult> & { data: ChatResult } {
-    return (
-        error instanceof ResponseError ||
-        (typeof error === 'object' &&
-            error !== null &&
-            'code' in error &&
-            typeof error.code === 'number' &&
-            'message' in error &&
-            typeof error.message === 'string' &&
-            'data' in error &&
-            error.data !== undefined)
-    )
 }

--- a/packages/amazonq/test/unit/amazonq/lsp/chat/error.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/chat/error.test.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isValidResponseError } from '../../../../../src/lsp/chat/error'
+import { ResponseError } from '@aws/language-server-runtimes/protocol'
+import * as assert from 'assert'
+
+describe('isValidResponseError', async function () {
+    it('requires the data field', function () {
+        assert.ok(isValidResponseError(new ResponseError(0, 'this one has data', {})))
+        assert.ok(!isValidResponseError(new ResponseError(0, 'this one does not have data')))
+    })
+})


### PR DESCRIPTION
## Problem
Response errors returned by the LSP are returned to chat after prepending a custom error message. We can remove this custom error message and rely on flare for a single implementation of this error message. 


## Solution
- perform a sanity check on the response before casting it to the proper type. 
- log the last result from the language server to help debug. 
- include the requestId clearly in the logs. 

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/fd71ed26-7266-47ee-9204-c1ec412ca452" />



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
