### PR TITLE
feat(amazonq): support multiple uri in a single diff scheme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10829,9 +10829,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.22",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.22.tgz",
-            "integrity": "sha512-cyNrq6TqCcD9+vYUvvXJ5EJzfB4DrLtDBzBXgv/4zPIMRH0YwGEsRZLzPDwCPCxuZ5kGlal3GlBMkLkMCRGPdQ==",
+            "version": "0.1.26",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.26.tgz",
+            "integrity": "sha512-c63rpUbcrtLqaC33t6elRApQqLbQvFgKzIQ2z/VCavE5F7HSLBfzhHkhgUFd775fBpsF4MHrIzwNitYLhDGobw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -26484,7 +26484,7 @@
                 "@aws/chat-client": "^0.1.4",
                 "@aws/chat-client-ui-types": "^0.1.24",
                 "@aws/language-server-runtimes": "^0.2.70",
-                "@aws/language-server-runtimes-types": "^0.1.21",
+                "@aws/language-server-runtimes-types": "^0.1.26",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -59,7 +59,12 @@ import * as jose from 'jose'
 import { AmazonQChatViewProvider } from './webviewProvider'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { amazonQDiffScheme, AmazonQPromptSettings, messages, openUrl } from 'aws-core-vscode/shared'
-import { DefaultAmazonQAppInitContext, messageDispatcher, EditorContentController } from 'aws-core-vscode/amazonq'
+import {
+    DefaultAmazonQAppInitContext,
+    messageDispatcher,
+    EditorContentController,
+    ViewDiffMessage,
+} from 'aws-core-vscode/amazonq'
 import { telemetry, TelemetryBase } from 'aws-core-vscode/telemetry'
 
 export function registerLanguageServerEventListener(languageClient: LanguageClient, provider: AmazonQChatViewProvider) {
@@ -454,17 +459,24 @@ export function registerMessageListeners(
             new vscode.Position(0, 0),
             new vscode.Position(doc.lineCount - 1, doc.lineAt(doc.lineCount - 1).text.length)
         )
-        await ecc.viewDiff(
-            {
-                context: {
-                    activeFileContext: { filePath: params.originalFileUri },
-                    focusAreaContext: { selectionInsideExtendedCodeBlock: entireDocumentSelection },
+        const viewDiffMessage: ViewDiffMessage = {
+            context: {
+                activeFileContext: {
+                    filePath: params.originalFileUri,
+                    fileText: params.originalFileContent ?? '',
+                    fileLanguage: undefined,
+                    matchPolicy: undefined,
                 },
-                code: params.fileContent ?? '',
+                focusAreaContext: {
+                    selectionInsideExtendedCodeBlock: entireDocumentSelection,
+                    codeBlock: '',
+                    extendedCodeBlock: '',
+                    names: undefined,
+                },
             },
-            amazonQDiffScheme,
-            true
-        )
+            code: params.fileContent ?? '',
+        }
+        await ecc.viewDiff(viewDiffMessage, amazonQDiffScheme)
     })
 
     languageClient.onNotification(chatUpdateNotificationType.method, (params: ChatUpdateParams) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -444,7 +444,7 @@
         "@aws/chat-client": "^0.1.4",
         "@aws/chat-client-ui-types": "^0.1.24",
         "@aws/language-server-runtimes": "^0.2.70",
-        "@aws/language-server-runtimes-types": "^0.1.21",
+        "@aws/language-server-runtimes-types": "^0.1.26",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",

--- a/packages/core/src/amazonq/commons/controllers/contentController.ts
+++ b/packages/core/src/amazonq/commons/controllers/contentController.ts
@@ -11,7 +11,7 @@ import { amazonQDiffScheme, amazonQTabSuffix } from '../../../shared/constants'
 import { disposeOnEditorClose } from '../../../shared/utilities/editorUtilities'
 import {
     applyChanges,
-    createTempFileForDiff,
+    createTempUrisForDiff,
     getIndentedCode,
     getSelectionFromRange,
 } from '../../../shared/utilities/textDocumentUtilities'
@@ -19,6 +19,11 @@ import { ToolkitError, getErrorMsg } from '../../../shared/errors'
 import fs from '../../../shared/fs/fs'
 import { extractFileAndCodeSelectionFromMessage } from '../../../shared/utilities/textUtilities'
 import { UserWrittenCodeTracker } from '../../../codewhisperer/tracker/userWrittenCodeTracker'
+import type { ViewDiff } from '../../../codewhispererChat/controllers/chat/model'
+import type { TriggerEvent } from '../../../codewhispererChat/storages/triggerEvents'
+import { DiffContentProvider } from './diffContentProvider'
+
+export type ViewDiffMessage = Pick<ViewDiff, 'code'> & Partial<Pick<TriggerEvent, 'context'>>
 
 export class ContentProvider implements vscode.TextDocumentContentProvider {
     constructor(private uri: vscode.Uri) {}
@@ -155,26 +160,35 @@ export class EditorContentController {
      * isolating them from any other modifications in the original file.
      *
      * @param message the message from Amazon Q chat
+     * @param scheme the URI scheme to use for the diff view
      */
-    public async viewDiff(message: any, scheme: string = amazonQDiffScheme, reverseOrder = false) {
+    public async viewDiff(message: ViewDiffMessage, scheme: string = amazonQDiffScheme) {
         const errorNotification = 'Unable to Open Diff.'
-        const { filePath, selection } = extractFileAndCodeSelectionFromMessage(message)
+        const { filePath, fileText, selection } = extractFileAndCodeSelectionFromMessage(message)
 
         try {
             if (filePath && message?.code !== undefined && selection) {
-                const originalFileUri = vscode.Uri.file(filePath)
-                const uri = await createTempFileForDiff(originalFileUri, message, selection, scheme)
-
                 // Register content provider and show diff
-                const contentProvider = new ContentProvider(uri)
+                const contentProvider = new DiffContentProvider()
                 const disposable = vscode.workspace.registerTextDocumentContentProvider(scheme, contentProvider)
+
+                const [originalFileUri, modifiedFileUri] = await createTempUrisForDiff(
+                    filePath,
+                    fileText,
+                    message,
+                    selection,
+                    scheme,
+                    contentProvider
+                )
+
                 await vscode.commands.executeCommand(
                     'vscode.diff',
-                    ...(reverseOrder ? [uri, originalFileUri] : [originalFileUri, uri]),
+                    originalFileUri,
+                    modifiedFileUri,
                     `${path.basename(filePath)} ${amazonQTabSuffix}`
                 )
 
-                disposeOnEditorClose(uri, disposable)
+                disposeOnEditorClose(originalFileUri, disposable)
             }
         } catch (error) {
             void vscode.window.showInformationMessage(errorNotification)

--- a/packages/core/src/amazonq/commons/controllers/diffContentProvider.ts
+++ b/packages/core/src/amazonq/commons/controllers/diffContentProvider.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import vscode from 'vscode'
+import { getLogger } from '../../../shared/logger/logger'
+
+/**
+ * A TextDocumentContentProvider that can handle multiple URIs with the same scheme.
+ * This provider maintains a mapping of URIs to their content.
+ */
+export class DiffContentProvider implements vscode.TextDocumentContentProvider {
+    private contentMap = new Map<string, string>()
+    private _onDidChange = new vscode.EventEmitter<vscode.Uri>()
+
+    public readonly onDidChange = this._onDidChange.event
+
+    /**
+     * Register content for a specific URI
+     * @param uri The URI to register content for
+     * @param content The content to serve for this URI
+     */
+    public registerContent(uri: vscode.Uri, content: string): void {
+        this.contentMap.set(uri.toString(), content)
+        this._onDidChange.fire(uri)
+    }
+
+    /**
+     * Unregister a URI
+     * @param uri The URI to unregister
+     */
+    public unregisterUri(uri: vscode.Uri): void {
+        this.contentMap.delete(uri.toString())
+    }
+
+    /**
+     * Provides the content for a given URI
+     * @param uri The URI to provide content for
+     * @returns The content as a string
+     */
+    public provideTextDocumentContent(uri: vscode.Uri): string {
+        const content = this.contentMap.get(uri.toString())
+
+        if (content === undefined) {
+            getLogger().warn('No content registered for URI: %s', uri.toString())
+            return ''
+        }
+
+        return content
+    }
+}

--- a/packages/core/src/amazonq/index.ts
+++ b/packages/core/src/amazonq/index.ts
@@ -47,7 +47,7 @@ export * as authConnection from '../auth/connection'
 export * as featureConfig from './webview/generators/featureConfig'
 export * as messageDispatcher from './webview/messages/messageDispatcher'
 import { FeatureContext } from '../shared/featureConfig'
-export { EditorContentController } from './commons/controllers/contentController'
+export { EditorContentController, ViewDiffMessage } from './commons/controllers/contentController'
 
 /**
  * main from createMynahUI is a purely browser dependency. Due to this

--- a/packages/core/src/shared/utilities/textUtilities.ts
+++ b/packages/core/src/shared/utilities/textUtilities.ts
@@ -8,6 +8,7 @@ import * as crypto from 'crypto'
 import * as fs from 'fs' // eslint-disable-line no-restricted-imports
 import { default as stripAnsi } from 'strip-ansi'
 import { getLogger } from '../logger/logger'
+import { ViewDiffMessage } from '../../amazonq/commons/controllers/contentController'
 
 /**
  * Truncates string `s` if it exceeds `n` chars.
@@ -268,10 +269,11 @@ export function decodeBase64(base64Str: string): string {
  * @param {any} message - The message object containing the file and selection context.
  * @returns {Object} - An object with `filePath` and `selection` properties.
  */
-export function extractFileAndCodeSelectionFromMessage(message: any) {
+export function extractFileAndCodeSelectionFromMessage(message: ViewDiffMessage) {
     const filePath = message?.context?.activeFileContext?.filePath
+    const fileText = message?.context?.activeFileContext?.fileText
     const selection = message?.context?.focusAreaContext?.selectionInsideExtendedCodeBlock as vscode.Selection
-    return { filePath, selection }
+    return { filePath, fileText, selection }
 }
 
 export function matchesPattern(source: string, target: string | RegExp) {

--- a/packages/core/src/test/amazonq/commons/controllers/contentController.test.ts
+++ b/packages/core/src/test/amazonq/commons/controllers/contentController.test.ts
@@ -1,0 +1,143 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as sinon from 'sinon'
+import assert from 'assert'
+import { EditorContentController, ViewDiffMessage } from '../../../../amazonq/commons/controllers/contentController'
+import * as textDocumentUtilities from '../../../../shared/utilities/textDocumentUtilities'
+import * as textUtilities from '../../../../shared/utilities/textUtilities'
+import { amazonQDiffScheme, amazonQTabSuffix } from '../../../../shared/constants'
+import * as editorUtilities from '../../../../shared/utilities/editorUtilities'
+
+describe('EditorContentController', () => {
+    let sandbox: sinon.SinonSandbox
+    let controller: EditorContentController
+    let executeCommandStub: sinon.SinonStub
+    let registerTextDocumentContentProviderStub: sinon.SinonStub
+    let createTempUrisForDiffStub: sinon.SinonStub
+    let disposeOnEditorCloseStub: sinon.SinonStub
+    let extractParamsFromMessageStub: sinon.SinonStub
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+        controller = new EditorContentController()
+
+        // Stub VS Code API calls
+        executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves()
+        registerTextDocumentContentProviderStub = sandbox
+            .stub(vscode.workspace, 'registerTextDocumentContentProvider')
+            .returns({ dispose: () => {} })
+
+        // Stub utility functions
+        createTempUrisForDiffStub = sandbox.stub(textDocumentUtilities, 'createTempUrisForDiff')
+        disposeOnEditorCloseStub = sandbox.stub(editorUtilities, 'disposeOnEditorClose')
+        extractParamsFromMessageStub = sandbox.stub(textUtilities, 'extractFileAndCodeSelectionFromMessage')
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    describe('viewDiff', () => {
+        const testFilePath = '/path/to/testFile.js'
+        const testCode = 'new code'
+        const testSelection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(2, 0))
+        const testMessage: ViewDiffMessage = {
+            code: testCode,
+        }
+        const originalUri = vscode.Uri.parse('test-scheme:/original/testFile.js')
+        const modifiedUri = vscode.Uri.parse('test-scheme:/modified/testFile.js')
+
+        beforeEach(() => {
+            extractParamsFromMessageStub.returns({
+                filePath: testFilePath,
+                selection: testSelection,
+            })
+            createTempUrisForDiffStub.resolves([originalUri, modifiedUri])
+        })
+
+        it('should show diff view with correct URIs and title', async () => {
+            await controller.viewDiff(testMessage)
+
+            // Verify content provider was registered
+            assert.strictEqual(registerTextDocumentContentProviderStub.calledOnce, true)
+            assert.strictEqual(registerTextDocumentContentProviderStub.firstCall.args[0], amazonQDiffScheme)
+
+            // Verify createTempUrisForDiff was called with correct parameters
+            assert.strictEqual(createTempUrisForDiffStub.calledOnce, true)
+            assert.strictEqual(createTempUrisForDiffStub.firstCall.args[0], testFilePath)
+            assert.strictEqual(createTempUrisForDiffStub.firstCall.args[2], testMessage)
+            assert.strictEqual(createTempUrisForDiffStub.firstCall.args[3], testSelection)
+            assert.strictEqual(createTempUrisForDiffStub.firstCall.args[4], amazonQDiffScheme)
+
+            // Verify vscode.diff command was executed with correct parameters
+            assert.strictEqual(executeCommandStub.calledOnce, true)
+            assert.strictEqual(executeCommandStub.firstCall.args[0], 'vscode.diff')
+            assert.strictEqual(executeCommandStub.firstCall.args[1], originalUri)
+            assert.strictEqual(executeCommandStub.firstCall.args[2], modifiedUri)
+            assert.strictEqual(executeCommandStub.firstCall.args[3], `testFile.js ${amazonQTabSuffix}`)
+
+            // Verify disposeOnEditorClose was called
+            assert.strictEqual(disposeOnEditorCloseStub.calledOnce, true)
+            assert.strictEqual(disposeOnEditorCloseStub.firstCall.args[0], originalUri)
+        })
+
+        it('should use custom scheme when provided', async () => {
+            const customScheme = 'custom-scheme'
+            await controller.viewDiff(testMessage, customScheme)
+
+            assert.strictEqual(registerTextDocumentContentProviderStub.firstCall.args[0], customScheme)
+            assert.strictEqual(createTempUrisForDiffStub.firstCall.args[4], customScheme)
+        })
+
+        it('should pass fileText to createTempUrisForDiff when available', async () => {
+            const testFileText = 'original file content'
+            extractParamsFromMessageStub.returns({
+                filePath: testFilePath,
+                fileText: testFileText,
+                selection: testSelection,
+            })
+
+            await controller.viewDiff(testMessage)
+
+            assert.strictEqual(createTempUrisForDiffStub.firstCall.args[1], testFileText)
+        })
+
+        it('should not attempt to show diff when filePath is missing', async () => {
+            extractParamsFromMessageStub.returns({
+                filePath: undefined,
+                selection: testSelection,
+            })
+
+            await controller.viewDiff(testMessage)
+
+            assert.strictEqual(registerTextDocumentContentProviderStub.called, false)
+            assert.strictEqual(createTempUrisForDiffStub.called, false)
+            assert.strictEqual(executeCommandStub.called, false)
+        })
+
+        it('should not attempt to show diff when code is missing', async () => {
+            await controller.viewDiff({ code: undefined as unknown as string })
+
+            assert.strictEqual(registerTextDocumentContentProviderStub.called, false)
+            assert.strictEqual(createTempUrisForDiffStub.called, false)
+            assert.strictEqual(executeCommandStub.called, false)
+        })
+
+        it('should not attempt to show diff when selection is missing', async () => {
+            extractParamsFromMessageStub.returns({
+                filePath: testFilePath,
+                selection: undefined,
+            })
+
+            await controller.viewDiff(testMessage)
+
+            assert.strictEqual(registerTextDocumentContentProviderStub.called, false)
+            assert.strictEqual(createTempUrisForDiffStub.called, false)
+            assert.strictEqual(executeCommandStub.called, false)
+        })
+    })
+})

--- a/packages/core/src/test/shared/utilities/textDocumentUtilities.test.ts
+++ b/packages/core/src/test/shared/utilities/textDocumentUtilities.test.ts
@@ -1,0 +1,140 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as sinon from 'sinon'
+import assert from 'assert'
+import { createTempUrisForDiff } from '../../../shared/utilities/textDocumentUtilities'
+import { DiffContentProvider } from '../../../amazonq/commons/controllers/diffContentProvider'
+import fs from '../../../shared/fs/fs'
+
+describe('textDocumentUtilities', () => {
+    let sandbox: sinon.SinonSandbox
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    describe('createTempUrisForDiff', () => {
+        const testScheme = 'test-scheme'
+        const testFilePath = '/path/to/testFile.js'
+        const testFileContent = 'line 1\nline 2\nline 3\nline 4\nline 5'
+        const testMessage = {
+            code: 'new line 3',
+        }
+        const testSelection = new vscode.Selection(
+            new vscode.Position(2, 0), // Start at line 3 (index 2)
+            new vscode.Position(2, 6) // End at line 3 (index 2)
+        )
+
+        let diffProvider: DiffContentProvider
+        let fsReadFileTextStub: sinon.SinonStub
+
+        beforeEach(() => {
+            diffProvider = new DiffContentProvider()
+            sandbox.stub(diffProvider, 'registerContent')
+            fsReadFileTextStub = sandbox.stub(fs, 'readFileText').resolves(testFileContent)
+        })
+
+        it('should create URIs with the correct scheme and file name', async () => {
+            const [originalUri, modifiedUri] = await createTempUrisForDiff(
+                testFilePath,
+                undefined,
+                testMessage,
+                testSelection,
+                testScheme,
+                diffProvider
+            )
+
+            assert.strictEqual(originalUri.scheme, testScheme)
+            assert.strictEqual(modifiedUri.scheme, testScheme)
+            assert.ok(originalUri.path.includes('testFile_original-'))
+            assert.ok(modifiedUri.path.includes('testFile_proposed-'))
+        })
+
+        it('should use provided fileText instead of reading from file when available', async () => {
+            const providedFileText = 'provided line 1\nprovided line 2\nprovided line 3'
+
+            await createTempUrisForDiff(
+                testFilePath,
+                providedFileText,
+                testMessage,
+                testSelection,
+                testScheme,
+                diffProvider
+            )
+
+            // Verify fs.readFileText was not called
+            assert.strictEqual(fsReadFileTextStub.called, false)
+
+            // Verify the diffProvider was called with the provided content
+            const registerContentCalls = (diffProvider.registerContent as sinon.SinonStub).getCalls()
+            assert.strictEqual(registerContentCalls.length, 2)
+            assert.strictEqual(registerContentCalls[0].args[1], providedFileText)
+        })
+
+        it('should read from file when fileText is not provided', async () => {
+            await createTempUrisForDiff(testFilePath, undefined, testMessage, testSelection, testScheme, diffProvider)
+
+            // Verify fs.readFileText was called with the correct path
+            assert.strictEqual(fsReadFileTextStub.calledWith(testFilePath), true)
+
+            // Verify the diffProvider was called with the file content
+            const registerContentCalls = (diffProvider.registerContent as sinon.SinonStub).getCalls()
+            assert.strictEqual(registerContentCalls.length, 2)
+            assert.strictEqual(registerContentCalls[0].args[1], testFileContent)
+        })
+
+        it('should create modified content by replacing the selected lines', async () => {
+            await createTempUrisForDiff(
+                testFilePath,
+                testFileContent,
+                testMessage,
+                testSelection,
+                testScheme,
+                diffProvider
+            )
+
+            // Verify the diffProvider was called with the correct modified content
+            const registerContentCalls = (diffProvider.registerContent as sinon.SinonStub).getCalls()
+            assert.strictEqual(registerContentCalls.length, 2)
+
+            // First call is for original content
+            assert.strictEqual(registerContentCalls[0].args[1], testFileContent)
+
+            // Second call is for modified content
+            const expectedModifiedContent = 'line 1\nline 2\nnew line 3\nline 4\nline 5'
+            assert.strictEqual(registerContentCalls[1].args[1], expectedModifiedContent)
+        })
+
+        it('should handle multi-line selections correctly', async () => {
+            // Selection spanning multiple lines (lines 2-4)
+            const multiLineSelection = new vscode.Selection(
+                new vscode.Position(1, 0), // Start at line 2 (index 1)
+                new vscode.Position(3, 6) // End at line 4 (index 3)
+            )
+
+            await createTempUrisForDiff(
+                testFilePath,
+                testFileContent,
+                testMessage,
+                multiLineSelection,
+                testScheme,
+                diffProvider
+            )
+
+            // Verify the diffProvider was called with the correct modified content
+            const registerContentCalls = (diffProvider.registerContent as sinon.SinonStub).getCalls()
+
+            // Expected content should have lines 2-4 replaced with the new code
+            const expectedModifiedContent = 'line 1\nnew line 3\nline 5'
+            assert.strictEqual(registerContentCalls[1].args[1], expectedModifiedContent)
+        })
+    })
+})


### PR DESCRIPTION
## Problem
The current viewDiff implementation is restricted to only allowing comparing the current file contents. This means it's not possible to view a diff for a change that was applied at a previous point in time.

## Solution
- Create a new `DiffContentProvider` that can support showing multiple URIs in the same scheme. The current `ContentProvider` has a limitation that it can only show a single URI. 
- Refactor the code to use a defined type `ViewDiffMessage` instead of `any`
- Change the logic so that diffs are stored in memory instead of a temp file on disk

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
