### PR TITLE
fix(amazonq): handle explain, refactor, fix, optimize, sendToPrompt

### DIFF
--- a/packages/amazonq/src/lsp/chat/commands.ts
+++ b/packages/amazonq/src/lsp/chat/commands.ts
@@ -4,7 +4,7 @@
  */
 
 import { Commands, globals } from 'aws-core-vscode/shared'
-// import { window } from 'vscode'
+import { window } from 'vscode'
 import { AmazonQChatViewProvider } from './webviewProvider'
 
 /**
@@ -13,21 +13,21 @@ import { AmazonQChatViewProvider } from './webviewProvider'
  */
 export function registerCommands(provider: AmazonQChatViewProvider) {
     globals.context.subscriptions.push(
-        // registerGenericCommand('aws.amazonq.explainCode', 'Explain', provider),
-        // registerGenericCommand('aws.amazonq.refactorCode', 'Refactor', provider),
-        // registerGenericCommand('aws.amazonq.fixCode', 'Fix', provider),
-        // registerGenericCommand('aws.amazonq.optimizeCode', 'Optimize', provider),
-        // Commands.register('aws.amazonq.sendToPrompt', (data) => {
-        //     const triggerType = getCommandTriggerType(data)
-        //     const selection = getSelectedText()
+        registerGenericCommand('aws.amazonq.explainCode', 'Explain', provider),
+        registerGenericCommand('aws.amazonq.refactorCode', 'Refactor', provider),
+        registerGenericCommand('aws.amazonq.fixCode', 'Fix', provider),
+        registerGenericCommand('aws.amazonq.optimizeCode', 'Optimize', provider),
+        Commands.register('aws.amazonq.sendToPrompt', (data) => {
+            const triggerType = getCommandTriggerType(data)
+            const selection = getSelectedText()
 
-        //     void focusAmazonQPanel().then(() => {
-        //         void provider.webview?.postMessage({
-        //             command: 'sendToPrompt',
-        //             params: { selection: selection, triggerType },
-        //         })
-        //     })
-        // }),
+            void focusAmazonQPanel().then(() => {
+                void provider.webview?.postMessage({
+                    command: 'sendToPrompt',
+                    params: { selection: selection, triggerType },
+                })
+            })
+        }),
         Commands.register('aws.amazonq.openTab', () => {
             void focusAmazonQPanel().then(() => {
                 void provider.webview?.postMessage({
@@ -39,36 +39,36 @@ export function registerCommands(provider: AmazonQChatViewProvider) {
     )
 }
 
-// function getSelectedText(): string {
-//     const editor = window.activeTextEditor
-//     if (editor) {
-//         const selection = editor.selection
-//         const selectedText = editor.document.getText(selection)
-//         return selectedText
-//     }
+function getSelectedText(): string {
+    const editor = window.activeTextEditor
+    if (editor) {
+        const selection = editor.selection
+        const selectedText = editor.document.getText(selection)
+        return selectedText
+    }
 
-//     return ' '
-// }
+    return ' '
+}
 
-// function getCommandTriggerType(data: any): string {
-//     // data is undefined when commands triggered from keybinding or command palette. Currently no
-//     // way to differentiate keybinding and command palette, so both interactions are recorded as keybinding
-//     return data === undefined ? 'hotkeys' : 'contextMenu'
-// }
+function getCommandTriggerType(data: any): string {
+    // data is undefined when commands triggered from keybinding or command palette. Currently no
+    // way to differentiate keybinding and command palette, so both interactions are recorded as keybinding
+    return data === undefined ? 'hotkeys' : 'contextMenu'
+}
 
-// function registerGenericCommand(commandName: string, genericCommand: string, provider: AmazonQChatViewProvider) {
-//     return Commands.register(commandName, (data) => {
-//         const triggerType = getCommandTriggerType(data)
-//         const selection = getSelectedText()
+function registerGenericCommand(commandName: string, genericCommand: string, provider: AmazonQChatViewProvider) {
+    return Commands.register(commandName, (data) => {
+        const triggerType = getCommandTriggerType(data)
+        const selection = getSelectedText()
 
-//         void focusAmazonQPanel().then(() => {
-//             void provider.webview?.postMessage({
-//                 command: 'genericCommand',
-//                 params: { genericCommand, selection, triggerType },
-//             })
-//         })
-//     })
-// }
+        void focusAmazonQPanel().then(() => {
+            void provider.webview?.postMessage({
+                command: 'genericCommand',
+                params: { genericCommand, selection, triggerType },
+            })
+        })
+    })
+}
 
 /**
  * Importing focusAmazonQPanel from aws-core-vscode/amazonq leads to several dependencies down the chain not resolving since AmazonQ chat

--- a/packages/core/src/codewhispererChat/app.ts
+++ b/packages/core/src/codewhispererChat/app.ts
@@ -236,5 +236,5 @@ export function init(appContext: AmazonQAppInitContext) {
 
     appContext.registerWebViewToAppMessagePublisher(new MessagePublisher<any>(cwChatUIInputEventEmitter), 'cwc')
 
-    registerCommands(cwChatControllerMessagePublishers)
+    registerCommands()
 }

--- a/packages/core/src/codewhispererChat/commands/registerCommands.ts
+++ b/packages/core/src/codewhispererChat/commands/registerCommands.ts
@@ -6,7 +6,6 @@
 import { commandPalette } from '../../codewhisperer/commands/types'
 import { CodeScanIssue } from '../../codewhisperer/models/model'
 import { Commands, VsCodeCommandArg, placeholder } from '../../shared/vscode/commands2'
-import { ChatControllerMessagePublishers } from '../controllers/chat/controller'
 
 /**
  * Opens the Amazon Q panel, showing the correct View that should
@@ -37,73 +36,13 @@ export const focusAmazonQPanelKeybinding = Commands.declare('_aws.amazonq.focusC
     await focusAmazonQPanel.execute(placeholder, 'keybinding')
 })
 
-const getCommandTriggerType = (data: any): EditorContextCommandTriggerType => {
-    // data is undefined when commands triggered from keybinding or command palette. Currently no
-    // way to differentiate keybinding and command palette, so both interactions are recorded as keybinding
-    return data === undefined ? 'keybinding' : 'contextMenu'
-}
-
-export function registerCommands(controllerPublishers: ChatControllerMessagePublishers) {
-    Commands.register('aws.amazonq.explainCode', async (data) => {
-        return focusAmazonQPanel.execute(placeholder, 'amazonq.explainCode').then(() => {
-            controllerPublishers.processContextMenuCommand.publish({
-                type: 'aws.amazonq.explainCode',
-                triggerType: getCommandTriggerType(data),
-            })
-        })
-    })
-    Commands.register('aws.amazonq.refactorCode', async (data) => {
-        return focusAmazonQPanel.execute(placeholder, 'amazonq.refactorCode').then(() => {
-            controllerPublishers.processContextMenuCommand.publish({
-                type: 'aws.amazonq.refactorCode',
-                triggerType: getCommandTriggerType(data),
-            })
-        })
-    })
-    Commands.register('aws.amazonq.fixCode', async (data) => {
-        return focusAmazonQPanel.execute(placeholder, 'amazonq.fixCode').then(() => {
-            controllerPublishers.processContextMenuCommand.publish({
-                type: 'aws.amazonq.fixCode',
-                triggerType: getCommandTriggerType(data),
-            })
-        })
-    })
-    Commands.register('aws.amazonq.optimizeCode', async (data) => {
-        return focusAmazonQPanel.execute(placeholder, 'amazonq.optimizeCode').then(() => {
-            controllerPublishers.processContextMenuCommand.publish({
-                type: 'aws.amazonq.optimizeCode',
-                triggerType: getCommandTriggerType(data),
-            })
-        })
-    })
-    Commands.register('aws.amazonq.sendToPrompt', async (data) => {
-        return focusAmazonQPanel.execute(placeholder, 'amazonq.sendToPrompt').then(() => {
-            controllerPublishers.processContextMenuCommand.publish({
-                type: 'aws.amazonq.sendToPrompt',
-                triggerType: getCommandTriggerType(data),
-            })
-        })
-    })
-    Commands.register('aws.amazonq.explainIssue', async (issue) => {
-        return focusAmazonQPanel.execute(placeholder, 'amazonq.explainIssue').then(() => {
-            controllerPublishers.processContextMenuCommand.publish({
-                type: 'aws.amazonq.explainIssue',
-                triggerType: 'click',
-                issue,
-            })
-        })
-    })
-    Commands.register('aws.amazonq.generateUnitTests', async (data) => {
-        return focusAmazonQPanel.execute(placeholder, 'amazonq.generateUnitTests').then(() => {
-            controllerPublishers.processContextMenuCommand.publish({
-                type: 'aws.amazonq.generateUnitTests',
-                triggerType: getCommandTriggerType(data),
-            })
-        })
-    })
-    Commands.register('aws.amazonq.updateContextCommandItems', () => {
-        controllerPublishers.processContextCommandUpdateMessage.publish()
-    })
+export function registerCommands() {
+    /**
+     * make these no-ops, since theres still callers that need to be deprecated
+     */
+    Commands.register('aws.amazonq.explainIssue', async (issue) => {})
+    Commands.register('aws.amazonq.generateUnitTests', async (data) => {})
+    Commands.register('aws.amazonq.updateContextCommandItems', () => {})
 }
 
 export type EditorContextBaseCommandType =


### PR DESCRIPTION
## Problem
explain, refactor, fix, optimize right click menus aren't working

## Solution
re-enable them through flare's genericCommand message

## TODO
- handle generateUnitTests
- handle explainIssue
both of these need flare API changes to send generic prompts from the frontend to the backend

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
