### PR TITLE
test: hang in "Linked Connections"

### DIFF
--- a/packages/core/src/test/credentials/auth.test.ts
+++ b/packages/core/src/test/credentials/auth.test.ts
@@ -350,7 +350,7 @@ describe('Auth', function () {
         })
     })
 
-    describe('Linked Connections', function () {
+    describe.skip('Linked Connections', function () {
         const linkedSsoProfile = createSsoProfile({ scopes: scopesSsoAccountAccess })
         const accountRoles = [
             { accountId: '1245678910', roleName: 'foo' },
@@ -393,7 +393,7 @@ describe('Auth', function () {
             )
         })
 
-        it('shows a user message if SSO connection returned no accounts/roles', async function () {
+        it.skip('shows a user message if SSO connection returned no accounts/roles', async function () {
             auth.ssoClient.listAccounts.returns(
                 toCollection(async function* () {
                     yield []


### PR DESCRIPTION
CI logs stop after:

```
Linked Connections
--
2067 | ✔ lists linked conections for SSO connections
```


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
