### PR TITLE
feat(amazonq): add setting to configure lsp log level (WIP)

### DIFF
--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DevSettings, getServiceEnvVarConfig } from 'aws-core-vscode/shared'
+import { DevSettings, getServiceEnvVarConfig, Settings } from 'aws-core-vscode/shared'
 import { LspConfig } from 'aws-core-vscode/amazonq'
 
 export interface ExtendedAmazonQLSPConfig extends LspConfig {
@@ -24,5 +24,18 @@ export function getAmazonQLspConfig(): ExtendedAmazonQLSPConfig {
         ...defaultAmazonQLspConfig,
         ...(DevSettings.instance.getServiceConfig('amazonqLsp', {}) as ExtendedAmazonQLSPConfig),
         ...getServiceEnvVarConfig('amazonqLsp', Object.keys(defaultAmazonQLspConfig)),
+    }
+}
+
+// TODO: expose lsp logging settings to users
+// trace.server -> pipe LSP logs to seperate output channel.
+// lsp.logLevel -> log level to pass to the lsp.
+export function getLspLogLevel(clientId: string) {
+    const traceServerSetting = `${clientId}.trace.server`
+    const lspLogLevelSetting = `${clientId}.lsp.logLevel`
+
+    return {
+        seperateTraceChannel: Settings.instance.get(traceServerSetting),
+        lspLogLevel: Settings.instance.get(lspLogLevelSetting, String, 'info'),
     }
 }


### PR DESCRIPTION
## Problem
We don't pass log level to the LSP, meaning it always defaults to info. 

## Solution
- add a setting `amazonq.lsp.logLevel` to allow this to be configured. The allowed options are listed here: https://github.com/aws/language-server-runtimes/blob/eae85672c345d8adaf4c8cbd741260b8a59750c4/runtimes/runtimes/util/loggingUtil.ts#L4. 
- These means are are two settings:
   - `.trace.server` sends amazonq logs to a separate channel. 
   - `.lsp.logLevel` determines which level these should be logged at. 

## Future Work
- We will eventually want to expose these settings to the user. But this isn't needed until this is no longer hidden behind a feature flag. 
- The log messages in the `Amazon Q Logs` show `info` from the LSP even when they are `debug`, more investigation needed here. 


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
