### PR TITLE
fix(resourceCache): patch #7151

### DIFF
--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -143,9 +143,8 @@ export class AuthUtil {
 
             if (!this.isConnected()) {
                 await this.regionProfileManager.invalidateProfile(this.regionProfileManager.activeRegionProfile?.arn)
+                await this.regionProfileManager.clearCache()
             }
-
-            await this.regionProfileManager.clearCache()
         })
 
         this.regionProfileManager.onDidChangeRegionProfile(async () => {


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/pull/7151/commits/97a44821ee9bb65cdc737011e81dc6e87ab23136

this commit breaks the cache by resetting the flag/lock on connection changed. When users sign in and have multiple VSCode instances, all windows will get a `onConnectionChanged` hence overwrite the lock/flag and load the resource from live.

## Solution
Only clear the cache when users sign out, and it's sufficient for "change connection" use case as well. (users have to sign out before connecting with different connection)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
