### PR TITLE
fix(amazonq): enable local context for falcon

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -92,7 +92,8 @@ export async function startLanguageServer(
                                 customization,
                                 optOutTelemetry: getOptOutPreference() === 'OPTOUT',
                                 projectContext: {
-                                    enableLocalIndexing: CodeWhispererSettings.instance.isLocalIndexEnabled(),
+                                    // TODO: we might need another setting to control the actual indexing
+                                    enableLocalIndexing: true,
                                     enableGpuAcceleration: CodeWhispererSettings.instance.isLocalIndexGPUEnabled(),
                                     indexWorkerThreads: CodeWhispererSettings.instance.getIndexWorkerThreads(),
                                     localIndexing: {


### PR DESCRIPTION
## Problem
context items should be always on and not controlled by workspace setting
there need to be a separate setting to control @workspace indexing, out of scope for this PR

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
