### PR TITLE
fix(amazonq): Remove the 'Cancel' button on LSP download

### DIFF
--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -13,9 +13,10 @@ import { TargetContent, logger, LspResult, LspVersion, Manifest } from './types'
 import { createHash } from '../crypto'
 import { lspSetupStage, StageResolver, tryStageResolvers } from './utils/setupStage'
 import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
-import { showMessageWithCancel } from '../../shared/utilities/messages'
+import { showProgressWithTimeout } from '../../shared/utilities/messages'
 import { Timeout } from '../utilities/timeoutUtils'
 import { oneMinute } from '../datetime'
+import vscode from 'vscode'
 
 // max timeout for downloading remote LSP assets. Some asserts are large (100+ MB) so this needs to be large for slow connections.
 // Since the user can cancel this one we can let it run very long.
@@ -106,7 +107,15 @@ export class LanguageServerResolver {
      */
     private async showDownloadProgress() {
         const timeout = new Timeout(remoteDownloadTimeout)
-        await showMessageWithCancel(`Downloading '${this.lsName}' language server`, timeout)
+        void showProgressWithTimeout(
+            {
+                title: `Downloading '${this.lsName}' language server`,
+                location: vscode.ProgressLocation.Notification,
+                cancellable: false,
+            },
+            timeout,
+            0
+        )
         return timeout
     }
 

--- a/packages/core/src/shared/utilities/messages.ts
+++ b/packages/core/src/shared/utilities/messages.ts
@@ -236,7 +236,7 @@ export function showOutputMessage(message: string, outputChannel: vscode.OutputC
  *
  * @see showMessageWithCancel for an example usage
  */
-async function showProgressWithTimeout(
+export async function showProgressWithTimeout(
     options: vscode.ProgressOptions,
     timeout: Timeout,
     showAfterMs: number


### PR DESCRIPTION
Just remove the 'Cancel' button for now when downloading the language server. We do not want to deal with the edge case of a user cancelling part way and then their Q features don't work since it depends on the language server.


<img width="402" alt="Screenshot 2025-04-28 at 12 18 54 PM" src="https://github.com/user-attachments/assets/96d53b34-b12a-4d96-a761-c4600f12486a" />

---

TODO: Figure out a better solution for allowing users to cancel the LS download, but then making it easy to download again if they eventually want it. We will also need to design it so they are aware that cancelling will prevent Q features from working.

This will require an update to the spec.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
