### PR TITLE
refactor(amazonq): Change Q LSP downloading message text

### DIFF
--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -40,4 +40,6 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
             ui: path.join(assetDirectory, 'clients/amazonq-ui.js'),
         }
     }
+
+    protected override downloadMessageOverride: string | undefined = 'Updating Amazon Q plugin'
 }

--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -44,7 +44,8 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, 
             id,
             new Range(supportedVersions, {
                 includePrerelease: true,
-            })
+            }),
+            this.downloadMessageOverride
         ).resolve()
 
         const assetDirectory = installationResult.assetDirectory
@@ -74,6 +75,12 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, 
         }
         return r
     }
+
+    /**
+     * Allows implementations of this class to set a custom message to show users
+     * when the artifacts are being downloaded. If not set, a default message will be shown.
+     */
+    protected downloadMessageOverride: string | undefined = undefined
 
     protected abstract postInstall(assetDirectory: string): Promise<void>
     protected abstract resourcePaths(assetDirectory?: string): T

--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -23,12 +23,20 @@ import vscode from 'vscode'
 const remoteDownloadTimeout = oneMinute * 30
 
 export class LanguageServerResolver {
+    private readonly downloadMessage: string
+
     constructor(
         private readonly manifest: Manifest,
         private readonly lsName: string,
         private readonly versionRange: semver.Range,
+        /**
+         * Custom message to show user when downloading, if undefined it will use the default.
+         */
+        downloadMessage?: string,
         private readonly _defaultDownloadFolder?: string
-    ) {}
+    ) {
+        this.downloadMessage = downloadMessage ?? `Updating '${this.lsName}' language server`
+    }
 
     /**
      * Downloads and sets up the Language Server, attempting different locations in order:
@@ -109,7 +117,7 @@ export class LanguageServerResolver {
         const timeout = new Timeout(remoteDownloadTimeout)
         void showProgressWithTimeout(
             {
-                title: `Downloading '${this.lsName}' language server`,
+                title: this.downloadMessage,
                 location: vscode.ProgressLocation.Notification,
                 cancellable: false,
             },


### PR DESCRIPTION
## PROBLEM:

When installing the LSP for Q we get a message that says `"Installing 'Amazon Q' language server"`, but they want it to be slightly different (`"Updating Amazon Q plugin"`). The issue is the base class for the lsp installer class has a generic message that is not easy to customize.

## SOLUTION:

Allow an override downloading message to be defined in each specific LspInstaller implementation. This message is then routed in to the LspResolver (the thing that downloads the Lsp), and the message is displayed here. This override message will show when the download is happening. Everyone is happy.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
