### PR TITLE
fix(amazonq): type error for workspaceIndexCacheDirPath

### DIFF
--- a/packages/core/src/codewhisperer/util/codewhispererSettings.ts
+++ b/packages/core/src/codewhisperer/util/codewhispererSettings.ts
@@ -67,7 +67,7 @@ export class CodeWhispererSettings extends fromExtensionManifest('amazonQ', desc
     }
 
     public getIndexCacheDirPath(): string {
-        return this.get('workspaceIndexCacheDirPath', undefined)
+        return this.get('workspaceIndexCacheDirPath', '')
     }
 
     public getIndexIgnoreFilePatterns(): string[] {


### PR DESCRIPTION
## Problem
set default to empty string instead of undefined for workspaceIndexCacheDirPath

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
