### PR TITLE
feat(amazonq): Log attribution notice when downloading language server

### DIFF
--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -41,7 +41,7 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, 
         const manifest = await new ManifestResolver(manifestUrl, id, suppressPromptPrefix).resolve()
         const installationResult = await new LanguageServerResolver(
             manifest,
-            id,
+            id, // TODO: We may want a display name instead of the ID
             new Range(supportedVersions, {
                 includePrerelease: true,
             }),

--- a/packages/core/src/shared/lsp/types.ts
+++ b/packages/core/src/shared/lsp/types.ts
@@ -72,6 +72,10 @@ export interface LspVersion {
     serverVersion: string
     isDelisted: boolean
     targets: Target[]
+    /**
+     * I'm not sure if this **always** exists (couldn't find it in the spec)
+     */
+    thirdPartyLicenses?: string
 }
 
 export interface Manifest {


### PR DESCRIPTION
## Problem:

Legal requires us to log the attribution notice when downloading the language server. We do not currently do this.

## Solution:

- We follow a similar message format to what Visual Studio is already doing.
- What we will do: `lsp: Installing 'AmazonQ' Language Server v0.1.0-alpha.100 to /Users/nkomonen/Library/Caches/aws/toolkits/language-servers/AmazonQ/0.1.0-alpha.100 (Attribution notice can be found at https://dhi0h88q3j9q6.cloudfront.net/6a0c7aa8-8b63-43a7-b14b-ee7594a29c9d/THIRD_PARTY_LICENSES)`
- This log message is in the generic part of our LSP downloader, and will show for all LSPs downloaded. The link to the attribution notice is already part of the manifest, so we grab it from there.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
