### PR TITLE
fix(amazonq): explain issue fails

### DIFF
--- a/packages/amazonq/src/lsp/chat/commands.ts
+++ b/packages/amazonq/src/lsp/chat/commands.ts
@@ -6,6 +6,8 @@
 import { Commands, globals } from 'aws-core-vscode/shared'
 import { window } from 'vscode'
 import { AmazonQChatViewProvider } from './webviewProvider'
+import { CodeScanIssue } from 'aws-core-vscode/codewhisperer'
+import { EditorContextExtractor } from 'aws-core-vscode/codewhispererChat'
 
 /**
  * TODO: Re-enable these once we can figure out which path they're going to live in
@@ -17,6 +19,45 @@ export function registerCommands(provider: AmazonQChatViewProvider) {
         registerGenericCommand('aws.amazonq.refactorCode', 'Refactor', provider),
         registerGenericCommand('aws.amazonq.fixCode', 'Fix', provider),
         registerGenericCommand('aws.amazonq.optimizeCode', 'Optimize', provider),
+        Commands.register('aws.amazonq.explainIssue', async (issue: CodeScanIssue) => {
+            void focusAmazonQPanel().then(async () => {
+                const editorContextExtractor = new EditorContextExtractor()
+                const extractedContext = await editorContextExtractor.extractContextForTrigger('ContextMenu')
+                const selectedCode =
+                    extractedContext?.activeFileContext?.fileText
+                        ?.split('\n')
+                        .slice(issue.startLine, issue.endLine)
+                        .join('\n') ?? ''
+
+                // The message that gets sent to the UI
+                const uiMessage = [
+                    'Explain the ',
+                    issue.title,
+                    ' issue in the following code:',
+                    '\n```\n',
+                    selectedCode,
+                    '\n```',
+                ].join('')
+
+                // The message that gets sent to the backend
+                const contextMessage = `Explain the issue "${issue.title}" (${JSON.stringify(
+                    issue
+                )}) and generate code demonstrating the fix`
+
+                void provider.webview?.postMessage({
+                    command: 'sendToPrompt',
+                    params: {
+                        selection: '',
+                        triggerType: 'contextMenu',
+                        prompt: {
+                            prompt: uiMessage, // what gets sent to the user
+                            escapedPrompt: contextMessage, // what gets sent to the backend
+                        },
+                        autoSubmit: true,
+                    },
+                })
+            })
+        }),
         Commands.register('aws.amazonq.sendToPrompt', (data) => {
             const triggerType = getCommandTriggerType(data)
             const selection = getSelectedText()

--- a/packages/core/src/codewhispererChat/commands/registerCommands.ts
+++ b/packages/core/src/codewhispererChat/commands/registerCommands.ts
@@ -40,7 +40,6 @@ export function registerCommands() {
     /**
      * make these no-ops, since theres still callers that need to be deprecated
      */
-    Commands.register('aws.amazonq.explainIssue', async (issue) => {})
     Commands.register('aws.amazonq.generateUnitTests', async (data) => {})
     Commands.register('aws.amazonq.updateContextCommandItems', () => {})
 }


### PR DESCRIPTION
## Problem
- Explain issue from security scan hasn't been hooked up when moving to flare

## Solution
- use sendToPrompt from flare to automatically submit an "explain message". This message contains a prompt that gets shown to the user and an escaped prompt that gets sent to the backend
- text/formatting for uiMessage and contextMessage were taken from codewhisperer chat


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
