### PR TITLE
fix(amazonq): open review tab for generate tests

### DIFF
--- a/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
@@ -155,7 +155,7 @@ export class QuickActionHandler {
         }
     }
 
-    private handleTestCommand(chatPrompt: ChatPrompt, tabID: string, eventId: string | undefined) {
+    private handleTestCommand(chatPrompt: ChatPrompt, tabID: string | undefined, eventId: string | undefined) {
         if (!this.isTestEnabled || !this.mynahUI) {
             return
         }
@@ -167,6 +167,15 @@ export class QuickActionHandler {
             this.connector.onTabChange(testTabId)
             this.connector.startTestGen(testTabId, realPromptText)
             return
+        }
+
+        /**
+         * right click -> generate test has no tab id
+         * we have to manually create one if a testgen tab
+         * wasn't previously created
+         */
+        if (!tabID) {
+            tabID = this.mynahUI.updateStore('', {})
         }
 
         // if there is no test tab, open a new one


### PR DESCRIPTION
## Problem
using the generate tests right click command won't work because a new tab never gets created, causing a "no more tabs available" warning

## Solution
If we're using the right click -> generate tests command AND there isn't a /test tab open then create a new tab

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
