### PR TITLE
fix(amazonq): stop workspace indexing in extension

### DIFF
--- a/packages/amazonq/src/app/chat/activation.ts
+++ b/packages/amazonq/src/app/chat/activation.ts
@@ -18,7 +18,7 @@ export async function activate(context: ExtensionContext) {
         void amazonq.LspController.instance.trySetupLsp(context, {
             startUrl: AuthUtil.instance.startUrl,
             maxIndexSize: CodeWhispererSettings.instance.getMaxIndexSize(),
-            isVectorIndexEnabled: CodeWhispererSettings.instance.isLocalIndexEnabled(),
+            isVectorIndexEnabled: false,
         })
     }, 5000)
 
@@ -30,14 +30,7 @@ export async function activate(context: ExtensionContext) {
         amazonq.listCodeWhispererCommandsWalkthrough.register(),
         amazonq.focusAmazonQPanel.register(),
         amazonq.focusAmazonQPanelKeybinding.register(),
-        amazonq.tryChatCodeLensCommand.register(),
-        vscode.workspace.onDidChangeConfiguration(async (configurationChangeEvent) => {
-            if (configurationChangeEvent.affectsConfiguration('amazonQ.workspaceIndex')) {
-                if (CodeWhispererSettings.instance.isLocalIndexEnabled()) {
-                    void setupLsp()
-                }
-            }
-        })
+        amazonq.tryChatCodeLensCommand.register()
     )
 
     Commands.register('aws.amazonq.learnMore', () => {


### PR DESCRIPTION
## Problem
- we don't need workspace indexing on extension side anymore,
the `isVectorIndexEnabled` setting controls if we build vector index used for @workspace feature, since now chat is moving to language server, the extension side workspace lsp should be only responsible for building BM25 index for inline, and not responsible for vector indexing for chat.

## Solution
- stop vector indexing on extension
- next step is to tie workspace index setting to language server workspace indexing, will be in next PR

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
