### PR TITLE
fix(amazonq): add event publisher for generateUnitTests

### DIFF
--- a/packages/amazonq/src/lsp/chat/commands.ts
+++ b/packages/amazonq/src/lsp/chat/commands.ts
@@ -8,6 +8,7 @@ import { window } from 'vscode'
 import { AmazonQChatViewProvider } from './webviewProvider'
 import { CodeScanIssue } from 'aws-core-vscode/codewhisperer'
 import { EditorContextExtractor } from 'aws-core-vscode/codewhispererChat'
+import { DefaultAmazonQAppInitContext } from 'aws-core-vscode/amazonq'
 
 /**
  * TODO: Re-enable these once we can figure out which path they're going to live in
@@ -19,6 +20,13 @@ export function registerCommands(provider: AmazonQChatViewProvider) {
         registerGenericCommand('aws.amazonq.refactorCode', 'Refactor', provider),
         registerGenericCommand('aws.amazonq.fixCode', 'Fix', provider),
         registerGenericCommand('aws.amazonq.optimizeCode', 'Optimize', provider),
+        Commands.register('aws.amazonq.generateUnitTests', async () => {
+            DefaultAmazonQAppInitContext.instance.getAppsToWebViewMessagePublisher().publish({
+                sender: 'testChat',
+                command: 'test',
+                type: 'chatMessage',
+            })
+        }),
         Commands.register('aws.amazonq.explainIssue', async (issue: CodeScanIssue) => {
             void focusAmazonQPanel().then(async () => {
                 const editorContextExtractor = new EditorContextExtractor()

--- a/packages/core/src/codewhispererChat/commands/registerCommands.ts
+++ b/packages/core/src/codewhispererChat/commands/registerCommands.ts
@@ -40,7 +40,6 @@ export function registerCommands() {
     /**
      * make these no-ops, since theres still callers that need to be deprecated
      */
-    Commands.register('aws.amazonq.generateUnitTests', async (data) => {})
     Commands.register('aws.amazonq.updateContextCommandItems', () => {})
 }
 


### PR DESCRIPTION
## Problem
`aws.amazonq.generateUnitTests` is not sending any events to /review

## Solution
publish a chat message event to the /review tab to start

I forgot to include these changes in https://github.com/aws/aws-toolkit-vscode/pull/7195


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
