### PR TITLE
fix(amazonq): tie enableLocalIndex back to user setting

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -281,8 +281,7 @@ function getConfigSection(section: ConfigSection) {
                     customization: undefinedIfEmpty(getSelectedCustomization().arn),
                     optOutTelemetry: getOptOutPreference() === 'OPTOUT',
                     projectContext: {
-                        // TODO: we might need another setting to control the actual indexing
-                        enableLocalIndexing: true,
+                        enableLocalIndexing: CodeWhispererSettings.instance.isLocalIndexEnabled(),
                         enableGpuAcceleration: CodeWhispererSettings.instance.isLocalIndexGPUEnabled(),
                         indexWorkerThreads: CodeWhispererSettings.instance.getIndexWorkerThreads(),
                         localIndexing: {


### PR DESCRIPTION
## Problem
With https://github.com/aws/language-servers/pull/1201 we can now use userSetting to control vector indexing

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
