### PR TITLE
fix(amazonq): dev profile selection breaks if certain regions aren't …

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-415cbf18-1985-4e66-9918-6789133896c7.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-415cbf18-1985-4e66-9918-6789133896c7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Q profile selection hangs when a region is blocked"
+}

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -172,8 +172,8 @@ export class RegionProfileManager {
             }
         }
 
-        if (availableProfiles.length === 0 && failedRegions.length > 0) {
-            // Only throw error if all regions fail
+        // Only throw error if all regions fail
+        if (failedRegions.length === endpoints.size) {
             throw new Error(`Failed to list profiles for all regions: ${failedRegions.join(', ')}`)
         }
 

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -138,6 +138,8 @@ export class RegionProfileManager {
             return []
         }
         const availableProfiles: RegionProfile[] = []
+        const failedRegions: string[] = []
+
         for (const [region, endpoint] of endpoints.entries()) {
             const client = await this.createQClient(region, endpoint, conn as SsoConnection)
             const requester = async (request: CodeWhispererUserClient.ListAvailableProfilesRequest) =>
@@ -162,13 +164,17 @@ export class RegionProfileManager {
                 })
 
                 availableProfiles.push(...mappedPfs)
+                RegionProfileManager.logger.debug(`Found ${mappedPfs.length} profiles in region ${region}`)
             } catch (e) {
                 const logMsg = isAwsError(e) ? `requestId=${e.requestId}; message=${e.message}` : (e as Error).message
-                RegionProfileManager.logger.error(`failed to listRegionProfile: ${logMsg}`)
-                throw e
+                RegionProfileManager.logger.error(`Failed to list profiles for region ${region}: ${logMsg}`)
+                failedRegions.push(region)
             }
+        }
 
-            RegionProfileManager.logger.info(`available amazonq profiles: ${availableProfiles.length}`)
+        if (availableProfiles.length === 0 && failedRegions.length > 0) {
+            // Only throw error if all regions fail
+            throw new Error(`Failed to list profiles for all regions: ${failedRegions.join(', ')}`)
         }
 
         this._profiles = availableProfiles


### PR DESCRIPTION
## Problem
Customer reported when a certain region is blocked(i.e. by cooperate network), it causes the Q developer profile list to break, and the customer can no longer use Q. 

## Solution
Don't throw immediately when a region is unavailable. So that the user still have access to working regions. 

Only throw if all regions are failing. 


## Testing
Shared the VSIX with customer and confirmed that issue is resolved. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
