### PR TITLE
feat(amazonq): allow child processes to define custom thresholds

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -33,6 +33,7 @@ import {
     undefinedIfEmpty,
     getOptOutPreference,
 } from 'aws-core-vscode/shared'
+import { processUtils } from 'aws-core-vscode/shared'
 import { activate } from './chat/activation'
 import { AmazonQResourcePaths } from './lspInstaller'
 import { ConfigSection, isValidConfigSection, toAmazonQLSPLogLevel } from './config'
@@ -55,7 +56,7 @@ export async function startLanguageServer(
         '--pre-init-encryption',
         '--set-credentials-encryption-key',
     ]
-    const memoryWarnThreshold = 200 * 1024 * 1024 // 200 MB
+    const memoryWarnThreshold = 200 * processUtils.oneMB // 200 MB
     const serverOptions = createServerOptions({
         encryptionKey,
         executable: resourcePaths.node,

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -81,7 +81,7 @@ export async function startLanguageServer(
         executable = [resourcePaths.node]
     }
 
-    const memoryWarnThreshold = 200 * processUtils.oneMB // 200 MB
+    const memoryWarnThreshold = 200 * processUtils.oneMB
     const serverOptions = createServerOptions({
         encryptionKey,
         executable: executable,

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -55,11 +55,13 @@ export async function startLanguageServer(
         '--pre-init-encryption',
         '--set-credentials-encryption-key',
     ]
+    const memoryWarnThreshold = 200 * 1024 * 1024 // 200 MB
     const serverOptions = createServerOptions({
         encryptionKey,
         executable: resourcePaths.node,
         serverModule,
         execArgv: argv,
+        warnThresholds: { memory: memoryWarnThreshold },
     })
 
     const documentSelector = [{ scheme: 'file', language: '*' }]

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -81,7 +81,7 @@ export async function startLanguageServer(
         executable = [resourcePaths.node]
     }
 
-    const memoryWarnThreshold = 200 * processUtils.oneMB
+    const memoryWarnThreshold = 1024 * processUtils.oneMB
     const serverOptions = createServerOptions({
         encryptionKey,
         executable: executable,

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -252,6 +252,7 @@ export async function activate(extensionContext: ExtensionContext, resourcePaths
     }
 
     const serverModule = resourcePaths.lsp
+    const memoryWarnThreshold = 600 * 1024 * 1024 // 600 MB
 
     const serverOptions = createServerOptions({
         encryptionKey: key,
@@ -259,6 +260,7 @@ export async function activate(extensionContext: ExtensionContext, resourcePaths
         serverModule,
         // TODO(jmkeyes): we always use the debug options...?
         execArgv: debugOptions.execArgv,
+        warnThresholds: { memory: memoryWarnThreshold },
     })
 
     const documentSelector = [{ scheme: 'file', language: '*' }]

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -8,6 +8,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  */
 import * as vscode from 'vscode'
+import { oneMB } from '../../shared/utilities/processUtils'
 import * as path from 'path'
 import * as nls from 'vscode-nls'
 import * as crypto from 'crypto'
@@ -252,7 +253,7 @@ export async function activate(extensionContext: ExtensionContext, resourcePaths
     }
 
     const serverModule = resourcePaths.lsp
-    const memoryWarnThreshold = 600 * 1024 * 1024 // 600 MB
+    const memoryWarnThreshold = 600 * oneMB // 600 MB
 
     const serverOptions = createServerOptions({
         encryptionKey: key,

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -253,7 +253,7 @@ export async function activate(extensionContext: ExtensionContext, resourcePaths
     }
 
     const serverModule = resourcePaths.lsp
-    const memoryWarnThreshold = 800 * oneMB // 800 MB
+    const memoryWarnThreshold = 800 * oneMB
 
     const serverOptions = createServerOptions({
         encryptionKey: key,

--- a/packages/core/src/amazonq/lsp/lspClient.ts
+++ b/packages/core/src/amazonq/lsp/lspClient.ts
@@ -253,7 +253,7 @@ export async function activate(extensionContext: ExtensionContext, resourcePaths
     }
 
     const serverModule = resourcePaths.lsp
-    const memoryWarnThreshold = 600 * oneMB // 600 MB
+    const memoryWarnThreshold = 800 * oneMB // 800 MB
 
     const serverOptions = createServerOptions({
         encryptionKey: key,

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -78,18 +78,20 @@ export function createServerOptions({
     executable,
     serverModule,
     execArgv,
+    warnThresholds,
 }: {
     encryptionKey: Buffer
     executable: string
     serverModule: string
     execArgv: string[]
+    warnThresholds?: { cpu?: number; memory?: number }
 }) {
     return async () => {
         const args = [serverModule, ...execArgv]
         if (isDebugInstance()) {
             args.unshift('--inspect=6080')
         }
-        const lspProcess = new ChildProcess(executable, args)
+        const lspProcess = new ChildProcess(executable, args, { warnThresholds })
 
         // this is a long running process, awaiting it will never resolve
         void lspProcess.run()

--- a/packages/core/src/shared/utilities/processUtils.ts
+++ b/packages/core/src/shared/utilities/processUtils.ts
@@ -44,6 +44,13 @@ export interface ChildProcessOptions {
     onStdout?: (text: string, context: RunParameterContext) => void
     /** Callback for intercepting text from the stderr stream. */
     onStderr?: (text: string, context: RunParameterContext) => void
+    /** Thresholds to configure warning logs */
+    warnThresholds?: {
+        /** Threshold for memory usage in bytes */
+        memory?: number
+        /** Threshold for CPU usage in percent */
+        cpu?: number
+    }
 }
 
 export interface ChildProcessRunOptions extends Omit<ChildProcessOptions, 'logging'> {
@@ -60,8 +67,12 @@ export interface ChildProcessResult {
     stderr: string
     signal?: string
 }
-
+export const oneMB = 1024 * 1024
 export const eof = Symbol('EOF')
+export const defaultProcessWarnThresholds = {
+    memory: 100 * oneMB, // 100 MB
+    cpu: 50,
+}
 
 export interface ProcessStats {
     memory: number
@@ -69,10 +80,6 @@ export interface ProcessStats {
 }
 export class ChildProcessTracker {
     static readonly pollingInterval: number = 10000 // Check usage every 10 seconds
-    static readonly thresholds: ProcessStats = {
-        memory: 100 * 1024 * 1024, // 100 MB
-        cpu: 50,
-    }
     static readonly logger = logger.getLogger('childProcess')
     static readonly loggedPids = new CircularBuffer(1000)
     #processByPid: Map<number, ChildProcess> = new Map<number, ChildProcess>()
@@ -80,6 +87,15 @@ export class ChildProcessTracker {
 
     public constructor() {
         this.#pids = new PollingSet(ChildProcessTracker.pollingInterval, () => this.monitor())
+    }
+
+    private getThreshold(pid: number) {
+        if (!this.#processByPid.has(pid)) {
+            ChildProcessTracker.logOnce(pid, `Missing process with id ${pid}, returning default threshold`)
+            return defaultProcessWarnThresholds
+        }
+        // Safe to assert since it exists from check above.
+        return this.#processByPid.get(pid)!.getWarnThresholds()
     }
 
     private cleanUp() {
@@ -106,13 +122,14 @@ export class ChildProcessTracker {
             return
         }
         const stats = this.getUsage(pid)
+        const threshold = this.getThreshold(pid)
         if (stats) {
             ChildProcessTracker.logger.debug(`Process ${pid} usage: %O`, stats)
-            if (stats.memory > ChildProcessTracker.thresholds.memory) {
-                ChildProcessTracker.logOnce(pid, `Process ${pid} exceeded memory threshold: ${stats.memory}`)
+            if (stats.memory > threshold.memory) {
+                ChildProcessTracker.logOnce(pid, `Process ${pid} exceeded memory threshold: ${stats.memory / oneMB} MB`)
             }
-            if (stats.cpu > ChildProcessTracker.thresholds.cpu) {
-                ChildProcessTracker.logOnce(pid, `Process ${pid} exceeded cpu threshold: ${stats.cpu}`)
+            if (stats.cpu > threshold.cpu) {
+                ChildProcessTracker.logOnce(pid, `Process ${pid} exceeded cpu threshold: %${stats.cpu}`)
             }
         }
     }
@@ -246,6 +263,10 @@ export class ChildProcess {
         options?: ChildProcessOptions
     ): Promise<ChildProcessResult> {
         return await new ChildProcess(command, args, options).run()
+    }
+
+    public getWarnThresholds(): ProcessStats {
+        return { ...defaultProcessWarnThresholds, ...this.#baseOptions.warnThresholds }
     }
 
     // Inspired by 'got'

--- a/packages/core/src/shared/utilities/processUtils.ts
+++ b/packages/core/src/shared/utilities/processUtils.ts
@@ -89,7 +89,7 @@ export class ChildProcessTracker {
         this.#pids = new PollingSet(ChildProcessTracker.pollingInterval, () => this.monitor())
     }
 
-    private getThreshold(pid: number) {
+    private getThreshold(pid: number): ProcessStats {
         if (!this.#processByPid.has(pid)) {
             ChildProcessTracker.logOnce(pid, `Missing process with id ${pid}, returning default threshold`)
             return defaultProcessWarnThresholds
@@ -126,10 +126,13 @@ export class ChildProcessTracker {
         if (stats) {
             ChildProcessTracker.logger.debug(`Process ${pid} usage: %O`, stats)
             if (stats.memory > threshold.memory) {
-                ChildProcessTracker.logOnce(pid, `Process ${pid} exceeded memory threshold: ${stats.memory / oneMB} MB`)
+                ChildProcessTracker.logOnce(
+                    pid,
+                    `Process ${pid} exceeded memory threshold: ${(stats.memory / oneMB).toFixed(2)} MB`
+                )
             }
             if (stats.cpu > threshold.cpu) {
-                ChildProcessTracker.logOnce(pid, `Process ${pid} exceeded cpu threshold: %${stats.cpu}`)
+                ChildProcessTracker.logOnce(pid, `Process ${pid} exceeded cpu threshold: ${stats.cpu}%`)
             }
         }
     }

--- a/packages/core/src/shared/utilities/processUtils.ts
+++ b/packages/core/src/shared/utilities/processUtils.ts
@@ -48,7 +48,7 @@ export interface ChildProcessOptions {
     warnThresholds?: {
         /** Threshold for memory usage in bytes */
         memory?: number
-        /** Threshold for CPU usage in percent */
+        /** Threshold for CPU usage by percentage */
         cpu?: number
     }
 }
@@ -70,7 +70,7 @@ export interface ChildProcessResult {
 export const oneMB = 1024 * 1024
 export const eof = Symbol('EOF')
 export const defaultProcessWarnThresholds = {
-    memory: 100 * oneMB, // 100 MB
+    memory: 100 * oneMB,
     cpu: 50,
 }
 

--- a/packages/core/src/test/shared/utilities/processUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/processUtils.test.ts
@@ -10,8 +10,10 @@ import * as sinon from 'sinon'
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../../shared/filesystemUtilities'
 import {
     ChildProcess,
+    ChildProcessOptions,
     ChildProcessResult,
     ChildProcessTracker,
+    defaultProcessWarnThresholds,
     eof,
     ProcessStats,
 } from '../../../shared/utilities/processUtils'
@@ -376,8 +378,8 @@ async function stopAndWait(runningProcess: RunningProcess): Promise<void> {
     await runningProcess.result
 }
 
-function startSleepProcess(timeout: number = 90): RunningProcess {
-    const childProcess = new ChildProcess(getSleepCmd(), [timeout.toString()])
+function startSleepProcess(options?: ChildProcessOptions, timeout: number = 90): RunningProcess {
+    const childProcess = new ChildProcess(getSleepCmd(), [timeout.toString()], options)
     const result = childProcess.run().catch(() => assert.fail('sleep command threw an error'))
     return { childProcess, result }
 }
@@ -454,12 +456,12 @@ describe('ChildProcessTracker', function () {
         tracker.add(runningProcess.childProcess)
 
         const highCpu: ProcessStats = {
-            cpu: ChildProcessTracker.thresholds.cpu + 1,
+            cpu: defaultProcessWarnThresholds.cpu + 1,
             memory: 0,
         }
         const highMemory: ProcessStats = {
             cpu: 0,
-            memory: ChildProcessTracker.thresholds.memory + 1,
+            memory: defaultProcessWarnThresholds.memory + 1,
         }
 
         usageMock.returns(highCpu)
@@ -480,7 +482,7 @@ describe('ChildProcessTracker', function () {
         tracker.add(runningProcess.childProcess)
 
         usageMock.returns({
-            cpu: ChildProcessTracker.thresholds.cpu + 1,
+            cpu: defaultProcessWarnThresholds.cpu + 1,
             memory: 0,
         })
 
@@ -494,13 +496,49 @@ describe('ChildProcessTracker', function () {
         const runningProcess = startSleepProcess()
 
         usageMock.returns({
-            cpu: ChildProcessTracker.thresholds.cpu - 1,
-            memory: ChildProcessTracker.thresholds.memory - 1,
+            cpu: defaultProcessWarnThresholds.cpu - 1,
+            memory: defaultProcessWarnThresholds.memory - 1,
         })
 
         await clock.tickAsync(ChildProcessTracker.pollingInterval)
 
         assert.throws(() => assertLogsContain(runningProcess.childProcess.pid().toString(), false, 'warn'))
+
+        await stopAndWait(runningProcess)
+    })
+
+    it('respects custom thresholds', async function () {
+        const runningProcess = startSleepProcess({
+            warnThresholds: {
+                cpu: defaultProcessWarnThresholds.cpu + 10,
+                memory: defaultProcessWarnThresholds.memory + 10,
+            },
+        })
+
+        usageMock.returns({
+            cpu: defaultProcessWarnThresholds.cpu + 5,
+            memory: defaultProcessWarnThresholds.memory + 5,
+        })
+
+        await clock.tickAsync(ChildProcessTracker.pollingInterval)
+        assert.throws(() => assertLogsContain(runningProcess.childProcess.pid().toString(), false, 'warn'))
+
+        await stopAndWait(runningProcess)
+    })
+
+    it('fills custom thresholds with default', async function () {
+        const runningProcess = startSleepProcess({
+            warnThresholds: {
+                cpu: defaultProcessWarnThresholds.cpu + 10,
+            },
+        })
+
+        usageMock.returns({
+            memory: defaultProcessWarnThresholds.memory + 1,
+        })
+
+        await clock.tickAsync(ChildProcessTracker.pollingInterval)
+        assertLogsContain(runningProcess.childProcess.pid().toString(), false, 'warn')
 
         await stopAndWait(runningProcess)
     })


### PR DESCRIPTION
## Problem
Some processes use significantly more cpu/memory than others, so we shouldn't hold them to the same static threshold. 
As an example, the language servers are consistently using more memory than the 100 MB threshold. 

Based on some experimentation with different sized workspaces, I've noticed that the process running agentic chat uses roughly 80MB-150MB of memory, and the workspace indexing uses 550 - 700 MB memory.  

## Solution
- Allow each child process to set a warning threshold, with a default of 100MB of memory. 
- Set the Q LSP threshold to 200 MB, and workspace indexing to 800 MB. 
- This should help to allow these logs to point to real concerns, rather than be noise. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
