### PR TITLE
feat(amazonq): add reference log for chat messages

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -57,13 +57,14 @@ import * as vscode from 'vscode'
 import { Disposable, LanguageClient, Position, TextDocumentIdentifier } from 'vscode-languageclient'
 import * as jose from 'jose'
 import { AmazonQChatViewProvider } from './webviewProvider'
-import { AuthUtil } from 'aws-core-vscode/codewhisperer'
+import { AuthUtil, ReferenceLogViewProvider } from 'aws-core-vscode/codewhisperer'
 import { amazonQDiffScheme, AmazonQPromptSettings, messages, openUrl } from 'aws-core-vscode/shared'
 import {
     DefaultAmazonQAppInitContext,
     messageDispatcher,
     EditorContentController,
     ViewDiffMessage,
+    referenceLogText,
 } from 'aws-core-vscode/amazonq'
 import { telemetry, TelemetryBase } from 'aws-core-vscode/telemetry'
 import { isValidResponseError } from './error'
@@ -531,13 +532,17 @@ async function handlePartialResult<T extends ChatResult>(
             tabId: tabId,
         })
     }
+
+    for (const ref of decryptedMessage.codeReference ?? []) {
+        ReferenceLogViewProvider.instance.addReferenceLog(referenceLogText(ref))
+    }
 }
 
 /**
  * Decodes the final chat responses from the language server before sending it to mynah UI.
  * Once this is called the answer response is finished
  */
-async function handleCompleteResult<T>(
+async function handleCompleteResult<T extends ChatResult>(
     result: string | T,
     encryptionKey: Buffer | undefined,
     provider: AmazonQChatViewProvider,
@@ -545,12 +550,15 @@ async function handleCompleteResult<T>(
     disposable: Disposable
 ) {
     const decryptedMessage =
-        typeof result === 'string' && encryptionKey ? await decodeRequest(result, encryptionKey) : result
+        typeof result === 'string' && encryptionKey ? await decodeRequest<T>(result, encryptionKey) : (result as T)
     void provider.webview?.postMessage({
         command: chatRequestType.method,
         params: decryptedMessage,
         tabId: tabId,
     })
+    for (const ref of decryptedMessage.codeReference ?? []) {
+        ReferenceLogViewProvider.instance.addReferenceLog(referenceLogText(ref))
+    }
     disposable.dispose()
 }
 

--- a/packages/core/src/amazonq/commons/model.ts
+++ b/packages/core/src/amazonq/commons/model.ts
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { LicenseUtil } from '../../codewhisperer/util/licenseUtil'
+import { CodeReference } from '../../codewhispererChat/view/connector/connector'
+
 // Currently importing ChatItemType in Mynah UI from the vscode side causes an error
 // TODO remove this once the import stops failing
 export type ChatItemType =
@@ -13,3 +16,10 @@ export type ChatItemType =
     | 'answer-stream'
     | 'answer-part'
     | 'code-result'
+
+export const referenceLogText = (reference: CodeReference) =>
+    `[${new Date().toLocaleString()}] Accepted recommendation from Amazon Q. Code provided with reference under <a href="${LicenseUtil.getLicenseHtml(
+        reference.licenseName
+    )}" target="_blank">${reference.licenseName}</a> license from repository <a href="${
+        reference.url
+    }" target="_blank">${reference.repository}</a>.<br><br>`

--- a/packages/core/src/amazonq/index.ts
+++ b/packages/core/src/amazonq/index.ts
@@ -35,7 +35,7 @@ export {
     computeDiff,
 } from './commons/diff'
 export { AuthFollowUpType, AuthMessageDataMap } from './auth/model'
-export { ChatItemType } from './commons/model'
+export { ChatItemType, referenceLogText } from './commons/model'
 export { ExtensionMessage } from '../amazonq/webview/ui/commands'
 export { CodeReference } from '../codewhispererChat/view/connector/connector'
 export { extractAuthFollowUp } from './util/authUtils'

--- a/packages/core/src/amazonqDoc/session/session.ts
+++ b/packages/core/src/amazonqDoc/session/session.ts
@@ -15,7 +15,7 @@ import { TelemetryHelper } from '../../amazonq/util/telemetryHelper'
 import { ConversationNotStartedState } from '../../amazonqFeatureDev/session/sessionState'
 import { logWithConversationId } from '../../amazonqFeatureDev/userFacingText'
 import { ConversationIdNotFoundError, IllegalStateError } from '../../amazonqFeatureDev/errors'
-import { referenceLogText } from '../../amazonqFeatureDev/constants'
+import { referenceLogText } from '../../amazonq/commons/model'
 import {
     DocInteractionType,
     DocV2AcceptanceEvent,

--- a/packages/core/src/amazonqFeatureDev/constants.ts
+++ b/packages/core/src/amazonqFeatureDev/constants.ts
@@ -26,14 +26,6 @@ export const clientErrorMessages = [
     'The folder you chose did not contain any source files in a supported language. Choose another folder and try again.',
 ]
 
-// License text that's used in codewhisperer reference log
-export const referenceLogText = (reference: CodeReference) =>
-    `[${new Date().toLocaleString()}] Accepted recommendation from Amazon Q. Code provided with reference under <a href="${LicenseUtil.getLicenseHtml(
-        reference.licenseName
-    )}" target="_blank">${reference.licenseName}</a> license from repository <a href="${
-        reference.url
-    }" target="_blank">${reference.repository}</a>.<br><br>`
-
 // License text that's used in the file view
 export const licenseText = (reference: CodeReference) =>
     `<a href="${LicenseUtil.getLicenseHtml(reference.licenseName)}" target="_blank">${

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -15,7 +15,7 @@ import {
     UpdateFilesPathsParams,
 } from '../../amazonq/commons/types'
 import { ContentLengthError, ConversationIdNotFoundError, IllegalStateError } from '../errors'
-import { featureDevChat, referenceLogText, featureDevScheme } from '../constants'
+import { featureDevChat, featureDevScheme } from '../constants'
 import fs from '../../shared/fs/fs'
 import { FeatureDevClient } from '../client/featureDev'
 import { codeGenRetryLimit } from '../limits'
@@ -34,6 +34,8 @@ import { FollowUpTypes } from '../../amazonq/commons/types'
 import { SessionConfig } from '../../amazonq/commons/session/sessionConfigFactory'
 import { Messenger } from '../../amazonq/commons/connector/baseMessenger'
 import { ContentLengthError as CommonContentLengthError } from '../../shared/errors'
+import { referenceLogText } from '../../amazonq/commons/model'
+
 export class Session {
     private _state?: SessionState | Omit<SessionState, 'uploadId'>
     private task: string = ''


### PR DESCRIPTION
## Problem
Chat results are never getting added to the reference tracker

## Solution
If code references are available, add them to the reference tracker



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
