### PR TITLE
fix(amazonq): full project scan command not working

### DIFF
--- a/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
@@ -107,7 +107,7 @@ export class QuickActionHandler {
         }
     }
 
-    private handleScanCommand(tabID: string, eventId: string | undefined) {
+    private handleScanCommand(tabID: string | undefined, eventId: string | undefined) {
         if (!this.isScanEnabled || !this.mynahUI) {
             return
         }
@@ -124,6 +124,14 @@ export class QuickActionHandler {
             this.connector.onTabChange(scanTabId)
             this.connector.scans(scanTabId)
             return
+        }
+
+        /**
+         * status bar -> "full project scan is now /review" doesn't have a tab ID
+         * since it's called via a command so we need to manually create one
+         */
+        if (!tabID) {
+            tabID = this.mynahUI.updateStore('', {})
         }
 
         // if there is no scan tab, open a new one


### PR DESCRIPTION
## Problem
a tab id isn't getting created when you call `status bar` -> `full project scan with /review` causing the command to fail with "you cannot open more then 10 tabs"

## Solution
create a new tab if tabId is undefined. This can only happen when it's called via a command


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
