### PR TITLE
fix(amazonq): duplicate code reference in reference log

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -532,10 +532,6 @@ async function handlePartialResult<T extends ChatResult>(
             tabId: tabId,
         })
     }
-
-    for (const ref of decryptedMessage.codeReference ?? []) {
-        ReferenceLogViewProvider.instance.addReferenceLog(referenceLogText(ref))
-    }
 }
 
 /**
@@ -556,6 +552,8 @@ async function handleCompleteResult<T extends ChatResult>(
         params: decryptedMessage,
         tabId: tabId,
     })
+
+    // only add the reference log once the request is complete, otherwise we will get duplicate log items
     for (const ref of decryptedMessage.codeReference ?? []) {
         ReferenceLogViewProvider.instance.addReferenceLog(referenceLogText(ref))
     }


### PR DESCRIPTION
## Problem
We're currently adding the reference log on partial responses and on complete responses, causing duplicate messages

## Solution
on flare side we're combining all code references into the final response, so we just need to emit once


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
