### PR TITLE
fix(amazonq): enable agentic chat in AL2

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-534a4369-a0e1-4789-9f55-fa172b9fb93f.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-534a4369-a0e1-4789-9f55-fa172b9fb93f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Enable Amazon Q LSP in AL2 instances"
+}

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -33,6 +33,7 @@ import {
     maybeShowMinVscodeWarning,
     Experiments,
     isSageMaker,
+    isAmazonInternalOs,
 } from 'aws-core-vscode/shared'
 import { ExtStartUpSources } from 'aws-core-vscode/telemetry'
 import { VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
@@ -43,6 +44,7 @@ import { registerCommands } from './commands'
 import { focusAmazonQPanel } from 'aws-core-vscode/codewhispererChat'
 import { activate as activateAmazonqLsp } from './lsp/activation'
 import { activate as activateInlineCompletion } from './app/inline/activation'
+import { hasGlibcPatch } from './lsp/client'
 
 export const amazonQContextPrefix = 'amazonq'
 
@@ -119,8 +121,12 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     }
     // This contains every lsp agnostic things (auth, security scan, code scan)
     await activateCodeWhisperer(extContext as ExtContext)
-    if (Experiments.instance.get('amazonqLSP', true) || Auth.instance.isInternalAmazonUser()) {
+    if (
+        (Experiments.instance.get('amazonqLSP', true) || Auth.instance.isInternalAmazonUser()) &&
+        (!isAmazonInternalOs() || (await hasGlibcPatch()))
+    ) {
         // start the Amazon Q LSP for internal users first
+        // for AL2, start LSP if glibc patch is found
         await activateAmazonqLsp(context)
     }
     if (!Experiments.instance.get('amazonqLSPInline', false)) {

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -43,7 +43,6 @@ import { registerCommands } from './commands'
 import { focusAmazonQPanel } from 'aws-core-vscode/codewhispererChat'
 import { activate as activateAmazonqLsp } from './lsp/activation'
 import { activate as activateInlineCompletion } from './app/inline/activation'
-import { isAmazonInternalOs } from 'aws-core-vscode/shared'
 
 export const amazonQContextPrefix = 'amazonq'
 
@@ -120,10 +119,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     }
     // This contains every lsp agnostic things (auth, security scan, code scan)
     await activateCodeWhisperer(extContext as ExtContext)
-    if (
-        (Experiments.instance.get('amazonqLSP', true) || Auth.instance.isInternalAmazonUser()) &&
-        !isAmazonInternalOs()
-    ) {
+    if (Experiments.instance.get('amazonqLSP', true) || Auth.instance.isInternalAmazonUser()) {
         // start the Amazon Q LSP for internal users first
         await activateAmazonqLsp(context)
     }

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -39,7 +39,7 @@ import {
 import { activate } from './chat/activation'
 import { AmazonQResourcePaths } from './lspInstaller'
 import { ConfigSection, isValidConfigSection, toAmazonQLSPLogLevel } from './config'
-import { chmodSync } from 'fs'
+import { chmodSync } from 'fs' // eslint-disable-line no-restricted-imports
 
 const localize = nls.loadMessageBundle()
 const logger = getLogger('amazonqLsp.lspClient')

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -26,23 +26,25 @@ function getEncryptionInit(key: Buffer): string {
     return JSON.stringify(request) + '\n'
 }
 
+// use dynamic linking to let node binary
+// pick up GLIBC >= 2.28
 const al2Config = {
     path: '/opt/vsc-sysroot/lib64/ld-linux-x86-64.so.2',
     args: ['--library-path', '/opt/vsc-sysroot/lib64'],
 }
-
+function createNodeProcess(nodePath: string, args: string[]) {
+    return new ChildProcess(
+        isAmazonInternalOs() ? al2Config.path : nodePath,
+        isAmazonInternalOs() ? [...al2Config.args, nodePath, ...args] : [...args],
+        { logging: 'no' }
+    )
+}
 /**
  * Checks that we can actually run the `node` executable and execute code with it.
  */
 export async function validateNodeExe(nodePath: string, lsp: string, args: string[], logger: Logger) {
     // Check that we can start `node` by itself.
-    const proc = new ChildProcess(
-        isAmazonInternalOs() ? al2Config.path : nodePath,
-        isAmazonInternalOs()
-            ? [...al2Config.args, nodePath, '-e', 'console.log("ok " + process.version)']
-            : ['-e', 'console.log("ok " + process.version)'],
-        { logging: 'no' }
-    )
+    const proc = createNodeProcess(nodePath, ['-e', 'console.log("ok")'])
     const r = await proc.run()
     const ok = r.exitCode === 0 && r.stdout.includes('ok')
     if (!ok) {
@@ -52,11 +54,7 @@ export async function validateNodeExe(nodePath: string, lsp: string, args: strin
     }
 
     // Check that we can start `node …/lsp.js --stdio …`.
-    const lspProc = new ChildProcess(
-        isAmazonInternalOs() ? al2Config.path : nodePath,
-        isAmazonInternalOs() ? [...al2Config.args, nodePath, lsp, ...args] : [lsp, ...args],
-        { logging: 'no' }
-    )
+    const lspProc = createNodeProcess(nodePath, [lsp, ...args])
 
     try {
         // Start asynchronously (it never stops; we need to stop it below).
@@ -105,11 +103,7 @@ export function createServerOptions({
         if (isDebugInstance()) {
             args.unshift('--inspect=6080')
         }
-        const lspProcess = new ChildProcess(
-            isAmazonInternalOs() ? al2Config.path : executable,
-            isAmazonInternalOs() ? [...al2Config.args, executable, ...args] : args,
-            { logging: 'no' }
-        )
+        const lspProcess = createNodeProcess(executable, args)
         // this is a long running process, awaiting it will never resolve
         void lspProcess.run()
 

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -42,7 +42,6 @@ export async function validateNodeExe(nodePath: string, lsp: string, args: strin
 
     // Check that we can start `node …/lsp.js --stdio …`.
     const lspProc = new ChildProcess(nodePath, [lsp, ...args], { logging: 'no' })
-
     try {
         // Start asynchronously (it never stops; we need to stop it below).
         lspProc.run().catch((e) => logger.error('failed to run: %s', lspProc.toString(false, true)))
@@ -91,6 +90,7 @@ export function createServerOptions({
             args.unshift('--inspect=6080')
         }
         const lspProcess = new ChildProcess(executable, args)
+
         // this is a long running process, awaiting it will never resolve
         void lspProcess.run()
 

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -44,7 +44,7 @@ function createNodeProcess(nodePath: string, args: string[]) {
  */
 export async function validateNodeExe(nodePath: string, lsp: string, args: string[], logger: Logger) {
     // Check that we can start `node` by itself.
-    const proc = createNodeProcess(nodePath, ['-e', 'console.log("ok")'])
+    const proc = createNodeProcess(nodePath, ['-e', 'console.log("ok " + process.version)'])
     const r = await proc.run()
     const ok = r.exitCode === 0 && r.stdout.includes('ok')
     if (!ok) {

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -7,7 +7,7 @@ import { ToolkitError } from '../../errors'
 import { Logger } from '../../logger/logger'
 import { ChildProcess } from '../../utilities/processUtils'
 import { waitUntil } from '../../utilities/timeoutUtils'
-import { isDebugInstance } from '../../vscode/env'
+import { isAmazonInternalOs, isDebugInstance } from '../../vscode/env'
 
 export function getNodeExecutableName(): string {
     return process.platform === 'win32' ? 'node.exe' : 'node'
@@ -26,12 +26,23 @@ function getEncryptionInit(key: Buffer): string {
     return JSON.stringify(request) + '\n'
 }
 
+const al2Config = {
+    path: '/opt/vsc-sysroot/lib64/ld-linux-x86-64.so.2',
+    args: ['--library-path', '/opt/vsc-sysroot/lib64'],
+}
+
 /**
  * Checks that we can actually run the `node` executable and execute code with it.
  */
 export async function validateNodeExe(nodePath: string, lsp: string, args: string[], logger: Logger) {
     // Check that we can start `node` by itself.
-    const proc = new ChildProcess(nodePath, ['-e', 'console.log("ok " + process.version)'], { logging: 'no' })
+    const proc = new ChildProcess(
+        isAmazonInternalOs() ? al2Config.path : nodePath,
+        isAmazonInternalOs()
+            ? [...al2Config.args, nodePath, '-e', 'console.log("ok " + process.version)']
+            : ['-e', 'console.log("ok " + process.version)'],
+        { logging: 'no' }
+    )
     const r = await proc.run()
     const ok = r.exitCode === 0 && r.stdout.includes('ok')
     if (!ok) {
@@ -41,7 +52,12 @@ export async function validateNodeExe(nodePath: string, lsp: string, args: strin
     }
 
     // Check that we can start `node …/lsp.js --stdio …`.
-    const lspProc = new ChildProcess(nodePath, [lsp, ...args], { logging: 'no' })
+    const lspProc = new ChildProcess(
+        isAmazonInternalOs() ? al2Config.path : nodePath,
+        isAmazonInternalOs() ? [...al2Config.args, nodePath, lsp, ...args] : [lsp, ...args],
+        { logging: 'no' }
+    )
+
     try {
         // Start asynchronously (it never stops; we need to stop it below).
         lspProc.run().catch((e) => logger.error('failed to run: %s', lspProc.toString(false, true)))
@@ -89,8 +105,11 @@ export function createServerOptions({
         if (isDebugInstance()) {
             args.unshift('--inspect=6080')
         }
-        const lspProcess = new ChildProcess(executable, args)
-
+        const lspProcess = new ChildProcess(
+            isAmazonInternalOs() ? al2Config.path : executable,
+            isAmazonInternalOs() ? [...al2Config.args, executable, ...args] : args,
+            { logging: 'no' }
+        )
         // this is a long running process, awaiting it will never resolve
         void lspProcess.run()
 

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -41,7 +41,7 @@ export async function validateNodeExe(nodePath: string, lsp: string, args: strin
     }
 
     // Check that we can start `node …/lsp.js --stdio …`.
-    const lspProc = new ChildProcess(nodePath, [lsp, ...args])
+    const lspProc = new ChildProcess(nodePath, [lsp, ...args], { logging: 'no' })
 
     try {
         // Start asynchronously (it never stops; we need to stop it below).


### PR DESCRIPTION
## Problem
LSP depends on node 18 which depends on GLIBC >=2.28. 
Amzn al2 instances do not have GLIBC >=2.28. 

## Solution
Use the patch of glibc if it is available.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
