### PR TITLE
feat(amazonq): point to flare prod manifest

### DIFF
--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -31,8 +31,8 @@ export function isValidConfigSection(section: unknown): section is ConfigSection
 }
 
 export const defaultAmazonQLspConfig: ExtendedAmazonQLSPConfig = {
-    manifestUrl: 'https://d3akiidp1wvqyg.cloudfront.net/qAgenticChatServer/0/manifest.json', // TODO swap this back
-    supportedVersions: '*', // TODO swap this back
+    manifestUrl: 'https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json',
+    supportedVersions: '1.*.*',
     id: 'AmazonQ', // used across IDEs for identifying global storage/local disk locations. Do not change.
     suppressPromptPrefix: 'amazonQ',
     path: undefined,


### PR DESCRIPTION
## Problem
We currently point to the alpha manifest and Flare deployment is ready for us to point to prod. 

## Solution
- switch the config to point to prod. 
- supported version `1.*.*` will force us to explicitly commit when the major version changes. Following the LSP toolkit spec. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
