### PR TITLE
refactor(amazonq): remove amazonqLSP and amazonqChatLsp experiments

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -26,9 +26,7 @@ sequenceDiagram
 
 ## Language Server Debugging
 
-1. Clone https://github.com/aws/language-servers.git and set it up in the same workspace as this project by cmd+shift+p and "add folder to workspace" and selecting the language-servers folder that you just cloned. Your VS code folder structure should look like  below.
-
-    
+1. Clone https://github.com/aws/language-servers.git and set it up in the same workspace as this project by cmd+shift+p and "add folder to workspace" and selecting the language-servers folder that you just cloned. Your VS code folder structure should look like below.
 
     ```
     /aws-toolkit-vscode
@@ -45,17 +43,9 @@ sequenceDiagram
     npm run package
     ```
     to get the project setup
-3. Enable the lsp experiment:
-    ```
-    "aws.experiments": {
-      "amazonqLSP": true,
-      "amazonqLSPInline": true, // optional: enables inline completion from flare
-      "amazonqLSPChat": true // optional: enables chat from flare
-    }
-    ```
-4. Uncomment the `__AMAZONQLSP_PATH` and `__AMAZONQLSP_UI` variables in the `amazonq/.vscode/launch.json` extension configuration
-5. Use the `Launch LSP with Debugging` configuration and set breakpoints in VSCode or the language server
-6. (Optional): Enable `"amazonq.trace.server": "on"` or `"amazonq.trace.server": "verbose"` in your VSCode settings to view detailed log messages sent to/from the language server. These log messages will show up in the "Amazon Q Language Server" output channel
+3. Uncomment the `__AMAZONQLSP_PATH` and `__AMAZONQLSP_UI` variables in the `amazonq/.vscode/launch.json` extension configuration
+4. Use the `Launch LSP with Debugging` configuration and set breakpoints in VSCode or the language server
+5. (Optional): Enable `"amazonq.trace.server": "on"` or `"amazonq.trace.server": "verbose"` in your VSCode settings to view detailed log messages sent to/from the language server. These log messages will show up in the "Amazon Q Language Server" output channel
 
 ## Amazon Q Inline Activation
 

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -121,10 +121,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     }
     // This contains every lsp agnostic things (auth, security scan, code scan)
     await activateCodeWhisperer(extContext as ExtContext)
-    if (
-        (Experiments.instance.get('amazonqLSP', true) || Auth.instance.isInternalAmazonUser()) &&
-        (!isAmazonInternalOs() || (await hasGlibcPatch()))
-    ) {
+    if (!isAmazonInternalOs() || (await hasGlibcPatch())) {
         // start the Amazon Q LSP for internal users first
         // for AL2, start LSP if glibc patch is found
         await activateAmazonqLsp(context)
@@ -172,7 +169,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
 
     context.subscriptions.push(
         Experiments.instance.onDidChange(async (event) => {
-            if (event.key === 'amazonqLSP' || event.key === 'amazonqChatLSP' || event.key === 'amazonqLSPInline') {
+            if (event.key === 'amazonqLSPInline') {
                 await vscode.window
                     .showInformationMessage(
                         'Amazon Q LSP setting has changed. Reload VS Code for the changes to take effect.',

--- a/packages/core/src/shared/settings-toolkit.gen.ts
+++ b/packages/core/src/shared/settings-toolkit.gen.ts
@@ -42,9 +42,7 @@ export const toolkitSettings = {
     },
     "aws.experiments": {
         "jsonResourceModification": {},
-        "amazonqLSP": {},
-        "amazonqLSPInline": {},
-        "amazonqChatLSP": {}
+        "amazonqLSPInline": {}
     },
     "aws.resources.enabledResources": {},
     "aws.lambda.recentlyUploaded": {},

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -247,17 +247,9 @@
                             "type": "boolean",
                             "default": false
                         },
-                        "amazonqLSP": {
-                            "type": "boolean",
-                            "default": true
-                        },
                         "amazonqLSPInline": {
                             "type": "boolean",
                             "default": false
-                        },
-                        "amazonqChatLSP": {
-                            "type": "boolean",
-                            "default": true
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
## Problem
`amazonqLSP` and `amazonqChatLSP` experiments are enabled by default

## Solution
remove them from experiements


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
