### PR TITLE
feat(auth): memorize and autofill users' last sso login info

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-3fb0a20d-75e8-4141-a1a6-d8cfd9b7f3f0.json
+++ b/packages/amazonq/.changes/next-release/Feature-3fb0a20d-75e8-4141-a1a6-d8cfd9b7f3f0.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Memorize and autofill users' last Sso login profile"
+}

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -27,7 +27,6 @@ import { randomUUID } from '../../../../shared/crypto'
 import globals from '../../../../shared/extensionGlobals'
 import { telemetry } from '../../../../shared/telemetry/telemetry'
 import { ProfileSwitchIntent } from '../../../../codewhisperer/region/regionProfileManager'
-import { setContext } from '../../../../shared'
 
 const className = 'AmazonQLoginWebview'
 export class AmazonQLoginWebview extends CommonAuthWebview {

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -27,6 +27,7 @@ import { randomUUID } from '../../../../shared/crypto'
 import globals from '../../../../shared/extensionGlobals'
 import { telemetry } from '../../../../shared/telemetry/telemetry'
 import { ProfileSwitchIntent } from '../../../../codewhisperer/region/regionProfileManager'
+import { setContext } from '../../../../shared'
 
 const className = 'AmazonQLoginWebview'
 export class AmazonQLoginWebview extends CommonAuthWebview {
@@ -80,6 +81,10 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
 
     async startEnterpriseSetup(startUrl: string, region: string): Promise<AuthError | undefined> {
         getLogger().debug(`called startEnterpriseSetup() with startUrl: '${startUrl}', region: '${region}'`)
+        await globals.globalState.update('recentSso', {
+            startUrl: startUrl,
+            region: region,
+        })
         return await this.ssoSetup('startCodeWhispererEnterpriseSetup', async () => {
             this.storeMetricMetadata({
                 credentialStartUrl: startUrl,

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -290,8 +290,13 @@ export abstract class CommonAuthWebview extends VueWebview {
         return authEnabledFeatures.join(',')
     }
 
-    getDefaultStartUrl() {
-        return DevSettings.instance.get('autofillStartUrl', '')
+    getDefaultSsoProfile(): { startUrl: string; region: string } {
+        const devSettings = DevSettings.instance.get('autofillStartUrl', '')
+        if (devSettings) {
+            return { startUrl: devSettings, region: 'us-east-1' }
+        }
+
+        return globals.globalState.tryGet('recentSso', Object, { startUrl: '', region: 'us-east-1' })
     }
 
     cancelAuthFlow() {

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -343,7 +343,7 @@ export default defineComponent({
             regions: [] as Region[],
             startUrlError: '',
             startUrlWarning: '',
-            selectedRegion: 'us-east-1',
+            selectedRegion: '',
             startUrl: '',
             app: this.app,
             LoginOption,
@@ -353,7 +353,9 @@ export default defineComponent({
         }
     },
     async created() {
-        this.startUrl = await this.getDefaultStartUrl()
+        const defaultSso = await this.getDefaultSso()
+        this.startUrl = defaultSso.startUrl
+        this.selectedRegion = defaultSso.region
         await this.emitUpdate('created')
     },
 
@@ -564,8 +566,8 @@ export default defineComponent({
         async updateExistingStartUrls() {
             this.existingStartUrls = (await client.listSsoConnections()).map((conn) => conn.startUrl)
         },
-        async getDefaultStartUrl() {
-            return await client.getDefaultStartUrl()
+        async getDefaultSso() {
+            return await client.getDefaultSsoProfile()
         },
         handleHelpLinkClick() {
             void client.emitUiClick('auth_helpLink')

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -23,6 +23,7 @@ import { setContext } from '../../../../shared/vscode/setContext'
 import { builderIdStartUrl } from '../../../../auth/sso/constants'
 import { RegionProfile } from '../../../../codewhisperer/models/model'
 import { ProfileSwitchIntent } from '../../../../codewhisperer/region/regionProfileManager'
+import globals from '../../../../shared/extensionGlobals'
 
 export class ToolkitLoginWebview extends CommonAuthWebview {
     public override id: string = 'aws.toolkit.AmazonCommonAuth'
@@ -46,6 +47,10 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
             credentialStartUrl: startUrl,
             isReAuth: false,
         }
+        await globals.globalState.update('recentSso', {
+            startUrl: startUrl,
+            region: region,
+        })
 
         if (this.isCodeCatalystLogin) {
             return this.ssoSetup('startCodeCatalystSSOSetup', async () => {

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -69,6 +69,7 @@ export type globalKey =
     | 'lastSelectedRegion'
     | 'lastOsStartTime'
     | 'recentCredentials'
+    | 'recentSso'
     // List of regions enabled in AWS Explorer.
     | 'region'
     // TODO: implement this via `PromptSettings` instead of globalState.


### PR DESCRIPTION
## Problem
Customers hope we could auto-fill the url and region with the last used one. Actually there is a customer saying it would cause friction for their adoption

## Solution
Memorize the url/region as a global state within VSCode and use them when they're present

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
