### PR TITLE
feat(amazonq): Add telemetry for auth through LSP

### DIFF
--- a/packages/core/src/login/webview/commonAuthViewProvider.ts
+++ b/packages/core/src/login/webview/commonAuthViewProvider.ts
@@ -45,6 +45,7 @@ import { telemetry } from '../../shared/telemetry/telemetry'
 import { AuthSources } from './util'
 import { AuthFlowStates } from './vue/types'
 import { ExtensionUse } from '../../auth/utils'
+import { AuthUtil } from '../../codewhisperer/util/authUtil'
 
 export class CommonAuthViewProvider implements WebviewViewProvider {
     public readonly viewType: string
@@ -107,7 +108,7 @@ export class CommonAuthViewProvider implements WebviewViewProvider {
                 if (authState === AuthFlowStates.REAUTHNEEDED || authState === AuthFlowStates.REAUTHENTICATING) {
                     this.webView!.server.storeMetricMetadata({
                         isReAuth: true,
-                        // ...(await getTelemetryMetadataForConn(AuthUtil.instance.conn)), // TODO: @opieter Re-add telemetry
+                        ...(await AuthUtil.instance.getTelemetryMetadata()),
                     })
                 } else {
                     this.webView!.server.storeMetricMetadata({ isReAuth: false })

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -65,8 +65,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                 isReAuth: false,
             })
             await awsIdSignIn()
-            // this.storeMetricMetadata(await getTelemetryMetadataForConn(conn))
-            // TODO: @opieter re-add metrics
+            this.storeMetricMetadata(await AuthUtil.instance.getTelemetryMetadata())
 
             void vscode.window.showInformationMessage('AmazonQ: Successfully connected to AWS Builder ID')
         })
@@ -83,8 +82,7 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
             })
 
             await connectToEnterpriseSso(startUrl, region)
-            // this.storeMetricMetadata(await getTelemetryMetadataForConn(conn))
-            // TODO: @opieter re-add metrics
+            this.storeMetricMetadata(await AuthUtil.instance.getTelemetryMetadata())
 
             void vscode.window.showInformationMessage('AmazonQ: Successfully connected to AWS IAM Identity Center')
         })
@@ -110,16 +108,15 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
              * causes the reauth page to refresh before the user is actually done the whole reauth flow.
              */
             this.reauthError = await this.ssoSetup('reauthenticateAmazonQ', async () => {
-                // TODO: @ opieter Re-add metrics
-                // this.storeMetricMetadata({
-                //     authEnabledFeatures: this.getAuthEnabledFeatures(conn),
-                //     isReAuth: true,
-                //     ...(await getTelemetryMetadataForConn(conn)),
-                // })
+                this.storeMetricMetadata({
+                    authEnabledFeatures: 'codewhisperer',
+                    isReAuth: true,
+                    ...(await AuthUtil.instance.getTelemetryMetadata()),
+                })
                 await AuthUtil.instance.reauthenticate()
-                // this.storeMetricMetadata({
-                //     ...(await getTelemetryMetadataForConn(conn)),
-                // })
+                this.storeMetricMetadata({
+                    ...(await AuthUtil.instance.getTelemetryMetadata()),
+                })
             })
         } finally {
             this.isReauthenticating = false


### PR DESCRIPTION
## Problem

The new auth util on Flare LSP is not yet supporting telemetry events

## Solution

* Migrate `getTelemetryMetadata` and `getAuthFormIds` to the new AuthUtil
* Restore commented-out references

**Note: CI is exepected to fail, unti tests not yet addressed and rebase with mainline is needed**

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
