### PR TITLE
fix(amazonq): Bug fixes for LSP auth on agentic mode

### DIFF
--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -3,13 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CredentialsStore, LoginManager, authUtils, initializeAuth } from 'aws-core-vscode/auth'
-import { Auth, AuthUtils, CredentialsStore, LoginManager, initializeAuth } from 'aws-core-vscode/auth'
-import {
-    activate as activateCodeWhisperer,
-    AuthUtil,
-    shutdown as shutdownCodeWhisperer,
-} from 'aws-core-vscode/codewhisperer'
+import { authUtils, CredentialsStore, LoginManager, initializeAuth } from 'aws-core-vscode/auth'
+import { activate as activateCodeWhisperer, shutdown as shutdownCodeWhisperer } from 'aws-core-vscode/codewhisperer'
 import { makeEndpointsProvider, registerGenericCommands } from 'aws-core-vscode'
 import { CommonAuthWebview } from 'aws-core-vscode/login'
 import {
@@ -39,7 +34,6 @@ import {
     Experiments,
     isSageMaker,
     Commands,
-    isAmazonInternalOs,
 } from 'aws-core-vscode/shared'
 import { ExtStartUpSources } from 'aws-core-vscode/telemetry'
 import { VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
@@ -50,8 +44,6 @@ import { registerCommands } from './commands'
 import { focusAmazonQPanel } from 'aws-core-vscode/codewhispererChat'
 import { activate as activateAmazonqLsp } from './lsp/activation'
 import { activate as activateInlineCompletion } from './app/inline/activation'
-import { isAmazonInternalOs } from 'aws-core-vscode/shared'
-import { hasGlibcPatch } from './lsp/client'
 
 export const amazonQContextPrefix = 'amazonq'
 
@@ -127,17 +119,12 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
         extensionContext: context,
     }
 
+    // Auth is dependent on LSP, needs to be activated before CW and Inline
+    await activateAmazonqLsp(context)
+
     // This contains every lsp agnostic things (auth, security scan, code scan)
     await activateCodeWhisperer(extContext as ExtContext)
 
-    if (
-        (Experiments.instance.get('amazonqLSP', true) || AuthUtil.instance.isInternalAmazonUser()) &&
-        (!isAmazonInternalOs() || (await hasGlibcPatch()))
-    ) {
-        // start the Amazon Q LSP for internal users first
-        // for AL2, start LSP if glibc patch is found
-        await activateAmazonqLsp(context)
-    }
     if (!Experiments.instance.get('amazonqLSPInline', false)) {
         await activateInlineCompletion()
     }

--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -19,7 +19,6 @@ import api from './api'
 import { activate as activateCWChat } from './app/chat/activation'
 import { activate as activateInlineChat } from './inlineChat/activation'
 import { beta } from 'aws-core-vscode/dev'
-import * as amazonq from 'aws-core-vscode/amazonq'
 import { activate as activateNotifications, NotificationsController } from 'aws-core-vscode/notifications'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { telemetry, AuthUserState } from 'aws-core-vscode/telemetry'
@@ -67,8 +66,6 @@ async function activateAmazonQNode(context: vscode.ExtensionContext) {
     activateAgents()
     await activateTransformationHub(extContext as ExtContext)
     activateInlineChat(context)
-
-    context.subscriptions.push(amazonq.focusAmazonQPanel.register(), amazonq.focusAmazonQPanelKeybinding.register())
 
     const authProvider = new CommonAuthViewProvider(
         context,

--- a/packages/amazonq/src/lsp/activation.ts
+++ b/packages/amazonq/src/lsp/activation.ts
@@ -4,19 +4,17 @@
  */
 
 import vscode from 'vscode'
-import { clientId, encryptionKey, startLanguageServer } from './client'
+import { startLanguageServer } from './client'
 import { AmazonQLspInstaller } from './lspInstaller'
 import { lspSetupStage, ToolkitError, messages } from 'aws-core-vscode/shared'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
-import { auth2 } from 'aws-core-vscode/auth'
 
 export async function activate(ctx: vscode.ExtensionContext) {
     try {
-        const client = await lspSetupStage('all', async () => {
+        await lspSetupStage('all', async () => {
             const installResult = await new AmazonQLspInstaller().resolve()
             return await lspSetupStage('launch', () => startLanguageServer(ctx, installResult.resourcePaths))
         })
-        AuthUtil.create(new auth2.LanguageClientAuth(client, clientId, encryptionKey))
         await AuthUtil.instance.restore()
     } catch (err) {
         const e = err as ToolkitError

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -36,9 +36,6 @@ import {
     ShowSaveFileDialogParams,
     LSPErrorCodes,
     tabBarActionRequestType,
-    ShowDocumentParams,
-    ShowDocumentResult,
-    ShowDocumentRequest,
     contextCommandsNotificationType,
     ContextCommandParams,
     openFileDiffNotificationType,
@@ -58,7 +55,7 @@ import { Disposable, LanguageClient, Position, TextDocumentIdentifier } from 'vs
 import * as jose from 'jose'
 import { AmazonQChatViewProvider } from './webviewProvider'
 import { AuthUtil, ReferenceLogViewProvider } from 'aws-core-vscode/codewhisperer'
-import { amazonQDiffScheme, AmazonQPromptSettings, getLogger, messages, openUrl } from 'aws-core-vscode/shared'
+import { amazonQDiffScheme, AmazonQPromptSettings, messages, openUrl } from 'aws-core-vscode/shared'
 import {
     DefaultAmazonQAppInitContext,
     messageDispatcher,
@@ -422,31 +419,6 @@ export function registerMessageListeners(
             targetUri: targetUri.toString(),
         }
     })
-
-    languageClient.onRequest<ShowDocumentParams, ShowDocumentResult>(
-        ShowDocumentRequest.method,
-        async (params: ShowDocumentParams): Promise<ShowDocumentParams | ResponseError<ShowDocumentResult>> => {
-            try {
-                const uri = vscode.Uri.parse(params.uri)
-                if (uri.scheme.startsWith('http')) {
-                    try {
-                        await openUrl(vscode.Uri.parse(params.uri))
-                        return params
-                    } catch (err: any) {
-                        getLogger().error(`Failed to open http from LSP: error: %s`, err)
-                    }
-                }
-                const doc = await vscode.workspace.openTextDocument(uri)
-                await vscode.window.showTextDocument(doc, { preview: false })
-                return params
-            } catch (e) {
-                return new ResponseError(
-                    LSPErrorCodes.RequestFailed,
-                    `Failed to open document: ${(e as Error).message}`
-                )
-            }
-        }
-    )
 
     languageClient.onNotification(contextCommandsNotificationType.method, (params: ContextCommandParams) => {
         void provider.webview?.postMessage({

--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -137,7 +137,7 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
                 let qChat = undefined
                 const init = () => {
                     const vscodeApi = acquireVsCodeApi()
-                    const hybridChatConnector = new HybridChatAdapter(${(await AuthUtil.instance.getChatAuthState()).amazonQ === 'connected'},${featureConfigData},${welcomeCount},${disclaimerAcknowledged},${regionProfileString},${disabledCommands},${isSMUS},${isSM},vscodeApi.postMessage)
+                    const hybridChatConnector = new HybridChatAdapter(${AuthUtil.instance.isConnected()},${featureConfigData},${welcomeCount},${disclaimerAcknowledged},${regionProfileString},${disabledCommands},${isSMUS},${isSM},vscodeApi.postMessage)
                     const commands = [hybridChatConnector.initialQuickActions[0]]
                     qChat = amazonQChat.createChat(vscodeApi, {disclaimerAcknowledged: ${disclaimerAcknowledged}, pairProgrammingAcknowledged: ${pairProgrammingAcknowledged}, agenticMode: true, quickActionCommands: commands}, hybridChatConnector, ${JSON.stringify(featureConfigData)});
                 }

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -26,9 +26,6 @@ import {
     ShowMessageRequest,
     ShowMessageRequestParams,
     ConnectionMetadata,
-    // ShowDocumentResult,
-    // ShowDocumentRequest,
-    // ShowDocumentParams,
 } from '@aws/language-server-runtimes/protocol'
 import { AuthUtil, CodeWhispererSettings, getSelectedCustomization } from 'aws-core-vscode/codewhisperer'
 import {
@@ -44,7 +41,6 @@ import {
     isAmazonInternalOs,
     fs,
     oidcClientName,
-    //openUrl,
 } from 'aws-core-vscode/shared'
 import { processUtils } from 'aws-core-vscode/shared'
 import { activate } from './chat/activation'
@@ -189,15 +185,6 @@ export async function startLanguageServer(
             return params.actions?.find((a) => a.title === response) ?? (undefined as unknown as null)
         }
     )
-
-    // client.onRequest<ShowDocumentResult, Error>(ShowDocumentRequest.method, async (params: ShowDocumentParams) => {
-    //     try {
-    //         return { success: await openUrl(vscode.Uri.parse(params.uri), lspName) }
-    //     } catch (err: any) {
-    //         getLogger().error(`Failed to open document for LSP: ${lspName}, error: %s`, err)
-    //         return { success: false }
-    //     }
-    // })
 
     const sendProfileToLsp = async () => {
         try {

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -251,7 +251,7 @@ export async function startLanguageServer(
         )
     }
 
-    activate(client, encryptionKey, resourcePaths.ui)
+    await activate(client, encryptionKey, resourcePaths.ui)
 
     toDispose.push(
         AuthUtil.instance.regionProfileManager.onDidChangeRegionProfile(sendProfileToLsp),

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -88,6 +88,9 @@ export class AuthUtil implements IAuthProvider {
 
     async restore() {
         await this.session.restore()
+        if (!this.isConnected()) {
+            await this.refreshState()
+        }
     }
 
     async login(startUrl: string, region: string) {


### PR DESCRIPTION
## Problem
Agentic chat introduced code changes that break auth on LSP

## Solution
Fixes for the auth flow:
* Move instantiation of `AuthUtil` into `startLanguageServer` sinc ethe function uses several AuthUtil calls, which fail if it is not instantiated yet
* Remove the dependency of LSP on glibc patch, since auth doesn't work if LSP is not started
* Add URL opening capability to the new `ShowDocumentRequest` handler, and remove the old handler from `client.ts`.
* Fix bug where session isn't restored upon start of extension when SSO is expired.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
