### PR TITLE
feat(amazonq): enable inline suggestions through flare by default

### DIFF
--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -129,7 +129,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
         // for AL2, start LSP if glibc patch is found
         await activateAmazonqLsp(context)
     }
-    if (!Experiments.instance.get('amazonqLSPInline', false)) {
+    if (!Experiments.instance.get('amazonqLSPInline', true)) {
         await activateInlineCompletion()
     }
 

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -164,7 +164,7 @@ export async function startLanguageServer(
     return client.onReady().then(async () => {
         await auth.refreshConnection()
 
-        if (Experiments.instance.get('amazonqLSPInline', false)) {
+        if (Experiments.instance.get('amazonqLSPInline', true)) {
             const inlineManager = new InlineCompletionManager(client)
             inlineManager.registerInlineCompletion()
             toDispose.push(


### PR DESCRIPTION
## Problem
We want to enable inline suggestions from flare on this branch

## Solution
- enable it
- leave the toggle setting so its easy to turn off/on to compare behaviours


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
