### PR TITLE
fix(amazonq): respect suggestions enabled setting for auto trigger

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -16,6 +16,7 @@ import {
     Disposable,
     window,
     TextEditor,
+    InlineCompletionTriggerKind,
 } from 'vscode'
 import { LanguageClient } from 'vscode-languageclient'
 import {
@@ -30,6 +31,7 @@ import {
     ReferenceInlineProvider,
     ReferenceLogViewProvider,
     ImportAdderProvider,
+    CodeSuggestionsState,
 } from 'aws-core-vscode/codewhisperer'
 
 export class InlineCompletionManager implements Disposable {
@@ -180,6 +182,12 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         token: CancellationToken
     ): Promise<InlineCompletionItem[] | InlineCompletionList> {
         if (this.isNewSession) {
+            const isAutoTrigger = context.triggerKind === InlineCompletionTriggerKind.Automatic
+            if (isAutoTrigger && !CodeSuggestionsState.instance.isSuggestionsEnabled()) {
+                // return early when suggestions are disabled with auto trigger
+                return []
+            }
+
             // make service requests if it's a new session
             await this.recommendationService.getAllRecommendations(
                 this.languageClient,


### PR DESCRIPTION
## Problem
the isSuggestionsEnable setting isn't respected

## Solution
if someone disabled suggestions via a setting or from the status bar then don't return anything for automatic triggers


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
