### PR TITLE
telemetry(amazonq): implement codewhisperer_clientComponentLatency

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -36,6 +36,7 @@ import {
 import { InlineGeneratingMessage } from './inlineGeneratingMessage'
 import { LineTracker } from './stateTracker/lineTracker'
 import { InlineTutorialAnnotation } from './tutorials/inlineTutorialAnnotation'
+import { TelemetryHelper } from './telemetryHelper'
 
 export class InlineCompletionManager implements Disposable {
     private disposable: Disposable
@@ -212,6 +213,8 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
 
             // tell the tutorial that completions has been triggered
             await this.inlineTutorialAnnotation.triggered(context.triggerKind)
+            TelemetryHelper.instance.setInvokeSuggestionStartTime()
+            TelemetryHelper.instance.setTriggerType(context.triggerKind)
 
             // make service requests if it's a new session
             await this.recommendationService.getAllRecommendations(

--- a/packages/amazonq/src/app/inline/telemetryHelper.ts
+++ b/packages/amazonq/src/app/inline/telemetryHelper.ts
@@ -1,0 +1,162 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthUtil, getSelectedCustomization } from 'aws-core-vscode/codewhisperer'
+import { CodewhispererLanguage } from 'aws-core-vscode/shared'
+import { CodewhispererTriggerType, telemetry } from 'aws-core-vscode/telemetry'
+import { InlineCompletionTriggerKind } from 'vscode'
+
+export class TelemetryHelper {
+    // Variables needed for client component latency
+    private _invokeSuggestionStartTime = 0
+    private _preprocessEndTime = 0
+    private _sdkApiCallStartTime = 0
+    private _sdkApiCallEndTime = 0
+    private _allPaginationEndTime = 0
+    private _firstSuggestionShowTime = 0
+    private _firstResponseRequestId = ''
+    private _sessionId = ''
+    private _language: CodewhispererLanguage = 'java'
+    private _triggerType: CodewhispererTriggerType = 'OnDemand'
+
+    constructor() {}
+
+    static #instance: TelemetryHelper
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    public resetClientComponentLatencyTime() {
+        this._invokeSuggestionStartTime = 0
+        this._preprocessEndTime = 0
+        this._sdkApiCallStartTime = 0
+        this._sdkApiCallEndTime = 0
+        this._firstSuggestionShowTime = 0
+        this._allPaginationEndTime = 0
+        this._firstResponseRequestId = ''
+    }
+
+    public setInvokeSuggestionStartTime() {
+        this.resetClientComponentLatencyTime()
+        this._invokeSuggestionStartTime = performance.now()
+    }
+
+    get invokeSuggestionStartTime(): number {
+        return this._invokeSuggestionStartTime
+    }
+
+    public setPreprocessEndTime() {
+        this._preprocessEndTime = performance.now()
+    }
+
+    get preprocessEndTime(): number {
+        return this._preprocessEndTime
+    }
+
+    public setSdkApiCallStartTime() {
+        if (this._sdkApiCallStartTime === 0) {
+            this._sdkApiCallStartTime = performance.now()
+        }
+    }
+
+    get sdkApiCallStartTime(): number {
+        return this._sdkApiCallStartTime
+    }
+
+    public setSdkApiCallEndTime() {
+        if (this._sdkApiCallEndTime === 0 && this._sdkApiCallStartTime !== 0) {
+            this._sdkApiCallEndTime = performance.now()
+        }
+    }
+
+    get sdkApiCallEndTime(): number {
+        return this._sdkApiCallEndTime
+    }
+
+    public setAllPaginationEndTime() {
+        if (this._allPaginationEndTime === 0 && this._sdkApiCallEndTime !== 0) {
+            this._allPaginationEndTime = performance.now()
+        }
+    }
+
+    get allPaginationEndTime(): number {
+        return this._allPaginationEndTime
+    }
+
+    public setFirstSuggestionShowTime() {
+        if (this._firstSuggestionShowTime === 0 && this._sdkApiCallEndTime !== 0) {
+            this._firstSuggestionShowTime = performance.now()
+        }
+    }
+
+    get firstSuggestionShowTime(): number {
+        return this._firstSuggestionShowTime
+    }
+
+    public setFirstResponseRequestId(requestId: string) {
+        if (this._firstResponseRequestId === '') {
+            this._firstResponseRequestId = requestId
+        }
+    }
+
+    get firstResponseRequestId(): string {
+        return this._firstResponseRequestId
+    }
+
+    public setSessionId(sessionId: string) {
+        if (this._sessionId === '') {
+            this._sessionId = sessionId
+        }
+    }
+
+    get sessionId(): string {
+        return this._sessionId
+    }
+
+    public setLanguage(language: CodewhispererLanguage) {
+        this._language = language
+    }
+
+    get language(): CodewhispererLanguage {
+        return this._language
+    }
+
+    public setTriggerType(triggerType: InlineCompletionTriggerKind) {
+        if (triggerType === InlineCompletionTriggerKind.Invoke) {
+            this._triggerType = 'OnDemand'
+        } else if (triggerType === InlineCompletionTriggerKind.Automatic) {
+            this._triggerType = 'AutoTrigger'
+        }
+    }
+
+    get triggerType(): string {
+        return this._triggerType
+    }
+
+    // report client component latency after all pagination call finish
+    // and at least one suggestion is shown to the user
+    public tryRecordClientComponentLatency() {
+        if (this._firstSuggestionShowTime === 0 || this._allPaginationEndTime === 0) {
+            return
+        }
+        telemetry.codewhisperer_clientComponentLatency.emit({
+            codewhispererAllCompletionsLatency: this._allPaginationEndTime - this._sdkApiCallStartTime,
+            codewhispererCompletionType: 'Line',
+            codewhispererCredentialFetchingLatency: 0, // no longer relevant, because we don't re-build the sdk. Flare already has that set
+            codewhispererCustomizationArn: getSelectedCustomization().arn,
+            codewhispererEndToEndLatency: this._firstSuggestionShowTime - this._invokeSuggestionStartTime,
+            codewhispererFirstCompletionLatency: this._sdkApiCallEndTime - this._sdkApiCallStartTime,
+            codewhispererLanguage: this._language,
+            codewhispererPostprocessingLatency: this._firstSuggestionShowTime - this._sdkApiCallEndTime,
+            codewhispererPreprocessingLatency: this._preprocessEndTime - this._invokeSuggestionStartTime,
+            codewhispererRequestId: this._firstResponseRequestId,
+            codewhispererSessionId: this._sessionId,
+            codewhispererTriggerType: this._triggerType,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+            result: 'Succeeded',
+        })
+    }
+}


### PR DESCRIPTION
## Problem
the only metric it looks like we're missing for inline on the vscode side is `codewhisperer_clientComponentLatency`

## Solution
codewhisperer_clientComponentLatency uses a very similar implementation as before the only differences are:
1. codewhispererCredentialFetchingLatency is no longer relevant because the token is always injected into the language server and it doesn't need to build the client on demand like before.
    - This causes the preprocessing latency to decrease, because that used to contain the time it takes to fetch the credentials
2. postProcessing latency is way lower because once we get the result vscode instantly displays it -- we no longer have control of that

example metric now:
```
2025-05-06 11:53:59.858 [debug] telemetry: codewhisperer_clientComponentLatency {
  Metadata: {
    codewhispererAllCompletionsLatency: '792.7122090000048',
    codewhispererCompletionType: 'Line',
    codewhispererCredentialFetchingLatency: '0',
    codewhispererCustomizationArn: 'arn:aws:codewhisperer:us-east-1:12345678910:customization/AAAAAAAAAA',
    codewhispererEndToEndLatency: '792.682249999998',
    codewhispererFirstCompletionLatency: '792.6440000000002',
    codewhispererLanguage: 'java',
    codewhispererPostprocessingLatency: '0.019500000002153683',
    codewhispererPreprocessingLatency: '0.007166999996115919',
    codewhispererRequestId: 'XXXXXXXXXXXXXXXXXXXXXXXXXXX',
    codewhispererTriggerType: 'AutoTrigger',
    credentialStartUrl: 'https://XXXXX.XXXXX.com/start',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: true
}
```



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
