### PR TITLE
feat(amazonq): add experiment for basic e2e flow of inline chat through Flare.

### DIFF
--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -25,7 +25,6 @@ import { DevOptions } from 'aws-core-vscode/dev'
 import { Auth, AuthUtils, getTelemetryMetadataForConn, isAnySsoConnection } from 'aws-core-vscode/auth'
 import api from './api'
 import { activate as activateCWChat } from './app/chat/activation'
-import { activate as activateInlineChat } from './inlineChat/activation'
 import { beta } from 'aws-core-vscode/dev'
 import { activate as activateNotifications, NotificationsController } from 'aws-core-vscode/notifications'
 import { AuthState, AuthUtil } from 'aws-core-vscode/codewhisperer'
@@ -73,7 +72,6 @@ async function activateAmazonQNode(context: vscode.ExtensionContext) {
     }
     activateAgents()
     await activateTransformationHub(extContext as ExtContext)
-    activateInlineChat(context)
 
     const authProvider = new CommonAuthViewProvider(
         context,

--- a/packages/amazonq/src/inlineChat/activation.ts
+++ b/packages/amazonq/src/inlineChat/activation.ts
@@ -5,8 +5,9 @@
 import * as vscode from 'vscode'
 import { InlineChatController } from './controller/inlineChatController'
 import { registerInlineCommands } from './command/registerInlineCommands'
+import { LanguageClient } from 'vscode-languageclient'
 
-export function activate(context: vscode.ExtensionContext) {
-    const inlineChatController = new InlineChatController(context)
+export function activate(context: vscode.ExtensionContext, client: LanguageClient, encryptionKey: Buffer) {
+    const inlineChatController = new InlineChatController(context, client, encryptionKey)
     registerInlineCommands(context, inlineChatController)
 }

--- a/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
+++ b/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
@@ -249,11 +249,14 @@ export class InlineChatController {
             return
         }
 
+        // Update inline diff view
         const textDiff = computeDiff(response.body, this.task, false)
         const decorations = computeDecorations(this.task)
         this.task.decorations = decorations
         await this.applyDiff(this.task, textDiff ?? [])
         this.decorator.applyDecorations(this.task)
+
+        // Update Codelenses
         await this.updateTaskAndLenses(this.task, TaskState.WaitingForDecision)
         await setContext('amazonq.inline.codelensShortcutEnabled', true)
         this.undoListener(this.task)

--- a/packages/amazonq/src/inlineChat/provider/inlineChatProvider.ts
+++ b/packages/amazonq/src/inlineChat/provider/inlineChatProvider.ts
@@ -69,6 +69,7 @@ export class InlineChatProvider {
     }
 
     public async processPromptMessageLSP(message: PromptMessage): Promise<InlineChatResult> {
+        // TODO: handle partial responses.
         getLogger().info('Making inline chat request with message %O', message)
         const params = this.getCurrentEditorParams(message.message ?? '')
         const inlineChatRequest = await encryptRequest<InlineChatParams>(params, this.encryptionKey)

--- a/packages/amazonq/src/inlineChat/provider/inlineChatProvider.ts
+++ b/packages/amazonq/src/inlineChat/provider/inlineChatProvider.ts
@@ -56,12 +56,12 @@ export class InlineChatProvider {
         }
 
         const documentUri = editor.document.uri.toString()
-
+        const cursorState = getCursorState(editor.selections)
         return {
             prompt: {
                 prompt,
             },
-            cursorState: getCursorState(editor.selections),
+            cursorState,
             textDocument: {
                 uri: documentUri,
             },

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -55,7 +55,6 @@ import {
 import { v4 as uuidv4 } from 'uuid'
 import * as vscode from 'vscode'
 import { Disposable, LanguageClient, Position, TextDocumentIdentifier } from 'vscode-languageclient'
-import * as jose from 'jose'
 import { AmazonQChatViewProvider } from './webviewProvider'
 import { AuthUtil, ReferenceLogViewProvider } from 'aws-core-vscode/codewhisperer'
 import { amazonQDiffScheme, AmazonQPromptSettings, messages, openUrl } from 'aws-core-vscode/shared'
@@ -68,6 +67,7 @@ import {
 } from 'aws-core-vscode/amazonq'
 import { telemetry, TelemetryBase } from 'aws-core-vscode/telemetry'
 import { isValidResponseError } from './error'
+import { decodeRequest, encryptRequest } from '../encryption'
 
 export function registerLanguageServerEventListener(languageClient: LanguageClient, provider: AmazonQChatViewProvider) {
     languageClient.info(
@@ -485,29 +485,6 @@ export function registerMessageListeners(
 
 function isServerEvent(command: string) {
     return command.startsWith('aws/chat/') || command === 'telemetry/event'
-}
-
-async function encryptRequest<T>(params: T, encryptionKey: Buffer): Promise<{ message: string } | T> {
-    const payload = new TextEncoder().encode(JSON.stringify(params))
-
-    const encryptedMessage = await new jose.CompactEncrypt(payload)
-        .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
-        .encrypt(encryptionKey)
-
-    return { message: encryptedMessage }
-}
-
-async function decodeRequest<T>(request: string, key: Buffer): Promise<T> {
-    const result = await jose.jwtDecrypt(request, key, {
-        clockTolerance: 60, // Allow up to 60 seconds to account for clock differences
-        contentEncryptionAlgorithms: ['A256GCM'],
-        keyManagementAlgorithms: ['dir'],
-    })
-
-    if (!result.payload) {
-        throw new Error('JWT payload not found')
-    }
-    return result.payload as T
 }
 
 /**

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -68,6 +68,7 @@ import {
 import { telemetry, TelemetryBase } from 'aws-core-vscode/telemetry'
 import { isValidResponseError } from './error'
 import { decodeRequest, encryptRequest } from '../encryption'
+import { getCursorState } from '../utils'
 
 export function registerLanguageServerEventListener(languageClient: LanguageClient, provider: AmazonQChatViewProvider) {
     languageClient.info(
@@ -97,21 +98,6 @@ export function registerLanguageServerEventListener(languageClient: LanguageClie
             telemetry[telemetryName as keyof TelemetryBase].emit(e.data)
         }
     })
-}
-
-function getCursorState(selection: readonly vscode.Selection[]) {
-    return selection.map((s) => ({
-        range: {
-            start: {
-                line: s.start.line,
-                character: s.start.character,
-            },
-            end: {
-                line: s.end.line,
-                character: s.end.character,
-            },
-        },
-    }))
 }
 
 export function registerMessageListeners(

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -39,6 +39,7 @@ import { processUtils } from 'aws-core-vscode/shared'
 import { activate } from './chat/activation'
 import { AmazonQResourcePaths } from './lspInstaller'
 import { ConfigSection, isValidConfigSection, toAmazonQLSPLogLevel } from './config'
+import { activate as activateInline } from '../inlineChat/activation'
 
 const localize = nls.loadMessageBundle()
 const logger = getLogger('amazonqLsp.lspClient')
@@ -181,6 +182,8 @@ export async function startLanguageServer(
         if (Experiments.instance.get('amazonqChatLSP', true)) {
             await activate(client, encryptionKey, resourcePaths.ui)
         }
+
+        activateInline(extensionContext, client, encryptionKey)
 
         const refreshInterval = auth.startTokenRefreshInterval(10 * oneSecond)
 

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -39,7 +39,7 @@ import { processUtils } from 'aws-core-vscode/shared'
 import { activate } from './chat/activation'
 import { AmazonQResourcePaths } from './lspInstaller'
 import { ConfigSection, isValidConfigSection, toAmazonQLSPLogLevel } from './config'
-import { activate as activateInline } from '../inlineChat/activation'
+import { activate as activateInlineChat } from '../inlineChat/activation'
 
 const localize = nls.loadMessageBundle()
 const logger = getLogger('amazonqLsp.lspClient')
@@ -183,7 +183,7 @@ export async function startLanguageServer(
             await activate(client, encryptionKey, resourcePaths.ui)
         }
 
-        activateInline(extensionContext, client, encryptionKey)
+        activateInlineChat(extensionContext, client, encryptionKey)
 
         const refreshInterval = auth.startTokenRefreshInterval(10 * oneSecond)
 

--- a/packages/amazonq/src/lsp/encryption.ts
+++ b/packages/amazonq/src/lsp/encryption.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as jose from 'jose'
+
+export async function encryptRequest<T>(params: T, encryptionKey: Buffer): Promise<{ message: string } | T> {
+    const payload = new TextEncoder().encode(JSON.stringify(params))
+
+    const encryptedMessage = await new jose.CompactEncrypt(payload)
+        .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+        .encrypt(encryptionKey)
+
+    return { message: encryptedMessage }
+}
+
+export async function decodeRequest<T>(request: string, key: Buffer): Promise<T> {
+    const result = await jose.jwtDecrypt(request, key, {
+        clockTolerance: 60, // Allow up to 60 seconds to account for clock differences
+        contentEncryptionAlgorithms: ['A256GCM'],
+        keyManagementAlgorithms: ['dir'],
+    })
+
+    if (!result.payload) {
+        throw new Error('JWT payload not found')
+    }
+    return result.payload as T
+}

--- a/packages/amazonq/src/lsp/utils.ts
+++ b/packages/amazonq/src/lsp/utils.ts
@@ -3,8 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode'
+import { CursorState } from '@aws/language-server-runtimes-types'
 
-export function getCursorState(selection: readonly vscode.Selection[]) {
+/**
+ * Convert from vscode selection type to the general CursorState expected by the AmazonQLSP.
+ * @param selection
+ * @returns
+ */
+export function getCursorState(selection: readonly vscode.Selection[]): CursorState[] {
     return selection.map((s) => ({
         range: {
             start: {

--- a/packages/amazonq/src/lsp/utils.ts
+++ b/packages/amazonq/src/lsp/utils.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode'
+
+export function getCursorState(selection: readonly vscode.Selection[]) {
+    return selection.map((s) => ({
+        range: {
+            start: {
+                line: s.start.line,
+                character: s.start.character,
+            },
+            end: {
+                line: s.end.line,
+                character: s.end.character,
+            },
+        },
+    }))
+}

--- a/packages/core/src/shared/settings-toolkit.gen.ts
+++ b/packages/core/src/shared/settings-toolkit.gen.ts
@@ -44,6 +44,7 @@ export const toolkitSettings = {
         "jsonResourceModification": {},
         "amazonqLSP": {},
         "amazonqLSPInline": {},
+        "amazonqLSPInlineChat": {},
         "amazonqChatLSP": {}
     },
     "aws.resources.enabledResources": {},

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -255,6 +255,10 @@
                             "type": "boolean",
                             "default": false
                         },
+                        "amazonqLSPInlineChat": {
+                            "type": "boolean",
+                            "default": false
+                        },
                         "amazonqChatLSP": {
                             "type": "boolean",
                             "default": true


### PR DESCRIPTION
## Problem
This is the initial set of work required to get inline chat running through flare. 

## Solution
- **add a feature flag for inline chat**: this allows testing of the two implementations side-by-side by flipping the feature flag. 
- **move general utils out of chat**: stuff like encryption and editorState can all be reused. 
- **render full diff response from inline chat**: this does not include progress updates from the language server. 

## Testing and Verification

https://github.com/user-attachments/assets/0dff58b7-40f7-487d-9f9e-d58610201041



## Future Work / Next Steps
- ensure telemetry is still being emitted. 
- add tests for new flow. (there aren't any for the existing one)
- handle partial events from the language server. 

## Known Bugs
- selecting part of a line will cause the text to insert mid-line 
- running inline-chat without a selection causes the entire file to be copied (This is in JB, Eclipse Prod, but IMO it makes the feature unusable). 


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
