### PR TITLE
build(core): remove flare as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 * @aws/aws-ides-team
 packages/core/src/codewhisperer/ @aws/codewhisperer-team
 packages/core/src/amazonqFeatureDev/ @aws/earlybird
-packages/core/src/codewhispererChat/ @aws/flare
-packages/core/src/amazonq/ @aws/flare
 packages/core/src/awsService/accessanalyzer/ @aws/access-analyzer


### PR DESCRIPTION
## Problem
Flare is marked as codeowners of the following:
```
packages/core/src/codewhispererChat/ @aws/flare
packages/core/src/amazonq/ @aws/flare
```

AFAIK, the flare team hasn't done significant work in these folders, and does not have bandwidth to review changes here. 

- `packages/core/src/codewhispererChat/ ` will be mostly deleted when we complete the migration to Flare (ex. [here](https://github.com/aws/aws-toolkit-vscode/pull/7237)).
- `packages/core/src/amazonq/ ` contains most changes to the amazon q extension, which seems out of scope for the Flare team. 

Having flare as codeowners requires the toolkits team to bypass their approval on any PRs touching files in these directories. This can lead to delayed merges and confusion. 

## Solution
- remove flare as a code owner. 


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
