### PR TITLE
feat(amazonq): initialize feature branch with gamma endpoint. 

### DIFF
--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -31,8 +31,8 @@ export function isValidConfigSection(section: unknown): section is ConfigSection
 }
 
 export const defaultAmazonQLspConfig: ExtendedAmazonQLSPConfig = {
-    manifestUrl: 'https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json',
-    supportedVersions: '1.*.*',
+    manifestUrl: 'https://aws-language-servers-gamma.amazonaws.com/qAgenticChatServer/0/manifest.json',
+    supportedVersions: '*',
     id: 'AmazonQ', // used across IDEs for identifying global storage/local disk locations. Do not change.
     suppressPromptPrefix: 'amazonQ',
     path: undefined,


### PR DESCRIPTION
## Problem
There is currently no way to test gamma changes without manually overriding the endpoint. 

## Solution
- create a feature branch that points to gamma so that we can easily test in pre-prod. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
