### PR TITLE
fix(logging): misleading "settings failed" message

### DIFF
--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -389,6 +389,10 @@ function createSettingsClass<T extends TypeDescriptor>(section: string, descript
         public _getOrThrow<K extends keyof Inner>(key: K & string, defaultValue?: Inner[K]) {
             const value = this.#config.get(key, defaultValue)
 
+            if (defaultValue !== undefined && (value === undefined || value === null)) {
+                return defaultValue
+            }
+
             return cast<Inner[K]>(value, descriptor[key])
         }
 


### PR DESCRIPTION
## Problem

Misleading log message when a setting returns `null`, even if the caller specified `defaultValue`:

    [error] Settings (amazonQ): failed to read "workspaceIndexCacheDirPath":
    Unexpected type cast: got object, expected primitive String

`cast()` considers `null` to be "object" type, which is misleading. If the caller passed a `defaultValue`, they have intentionally opted-in to ignoring this situation, and *don't* want this kind of log message.

## Solution

If a setting returns `null|undefined`, skip `cast()` and return `defaultValue` immediately. Don't log an error message.





---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
