### PR TITLE
refactor(amazonq): reduce extra call of listAvailableCustomization

### DIFF
--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -59,7 +59,7 @@ export const onProfileChangedListener: (event: ProfileChangedEvent) => any = asy
     if (event.intent === 'customization') {
         return
     }
-    const logger = getLogger()
+
     if (!event.profile) {
         await setSelectedCustomization(baseCustomization)
         return
@@ -69,16 +69,7 @@ export const onProfileChangedListener: (event: ProfileChangedEvent) => any = asy
     const selectedCustomization = getSelectedCustomization()
     // No need to validate base customization which has empty arn.
     if (selectedCustomization.arn.length > 0) {
-        const customizationProvider = await CustomizationProvider.init(event.profile)
-        const customizations = await customizationProvider.listAvailableCustomizations()
-
-        const r = customizations.find((it) => it.arn === selectedCustomization.arn)
-        if (!r) {
-            logger.debug(
-                `profile ${event.profile.name} doesnt have access to customization ${selectedCustomization.name} but has access to ${customizations.map((it) => it.name)}`
-            )
-            await switchToBaseCustomizationAndNotify()
-        }
+        await switchToBaseCustomizationAndNotify()
     }
 }
 


### PR DESCRIPTION
## Problem

Customization will only have "1" parent profile, so theoretically we don't need another call of listAvailableCustomization to check if the new profile has access to given profile or not. Instead, we could simply switch to default.

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
