### PR TITLE
telemetry(amazonq): align flare/vscode codewhisperer_serviceInvocation metric

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -57,7 +57,7 @@ import * as vscode from 'vscode'
 import { Disposable, LanguageClient, Position, TextDocumentIdentifier } from 'vscode-languageclient'
 import * as jose from 'jose'
 import { AmazonQChatViewProvider } from './webviewProvider'
-import { AuthUtil, ReferenceLogViewProvider } from 'aws-core-vscode/codewhisperer'
+import { AuthUtil, CodeWhispererSettings, ReferenceLogViewProvider } from 'aws-core-vscode/codewhisperer'
 import { amazonQDiffScheme, AmazonQPromptSettings, messages, openUrl } from 'aws-core-vscode/shared'
 import {
     DefaultAmazonQAppInitContext,
@@ -94,6 +94,14 @@ export function registerLanguageServerEventListener(languageClient: LanguageClie
         const telemetryName: string = e.name
 
         if (telemetryName in telemetry) {
+            switch (telemetryName) {
+                case 'codewhisperer_serviceInvocation': {
+                    // this feature is entirely client side right now
+                    e.data.codewhispererImportRecommendationEnabled =
+                        CodeWhispererSettings.instance.isImportRecommendationEnabled()
+                    break
+                }
+            }
             telemetry[telemetryName as keyof TelemetryBase].emit(e.data)
         }
     })


### PR DESCRIPTION
## Problem
vscode keeps track of `codewhispererImportRecommendationEnabled` inside of the `codewhisperer_serviceInvocation` event but flare doesn't

## Solution
add it before emitting telemetry, since this is purely a client side feature


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
