### PR TITLE
fix(amazonq): Minor string change in quickActionCommands for /test

### DIFF
--- a/packages/core/src/amazonq/webview/ui/quickActions/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/generator.ts
@@ -60,7 +60,7 @@ export class QuickActionGenerator {
                                   command: '/test',
                                   icon: MynahIcons.CHECK_LIST,
                                   placeholder: 'Specify a function(s) in the current file (optional)',
-                                  description: 'Generate unit tests (python & java) for selected code',
+                                  description: 'Generate unit tests for selected code',
                               },
                           ]
                         : []),


### PR DESCRIPTION
## Problem
- IDE shows `Generate unit tests (python & java) for selected code` in quick actions but Q supports all the languages.

## Solution
- Made change accordingly.
![image](https://github.com/user-attachments/assets/fc0a0967-ebdd-471b-b7d6-8889c81da075)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
