### PR TITLE
refactor(amazonq): pull out all decryption logic to one place

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -205,17 +205,12 @@ export function registerMessageListeners(
                 const cancellationToken = new CancellationTokenSource()
                 chatStreamTokens.set(chatParams.tabId, cancellationToken)
 
-                const chatDisposable = languageClient.onProgress(
-                    chatRequestType,
-                    partialResultToken,
-                    (partialResult) => {
-                        // Store the latest partial result
-                        decryptResponse<ChatResult>(partialResult, encryptionKey).then((result) => {
+                const chatDisposable = languageClient.onProgress(chatRequestType, partialResultToken, (partialResult) =>
+                    handlePartialResult<ChatResult>(partialResult, encryptionKey, provider, chatParams.tabId).then(
+                        (result) => {
                             lastPartialResult = result
-                        })
-
-                        void handlePartialResult<ChatResult>(partialResult, encryptionKey, provider, chatParams.tabId)
-                    }
+                        }
+                    )
                 )
 
                 const editor =
@@ -488,6 +483,7 @@ async function handlePartialResult<T extends ChatResult>(
             tabId: tabId,
         })
     }
+    return decryptedMessage
 }
 
 /**

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -67,7 +67,7 @@ import {
 } from 'aws-core-vscode/amazonq'
 import { telemetry, TelemetryBase } from 'aws-core-vscode/telemetry'
 import { isValidResponseError } from './error'
-import { decodeRequest, encryptRequest } from '../encryption'
+import { decryptResponse, encryptRequest } from '../encryption'
 import { getCursorState } from '../utils'
 
 export function registerLanguageServerEventListener(languageClient: LanguageClient, provider: AmazonQChatViewProvider) {
@@ -210,13 +210,9 @@ export function registerMessageListeners(
                     partialResultToken,
                     (partialResult) => {
                         // Store the latest partial result
-                        if (typeof partialResult === 'string' && encryptionKey) {
-                            void decodeRequest<ChatResult>(partialResult, encryptionKey).then(
-                                (decoded) => (lastPartialResult = decoded)
-                            )
-                        } else {
-                            lastPartialResult = partialResult as ChatResult
-                        }
+                        decryptResponse<ChatResult>(partialResult, encryptionKey).then((result) => {
+                            lastPartialResult = result
+                        })
 
                         void handlePartialResult<ChatResult>(partialResult, encryptionKey, provider, chatParams.tabId)
                     }
@@ -482,10 +478,7 @@ async function handlePartialResult<T extends ChatResult>(
     provider: AmazonQChatViewProvider,
     tabId: string
 ) {
-    const decryptedMessage =
-        typeof partialResult === 'string' && encryptionKey
-            ? await decodeRequest<T>(partialResult, encryptionKey)
-            : (partialResult as T)
+    const decryptedMessage = await decryptResponse<T>(partialResult, encryptionKey)
 
     if (decryptedMessage.body !== undefined) {
         void provider.webview?.postMessage({
@@ -508,8 +501,8 @@ async function handleCompleteResult<T extends ChatResult>(
     tabId: string,
     disposable: Disposable
 ) {
-    const decryptedMessage =
-        typeof result === 'string' && encryptionKey ? await decodeRequest<T>(result, encryptionKey) : (result as T)
+    const decryptedMessage = await decryptResponse<T>(result, encryptionKey)
+
     void provider.webview?.postMessage({
         command: chatRequestType.method,
         params: decryptedMessage,

--- a/packages/amazonq/src/lsp/encryption.ts
+++ b/packages/amazonq/src/lsp/encryption.ts
@@ -14,8 +14,14 @@ export async function encryptRequest<T>(params: T, encryptionKey: Buffer): Promi
     return { message: encryptedMessage }
 }
 
-export async function decodeRequest<T>(request: string, key: Buffer): Promise<T> {
-    const result = await jose.jwtDecrypt(request, key, {
+export async function decryptResponse<T>(response: unknown, key: Buffer | undefined) {
+    // Note that casts are required since language client requests return 'unknown' type.
+    // If we can't decrypt, return original response casted.
+    if (typeof response !== 'string' || key === undefined) {
+        return response as T
+    }
+
+    const result = await jose.jwtDecrypt(response, key, {
         clockTolerance: 60, // Allow up to 60 seconds to account for clock differences
         contentEncryptionAlgorithms: ['A256GCM'],
         keyManagementAlgorithms: ['dir'],

--- a/packages/amazonq/test/unit/amazonq/lsp/encryption.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/encryption.test.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { decryptResponse, encryptRequest } from '../../../../src/lsp/encryption'
+import { encryptionKey } from '../../../../src/lsp/auth'
+
+describe('LSP encryption', function () {
+    it('encrypt and decrypt invert eachother with same key', async function () {
+        const key = encryptionKey
+        const request = {
+            id: 0,
+            name: 'my Request',
+            isRealRequest: false,
+            metadata: {
+                tags: ['tag1', 'tag2'],
+            },
+        }
+        const encryptedPayload = await encryptRequest<typeof request>(request, key)
+        const message = (encryptedPayload as { message: string }).message
+        const decrypted = await decryptResponse<typeof request>(message, key)
+
+        assert.deepStrictEqual(decrypted, request)
+    })
+})


### PR DESCRIPTION
## Problem
Follow up to https://github.com/aws/aws-toolkit-vscode/pull/7235#discussion_r2077892394. 

## Solution
- extract all decrypting and encrypting logic to a single location. 
- add a simple test for this logic (encrypt and decrypt are inverses). 
- refactor existing implementations. 

## Verification 
Used agentic chat with some tools, as well as inline chat and didn't notice a difference. If encryption were broken, I would expect this to fail immediately. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
