### PR TITLE
test(amazonq): switch to the merged manifest with both q agentic chat…

### DIFF
--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -31,7 +31,7 @@ export function isValidConfigSection(section: unknown): section is ConfigSection
 }
 
 export const defaultAmazonQLspConfig: ExtendedAmazonQLSPConfig = {
-    manifestUrl: 'https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json',
+    manifestUrl: 'https://aws-language-servers-gamma.amazonaws.com/qAgenticChatServer/0/manifest.json',
     supportedVersions: '1.*.*',
     id: 'AmazonQ', // used across IDEs for identifying global storage/local disk locations. Do not change.
     suppressPromptPrefix: 'amazonQ',


### PR DESCRIPTION
… and sspc

## Problem
DON'T MERGE THIS PR TO MAINLINE!!!!

On May 1's release of q agentic chat, it doesn't merge sspc. This PR is to replace the existing Flare manifest with a preprod manifest containing sspc. 

This PR is created to generate plugins for E2E test before release.

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
