### PR TITLE
fix(amazonq): add a more descriptive issue for firewall problems

### DIFF
--- a/packages/amazonq/test/e2e/lsp/lspInstallerUtil.ts
+++ b/packages/amazonq/test/e2e/lsp/lspInstallerUtil.ts
@@ -14,6 +14,7 @@ import {
     ManifestResolver,
     request,
     TargetContent,
+    ToolkitError,
 } from 'aws-core-vscode/shared'
 import * as semver from 'semver'
 import { assertTelemetry } from 'aws-core-vscode/test'
@@ -201,12 +202,6 @@ export function createLspInstallerTests({
                         id: lspConfig.id,
                         manifestLocation: 'remote',
                         languageServerSetupStage: 'getManifest',
-                        result: 'Failed',
-                    },
-                    {
-                        id: lspConfig.id,
-                        manifestLocation: 'cache',
-                        languageServerSetupStage: 'getManifest',
                         result: 'Succeeded',
                     },
                     {
@@ -281,6 +276,58 @@ export function createLspInstallerTests({
                 lspConfig.supportedVersions = version.startsWith('^') ? version : `^${version}`
                 const download = await createInstaller(lspConfig).resolve()
                 assert.ok(download.assetDirectory.endsWith('-rc.0'))
+            })
+
+            it('throws on firewall error', async () => {
+                // Stub the manifest resolver to return a valid manifest
+                sandbox.stub(ManifestResolver.prototype, 'resolve').resolves({
+                    manifestSchemaVersion: '0.0.0',
+                    artifactId: 'foo',
+                    artifactDescription: 'foo',
+                    isManifestDeprecated: false,
+                    versions: [createVersion('1.0.0', targetContents)],
+                })
+
+                // Fail all HTTP requests for the language server
+                sandbox.stub(request, 'fetch').returns({
+                    response: Promise.resolve({
+                        ok: false,
+                    }),
+                } as any)
+
+                // This should now throw a NetworkConnectivityError
+                await assert.rejects(
+                    async () => await installer.resolve(),
+                    (err: ToolkitError) => {
+                        assert.strictEqual(err.code, 'NetworkConnectivityError')
+                        assert.ok(err.message.includes('Unable to download dependencies'))
+                        return true
+                    }
+                )
+
+                // Verify telemetry for the failed attempts
+                // const expectedTelemetry: Partial<LanguageServerSetup>[] = [
+                //     {
+                //         id: lspConfig.id,
+                //         manifestLocation: 'remote',
+                //         languageServerSetupStage: 'getManifest',
+                //         result: 'Failed',
+                //     },
+                //     {
+                //         id: lspConfig.id,
+                //         languageServerLocation: 'cache',
+                //         languageServerSetupStage: 'getServer',
+                //         result: 'Failed',
+                //     },
+                //     {
+                //         id: lspConfig.id,
+                //         languageServerLocation: 'remote',
+                //         languageServerSetupStage: 'getServer',
+                //         result: 'Failed',
+                //     },
+                // ]
+
+                // assertTelemetry('languageServer_setup', expectedTelemetry)
             })
         })
     })

--- a/packages/amazonq/test/e2e/lsp/lspInstallerUtil.ts
+++ b/packages/amazonq/test/e2e/lsp/lspInstallerUtil.ts
@@ -304,30 +304,6 @@ export function createLspInstallerTests({
                         return true
                     }
                 )
-
-                // Verify telemetry for the failed attempts
-                // const expectedTelemetry: Partial<LanguageServerSetup>[] = [
-                //     {
-                //         id: lspConfig.id,
-                //         manifestLocation: 'remote',
-                //         languageServerSetupStage: 'getManifest',
-                //         result: 'Failed',
-                //     },
-                //     {
-                //         id: lspConfig.id,
-                //         languageServerLocation: 'cache',
-                //         languageServerSetupStage: 'getServer',
-                //         result: 'Failed',
-                //     },
-                //     {
-                //         id: lspConfig.id,
-                //         languageServerLocation: 'remote',
-                //         languageServerSetupStage: 'getServer',
-                //         result: 'Failed',
-                //     },
-                // ]
-
-                // assertTelemetry('languageServer_setup', expectedTelemetry)
             })
         })
     })

--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -45,6 +45,7 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, 
             new Range(supportedVersions, {
                 includePrerelease: true,
             }),
+            manifestUrl,
             this.downloadMessageOverride
         ).resolve()
 

--- a/packages/core/src/shared/lsp/manifestResolver.ts
+++ b/packages/core/src/shared/lsp/manifestResolver.ts
@@ -69,7 +69,6 @@ export class ManifestResolver {
 
             const localManifest = await this.getLocalManifest(true).catch(() => undefined)
             if (localManifest) {
-                localManifest.location = 'remote'
                 return localManifest
             } else {
                 // Will emit a `languageServer_setup` result=failed metric...


### PR DESCRIPTION
## Problem
If a users firewall is blocking downloading the zips or reaching the manifest its not clear to the user what to do

## Solution
If the user:
1. doesn't have the latest version cached
2. download of the manifest failed
3. they don't have any previous language servers downloaded

it might be a firewall issue. Rather than just `Unable to find a compatible version of the Language Server` we show a more descriptive message to the user

<img width="454" alt="Screenshot 2025-05-07 at 2 48 39 PM" src="https://github.com/user-attachments/assets/48053a0f-7dff-4ba2-8b7d-65769b30a56f" />


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
