### PR TITLE
feat(amazonq): pass workspaceIdentifier when initializing AmazonQ lan…

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -131,6 +131,9 @@ export async function startLanguageServer(
                         showSaveFileDialog: true,
                     },
                 },
+                contextConfiguration: {
+                    workspaceIdentifier: extensionContext.storageUri,
+                },
                 logLevel: toAmazonQLSPLogLevel(globals.logOutputChannel.logLevel),
             },
             credentials: {


### PR DESCRIPTION
## Problem

AmazonQ LSP needs an identifier for the IDE workspace, which should be stable and unique for each workspace, regardless of IDE restarts or system reboots.

## Solution

Use [ExtensionContext.storageUri](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext.storageUri) as such an identifier and pass it when initializing AmazonQ language server.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
