### PR TITLE
telemetry(amazonq): add an error code for when node validation fails. 

### DIFF
--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -68,7 +68,8 @@ export async function validateNodeExe(nodePath: string[], lsp: string, args: str
         })
         if (!ok2 || selfExit) {
             throw new ToolkitError(
-                `amazonqLsp: failed to run (exitcode=${lspProc.exitCode()}): ${lspProc.toString(false, true)}`
+                `amazonqLsp: failed to run (exitcode=${lspProc.exitCode()}): ${lspProc.toString(false, true)}`,
+                { code: 'InvalidLSP' }
             )
         }
     } finally {

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -40,7 +40,7 @@ export async function validateNodeExe(nodePath: string[], lsp: string, args: str
     if (!ok) {
         const msg = `failed to run basic "node -e" test (exitcode=${r.exitCode}): ${proc.toString(false, true)}`
         logger.error(msg)
-        throw new ToolkitError(`amazonqLsp: ${msg}`, { code: 'InvalidNode' })
+        throw new ToolkitError(`amazonqLsp: ${msg}`, { code: 'FailedToRunNode' })
     }
 
     // Check that we can start `node …/lsp.js --stdio …`.
@@ -69,7 +69,7 @@ export async function validateNodeExe(nodePath: string[], lsp: string, args: str
         if (!ok2 || selfExit) {
             throw new ToolkitError(
                 `amazonqLsp: failed to run (exitcode=${lspProc.exitCode()}): ${lspProc.toString(false, true)}`,
-                { code: 'InvalidLSP' }
+                { code: 'FailedToStartLanguageServer' }
             )
         }
     } finally {

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -40,7 +40,7 @@ export async function validateNodeExe(nodePath: string[], lsp: string, args: str
     if (!ok) {
         const msg = `failed to run basic "node -e" test (exitcode=${r.exitCode}): ${proc.toString(false, true)}`
         logger.error(msg)
-        throw new ToolkitError(`amazonqLsp: ${msg}`)
+        throw new ToolkitError(`amazonqLsp: ${msg}`, { code: 'InvalidNode' })
     }
 
     // Check that we can start `node …/lsp.js --stdio …`.


### PR DESCRIPTION
## Problem
These errors show up in telemetry with reason `Error`. All of the `reasonDesc` are different since they include unique PID values. This makes it hard to count/quantify how often this is happening. 

## Solution
- attach a unique error code to these errors. For when node can't be run we have `FailedToRunNode`, and when the language server can't be started we have `FailedToStartLanguageServer`. 


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
