### PR TITLE
fix(nep): truncate editor state

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-75375702-36b5-4e89-af57-4afe983a7238.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-75375702-36b5-4e89-af57-4afe983a7238.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Avoid inline completion 'Improperly formed request' errors when file is too large"
+}

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -87,6 +87,9 @@ export const lineBreakWin = '\r\n'
 export const supplementalContextTimeoutInMs = 100
 
 export const supplementalContextMaxTotalLength = 20480
+
+export const editorStateMaxLength = 40000
+
 /**
  * Ux of recommendations
  */

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -11,7 +11,7 @@ import { getTabSizeSetting } from '../../shared/utilities/editorUtilities'
 import { getLogger } from '../../shared/logger/logger'
 import { runtimeLanguageContext } from './runtimeLanguageContext'
 import { fetchSupplementalContext } from './supplementalContext/supplementalContextUtil'
-import { supplementalContextTimeoutInMs } from '../models/constants'
+import { editorStateMaxLength, supplementalContextTimeoutInMs } from '../models/constants'
 import { getSelectedCustomization } from './customizationUtil'
 import { selectFrom } from '../../shared/utilities/tsUtils'
 import { checkLeftContextKeywordsForJson } from './commonUtil'
@@ -220,11 +220,11 @@ export function getEditorState(editor: vscode.TextEditor, fileContext: codewhisp
         const cursorOffset = editor.document.offsetAt(cursorPosition)
         const documentText = editor.document.getText()
 
-        // Check if text needs truncation (longer than 40000 characters)
+        // Truncate if text needs truncation (longer than 40000 characters)
         let fileText = documentText
-        if (documentText.length > 40000) {
-            const startOffset = Math.max(0, cursorOffset - 20000)
-            const endOffset = Math.min(documentText.length, cursorOffset + 20000)
+        if (documentText.length > editorStateMaxLength) {
+            const startOffset = Math.max(0, cursorOffset - Math.floor(editorStateMaxLength / 2))
+            const endOffset = Math.min(documentText.length, cursorOffset + Math.floor(editorStateMaxLength / 2))
 
             fileText = documentText.substring(startOffset, endOffset)
         }

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -216,13 +216,26 @@ export function getTabSize(): number {
 
 export function getEditorState(editor: vscode.TextEditor, fileContext: codewhispererClient.FileContext): any {
     try {
+        const cursorPosition = editor.selection.active
+        const cursorOffset = editor.document.offsetAt(cursorPosition)
+        const documentText = editor.document.getText()
+
+        // Check if text needs truncation (longer than 40000 characters)
+        let fileText = documentText
+        if (documentText.length > 40000) {
+            const startOffset = Math.max(0, cursorOffset - 20000)
+            const endOffset = Math.min(documentText.length, cursorOffset + 20000)
+
+            fileText = documentText.substring(startOffset, endOffset)
+        }
+
         return {
             document: {
                 programmingLanguage: {
                     languageName: fileContext.programmingLanguage.languageName,
                 },
                 relativeFilePath: fileContext.filename,
-                text: editor.document.getText(),
+                text: fileText,
             },
             cursorState: {
                 position: {

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -8,6 +8,7 @@ import * as codewhispererClient from '../client/codewhisperer'
 import * as path from 'path'
 import * as CodeWhispererConstants from '../models/constants'
 import { getTabSizeSetting } from '../../shared/utilities/editorUtilities'
+import { truncate } from '../../shared/utilities/textUtilities'
 import { getLogger } from '../../shared/logger/logger'
 import { runtimeLanguageContext } from './runtimeLanguageContext'
 import { fetchSupplementalContext } from './supplementalContext/supplementalContextUtil'
@@ -223,10 +224,13 @@ export function getEditorState(editor: vscode.TextEditor, fileContext: codewhisp
         // Truncate if document content is too large (defined in constants.ts)
         let fileText = documentText
         if (documentText.length > editorStateMaxLength) {
-            const startOffset = Math.max(0, cursorOffset - Math.floor(editorStateMaxLength / 2))
-            const endOffset = Math.min(documentText.length, cursorOffset + Math.floor(editorStateMaxLength / 2))
+            const halfLength = Math.floor(editorStateMaxLength / 2)
 
-            fileText = documentText.substring(startOffset, endOffset)
+            // Use truncate function to get the text around the cursor position
+            const leftPart = truncate(documentText.substring(0, cursorOffset), -halfLength, '')
+            const rightPart = truncate(documentText.substring(cursorOffset), halfLength, '')
+
+            fileText = leftPart + rightPart
         }
 
         return {
@@ -291,8 +295,8 @@ function logSupplementalContext(supplementalContext: CodeWhispererSupplementalCo
         logString += indent(`\nChunk ${index}:\n`, 4, true)
         logString += indent(
             `Path: ${context.filePath}
-            Length: ${context.content.length}
-            Score: ${context.score}`,
+Length: ${context.content.length}
+Score: ${context.score}`,
             8,
             true
         )

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -220,7 +220,7 @@ export function getEditorState(editor: vscode.TextEditor, fileContext: codewhisp
         const cursorOffset = editor.document.offsetAt(cursorPosition)
         const documentText = editor.document.getText()
 
-        // Truncate if text needs truncation (longer than 40000 characters)
+        // Truncate if document content is too large (defined in constants.ts)
         let fileText = documentText
         if (documentText.length > editorStateMaxLength) {
             const startOffset = Math.max(0, cursorOffset - Math.floor(editorStateMaxLength / 2))

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -295,8 +295,8 @@ function logSupplementalContext(supplementalContext: CodeWhispererSupplementalCo
         logString += indent(`\nChunk ${index}:\n`, 4, true)
         logString += indent(
             `Path: ${context.filePath}
-Length: ${context.content.length}
-Score: ${context.score}`,
+            Length: ${context.content.length}
+            Score: ${context.score}`,
             8,
             true
         )


### PR DESCRIPTION
## Problem
We introduced `editorState` in data instrumentation launch. The service has a requirement of 40k character limit for the `text` field. 

## Solution
Implement a check on text length. If the text length exceeds 40k characters, section 20k max characters from the left and right side of current cursor position, so the final text is always less than 40k.

validated prod endpoint inline working for files > 40k characters.
Example request id: `57bbbe65-fbe7-47fc-81c4-c65262f47ce8`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
