### PR TITLE
telemetry(amazonq): expose FileCreationFailed exceptions

### DIFF
--- a/packages/core/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/core/src/amazonqFeatureDev/session/sessionState.ts
@@ -205,6 +205,14 @@ export class FeatureDevCodeGenState extends BaseCodeGenState {
                     429
                 )
             }
+            case codegenResult.codeGenerationStatusDetail?.includes('FileCreationFailed'): {
+                return new ApiServiceError(
+                    i18n('AWS.amazonq.featureDev.error.codeGen.default'),
+                    'GetTaskAssistCodeGeneration',
+                    'FileCreationFailedException',
+                    500
+                )
+            }
             default: {
                 return new ApiServiceError(
                     i18n('AWS.amazonq.featureDev.error.codeGen.default'),


### PR DESCRIPTION
## Problem
FileCreationFailed exceptions are displayed as UnknownException in telemetry. This exception is new and we want to separate this out from other unknown exceptions.

## Solution
Return API service error with `FileCreationFailedException`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
