### PR TITLE
feat(amazonq): add tutorial trackers for lsp

### DIFF
--- a/packages/amazonq/src/app/inline/sessionManager.ts
+++ b/packages/amazonq/src/app/inline/sessionManager.ts
@@ -18,6 +18,8 @@ interface CodeWhispererSession {
 export class SessionManager {
     private activeSession?: CodeWhispererSession
     private activeIndex: number = 0
+    private _acceptedSuggestionCount: number = 0
+
     constructor() {}
 
     public startSession(
@@ -93,6 +95,14 @@ export class SessionManager {
             })
         }
         return items
+    }
+
+    public get acceptedSuggestionCount(): number {
+        return this._acceptedSuggestionCount
+    }
+
+    public incrementSuggestionCount() {
+        this._acceptedSuggestionCount += 1
     }
 
     public clear() {

--- a/packages/amazonq/src/app/inline/stateTracker/inlineLineAnnotationTracker.ts
+++ b/packages/amazonq/src/app/inline/stateTracker/inlineLineAnnotationTracker.ts
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Container } from 'aws-core-vscode/codewhisperer'
 import * as vscode from 'vscode'
+import { LineAnnotationController } from './lineAnnotationTracker'
+import { globals } from 'aws-core-vscode/shared'
 
 export class InlineLineAnnotationController {
     private enabled: boolean = true
 
-    constructor(context: vscode.ExtensionContext) {
-        context.subscriptions.push(
+    constructor(private readonly lineAnnotationController: LineAnnotationController) {
+        globals.context.subscriptions.push(
             vscode.window.onDidChangeTextEditorSelection(async ({ selections, textEditor }) => {
                 let showShow = false
 
@@ -33,12 +34,12 @@ export class InlineLineAnnotationController {
     private async setVisible(editor: vscode.TextEditor, visible: boolean) {
         let needsRefresh: boolean
         if (visible) {
-            needsRefresh = await Container.instance.lineAnnotationController.tryShowInlineHint()
+            needsRefresh = await this.lineAnnotationController.tryShowInlineHint()
         } else {
-            needsRefresh = await Container.instance.lineAnnotationController.tryHideInlineHint()
+            needsRefresh = await this.lineAnnotationController.tryHideInlineHint()
         }
         if (needsRefresh) {
-            await Container.instance.lineAnnotationController.refresh(editor, 'codewhisperer')
+            await this.lineAnnotationController.refresh(editor, 'codewhisperer')
         }
     }
 

--- a/packages/amazonq/src/app/inline/stateTracker/lineAnnotationTracker.ts
+++ b/packages/amazonq/src/app/inline/stateTracker/lineAnnotationTracker.ts
@@ -5,31 +5,29 @@
 
 import * as vscode from 'vscode'
 import * as os from 'os'
-import { LineSelection, LinesChangeEvent } from '../tracker/lineTracker'
-import { isTextEditor } from '../../shared/utilities/editorUtilities'
-import { cancellableDebounce } from '../../shared/utilities/functionUtils'
-import { subscribeOnce } from '../../shared/utilities/vsCodeUtils'
-// import { RecommendationService } from '../service/recommendationService'
-import { AnnotationChangeSource, inlinehintKey } from '../models/constants'
-import globals from '../../shared/extensionGlobals'
-import { Container } from '../service/serviceContainer'
-import { telemetry } from '../../shared/telemetry/telemetry'
-import { getLogger } from '../../shared/logger/logger'
-// import { session } from '../util/codeWhispererSession'
-// import { RecommendationHandler } from '../service/recommendationHandler'
-import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
-import { setContext } from '../../shared/vscode/setContext'
+import {
+    AnnotationChangeSource,
+    AuthUtil,
+    inlinehintKey,
+    runtimeLanguageContext,
+    TelemetryHelper,
+} from 'aws-core-vscode/codewhisperer'
+import { editorUtilities, getLogger, globals, setContext, vscodeUtilities } from 'aws-core-vscode/shared'
+import { LinesChangeEvent, LineSelection, LineTracker } from './lineTracker'
+import { telemetry } from 'aws-core-vscode/telemetry'
+import { cancellableDebounce } from 'aws-core-vscode/utils'
+import { SessionManager } from '../sessionManager'
 
 const case3TimeWindow = 30000 // 30 seconds
 
 const maxSmallIntegerV8 = 2 ** 30 // Max number that can be stored in V8's smis (small integers)
 
-function fromId(id: string | undefined): AnnotationState | undefined {
+function fromId(id: string | undefined, sessionManager: SessionManager): AnnotationState | undefined {
     switch (id) {
         case AutotriggerState.id:
-            return new AutotriggerState()
+            return new AutotriggerState(sessionManager)
         case PressTabState.id:
-            return new AutotriggerState()
+            return new AutotriggerState(sessionManager)
         case ManualtriggerState.id:
             return new ManualtriggerState()
         case TryMoreExState.id:
@@ -72,15 +70,16 @@ export class AutotriggerState implements AnnotationState {
     text = () => 'Amazon Q Tip 1/3: Start typing to get suggestions ([ESC] to exit)'
     static acceptedCount = 0
 
+    constructor(private readonly sessionManager: SessionManager) {}
+
     updateState(changeSource: AnnotationChangeSource, force: boolean): AnnotationState | undefined {
-        // if (AutotriggerState.acceptedCount < RecommendationService.instance.acceptedSuggestionCount) {
-        //     return new ManualtriggerState()
-        // } else if (session.recommendations.length > 0 && RecommendationHandler.instance.isSuggestionVisible()) {
-        //     return new PressTabState()
-        // } else {
-        //     return this
-        // }
-        return undefined
+        if (AutotriggerState.acceptedCount < this.sessionManager.acceptedSuggestionCount) {
+            return new ManualtriggerState()
+        } else if (this.sessionManager.getActiveRecommendation().length > 0) {
+            return new PressTabState(this.sessionManager)
+        } else {
+            return this
+        }
     }
 
     isNextState(state: AnnotationState | undefined): boolean {
@@ -105,8 +104,10 @@ export class PressTabState implements AnnotationState {
 
     text = () => 'Amazon Q Tip 1/3: Press [TAB] to accept ([ESC] to exit)'
 
+    constructor(private readonly sessionManager: SessionManager) {}
+
     updateState(changeSource: AnnotationChangeSource, force: boolean): AnnotationState | undefined {
-        return new AutotriggerState().updateState(changeSource, force)
+        return new AutotriggerState(this.sessionManager).updateState(changeSource, force)
     }
 
     isNextState(state: AnnotationState | undefined): boolean {
@@ -183,7 +184,6 @@ export class TryMoreExState implements AnnotationState {
         return state instanceof EndState
     }
 
-    static triggerCount: number = 0
     static learnmoeCount: number = 0
 }
 
@@ -248,13 +248,16 @@ export class LineAnnotationController implements vscode.Disposable {
             rangeBehavior: vscode.DecorationRangeBehavior.OpenOpen,
         })
 
-    constructor(private readonly container: Container) {
-        const cachedState = fromId(globals.globalState.get<string>(inlinehintKey))
+    constructor(
+        private readonly lineTracker: LineTracker,
+        private readonly sessionManager: SessionManager
+    ) {
+        const cachedState = fromId(globals.globalState.get<string>(inlinehintKey), sessionManager)
         const cachedAutotriggerEnabled = globals.globalState.get<boolean>('CODEWHISPERER_AUTO_TRIGGER_ENABLED')
 
         // new users (has or has not seen tutorial)
         if (cachedAutotriggerEnabled === undefined || cachedState !== undefined) {
-            this._currentState = cachedState ?? new AutotriggerState()
+            this._currentState = cachedState ?? new AutotriggerState(this.sessionManager)
             getLogger().debug(
                 `codewhisperer: new user login, activating inline tutorial. (autotriggerEnabled=${cachedAutotriggerEnabled}; inlineState=${cachedState?.id})`
             )
@@ -264,53 +267,20 @@ export class LineAnnotationController implements vscode.Disposable {
         }
 
         this._disposable = vscode.Disposable.from(
-            subscribeOnce(this.container.lineTracker.onReady)(async (_) => {
+            vscodeUtilities.subscribeOnce(this.lineTracker.onReady)(async (_) => {
                 await this.onReady()
             }),
-            // RecommendationService.instance.suggestionActionEvent(async (e) => {
-            //     await telemetry.withTraceId(async () => {
-            //         if (!this._isReady) {
-            //             return
-            //         }
-
-            //         if (this._currentState instanceof ManualtriggerState) {
-            //             if (e.triggerType === 'OnDemand' && this._currentState.hasManualTrigger === false) {
-            //                 this._currentState.hasManualTrigger = true
-            //             }
-            //             if (
-            //                 e.response?.recommendationCount !== undefined &&
-            //                 e.response?.recommendationCount > 0 &&
-            //                 this._currentState.hasValidResponse === false
-            //             ) {
-            //                 this._currentState.hasValidResponse = true
-            //             }
-            //         }
-
-            //         await this.refresh(e.editor, 'codewhisperer')
-            //     }, TelemetryHelper.instance.traceId)
-            // }),
-            this.container.lineTracker.onDidChangeActiveLines(async (e) => {
+            this.lineTracker.onDidChangeActiveLines(async (e) => {
                 await this.onActiveLinesChanged(e)
             }),
-            this.container.auth.auth.onDidChangeConnectionState(async (e) => {
+            AuthUtil.instance.auth.onDidChangeConnectionState(async (e) => {
                 if (e.state !== 'authenticating') {
                     await this.refresh(vscode.window.activeTextEditor, 'editor')
                 }
             }),
-            this.container.auth.secondaryAuth.onDidChangeActiveConnection(async () => {
+            AuthUtil.instance.secondaryAuth.onDidChangeActiveConnection(async () => {
                 await this.refresh(vscode.window.activeTextEditor, 'editor')
             })
-            // Commands.register('aws.amazonq.dismissTutorial', async () => {
-            //     const editor = vscode.window.activeTextEditor
-            //     if (editor) {
-            //         this.clear()
-            //         try {
-            //             telemetry.ui_click.emit({ elementId: `dismiss_${this._currentState.id}` })
-            //         } catch (_) {}
-            //         await this.dismissTutorial()
-            //         getLogger().debug(`codewhisperer: user dismiss tutorial.`)
-            //     }
-            // })
         )
     }
 
@@ -323,6 +293,31 @@ export class LineAnnotationController implements vscode.Disposable {
     private async onReady(): Promise<void> {
         this._isReady = !(this._currentState instanceof EndState)
         await this._refresh(vscode.window.activeTextEditor, 'editor')
+    }
+
+    async triggered(triggerType: vscode.InlineCompletionTriggerKind): Promise<void> {
+        await telemetry.withTraceId(async () => {
+            if (!this._isReady) {
+                return
+            }
+
+            if (this._currentState instanceof ManualtriggerState) {
+                if (
+                    triggerType === vscode.InlineCompletionTriggerKind.Invoke &&
+                    this._currentState.hasManualTrigger === false
+                ) {
+                    this._currentState.hasManualTrigger = true
+                }
+                if (
+                    this.sessionManager.getActiveRecommendation().length > 0 &&
+                    this._currentState.hasValidResponse === false
+                ) {
+                    this._currentState.hasValidResponse = true
+                }
+            }
+
+            await this.refresh(vscode.window.activeTextEditor, 'codewhisperer')
+        }, TelemetryHelper.instance.traceId)
     }
 
     isTutorialDone(): boolean {
@@ -405,8 +400,8 @@ export class LineAnnotationController implements vscode.Disposable {
             return
         }
 
-        const selections = this.container.lineTracker.selections
-        if (editor === undefined || selections === undefined || !isTextEditor(editor)) {
+        const selections = this.lineTracker.selections
+        if (editor === undefined || selections === undefined || !editorUtilities.isTextEditor(editor)) {
             this.clear()
             return
         }
@@ -418,12 +413,12 @@ export class LineAnnotationController implements vscode.Disposable {
         }
 
         // Make sure the editor hasn't died since the await above and that we are still on the same line(s)
-        if (editor.document === undefined || !this.container.lineTracker.includes(selections)) {
+        if (editor.document === undefined || !this.lineTracker.includes(selections)) {
             this.clear()
             return
         }
 
-        if (!this.container.auth.isConnectionValid()) {
+        if (!AuthUtil.instance.isConnectionValid()) {
             this.clear()
             return
         }
@@ -483,7 +478,7 @@ export class LineAnnotationController implements vscode.Disposable {
         source: AnnotationChangeSource,
         force?: boolean
     ): Partial<vscode.DecorationOptions> | undefined {
-        const isCWRunning = true
+        const isCWRunning = this.sessionManager.getActiveSession()?.isRequestInProgress ?? false
 
         const textOptions: vscode.ThemableDecorationAttachmentRenderOptions = {
             contentText: '',
@@ -516,14 +511,16 @@ export class LineAnnotationController implements vscode.Disposable {
         this._currentState = updatedState
 
         // take snapshot of accepted session so that we can compre if there is delta -> users accept 1 suggestion after seeing this state
-        AutotriggerState.acceptedCount = 0
-        // take snapshot of total trigger count so that we can compare if there is delta -> users accept/reject suggestions after seeing this state
-        TryMoreExState.triggerCount = 0
+        AutotriggerState.acceptedCount = this.sessionManager.acceptedSuggestionCount
 
         textOptions.contentText = this._currentState.text()
 
         return {
             renderOptions: { after: textOptions },
         }
+    }
+
+    public get currentState(): AnnotationState {
+        return this._currentState
     }
 }

--- a/packages/amazonq/src/app/inline/tutorials/inlineChatTutorialAnnotation.ts
+++ b/packages/amazonq/src/app/inline/tutorials/inlineChatTutorialAnnotation.ts
@@ -4,13 +4,13 @@
  */
 
 import * as vscode from 'vscode'
-import { LineAnnotationController } from './lineAnnotationTracker'
+import { InlineTutorialAnnotation } from './inlineTutorialAnnotation'
 import { globals } from 'aws-core-vscode/shared'
 
-export class InlineLineAnnotationController {
+export class InlineChatTutorialAnnotation {
     private enabled: boolean = true
 
-    constructor(private readonly lineAnnotationController: LineAnnotationController) {
+    constructor(private readonly inlineTutorialAnnotation: InlineTutorialAnnotation) {
         globals.context.subscriptions.push(
             vscode.window.onDidChangeTextEditorSelection(async ({ selections, textEditor }) => {
                 let showShow = false
@@ -34,12 +34,12 @@ export class InlineLineAnnotationController {
     private async setVisible(editor: vscode.TextEditor, visible: boolean) {
         let needsRefresh: boolean
         if (visible) {
-            needsRefresh = await this.lineAnnotationController.tryShowInlineHint()
+            needsRefresh = await this.inlineTutorialAnnotation.tryShowInlineHint()
         } else {
-            needsRefresh = await this.lineAnnotationController.tryHideInlineHint()
+            needsRefresh = await this.inlineTutorialAnnotation.tryHideInlineHint()
         }
         if (needsRefresh) {
-            await this.lineAnnotationController.refresh(editor, 'codewhisperer')
+            await this.inlineTutorialAnnotation.refresh(editor, 'codewhisperer')
         }
     }
 

--- a/packages/amazonq/src/app/inline/tutorials/inlineTutorialAnnotation.ts
+++ b/packages/amazonq/src/app/inline/tutorials/inlineTutorialAnnotation.ts
@@ -13,7 +13,7 @@ import {
     TelemetryHelper,
 } from 'aws-core-vscode/codewhisperer'
 import { editorUtilities, getLogger, globals, setContext, vscodeUtilities } from 'aws-core-vscode/shared'
-import { LinesChangeEvent, LineSelection, LineTracker } from './lineTracker'
+import { LinesChangeEvent, LineSelection, LineTracker } from '../stateTracker/lineTracker'
 import { telemetry } from 'aws-core-vscode/telemetry'
 import { cancellableDebounce } from 'aws-core-vscode/utils'
 import { SessionManager } from '../sessionManager'
@@ -231,7 +231,7 @@ export class InlineChatState implements AnnotationState {
  * "new users who has seen tutorial" should have the context key "inlineKey" and "CODEWHISPERER_AUTO_TRIGGER_ENABLED"
  * the remaining grouop of users should belong to "new users who has not seen tutorial"
  */
-export class LineAnnotationController implements vscode.Disposable {
+export class InlineTutorialAnnotation implements vscode.Disposable {
     private readonly _disposable: vscode.Disposable
     private _editor: vscode.TextEditor | undefined
 

--- a/packages/amazonq/src/inlineChat/activation.ts
+++ b/packages/amazonq/src/inlineChat/activation.ts
@@ -6,19 +6,14 @@ import * as vscode from 'vscode'
 import { InlineChatController } from './controller/inlineChatController'
 import { registerInlineCommands } from './command/registerInlineCommands'
 import { LanguageClient } from 'vscode-languageclient'
-import { InlineLineAnnotationController } from '../app/inline/stateTracker/inlineLineAnnotationTracker'
+import { InlineChatTutorialAnnotation } from '../app/inline/tutorials/inlineChatTutorialAnnotation'
 
 export function activate(
     context: vscode.ExtensionContext,
     client: LanguageClient,
     encryptionKey: Buffer,
-    inlineLineAnnotationController: InlineLineAnnotationController
+    inlineChatTutorialAnnotation: InlineChatTutorialAnnotation
 ) {
-    const inlineChatController = new InlineChatController(
-        context,
-        client,
-        encryptionKey,
-        inlineLineAnnotationController
-    )
+    const inlineChatController = new InlineChatController(context, client, encryptionKey, inlineChatTutorialAnnotation)
     registerInlineCommands(context, inlineChatController)
 }

--- a/packages/amazonq/src/inlineChat/activation.ts
+++ b/packages/amazonq/src/inlineChat/activation.ts
@@ -6,8 +6,19 @@ import * as vscode from 'vscode'
 import { InlineChatController } from './controller/inlineChatController'
 import { registerInlineCommands } from './command/registerInlineCommands'
 import { LanguageClient } from 'vscode-languageclient'
+import { InlineLineAnnotationController } from '../app/inline/stateTracker/inlineLineAnnotationTracker'
 
-export function activate(context: vscode.ExtensionContext, client: LanguageClient, encryptionKey: Buffer) {
-    const inlineChatController = new InlineChatController(context, client, encryptionKey)
+export function activate(
+    context: vscode.ExtensionContext,
+    client: LanguageClient,
+    encryptionKey: Buffer,
+    inlineLineAnnotationController: InlineLineAnnotationController
+) {
+    const inlineChatController = new InlineChatController(
+        context,
+        client,
+        encryptionKey,
+        inlineLineAnnotationController
+    )
     registerInlineCommands(context, inlineChatController)
 }

--- a/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
+++ b/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
@@ -26,7 +26,7 @@ import {
     isSageMaker,
     Experiments,
 } from 'aws-core-vscode/shared'
-import { InlineLineAnnotationController } from '../decorations/inlineLineAnnotationController'
+import { InlineLineAnnotationController } from '../../app/inline/stateTracker/inlineLineAnnotationTracker'
 
 export class InlineChatController {
     private task: InlineTask | undefined
@@ -39,11 +39,16 @@ export class InlineChatController {
     private userQuery: string | undefined
     private listeners: vscode.Disposable[] = []
 
-    constructor(context: vscode.ExtensionContext, client: LanguageClient, encryptionKey: Buffer) {
+    constructor(
+        context: vscode.ExtensionContext,
+        client: LanguageClient,
+        encryptionKey: Buffer,
+        inlineLineAnnotationController: InlineLineAnnotationController
+    ) {
         this.inlineChatProvider = new InlineChatProvider(client, encryptionKey)
         this.inlineChatProvider.onErrorOccured(() => this.handleError())
         this.codeLenseProvider = new CodelensProvider(context)
-        this.inlineLineAnnotationController = new InlineLineAnnotationController(context)
+        this.inlineLineAnnotationController = inlineLineAnnotationController
         this.computeDiffAndRenderOnEditor = Experiments.instance.get('amazonqLSPInlineChat', false)
             ? this.computeDiffAndRenderOnEditorLSP.bind(this)
             : this.computeDiffAndRenderOnEditorLocal.bind(this)

--- a/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
+++ b/packages/amazonq/src/inlineChat/controller/inlineChatController.ts
@@ -26,7 +26,7 @@ import {
     isSageMaker,
     Experiments,
 } from 'aws-core-vscode/shared'
-import { InlineLineAnnotationController } from '../../app/inline/stateTracker/inlineLineAnnotationTracker'
+import { InlineChatTutorialAnnotation } from '../../app/inline/tutorials/inlineChatTutorialAnnotation'
 
 export class InlineChatController {
     private task: InlineTask | undefined
@@ -34,7 +34,7 @@ export class InlineChatController {
     private readonly inlineChatProvider: InlineChatProvider
     private readonly codeLenseProvider: CodelensProvider
     private readonly referenceLogController = new ReferenceLogController()
-    private readonly inlineLineAnnotationController: InlineLineAnnotationController
+    private readonly inlineChatTutorialAnnotation: InlineChatTutorialAnnotation
     private readonly computeDiffAndRenderOnEditor: (query: string) => Promise<void>
     private userQuery: string | undefined
     private listeners: vscode.Disposable[] = []
@@ -43,12 +43,12 @@ export class InlineChatController {
         context: vscode.ExtensionContext,
         client: LanguageClient,
         encryptionKey: Buffer,
-        inlineLineAnnotationController: InlineLineAnnotationController
+        inlineChatTutorialAnnotation: InlineChatTutorialAnnotation
     ) {
         this.inlineChatProvider = new InlineChatProvider(client, encryptionKey)
         this.inlineChatProvider.onErrorOccured(() => this.handleError())
         this.codeLenseProvider = new CodelensProvider(context)
-        this.inlineLineAnnotationController = inlineLineAnnotationController
+        this.inlineChatTutorialAnnotation = inlineChatTutorialAnnotation
         this.computeDiffAndRenderOnEditor = Experiments.instance.get('amazonqLSPInlineChat', false)
             ? this.computeDiffAndRenderOnEditorLSP.bind(this)
             : this.computeDiffAndRenderOnEditorLocal.bind(this)
@@ -149,7 +149,7 @@ export class InlineChatController {
         this.codeLenseProvider.updateLenses(task)
         if (task.state === TaskState.InProgress) {
             if (vscode.window.activeTextEditor) {
-                await this.inlineLineAnnotationController.hide(vscode.window.activeTextEditor)
+                await this.inlineChatTutorialAnnotation.hide(vscode.window.activeTextEditor)
             }
         }
         await this.refreshCodeLenses(task)
@@ -175,7 +175,7 @@ export class InlineChatController {
         this.listeners = []
 
         this.task = undefined
-        this.inlineLineAnnotationController.enable()
+        this.inlineChatTutorialAnnotation.enable()
         await setContext('amazonq.inline.codelensShortcutEnabled', undefined)
     }
 
@@ -216,7 +216,7 @@ export class InlineChatController {
                 this.userQuery = query
                 await textDocumentUtil.addEofNewline(editor)
                 this.task = await this.createTask(query, editor.document, editor.selection)
-                await this.inlineLineAnnotationController.disable(editor)
+                await this.inlineChatTutorialAnnotation.disable(editor)
                 await this.computeDiffAndRenderOnEditor(query).catch(async (err) => {
                     getLogger().error('computeDiffAndRenderOnEditor error: %s', (err as Error)?.message)
                     if (err instanceof Error) {

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -17,6 +17,7 @@ import {
 } from 'aws-core-vscode/codewhisperer'
 import { InlineGeneratingMessage } from '../../../../../src/app/inline/inlineGeneratingMessage'
 import { LineTracker } from '../../../../../src/app/inline/stateTracker/lineTracker'
+import { LineAnnotationController } from '../../../../../src/app/inline/stateTracker/lineAnnotationTracker'
 
 describe('InlineCompletionManager', () => {
     let manager: InlineCompletionManager
@@ -74,7 +75,10 @@ describe('InlineCompletionManager', () => {
             sendNotification: sendNotificationStub,
         } as unknown as LanguageClient
 
-        manager = new InlineCompletionManager(languageClient)
+        const sessionManager = new SessionManager()
+        const lineTracker = new LineTracker()
+        const lineAnnotationTracker = new LineAnnotationController(lineTracker, sessionManager)
+        manager = new InlineCompletionManager(languageClient, sessionManager, lineTracker, lineAnnotationTracker)
         getActiveSessionStub = sandbox.stub(manager['sessionManager'], 'getActiveSession')
         getActiveRecommendationStub = sandbox.stub(manager['sessionManager'], 'getActiveRecommendation')
         getReferenceStub = sandbox.stub(ReferenceLogViewProvider, 'getReferenceLog')
@@ -264,10 +268,12 @@ describe('InlineCompletionManager', () => {
             let getAllRecommendationsStub: sinon.SinonStub
             let recommendationService: RecommendationService
             let setInlineReferenceStub: sinon.SinonStub
+            let lineAnnotationTracker: LineAnnotationController
 
             beforeEach(() => {
                 const lineTracker = new LineTracker()
                 const activeStateController = new InlineGeneratingMessage(lineTracker)
+                lineAnnotationTracker = new LineAnnotationController(lineTracker, mockSessionManager)
                 recommendationService = new RecommendationService(mockSessionManager, activeStateController)
                 setInlineReferenceStub = sandbox.stub(ReferenceInlineProvider.instance, 'setInlineReference')
 
@@ -290,7 +296,8 @@ describe('InlineCompletionManager', () => {
                     provider = new AmazonQInlineCompletionItemProvider(
                         languageClient,
                         recommendationService,
-                        mockSessionManager
+                        mockSessionManager,
+                        lineAnnotationTracker
                     )
                     const items = await provider.provideInlineCompletionItems(
                         mockDocument,
@@ -306,6 +313,7 @@ describe('InlineCompletionManager', () => {
                         languageClient,
                         recommendationService,
                         mockSessionManager,
+                        lineAnnotationTracker,
                         false
                     )
                     const items = await provider.provideInlineCompletionItems(
@@ -322,6 +330,7 @@ describe('InlineCompletionManager', () => {
                         languageClient,
                         recommendationService,
                         mockSessionManager,
+                        lineAnnotationTracker,
                         false
                     )
                     await provider.provideInlineCompletionItems(mockDocument, mockPosition, mockContext, mockToken)

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -17,7 +17,7 @@ import {
 } from 'aws-core-vscode/codewhisperer'
 import { InlineGeneratingMessage } from '../../../../../src/app/inline/inlineGeneratingMessage'
 import { LineTracker } from '../../../../../src/app/inline/stateTracker/lineTracker'
-import { LineAnnotationController } from '../../../../../src/app/inline/stateTracker/lineAnnotationTracker'
+import { InlineTutorialAnnotation } from '../../../../../src/app/inline/tutorials/inlineTutorialAnnotation'
 
 describe('InlineCompletionManager', () => {
     let manager: InlineCompletionManager
@@ -77,8 +77,8 @@ describe('InlineCompletionManager', () => {
 
         const sessionManager = new SessionManager()
         const lineTracker = new LineTracker()
-        const lineAnnotationTracker = new LineAnnotationController(lineTracker, sessionManager)
-        manager = new InlineCompletionManager(languageClient, sessionManager, lineTracker, lineAnnotationTracker)
+        const inlineTutorialAnnotation = new InlineTutorialAnnotation(lineTracker, sessionManager)
+        manager = new InlineCompletionManager(languageClient, sessionManager, lineTracker, inlineTutorialAnnotation)
         getActiveSessionStub = sandbox.stub(manager['sessionManager'], 'getActiveSession')
         getActiveRecommendationStub = sandbox.stub(manager['sessionManager'], 'getActiveRecommendation')
         getReferenceStub = sandbox.stub(ReferenceLogViewProvider, 'getReferenceLog')
@@ -268,12 +268,12 @@ describe('InlineCompletionManager', () => {
             let getAllRecommendationsStub: sinon.SinonStub
             let recommendationService: RecommendationService
             let setInlineReferenceStub: sinon.SinonStub
-            let lineAnnotationTracker: LineAnnotationController
+            let inlineTutorialAnnotation: InlineTutorialAnnotation
 
             beforeEach(() => {
                 const lineTracker = new LineTracker()
                 const activeStateController = new InlineGeneratingMessage(lineTracker)
-                lineAnnotationTracker = new LineAnnotationController(lineTracker, mockSessionManager)
+                inlineTutorialAnnotation = new InlineTutorialAnnotation(lineTracker, mockSessionManager)
                 recommendationService = new RecommendationService(mockSessionManager, activeStateController)
                 setInlineReferenceStub = sandbox.stub(ReferenceInlineProvider.instance, 'setInlineReference')
 
@@ -297,7 +297,7 @@ describe('InlineCompletionManager', () => {
                         languageClient,
                         recommendationService,
                         mockSessionManager,
-                        lineAnnotationTracker
+                        inlineTutorialAnnotation
                     )
                     const items = await provider.provideInlineCompletionItems(
                         mockDocument,
@@ -313,7 +313,7 @@ describe('InlineCompletionManager', () => {
                         languageClient,
                         recommendationService,
                         mockSessionManager,
-                        lineAnnotationTracker,
+                        inlineTutorialAnnotation,
                         false
                     )
                     const items = await provider.provideInlineCompletionItems(
@@ -330,7 +330,7 @@ describe('InlineCompletionManager', () => {
                         languageClient,
                         recommendationService,
                         mockSessionManager,
-                        lineAnnotationTracker,
+                        inlineTutorialAnnotation,
                         false
                     )
                     await provider.provideInlineCompletionItems(mockDocument, mockPosition, mockContext, mockToken)


### PR DESCRIPTION
## Problem
the tutorial trackers aren't implemented when using the language server

## Solution
- re-add the inlineLineAnnotationController (inlineChatTutorialAnnotation) for adding hints with inline chat
- re-add the lineAnnotationController (inlineTutorialAnnotation) for adding the inline suggestions tutorial

## Notes
in a future PR I'll fully deprecate the old trackers

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
