### PR TITLE
fix(amazonq): agent tabs open with prompt options

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-b873a959-2742-4440-badc-c90c6ac754c3.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-b873a959-2742-4440-badc-c90c6ac754c3.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Named agent tabs sometimes open with unnecessary input options"
+}

--- a/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
@@ -355,6 +355,8 @@ export class QuickActionHandler {
                 loadingChat: true,
                 cancelButtonWhenLoading: false,
             })
+        } else {
+            this.mynahUI.updateStore(affectedTabId, { promptInputOptions: [] })
         }
 
         if (affectedTabId && this.isHybridChatEnabled) {


### PR DESCRIPTION
## Problem

Inconsistent behavior when opening agent tabs (/review, /doc, etc). When the tab is reused it keeps the prompt input options visible, but when a new tab is created it doesn't.


https://github.com/user-attachments/assets/2ff7264f-f7a3-46f6-9a34-e29835768833




## Solution

Set `promptInputOptions` to empty when an existing tab is reused.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
