### PR TITLE
fix(amazonq): Revert refactor(amazonq): reduce extra call of listAvailableCustomization (#7242)

### DIFF
--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -59,7 +59,7 @@ export const onProfileChangedListener: (event: ProfileChangedEvent) => any = asy
     if (event.intent === 'customization') {
         return
     }
-
+    const logger = getLogger()
     if (!event.profile) {
         await setSelectedCustomization(baseCustomization)
         return
@@ -69,7 +69,16 @@ export const onProfileChangedListener: (event: ProfileChangedEvent) => any = asy
     const selectedCustomization = getSelectedCustomization()
     // No need to validate base customization which has empty arn.
     if (selectedCustomization.arn.length > 0) {
-        await switchToBaseCustomizationAndNotify()
+        const customizationProvider = await CustomizationProvider.init(event.profile)
+        const customizations = await customizationProvider.listAvailableCustomizations()
+
+        const r = customizations.find((it) => it.arn === selectedCustomization.arn)
+        if (!r) {
+            logger.debug(
+                `profile ${event.profile.name} doesnt have access to customization ${selectedCustomization.name} but has access to ${customizations.map((it) => it.name)}`
+            )
+            await switchToBaseCustomizationAndNotify()
+        }
     }
 }
 


### PR DESCRIPTION
This reverts commit 98b0d5d1e9b1ea594e6ce0a76045072528b5fc7a.

## Problem
It regress #7181 and make 7181 not working: profile will be changed, but customization will be swapped to default always.


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
