### PR TITLE
refactor(amazonq): rename inline "generating" message class

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -33,7 +33,7 @@ import {
     ImportAdderProvider,
     CodeSuggestionsState,
 } from 'aws-core-vscode/codewhisperer'
-import { ActiveStateTracker } from './stateTracker/activeStateTracker'
+import { InlineGeneratingMessage } from './inlineGeneratingMessage'
 import { LineTracker } from './stateTracker/lineTracker'
 
 export class InlineCompletionManager implements Disposable {
@@ -43,14 +43,14 @@ export class InlineCompletionManager implements Disposable {
     private sessionManager: SessionManager
     private recommendationService: RecommendationService
     private lineTracker: LineTracker
-    private activeStateTracker: ActiveStateTracker
+    private activeStateTracker: InlineGeneratingMessage
     private readonly logSessionResultMessageName = 'aws/logInlineCompletionSessionResults'
 
     constructor(languageClient: LanguageClient) {
         this.languageClient = languageClient
         this.sessionManager = new SessionManager()
         this.lineTracker = new LineTracker()
-        this.activeStateTracker = new ActiveStateTracker(this.lineTracker)
+        this.activeStateTracker = new InlineGeneratingMessage(this.lineTracker)
         this.recommendationService = new RecommendationService(this.sessionManager, this.activeStateTracker)
         this.inlineCompletionProvider = new AmazonQInlineCompletionItemProvider(
             languageClient,

--- a/packages/amazonq/src/app/inline/inlineGeneratingMessage.ts
+++ b/packages/amazonq/src/app/inline/inlineGeneratingMessage.ts
@@ -5,11 +5,14 @@
 
 import { editorUtilities } from 'aws-core-vscode/shared'
 import * as vscode from 'vscode'
-import { LineSelection, LineTracker } from './lineTracker'
+import { LineSelection, LineTracker } from './stateTracker/lineTracker'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { cancellableDebounce } from 'aws-core-vscode/utils'
 
-export class ActiveStateTracker implements vscode.Disposable {
+/**
+ * Manages the inline ghost text message show when Inline Suggestions is "thinking".
+ */
+export class InlineGeneratingMessage implements vscode.Disposable {
     private readonly _disposable: vscode.Disposable
 
     private readonly cwLineHintDecoration: vscode.TextEditorDecorationType =

--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -11,12 +11,12 @@ import {
 import { CancellationToken, InlineCompletionContext, Position, TextDocument } from 'vscode'
 import { LanguageClient } from 'vscode-languageclient'
 import { SessionManager } from './sessionManager'
-import { ActiveStateTracker } from './stateTracker/activeStateTracker'
+import { InlineGeneratingMessage } from './inlineGeneratingMessage'
 
 export class RecommendationService {
     constructor(
         private readonly sessionManager: SessionManager,
-        private readonly activeStateTracker: ActiveStateTracker
+        private readonly inlineGeneratingMessage: InlineGeneratingMessage
     ) {}
 
     async getAllRecommendations(
@@ -35,7 +35,7 @@ export class RecommendationService {
         }
         const requestStartTime = Date.now()
 
-        await this.activeStateTracker.showGenerating(context.triggerKind)
+        await this.inlineGeneratingMessage.showGenerating(context.triggerKind)
 
         // Handle first request
         const firstResult: InlineCompletionListWithReferences = await languageClient.sendRequest(
@@ -61,7 +61,7 @@ export class RecommendationService {
             this.sessionManager.closeSession()
         }
 
-        this.activeStateTracker.hideGenerating()
+        this.inlineGeneratingMessage.hideGenerating()
     }
 
     private async processRemainingRequests(

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -15,7 +15,7 @@ import {
     ReferenceInlineProvider,
     ReferenceLogViewProvider,
 } from 'aws-core-vscode/codewhisperer'
-import { ActiveStateTracker } from '../../../../../src/app/inline/stateTracker/activeStateTracker'
+import { InlineGeneratingMessage } from '../../../../../src/app/inline/inlineGeneratingMessage'
 import { LineTracker } from '../../../../../src/app/inline/stateTracker/lineTracker'
 
 describe('InlineCompletionManager', () => {
@@ -267,7 +267,7 @@ describe('InlineCompletionManager', () => {
 
             beforeEach(() => {
                 const lineTracker = new LineTracker()
-                const activeStateController = new ActiveStateTracker(lineTracker)
+                const activeStateController = new InlineGeneratingMessage(lineTracker)
                 recommendationService = new RecommendationService(mockSessionManager, activeStateController)
                 setInlineReferenceStub = sandbox.stub(ReferenceInlineProvider.instance, 'setInlineReference')
 

--- a/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
@@ -11,7 +11,7 @@ import { RecommendationService } from '../../../../../src/app/inline/recommendat
 import { SessionManager } from '../../../../../src/app/inline/sessionManager'
 import { createMockDocument } from 'aws-core-vscode/test'
 import { LineTracker } from '../../../../../src/app/inline/stateTracker/lineTracker'
-import { ActiveStateTracker } from '../../../../../src/app/inline/stateTracker/activeStateTracker'
+import { InlineGeneratingMessage } from '../../../../../src/app/inline/inlineGeneratingMessage'
 
 describe('RecommendationService', () => {
     let languageClient: LanguageClient
@@ -31,7 +31,7 @@ describe('RecommendationService', () => {
     const mockPartialResultToken = 'some-random-token'
     const sessionManager = new SessionManager()
     const lineTracker = new LineTracker()
-    const activeStateController = new ActiveStateTracker(lineTracker)
+    const activeStateController = new InlineGeneratingMessage(lineTracker)
     const service = new RecommendationService(sessionManager, activeStateController)
 
     beforeEach(() => {


### PR DESCRIPTION
This new name more accurately represents what this class is for. It is just a util to create the "Amazon Q generating" inline message.

- Class is renamed
- File is renamed and move out of the "stateTracker" folder


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
