### PR TITLE
test(amazonq): update inline tests for flare

### DIFF
--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -34,6 +34,10 @@ interface VsCodeState {
      */
     isCodeWhispererEditing: boolean
     /**
+     * Keeps track of whether or not recommendations are currently running
+     */
+    isRecommendationsActive: boolean
+    /**
      * Timestamp of previous user edit
      */
     lastUserModificationTime: number
@@ -44,6 +48,9 @@ interface VsCodeState {
 export const vsCodeState: VsCodeState = {
     isIntelliSenseActive: false,
     isCodeWhispererEditing: false,
+    // hack to globally keep track of whether or not recommendations are currently running. This allows us to know
+    // when recommendations have ran during e2e tests
+    isRecommendationsActive: false,
     lastUserModificationTime: 0,
     isFreeTierLimitReached: false,
 }

--- a/packages/core/src/shared/telemetry/exemptMetrics.ts
+++ b/packages/core/src/shared/telemetry/exemptMetrics.ts
@@ -29,6 +29,8 @@ const validationExemptMetrics: Set<string> = new Set([
     'codewhisperer_codePercentage',
     'codewhisperer_userModification',
     'codewhisperer_userTriggerDecision',
+    'codewhisperer_perceivedLatency', // flare doesn't currently set result property
+    'codewhisperer_serviceInvocation', // flare doesn't currently set result property
     'dynamicresource_selectResources',
     'dynamicresource_copyIdentifier',
     'dynamicresource_mutateResource',


### PR DESCRIPTION
## Problem
inline tests don't work with the language server

## Solution
- I removed the `${name} invoke on unsupported filetype` test because you can't trigger inline completions at all for unsupported filetypes (vscode doesn't allow it -- you need to specify file extentions)
- hack: I have no way to spy on actual inline completions so I added a global variable that lets the tests know when recommendations are being generated :/. This allows us to wait for before accepting/rejecting requests
- hack: codewhisperer_perceivedLatency, codewhisperer_serviceInvocation don't have the result field set in flare so it causes a lot of noisy logs. TODO add the result field there


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
