### PR TITLE
fix(amazonq): adding logs for the agentic chat telemetry events

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -94,6 +94,7 @@ export function registerLanguageServerEventListener(languageClient: LanguageClie
         const telemetryName: string = e.name
 
         if (telemetryName in telemetry) {
+            languageClient.info(`[Telemetry] Emitting ${telemetryName} telemetry: ${JSON.stringify(e.data)}`)
             telemetry[telemetryName as keyof TelemetryBase].emit(e.data)
         }
     })

--- a/packages/core/src/amazonq/webview/ui/quickActions/generator.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/generator.ts
@@ -60,7 +60,7 @@ export class QuickActionGenerator {
                                   command: '/test',
                                   icon: MynahIcons.CHECK_LIST,
                                   placeholder: 'Specify a function(s) in the current file (optional)',
-                                  description: 'Generate unit tests (python & java) for selected code',
+                                  description: 'Generate unit tests for selected code',
                               },
                           ]
                         : []),


### PR DESCRIPTION
## Problem
- No logs is being emitted for  telemetry events.
## Solution
- Adding logs if telemetry events are emitted.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
