### PR TITLE
fix(amazonq): completions not showing in function args

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -17,6 +17,7 @@ import {
     window,
     TextEditor,
     InlineCompletionTriggerKind,
+    Range,
 } from 'vscode'
 import { LanguageClient } from 'vscode-languageclient'
 import {
@@ -228,10 +229,13 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         // get active item from session for displaying
         const items = this.sessionManager.getActiveRecommendation()
         const session = this.sessionManager.getActiveSession()
-        if (!session || !items.length) {
+        const editor = window.activeTextEditor
+        if (!session || !items.length || !editor) {
             return []
         }
-        const editor = window.activeTextEditor
+
+        const start = document.validatePosition(editor.selection.active)
+        const end = position
         for (const item of items) {
             item.command = {
                 command: 'aws.amazonq.acceptInline',
@@ -245,6 +249,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                     session.firstCompletionDisplayLatency,
                 ],
             }
+            item.range = new Range(start, end)
             ReferenceInlineProvider.instance.setInlineReference(
                 position.line,
                 item.insertText as string,

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import sinon from 'sinon'
-import { CancellationToken, commands, languages, Position } from 'vscode'
+import { CancellationToken, commands, languages, Position, window } from 'vscode'
 import assert from 'assert'
 import { LanguageClient } from 'vscode-languageclient'
 import { AmazonQInlineCompletionItemProvider, InlineCompletionManager } from '../../../../../src/app/inline/completion'
@@ -291,6 +291,7 @@ describe('InlineCompletionManager', () => {
                 getActiveRecommendationStub.returns(mockSuggestions)
                 getAllRecommendationsStub = sandbox.stub(recommendationService, 'getAllRecommendations')
                 getAllRecommendationsStub.resolves()
+                sandbox.stub(window, 'activeTextEditor').value(createMockTextEditor())
             }),
                 it('should call recommendation service to get new suggestions for new sessions', async () => {
                     provider = new AmazonQInlineCompletionItemProvider(


### PR DESCRIPTION
## Problem
For some reason inline suggestions won't auto complete in function args e.g.
```
def getName(
```
or
```
def getName(firstName, 
```
if you don't provide a range

## Solution
provide a range similar to what the old implementation was doing

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
