### PR TITLE
telemetry(amazonq): Emit metric on server crash

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -39,6 +39,7 @@ import { processUtils } from 'aws-core-vscode/shared'
 import { activate } from './chat/activation'
 import { AmazonQResourcePaths } from './lspInstaller'
 import { ConfigSection, isValidConfigSection, toAmazonQLSPLogLevel } from './config'
+import { telemetry } from 'aws-core-vscode/telemetry'
 
 const localize = nls.loadMessageBundle()
 const logger = getLogger('amazonqLsp.lspClient')
@@ -284,6 +285,12 @@ function onServerRestartHandler(client: LanguageClient, auth: AmazonQLspAuth) {
         if (!(e.oldState === State.Starting && e.newState === State.Running)) {
             return
         }
+
+        // Emit telemetry that a crash was detected.
+        // It is not guaranteed to 100% be a crash since somehow the server may have been intentionally restarted,
+        // but most of the time it probably will have been due to a crash.
+        // TODO: Port this metric override to common definitions
+        telemetry.languageServer_crash.emit({ id: 'AmazonQ' })
 
         // Need to set the auth token in the again
         await auth.refreshConnection(true)

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1020,6 +1020,15 @@
             ]
         },
         {
+            "name": "languageServer_crash",
+            "description": "Called when a language server crash is detected. TODO: Port this to common",
+            "metadata": [
+                {
+                    "type": "id"
+                }
+            ]
+        },
+        {
             "name": "ide_heartbeat",
             "description": "A heartbeat sent by the extension",
             "metadata": [


### PR DESCRIPTION
When the server crashes and then restarts again, we will emit a metric to indicate it crashed.

When querying look for: `metadata.metricName: languageServer_crash` & `metadata.id: AmazonQ`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
