### PR TITLE
fix(lsp): update extension version

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -34,6 +34,7 @@ import {
     isAmazonInternalOs,
     fs,
     getClientId,
+    extensionVersion,
 } from 'aws-core-vscode/shared'
 import { processUtils } from 'aws-core-vscode/shared'
 import { activate } from './chat/activation'
@@ -119,7 +120,7 @@ export async function startLanguageServer(
                     version: version,
                     extension: {
                         name: 'AmazonQ-For-VSCode',
-                        version: '0.0.1',
+                        version: extensionVersion,
                     },
                     clientId: getClientId(globals.globalState),
                 },


### PR DESCRIPTION
## Problem
- the extension version is a fix string.

## Solution
- update extension version

## Testing
Before change: the userAgent field received in RTS.
```
aws-sdk-nodejs/2.1692.0 darwin/v23.10.0 AWS-Language-Servers AWS-CodeWhisperer/0.1.0 AmazonQ-For-VSCode/0.0.1 Visual-Studio-Code---Insiders/1.100.0-insider ClientId/c342ab45-6aba-4118-b48c-44dcedb10a78 promise
```

After change: Verified via local testing of sending request to RTS.
```
aws-sdk-nodejs/2.1692.0 darwin/v23.10.0 AWS-Language-Servers AWS-CodeWhisperer/0.1.0 AmazonQ-For-VSCode/testPluginVersion Visual-Studio-Code---Insiders/1.100.0-insider ClientId/c342ab45-6aba-4118-b48c-44dcedb10a78 promise
```

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
