### PR TITLE
feat(amazonq): import userWrittenCode configuration for inline with lsp

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -332,6 +332,8 @@ function getConfigSection(section: ConfigSection) {
                     includeSuggestionsWithCodeReferences:
                         CodeWhispererSettings.instance.isSuggestionsWithCodeReferencesEnabled(),
                     shareCodeWhispererContentWithAWS: !CodeWhispererSettings.instance.isOptoutEnabled(),
+                    includeImportsWithSuggestions: CodeWhispererSettings.instance.isImportRecommendationEnabled(),
+                    sendUserWrittenCodeMetrics: true,
                 },
             ]
         case 'aws.logLevel':


### PR DESCRIPTION
## Problem
Add importAdder and userWrittenCode configuration to inline with LSP

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
