### PR TITLE
fix(amazonq): debounce inline suggestion requests.

### DIFF
--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -12,8 +12,9 @@ import { CancellationToken, InlineCompletionContext, Position, TextDocument } fr
 import { LanguageClient } from 'vscode-languageclient'
 import { SessionManager } from './sessionManager'
 import { InlineGeneratingMessage } from './inlineGeneratingMessage'
-import { CodeWhispererStatusBarManager } from 'aws-core-vscode/codewhisperer'
+import { CodeWhispererStatusBarManager, inlineCompletionsDebounceDelay } from 'aws-core-vscode/codewhisperer'
 import { TelemetryHelper } from './telemetryHelper'
+import { debounce } from 'aws-core-vscode/utils'
 
 export class RecommendationService {
     constructor(
@@ -21,7 +22,9 @@ export class RecommendationService {
         private readonly inlineGeneratingMessage: InlineGeneratingMessage
     ) {}
 
-    async getAllRecommendations(
+    getAllRecommendations = debounce(this._getAllRecommendations.bind(this), inlineCompletionsDebounceDelay)
+
+    private async _getAllRecommendations(
         languageClient: LanguageClient,
         document: TextDocument,
         position: Position,

--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -22,7 +22,7 @@ export class RecommendationService {
         private readonly inlineGeneratingMessage: InlineGeneratingMessage
     ) {}
 
-    getAllRecommendations = debounce(this._getAllRecommendations.bind(this), inlineCompletionsDebounceDelay)
+    getAllRecommendations = debounce(this._getAllRecommendations.bind(this), inlineCompletionsDebounceDelay, true)
 
     private async _getAllRecommendations(
         languageClient: LanguageClient,

--- a/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
@@ -214,6 +214,47 @@ describe('RecommendationService', () => {
 
                 await promise2
             })
+
+            it('makes request with the last call', async () => {
+                const mockResult = {
+                    sessionId: 'test-session',
+                    items: [mockInlineCompletionItemOne],
+                    partialResultToken: undefined,
+                }
+
+                sendRequestStub.resolves(mockResult)
+
+                const promise1 = service.getAllRecommendations(
+                    languageClient,
+                    mockDocument,
+                    mockPosition,
+                    mockContext,
+                    mockToken
+                )
+
+                const promise2 = service.getAllRecommendations(
+                    languageClient,
+                    mockDocument,
+                    { line: 2, character: 2 } as Position,
+                    mockContext,
+                    mockToken
+                )
+
+                await clock.tickAsync(inlineCompletionsDebounceDelay + 1000)
+
+                await promise1
+                await promise2
+
+                const expectedRequestArgs = {
+                    textDocument: {
+                        uri: 'file:///test.py',
+                    },
+                    position: { line: 2, character: 2 } as Position,
+                    context: mockContext,
+                }
+                const firstCallArgs = sendRequestStub.firstCall.args[1]
+                assert.deepStrictEqual(firstCallArgs, expectedRequestArgs)
+            })
         })
     })
 })

--- a/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
@@ -9,9 +9,10 @@ import { Position, CancellationToken, InlineCompletionItem } from 'vscode'
 import assert from 'assert'
 import { RecommendationService } from '../../../../../src/app/inline/recommendationService'
 import { SessionManager } from '../../../../../src/app/inline/sessionManager'
-import { createMockDocument } from 'aws-core-vscode/test'
+import { createMockDocument, installFakeClock } from 'aws-core-vscode/test'
 import { LineTracker } from '../../../../../src/app/inline/stateTracker/lineTracker'
 import { InlineGeneratingMessage } from '../../../../../src/app/inline/inlineGeneratingMessage'
+import { inlineCompletionsDebounceDelay } from 'aws-core-vscode/codewhisperer'
 
 describe('RecommendationService', () => {
     let languageClient: LanguageClient
@@ -118,6 +119,101 @@ describe('RecommendationService', () => {
             sessionManager.incrementActiveIndex()
             const items2 = sessionManager.getActiveRecommendation()
             assert.deepStrictEqual(items2, [mockInlineCompletionItemTwo, { insertText: '1' } as InlineCompletionItem])
+        })
+
+        describe('debounce functionality', () => {
+            let clock: ReturnType<typeof installFakeClock>
+
+            beforeEach(() => {
+                clock = installFakeClock()
+            })
+
+            afterEach(() => {
+                clock.uninstall()
+            })
+
+            it('debounces multiple rapid calls', async () => {
+                const mockResult = {
+                    sessionId: 'test-session',
+                    items: [mockInlineCompletionItemOne],
+                    partialResultToken: undefined,
+                }
+
+                sendRequestStub.resolves(mockResult)
+
+                // Make multiple rapid calls
+                const promise1 = service.getAllRecommendations(
+                    languageClient,
+                    mockDocument,
+                    mockPosition,
+                    mockContext,
+                    mockToken
+                )
+                const promise2 = service.getAllRecommendations(
+                    languageClient,
+                    mockDocument,
+                    mockPosition,
+                    mockContext,
+                    mockToken
+                )
+                const promise3 = service.getAllRecommendations(
+                    languageClient,
+                    mockDocument,
+                    mockPosition,
+                    mockContext,
+                    mockToken
+                )
+
+                // Verify that the promises are the same object (debounced)
+                assert.strictEqual(promise1, promise2)
+                assert.strictEqual(promise2, promise3)
+
+                await clock.tickAsync(inlineCompletionsDebounceDelay + 1000)
+
+                await promise1
+                await promise2
+                await promise3
+            })
+
+            it('allows new calls after debounce period', async () => {
+                const mockResult = {
+                    sessionId: 'test-session',
+                    items: [mockInlineCompletionItemOne],
+                    partialResultToken: undefined,
+                }
+
+                sendRequestStub.resolves(mockResult)
+
+                const promise1 = service.getAllRecommendations(
+                    languageClient,
+                    mockDocument,
+                    mockPosition,
+                    mockContext,
+                    mockToken
+                )
+
+                await clock.tickAsync(inlineCompletionsDebounceDelay + 1000)
+
+                await promise1
+
+                const promise2 = service.getAllRecommendations(
+                    languageClient,
+                    mockDocument,
+                    mockPosition,
+                    mockContext,
+                    mockToken
+                )
+
+                assert.notStrictEqual(
+                    promise1,
+                    promise2,
+                    'promises should be different when seperated by debounce period'
+                )
+
+                await clock.tickAsync(inlineCompletionsDebounceDelay + 1000)
+
+                await promise2
+            })
         })
     })
 })

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -196,7 +196,7 @@ export const identityPoolID = 'us-east-1:70717e99-906f-4add-908c-bd9074a2f5b9'
 /**
  * Delay for making requests once the user stops typing. Without a delay, inline suggestions request is triggered every keystroke.
  */
-export const inlineCompletionsDebounceDelay = 100
+export const inlineCompletionsDebounceDelay = 25
 
 export const referenceLog = 'Code Reference Log'
 

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -194,15 +194,9 @@ export const securityScanLearnMoreUri = 'https://docs.aws.amazon.com/amazonq/lat
 export const identityPoolID = 'us-east-1:70717e99-906f-4add-908c-bd9074a2f5b9'
 
 /**
- * the interval of the background thread invocation, which is triggered by the timer
+ * Delay for making requests once the user stops typing. Without a delay, inline suggestions request is triggered every keystroke.
  */
-export const defaultCheckPeriodMillis = 1000 * 60 * 5
-
-// suggestion show delay, in milliseconds
-export const suggestionShowDelay = 250
-
-// add 200ms more delay on top of inline default 30-50ms
-export const inlineSuggestionShowDelay = 200
+export const inlineCompletionsDebounceDelay = 100
 
 export const referenceLog = 'Code Reference Log'
 

--- a/packages/core/src/test/shared/utilities/functionUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/functionUtils.test.ts
@@ -160,7 +160,7 @@ describe('debounce', function () {
         before(function () {
             args = []
             clock = installFakeClock()
-            addToArgs = args.push
+            addToArgs = (n: number) => args.push(n)
         })
 
         afterEach(function () {
@@ -169,11 +169,12 @@ describe('debounce', function () {
         })
 
         it('only calls with the last args', async function () {
-            const debounced = debounce((i: number) => args.push(i), 10, true)
-            debounced(1)
-            debounced(2)
-            debounced(3)
+            const debounced = debounce(addToArgs, 10, true)
+            const p1 = debounced(1)
+            const p2 = debounced(2)
+            const p3 = debounced(3)
             await clock.tickAsync(100)
+            await Promise.all([p1, p2, p3])
             assert.deepStrictEqual(args, [3])
         })
     })

--- a/packages/core/src/test/shared/utilities/functionUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/functionUtils.test.ts
@@ -152,6 +152,32 @@ describe('debounce', function () {
         assert.strictEqual(counter, 2)
     })
 
+    describe('useLastCall option', function () {
+        let args: number[]
+        let clock: ReturnType<typeof installFakeClock>
+        let addToArgs: (i: number) => void
+
+        before(function () {
+            args = []
+            clock = installFakeClock()
+            addToArgs = args.push
+        })
+
+        afterEach(function () {
+            clock.uninstall()
+            args.length = 0
+        })
+
+        it('only calls with the last args', async function () {
+            const debounced = debounce((i: number) => args.push(i), 10, true)
+            debounced(1)
+            debounced(2)
+            debounced(3)
+            await clock.tickAsync(100)
+            assert.deepStrictEqual(args, [3])
+        })
+    })
+
     describe('window rolling', function () {
         let clock: ReturnType<typeof installFakeClock>
         const calls: ReturnType<typeof fn>[] = []


### PR DESCRIPTION
## Problem
When typing a decent amount of text in quick succession, the language server will get throttled in its requests to the backend. This is because we send a request for recommendations on every key stroke, causing the language server to make a request on each key stroke. This is rightfully getting throttled by the backend.

## Solution
- The ideal behavior is that we only make a request to the language server, and thus to the backend, when typing stops. Therefore, this is an ideal use case for `debounce`. However, we need to extend debounce slightly outlined below. 
- Apply `debounce` to the recommendations such that we wait 20 ms after typing stops before fetching the results. 
- By applying this at the recommendation level, none of the inline latency metrics are affected. 

### Debounce Changes
-Let f be some debounced function that takes a string argument, our current debounce does the following:
```
f('a') f('ab') f('abc') (pause for debounce delay) -> f would be called with 'a'
```
The issue is is that for suggestions, this means the language server request will be made with stale context (i.e. not including our most recent content). What we want instead is for the case above to call f with `'abc'` and not with `'a'` or `'ab'`. 

We can accomplish this by adding a flag to `debounce` allowing us to choose whether we call it with the first args of the debounce interval (default, and 'a' in the example above), or the most recent args ('abc' in the example above). 


## Verification
- I did not notice the added latency when testing inline. However it does seem slower than prod, with and without this change. 
- I was not able to get a throttling exception. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
