### PR TITLE
fix(amazonq): pass uri.path as workspaceIdentifier when initializing …

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -134,7 +134,7 @@ export async function startLanguageServer(
                     },
                 },
                 contextConfiguration: {
-                    workspaceIdentifier: extensionContext.storageUri,
+                    workspaceIdentifier: extensionContext.storageUri?.path,
                 },
                 logLevel: toAmazonQLSPLogLevel(globals.logOutputChannel.logLevel),
             },


### PR DESCRIPTION
## Problem

`workspaceIdentifier` should be a string:

- https://github.com/aws/language-server-runtimes/pull/497

## Solution

Update `extensionContext.storageUri` with `extensionContext.storageUri?.path`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
