### PR TITLE
refactor(amazonq): move debounce to top level. 

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -209,7 +209,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         true
     )
 
-    async _provideInlineCompletionItems(
+    private async _provideInlineCompletionItems(
         document: TextDocument,
         position: Position,
         context: InlineCompletionContext,

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -34,12 +34,14 @@ import {
     ImportAdderProvider,
     CodeSuggestionsState,
     vsCodeState,
+    inlineCompletionsDebounceDelay,
 } from 'aws-core-vscode/codewhisperer'
 import { InlineGeneratingMessage } from './inlineGeneratingMessage'
 import { LineTracker } from './stateTracker/lineTracker'
 import { InlineTutorialAnnotation } from './tutorials/inlineTutorialAnnotation'
 import { TelemetryHelper } from './telemetryHelper'
 import { getLogger } from 'aws-core-vscode/shared'
+import { debounce } from 'aws-core-vscode/utils'
 
 export class InlineCompletionManager implements Disposable {
     private disposable: Disposable
@@ -201,7 +203,13 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         private readonly isNewSession: boolean = true
     ) {}
 
-    async provideInlineCompletionItems(
+    provideInlineCompletionItems = debounce(
+        this._provideInlineCompletionItems.bind(this),
+        inlineCompletionsDebounceDelay,
+        true
+    )
+
+    async _provideInlineCompletionItems(
         document: TextDocument,
         position: Position,
         context: InlineCompletionContext,

--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -12,9 +12,8 @@ import { CancellationToken, InlineCompletionContext, Position, TextDocument } fr
 import { LanguageClient } from 'vscode-languageclient'
 import { SessionManager } from './sessionManager'
 import { InlineGeneratingMessage } from './inlineGeneratingMessage'
-import { CodeWhispererStatusBarManager, inlineCompletionsDebounceDelay } from 'aws-core-vscode/codewhisperer'
+import { CodeWhispererStatusBarManager } from 'aws-core-vscode/codewhisperer'
 import { TelemetryHelper } from './telemetryHelper'
-import { debounce } from 'aws-core-vscode/utils'
 
 export class RecommendationService {
     constructor(
@@ -22,9 +21,7 @@ export class RecommendationService {
         private readonly inlineGeneratingMessage: InlineGeneratingMessage
     ) {}
 
-    getAllRecommendations = debounce(this._getAllRecommendations.bind(this), inlineCompletionsDebounceDelay, true)
-
-    private async _getAllRecommendations(
+    async getAllRecommendations(
         languageClient: LanguageClient,
         document: TextDocument,
         position: Position,

--- a/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
@@ -9,10 +9,9 @@ import { Position, CancellationToken, InlineCompletionItem } from 'vscode'
 import assert from 'assert'
 import { RecommendationService } from '../../../../../src/app/inline/recommendationService'
 import { SessionManager } from '../../../../../src/app/inline/sessionManager'
-import { createMockDocument, installFakeClock } from 'aws-core-vscode/test'
+import { createMockDocument } from 'aws-core-vscode/test'
 import { LineTracker } from '../../../../../src/app/inline/stateTracker/lineTracker'
 import { InlineGeneratingMessage } from '../../../../../src/app/inline/inlineGeneratingMessage'
-import { inlineCompletionsDebounceDelay } from 'aws-core-vscode/codewhisperer'
 
 describe('RecommendationService', () => {
     let languageClient: LanguageClient
@@ -119,142 +118,6 @@ describe('RecommendationService', () => {
             sessionManager.incrementActiveIndex()
             const items2 = sessionManager.getActiveRecommendation()
             assert.deepStrictEqual(items2, [mockInlineCompletionItemTwo, { insertText: '1' } as InlineCompletionItem])
-        })
-
-        describe('debounce functionality', () => {
-            let clock: ReturnType<typeof installFakeClock>
-
-            beforeEach(() => {
-                clock = installFakeClock()
-            })
-
-            afterEach(() => {
-                clock.uninstall()
-            })
-
-            it('debounces multiple rapid calls', async () => {
-                const mockResult = {
-                    sessionId: 'test-session',
-                    items: [mockInlineCompletionItemOne],
-                    partialResultToken: undefined,
-                }
-
-                sendRequestStub.resolves(mockResult)
-
-                // Make multiple rapid calls
-                const promise1 = service.getAllRecommendations(
-                    languageClient,
-                    mockDocument,
-                    mockPosition,
-                    mockContext,
-                    mockToken
-                )
-                const promise2 = service.getAllRecommendations(
-                    languageClient,
-                    mockDocument,
-                    mockPosition,
-                    mockContext,
-                    mockToken
-                )
-                const promise3 = service.getAllRecommendations(
-                    languageClient,
-                    mockDocument,
-                    mockPosition,
-                    mockContext,
-                    mockToken
-                )
-
-                // Verify that the promises are the same object (debounced)
-                assert.strictEqual(promise1, promise2)
-                assert.strictEqual(promise2, promise3)
-
-                await clock.tickAsync(inlineCompletionsDebounceDelay + 1000)
-
-                await promise1
-                await promise2
-                await promise3
-            })
-
-            it('allows new calls after debounce period', async () => {
-                const mockResult = {
-                    sessionId: 'test-session',
-                    items: [mockInlineCompletionItemOne],
-                    partialResultToken: undefined,
-                }
-
-                sendRequestStub.resolves(mockResult)
-
-                const promise1 = service.getAllRecommendations(
-                    languageClient,
-                    mockDocument,
-                    mockPosition,
-                    mockContext,
-                    mockToken
-                )
-
-                await clock.tickAsync(inlineCompletionsDebounceDelay + 1000)
-
-                await promise1
-
-                const promise2 = service.getAllRecommendations(
-                    languageClient,
-                    mockDocument,
-                    mockPosition,
-                    mockContext,
-                    mockToken
-                )
-
-                assert.notStrictEqual(
-                    promise1,
-                    promise2,
-                    'promises should be different when seperated by debounce period'
-                )
-
-                await clock.tickAsync(inlineCompletionsDebounceDelay + 1000)
-
-                await promise2
-            })
-
-            it('makes request with the last call', async () => {
-                const mockResult = {
-                    sessionId: 'test-session',
-                    items: [mockInlineCompletionItemOne],
-                    partialResultToken: undefined,
-                }
-
-                sendRequestStub.resolves(mockResult)
-
-                const promise1 = service.getAllRecommendations(
-                    languageClient,
-                    mockDocument,
-                    mockPosition,
-                    mockContext,
-                    mockToken
-                )
-
-                const promise2 = service.getAllRecommendations(
-                    languageClient,
-                    mockDocument,
-                    { line: 2, character: 2 } as Position,
-                    mockContext,
-                    mockToken
-                )
-
-                await clock.tickAsync(inlineCompletionsDebounceDelay + 1000)
-
-                await promise1
-                await promise2
-
-                const expectedRequestArgs = {
-                    textDocument: {
-                        uri: 'file:///test.py',
-                    },
-                    position: { line: 2, character: 2 } as Position,
-                    context: mockContext,
-                }
-                const firstCallArgs = sendRequestStub.firstCall.args[1]
-                assert.deepStrictEqual(firstCallArgs, expectedRequestArgs)
-            })
         })
     })
 })

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -196,7 +196,7 @@ export const identityPoolID = 'us-east-1:70717e99-906f-4add-908c-bd9074a2f5b9'
 /**
  * Delay for making requests once the user stops typing. Without a delay, inline suggestions request is triggered every keystroke.
  */
-export const inlineCompletionsDebounceDelay = 25
+export const inlineCompletionsDebounceDelay = 200
 
 export const referenceLog = 'Code Reference Log'
 


### PR DESCRIPTION
## Problem
Adding logging statements to the top level is extremely noisy, since that part still triggers on each key stroke. This could also improve latency since any computation at the top-level will be redone on each keystroke. 

## Solution
- move the debounce up a layer. 
- remove outdated tests, since the debounce util already has tests for all this logic. 
- added new tests for new behavior. 

## Verification
- I tested this side-by-side with previous version and didn't notice a difference. 
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
