### PR TITLE
feat(codewhisperer): add fileUri to FileContext

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/editorContext.test.ts
@@ -56,6 +56,7 @@ describe('editorContext', function () {
             const editor = createMockTextEditor('import math\ndef two_sum(nums, target):\n', 'test.py', 'python', 1, 17)
             const actual = EditorContext.extractContextForCodeWhisperer(editor)
             const expected: codewhispererClient.FileContext = {
+                fileUri: 'file:///test.py',
                 filename: 'test.py',
                 programmingLanguage: {
                     languageName: 'python',
@@ -76,6 +77,7 @@ describe('editorContext', function () {
             )
             const actual = EditorContext.extractContextForCodeWhisperer(editor)
             const expected: codewhispererClient.FileContext = {
+                fileUri: 'file:///test.py',
                 filename: 'test.py',
                 programmingLanguage: {
                     languageName: 'python',
@@ -112,6 +114,7 @@ describe('editorContext', function () {
 
             const actual = EditorContext.extractContextForCodeWhisperer(editor)
             const expected: codewhispererClient.FileContext = {
+                fileUri: editor.document.uri.toString(),
                 filename: 'Untitled-1.py',
                 programmingLanguage: {
                     languageName: 'python',

--- a/packages/core/src/codewhisperer/client/service-2.json
+++ b/packages/core/src/codewhisperer/client/service-2.json
@@ -612,10 +612,19 @@
                 "filename": {
                     "shape": "FileContextFilenameString"
                 },
+                "fileUri": {
+                    "shape": "FileContextFileUriString"
+                },
                 "programmingLanguage": {
                     "shape": "ProgrammingLanguage"
                 }
             }
+        },
+        "FileContextFileUriString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
         },
         "FileContextFilenameString": {
             "type": "string",

--- a/packages/core/src/codewhisperer/client/user-service-2.json
+++ b/packages/core/src/codewhisperer/client/user-service-2.json
@@ -1852,8 +1852,15 @@
                 "leftFileContent": { "shape": "FileContextLeftFileContentString" },
                 "rightFileContent": { "shape": "FileContextRightFileContentString" },
                 "filename": { "shape": "FileContextFilenameString" },
+                "fileUri": { "shape": "FileContextFileUriString" },
                 "programmingLanguage": { "shape": "ProgrammingLanguage" }
             }
+        },
+        "FileContextFileUriString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
         },
         "FileContextFilenameString": {
             "type": "string",

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -167,6 +167,7 @@ export function extractContextForCodeWhisperer(editor: vscode.TextEditor): codew
     }
 
     return {
+        fileUri: editor.document.uri.toString().substring(0, CodeWhispererConstants.filenameCharsLimit),
         filename: getFileRelativePath(editor),
         programmingLanguage: {
             languageName: languageName,


### PR DESCRIPTION
## Problem

In order to coordinate the new https://github.com/aws/language-servers/pull/1348 change, GenerateCompletions requests would start expecting the `fileUri` field to be set.

## Solution

Add `fileUri` to FileContext

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
