### PR TITLE
fix(amazonq): push customizations on startup

### DIFF
--- a/packages/amazonq/src/lsp/chat/activation.ts
+++ b/packages/amazonq/src/lsp/chat/activation.ts
@@ -25,6 +25,11 @@ export async function activate(languageClient: LanguageClient, encryptionKey: Bu
         type: 'profile',
         profileArn: AuthUtil.instance.regionProfileManager.activeRegionProfile?.arn,
     })
+    // We need to push the cached customization on startup explicitly
+    await pushConfigUpdate(languageClient, {
+        type: 'customization',
+        customization: getSelectedCustomization(),
+    })
 
     const provider = new AmazonQChatViewProvider(mynahUIPath)
 


### PR DESCRIPTION
## Problem

At the startup of the extension, the customization that a user already decided previously was not being pushed to flare.
The only time we would push the customization to flare was if the customization was changed.

Otherwise everything else works as expected.


## Solution

On startup, push the customization to flare (if it already exists)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
