### PR TITLE
deps: bump @aws-toolkits/telemetry to 1.0.319

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.318",
+                "@aws-toolkits/telemetry": "^1.0.319",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -10760,10 +10760,11 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.318",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.318.tgz",
-            "integrity": "sha512-L64GJ+KRN0fdTIx1CPIbbgBeFcg9DilsIxfjeZyod7ld0mw6he70rPopBtK4jP+pTEkfUE4wTRsaco1nWXz3+w==",
+            "version": "1.0.319",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.319.tgz",
+            "integrity": "sha512-NMydYKj2evnYGQuVFoR1pHkyjimu/f5NYiMT4BJBUaKWsaUyxuFoYs497PXtg4ZlJx/sxj11rLLgjZR/ciIVQw==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^6.12.6",
                 "cross-spawn": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.318",
+        "@aws-toolkits/telemetry": "^1.0.319",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",


### PR DESCRIPTION
## Problem
- Added new metrics in aws-toolkit-common package: https://github.com/aws/aws-toolkit-common/pull/1024

## Solution
- Consume latest version of aws-toolkit-common package



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
