### PR TITLE
fix(amazonq): Customization/Profiles not being sent to LSP on startup

### DIFF
--- a/packages/amazonq/src/lsp/chat/activation.ts
+++ b/packages/amazonq/src/lsp/chat/activation.ts
@@ -73,10 +73,6 @@ export async function activate(languageClient: LanguageClient, encryptionKey: Bu
 
     disposables.push(
         AuthUtil.instance.regionProfileManager.onDidChangeRegionProfile(async () => {
-            void pushConfigUpdate(languageClient, {
-                type: 'profile',
-                profileArn: AuthUtil.instance.regionProfileManager.activeRegionProfile?.arn,
-            })
             await provider.refreshWebview()
         }),
         Commands.register('aws.amazonq.updateCustomizations', () => {

--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -5,6 +5,11 @@
 import * as vscode from 'vscode'
 import { DevSettings, getServiceEnvVarConfig } from 'aws-core-vscode/shared'
 import { LspConfig } from 'aws-core-vscode/amazonq'
+import { LanguageClient } from 'vscode-languageclient'
+import {
+    DidChangeConfigurationNotification,
+    updateConfigurationRequestType,
+} from '@aws/language-server-runtimes/protocol'
 
 export interface ExtendedAmazonQLSPConfig extends LspConfig {
     ui?: string
@@ -54,3 +59,45 @@ export function getAmazonQLspConfig(): ExtendedAmazonQLSPConfig {
 export function toAmazonQLSPLogLevel(logLevel: vscode.LogLevel): LspLogLevel {
     return lspLogLevelMapping.get(logLevel) ?? 'info'
 }
+
+/**
+ * Request/Notify a config value to the language server, effectively updating it with the
+ * latest configuration from the client.
+ *
+ * The issue is we need to push certain configs to different places, since there are
+ * different handlers for specific configs. So this determines the correct place to
+ * push the given config.
+ */
+export async function pushConfigUpdate(client: LanguageClient, config: QConfigs) {
+    switch (config.type) {
+        case 'profile':
+            await client.sendRequest(updateConfigurationRequestType.method, {
+                section: 'aws.q',
+                settings: { profileArn: config.profileArn },
+            })
+            break
+        case 'customization':
+            client.sendNotification(DidChangeConfigurationNotification.type.method, {
+                section: 'aws.q',
+                settings: { customization: config.customization },
+            })
+            break
+        case 'logLevel':
+            client.sendNotification(DidChangeConfigurationNotification.type.method, {
+                section: 'aws.logLevel',
+            })
+            break
+    }
+}
+type ProfileConfig = {
+    type: 'profile'
+    profileArn: string | undefined
+}
+type CustomizationConfig = {
+    type: 'customization'
+    customization: string | undefined
+}
+type LogLevelConfig = {
+    type: 'logLevel'
+}
+type QConfigs = ProfileConfig | CustomizationConfig | LogLevelConfig

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -72,7 +72,7 @@ import { AuthUtil } from './util/authUtil'
 import { ImportAdderProvider } from './service/importAdderProvider'
 import { TelemetryHelper } from './util/telemetryHelper'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
-import { notifyNewCustomizations, onProfileChangedListener } from './util/customizationUtil'
+import { onProfileChangedListener } from './util/customizationUtil'
 import { CodeWhispererCommandBackend, CodeWhispererCommandDeclarations } from './commands/gettingStartedPageCommands'
 import { SecurityIssueHoverProvider } from './service/securityIssueHoverProvider'
 import { SecurityIssueCodeActionProvider } from './service/securityIssueCodeActionProvider'
@@ -354,9 +354,6 @@ export async function activate(context: ExtContext): Promise<void> {
         { emit: false, functionId: { name: 'activateCwCore' } }
     )
 
-    if (AuthUtil.instance.isIdcConnection() && AuthUtil.instance.isConnected()) {
-        await notifyNewCustomizations()
-    }
     if (AuthUtil.instance.isBuilderIdConnection()) {
         await CodeScansState.instance.setScansEnabled(false)
     }

--- a/packages/core/src/codewhisperer/index.ts
+++ b/packages/core/src/codewhisperer/index.ts
@@ -107,6 +107,7 @@ export {
     baseCustomization,
     onProfileChangedListener,
     CustomizationProvider,
+    notifyNewCustomizations,
 } from './util/customizationUtil'
 export { Container } from './service/serviceContainer'
 export * from './util/gitUtil'


### PR DESCRIPTION
After some testing there is the edge case of cached Customizations/Profiles not being sent on startup.
This PR fixes that so that they are sent to the LSP on extension startup, when expected.

See each individual commit as they are isolated changes.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
