### PR TITLE
test(amazonq): add tests for edge cases

### DIFF
--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -48,7 +48,7 @@ export class RecommendationService {
 
             // Handle first request
             const firstResult: InlineCompletionListWithReferences = await languageClient.sendRequest(
-                inlineCompletionWithReferencesRequestType as any,
+                inlineCompletionWithReferencesRequestType.method,
                 request,
                 token
             )
@@ -98,7 +98,7 @@ export class RecommendationService {
         while (nextToken) {
             const request = { ...initialRequest, partialResultToken: nextToken }
             const result: InlineCompletionListWithReferences = await languageClient.sendRequest(
-                inlineCompletionWithReferencesRequestType as any,
+                inlineCompletionWithReferencesRequestType.method,
                 request,
                 token
             )


### PR DESCRIPTION
## Problem
There are two edge cases discovered during testing that warrant some tests. 
1. the language server will respond without a range, causing the result to not be rendered. 
2. the language server COULD respond with a `StringValue` instead of string (currently doesn't, but valid in the type contract). 

## Solution
- add tests for these cases, and do minor refactoring to make this easier. 


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
