### PR TITLE
fix(amazonq): standardize reference type for reference log

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/service/referenceLogViewProvider.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/service/referenceLogViewProvider.test.ts
@@ -5,7 +5,6 @@
 import assert from 'assert'
 import { createMockTextEditor, resetCodeWhispererGlobalVariables } from 'aws-core-vscode/test'
 import { ReferenceLogViewProvider, LicenseUtil } from 'aws-core-vscode/codewhisperer'
-
 describe('referenceLogViewProvider', function () {
     beforeEach(async function () {
         await resetCodeWhispererGlobalVariables()
@@ -65,5 +64,40 @@ describe('referenceLogViewProvider', function () {
             assert.ok(actual.includes(mockUrl))
             assert.ok(!actual.includes(LicenseUtil.getLicenseHtml('MIT')))
         })
+    })
+
+    it('accepts references from CW and language server', async function () {
+        const cwReference = {
+            licenseName: 'MIT',
+            repository: 'TEST_REPO',
+            url: 'cw.com',
+            recommendationContentSpan: {
+                start: 0,
+                end: 10,
+            },
+        }
+
+        const flareReference = {
+            referenceName: 'test reference',
+            referenceUrl: 'flare.com',
+            licenseName: 'apache',
+            position: {
+                startCharacter: 0,
+                endCharacter: 10,
+            },
+        }
+
+        const actual = ReferenceLogViewProvider.getReferenceLog(
+            '',
+            [cwReference, flareReference],
+            createMockTextEditor()
+        )
+
+        assert.ok(actual.includes('MIT'))
+        assert.ok(actual.includes('apache'))
+        assert.ok(actual.includes('TEST_REPO'))
+        assert.ok(actual.includes('test reference'))
+        assert.ok(actual.includes('flare.com'))
+        assert.ok(actual.includes('cw.com'))
     })
 })


### PR DESCRIPTION
## Problem
References are not added to the reference log at the bottom. The root cause is that the reference tracker log is expecting CW shaped references, but we are passing "Flare" shaped ones. 

## Solution
- Update the reference log to standardize the shape of incoming references. 

## Testing and Verification
- added unit test.
- Verified e2e:

https://github.com/user-attachments/assets/620f6f3d-1205-405e-96a2-322d5e8220c4


- 
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
