### PR TITLE
fix(amazonq): Profile needing to be selected on server restart

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-2471c584-3904-4d90-bb7c-61efff219e43.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-2471c584-3904-4d90-bb7c-61efff219e43.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix Error: 'Amazon Q service is not signed in'"
+}

--- a/packages/amazonq/.changes/next-release/Bug Fix-91d391d4-3777-4053-9e71-15b36dfa1f67.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-91d391d4-3777-4053-9e71-15b36dfa1f67.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix Error: 'Amazon Q Profile is not selected for IDC connection type'"
+}

--- a/packages/amazonq/src/lsp/auth.ts
+++ b/packages/amazonq/src/lsp/auth.ts
@@ -115,14 +115,11 @@ export class AmazonQLspAuth {
             .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
             .encrypt(encryptionKey)
 
-        const conn = AuthUtil.instance.conn
-        const startUrl = conn?.type === 'sso' ? conn.startUrl : undefined
-
         return {
             data: jwt,
             metadata: {
                 sso: {
-                    startUrl,
+                    startUrl: AuthUtil.instance.startUrl,
                 },
             },
             encrypted: true,

--- a/packages/amazonq/src/lsp/auth.ts
+++ b/packages/amazonq/src/lsp/auth.ts
@@ -18,6 +18,7 @@ import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { Writable } from 'stream'
 import { onceChanged } from 'aws-core-vscode/utils'
 import { getLogger, oneMinute } from 'aws-core-vscode/shared'
+import { isSsoConnection } from 'aws-core-vscode/auth'
 
 export const encryptionKey = crypto.randomBytes(32)
 
@@ -76,8 +77,8 @@ export class AmazonQLspAuth {
      * @param force bypass memoization, and forcefully update the bearer token
      */
     async refreshConnection(force: boolean = false) {
-        const activeConnection = this.authUtil.auth.activeConnection
-        if (activeConnection?.state === 'valid' && activeConnection?.type === 'sso') {
+        const activeConnection = this.authUtil.conn
+        if (this.authUtil.isConnectionValid() && isSsoConnection(activeConnection)) {
             // send the token to the language server
             const token = await this.authUtil.getBearerToken()
             await (force ? this._updateBearerToken(token) : this.updateBearerToken(token))

--- a/packages/amazonq/src/lsp/auth.ts
+++ b/packages/amazonq/src/lsp/auth.ts
@@ -115,11 +115,14 @@ export class AmazonQLspAuth {
             .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
             .encrypt(encryptionKey)
 
+        const conn = AuthUtil.instance.conn
+        const startUrl = conn?.type === 'sso' ? conn.startUrl : undefined
+
         return {
             data: jwt,
             metadata: {
                 sso: {
-                    startUrl: AuthUtil.instance.auth.startUrl,
+                    startUrl,
                 },
             },
             encrypted: true,

--- a/packages/amazonq/src/lsp/chat/activation.ts
+++ b/packages/amazonq/src/lsp/chat/activation.ts
@@ -17,22 +17,6 @@ import { pushConfigUpdate } from '../config'
 export async function activate(languageClient: LanguageClient, encryptionKey: Buffer, mynahUIPath: string) {
     const disposables = globals.context.subscriptions
 
-    // Make sure we've sent an auth profile to the language server before even initializing the UI
-    //
-    // Ideally the handler for onDidChangeRegionProfile would trigger this, but because the handler is set up too late (due to the current structure), the initial event is missed.
-    // So we have to explicitly do it here on startup.
-    if (AuthUtil.instance.isConnectionValid()) {
-        await pushConfigUpdate(languageClient, {
-            type: 'profile',
-            profileArn: AuthUtil.instance.regionProfileManager.activeRegionProfile?.arn,
-        })
-
-        await pushConfigUpdate(languageClient, {
-            type: 'customization',
-            customization: getSelectedCustomization(),
-        })
-    }
-
     const provider = new AmazonQChatViewProvider(mynahUIPath)
 
     disposables.push(

--- a/packages/amazonq/src/lsp/chat/activation.ts
+++ b/packages/amazonq/src/lsp/chat/activation.ts
@@ -12,10 +12,7 @@ import { Commands, getLogger, globals, undefinedIfEmpty } from 'aws-core-vscode/
 import { activate as registerLegacyChatListeners } from '../../app/chat/activation'
 import { DefaultAmazonQAppInitContext } from 'aws-core-vscode/amazonq'
 import { AuthUtil, getSelectedCustomization } from 'aws-core-vscode/codewhisperer'
-import {
-    DidChangeConfigurationNotification,
-    updateConfigurationRequestType,
-} from '@aws/language-server-runtimes/protocol'
+import { pushConfigUpdate } from '../config'
 
 export async function activate(languageClient: LanguageClient, encryptionKey: Buffer, mynahUIPath: string) {
     const disposables = globals.context.subscriptions
@@ -99,45 +96,3 @@ export async function activate(languageClient: LanguageClient, encryptionKey: Bu
         })
     )
 }
-
-/**
- * Push a config value to the language server, effectively updating it with the
- * latest configuration from the client.
- *
- * The issue is we need to push certain configs to different places, since there are
- * different handlers for specific configs. So this determines the correct place to
- * push the given config.
- */
-async function pushConfigUpdate(client: LanguageClient, config: QConfigs) {
-    switch (config.type) {
-        case 'profile':
-            await client.sendRequest(updateConfigurationRequestType.method, {
-                section: 'aws.q',
-                settings: { profileArn: config.profileArn },
-            })
-            break
-        case 'customization':
-            client.sendNotification(DidChangeConfigurationNotification.type.method, {
-                section: 'aws.q',
-                settings: { customization: config.customization },
-            })
-            break
-        case 'logLevel':
-            client.sendNotification(DidChangeConfigurationNotification.type.method, {
-                section: 'aws.logLevel',
-            })
-            break
-    }
-}
-type ProfileConfig = {
-    type: 'profile'
-    profileArn: string | undefined
-}
-type CustomizationConfig = {
-    type: 'customization'
-    customization: string | undefined
-}
-type LogLevelConfig = {
-    type: 'logLevel'
-}
-type QConfigs = ProfileConfig | CustomizationConfig | LogLevelConfig

--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -5,6 +5,11 @@
 import * as vscode from 'vscode'
 import { DevSettings, getServiceEnvVarConfig } from 'aws-core-vscode/shared'
 import { LspConfig } from 'aws-core-vscode/amazonq'
+import { LanguageClient } from 'vscode-languageclient'
+import {
+    DidChangeConfigurationNotification,
+    updateConfigurationRequestType,
+} from '@aws/language-server-runtimes/protocol'
 
 export interface ExtendedAmazonQLSPConfig extends LspConfig {
     ui?: string
@@ -54,3 +59,45 @@ export function getAmazonQLspConfig(): ExtendedAmazonQLSPConfig {
 export function toAmazonQLSPLogLevel(logLevel: vscode.LogLevel): LspLogLevel {
     return lspLogLevelMapping.get(logLevel) ?? 'info'
 }
+
+/**
+ * Request/Notify a config value to the language server, effectively updating it with the
+ * latest configuration from the client.
+ *
+ * The issue is we need to push certain configs to different places, since there are
+ * different handlers for specific configs. So this determines the correct place to
+ * push the given config.
+ */
+export async function pushConfigUpdate(client: LanguageClient, config: QConfigs) {
+    switch (config.type) {
+        case 'profile':
+            await client.sendRequest(updateConfigurationRequestType.method, {
+                section: 'aws.q',
+                settings: { profileArn: config.profileArn },
+            })
+            break
+        case 'customization':
+            client.sendNotification(DidChangeConfigurationNotification.type.method, {
+                section: 'aws.q',
+                settings: { customization: config.customization },
+            })
+            break
+        case 'logLevel':
+            client.sendNotification(DidChangeConfigurationNotification.type.method, {
+                section: 'aws.logLevel',
+            })
+            break
+    }
+}
+type ProfileConfig = {
+    type: 'profile'
+    profileArn: string | undefined
+}
+type CustomizationConfig = {
+    type: 'customization'
+    customization: string | undefined
+}
+type LogLevelConfig = {
+    type: 'logLevel'
+}
+type QConfigs = ProfileConfig | CustomizationConfig | LogLevelConfig

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -18,6 +18,7 @@ export {
     isBuilderIdConnection,
     getTelemetryMetadataForConn,
     isIamConnection,
+    isSsoConnection,
 } from './connection'
 export { Auth } from './auth'
 export { CredentialsStore } from './credentials/store'


### PR DESCRIPTION
See individual commits for isolated changes

## Problem

We were seeing the following errors from the Q Language Server on startup:
- `Amazon Q Profile is not selected for IDC connection type`
- `Amazon Q service is not signed in`

## Solution

We needed to do 2 solutions, each is a separate commit (see their message). There were also some minor refactors.

In short:
- The Auth bearer token MUST be sent to the Q LSP before Profile is sent. We were not doing this and it was causing an error
- When sending the Auth to the Q LSP, the startUrl MUST be included in the request or else it would fail. We thought we were sending it but based on the logs prefixed with `UpdateBearerToken` it showed`sso` did not contain the startUrl

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
