### PR TITLE
feat(amazonq): show a message when no suggestions are found on manual invoke

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -34,7 +34,7 @@ import {
     CodeSuggestionsState,
     vsCodeState,
     inlineCompletionsDebounceDelay,
-    noSuggestions,
+    noInlineSuggestionsMsg,
 } from 'aws-core-vscode/codewhisperer'
 import { InlineGeneratingMessage } from './inlineGeneratingMessage'
 import { LineTracker } from './stateTracker/lineTracker'
@@ -245,7 +245,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
 
             // Show message to user when manual invoke fails to produce results.
             if (items.length === 0 && context.triggerKind === InlineCompletionTriggerKind.Invoke) {
-                void messageUtils.showTimedMessage(noSuggestions, 2000)
+                void messageUtils.showTimedMessage(noInlineSuggestionsMsg, 2000)
             }
 
             if (!session || !items.length || !editor) {

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -249,7 +249,9 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
             }
 
             if (!session || !items.length || !editor) {
-                getLogger().info('Failed to produce inline suggestion results.')
+                getLogger().debug(
+                    `Failed to produce inline suggestion results. Recieved ${items.length} items from service`
+                )
                 return []
             }
 

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -250,7 +250,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
 
             if (!session || !items.length || !editor) {
                 getLogger().debug(
-                    `Failed to produce inline suggestion results. Recieved ${items.length} items from service`
+                    `Failed to produce inline suggestion results. Received ${items.length} items from service`
                 )
                 return []
             }

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -34,13 +34,14 @@ import {
     CodeSuggestionsState,
     vsCodeState,
     inlineCompletionsDebounceDelay,
+    noSuggestions,
 } from 'aws-core-vscode/codewhisperer'
 import { InlineGeneratingMessage } from './inlineGeneratingMessage'
 import { LineTracker } from './stateTracker/lineTracker'
 import { InlineTutorialAnnotation } from './tutorials/inlineTutorialAnnotation'
 import { TelemetryHelper } from './telemetryHelper'
 import { getLogger } from 'aws-core-vscode/shared'
-import { debounce } from 'aws-core-vscode/utils'
+import { debounce, messageUtils } from 'aws-core-vscode/utils'
 
 export class InlineCompletionManager implements Disposable {
     private disposable: Disposable
@@ -241,7 +242,14 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
             const items = this.sessionManager.getActiveRecommendation()
             const session = this.sessionManager.getActiveSession()
             const editor = window.activeTextEditor
+
+            // Show message to user when manual invoke fails to produce results.
+            if (items.length === 0 && context.triggerKind === InlineCompletionTriggerKind.Invoke) {
+                void messageUtils.showTimedMessage(noSuggestions, 2000)
+            }
+
             if (!session || !items.length || !editor) {
+                getLogger().info('Failed to produce inline suggestion results.')
                 return []
             }
 

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -29,7 +29,6 @@ import {
 import { InlineGeneratingMessage } from '../../../../../src/app/inline/inlineGeneratingMessage'
 import { LineTracker } from '../../../../../src/app/inline/stateTracker/lineTracker'
 import { InlineTutorialAnnotation } from '../../../../../src/app/inline/tutorials/inlineTutorialAnnotation'
-import { waitUntil } from 'aws-core-vscode/shared'
 
 describe('InlineCompletionManager', () => {
     let manager: InlineCompletionManager
@@ -420,20 +419,19 @@ describe('InlineCompletionManager', () => {
                         true
                     )
                     getActiveRecommendationStub.returns([])
-                    let messageShown = false
-                    getTestWindow().onDidShowMessage((e) => {
-                        assert.strictEqual(e.message, noInlineSuggestionsMsg)
-                        messageShown = true
-                    })
+                    const messageShown = new Promise((resolve) =>
+                        getTestWindow().onDidShowMessage((e) => {
+                            assert.strictEqual(e.message, noInlineSuggestionsMsg)
+                            resolve(true)
+                        })
+                    )
                     await provider.provideInlineCompletionItems(
                         mockDocument,
                         mockPosition,
                         { triggerKind: InlineCompletionTriggerKind.Invoke, selectedCompletionInfo: undefined },
                         mockToken
                     )
-                    // Wait up to a second for message to appear since there is potential race condition.
-                    await waitUntil(async () => messageShown, { timeout: 1000, interval: 100 })
-                    assert.ok(messageShown)
+                    await messageShown
                 })
             describe('debounce behavior', function () {
                 let clock: ReturnType<typeof installFakeClock>

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -21,7 +21,7 @@ import { RecommendationService } from '../../../../../src/app/inline/recommendat
 import { SessionManager } from '../../../../../src/app/inline/sessionManager'
 import { createMockDocument, createMockTextEditor, getTestWindow, installFakeClock } from 'aws-core-vscode/test'
 import {
-    noSuggestions,
+    noInlineSuggestionsMsg,
     ReferenceHoverProvider,
     ReferenceInlineProvider,
     ReferenceLogViewProvider,
@@ -422,7 +422,7 @@ describe('InlineCompletionManager', () => {
                     getActiveRecommendationStub.returns([])
                     let messageShown = false
                     getTestWindow().onDidShowMessage((e) => {
-                        assert.strictEqual(e.message, noSuggestions)
+                        assert.strictEqual(e.message, noInlineSuggestionsMsg)
                         messageShown = true
                     })
                     await provider.provideInlineCompletionItems(

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -155,7 +155,7 @@ export const runningSecurityScan = 'Reviewing project for code issues...'
 
 export const runningFileScan = 'Reviewing current file for code issues...'
 
-export const noSuggestions = 'No suggestions from Amazon Q'
+export const noInlineSuggestionsMsg = 'No suggestions from Amazon Q'
 
 export const licenseFilter = 'Amazon Q suggestions were filtered due to reference settings'
 

--- a/packages/core/src/shared/utilities/index.ts
+++ b/packages/core/src/shared/utilities/index.ts
@@ -6,3 +6,4 @@
 export { isExtensionInstalled, isExtensionActive } from './vsCodeUtils'
 export { VSCODE_EXTENSION_ID } from '../extensions'
 export * from './functionUtils'
+export * as messageUtils from './messages'


### PR DESCRIPTION
## Problem
When manually invoking inline suggestions, it is possible for the backend to still not reply with results. Since the user took an action to invoke this, we should let them know when it fails. 

## Solution
- add a message with same timeout as original implementation. 

## Testing and Verification
- added unit test. 
- E2E flow demo (notice it doesn't trigger on automatic failures, but does on manual invoke failures):


https://github.com/user-attachments/assets/7cf34178-e91e-4d38-8875-1259c5552a53


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
