### PR TITLE
fix(amazonq): inline suggestion scrolling now uses built-in VSC commands. 

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -28,7 +28,6 @@ import { RecommendationService } from './recommendationService'
 import {
     CodeWhispererConstants,
     ReferenceHoverProvider,
-    ReferenceInlineProvider,
     ReferenceLogViewProvider,
     ImportAdderProvider,
     CodeSuggestionsState,
@@ -234,11 +233,6 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                 }
                 item.range = new Range(cursorPosition, cursorPosition)
                 item.insertText = typeof item.insertText === 'string' ? item.insertText : item.insertText.value
-                ReferenceInlineProvider.instance.setInlineReference(
-                    cursorPosition.line,
-                    item.insertText,
-                    item.references
-                )
                 ImportAdderProvider.instance.onShowRecommendation(document, cursorPosition.line, item)
             }
             return items as InlineCompletionItem[]

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -181,10 +181,8 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         context: InlineCompletionContext,
         token: CancellationToken
     ): Promise<InlineCompletionItem[]> {
-        getLogger().debug(`provideInlineCompletionItems: ${context.triggerKind}`)
         try {
             vsCodeState.isRecommendationsActive = true
-            getLogger().debug(`provideInlineCompletionItems triggered`)
             const isAutoTrigger = context.triggerKind === InlineCompletionTriggerKind.Automatic
             if (isAutoTrigger && !CodeSuggestionsState.instance.isSuggestionsEnabled()) {
                 // return early when suggestions are disabled with auto trigger

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -158,39 +158,6 @@ export class InlineCompletionManager implements Disposable {
             this.languageClient.sendNotification(this.logSessionResultMessageName, params)
         }
         commands.registerCommand('aws.amazonq.rejectCodeSuggestion', onInlineRejection)
-
-        /*
-            We have to overwrite the prev. and next. commands because the inlineCompletionProvider only contained the current item
-            To show prev. and next. recommendation we need to re-register a new provider with the previous or next item
-        */
-
-        const swapProviderAndShow = async () => {
-            await commands.executeCommand('editor.action.inlineSuggest.hide')
-            this.disposable.dispose()
-            this.disposable = languages.registerInlineCompletionItemProvider(
-                CodeWhispererConstants.platformLanguageIds,
-                new AmazonQInlineCompletionItemProvider(
-                    this.languageClient,
-                    this.recommendationService,
-                    this.sessionManager,
-                    this.inlineTutorialAnnotation,
-                    false
-                )
-            )
-            await commands.executeCommand('editor.action.inlineSuggest.trigger')
-        }
-
-        const prevCommandHandler = async () => {
-            this.sessionManager.decrementActiveIndex()
-            await swapProviderAndShow()
-        }
-        commands.registerCommand('editor.action.inlineSuggest.showPrevious', prevCommandHandler)
-
-        const nextCommandHandler = async () => {
-            this.sessionManager.incrementActiveIndex()
-            await swapProviderAndShow()
-        }
-        commands.registerCommand('editor.action.inlineSuggest.showNext', nextCommandHandler)
     }
 }
 
@@ -199,8 +166,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         private readonly languageClient: LanguageClient,
         private readonly recommendationService: RecommendationService,
         private readonly sessionManager: SessionManager,
-        private readonly inlineTutorialAnnotation: InlineTutorialAnnotation,
-        private readonly isNewSession: boolean = true
+        private readonly inlineTutorialAnnotation: InlineTutorialAnnotation
     ) {}
 
     provideInlineCompletionItems = debounce(
@@ -215,29 +181,28 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         context: InlineCompletionContext,
         token: CancellationToken
     ): Promise<InlineCompletionItem[]> {
+        getLogger().debug(`provideInlineCompletionItems: ${context.triggerKind}`)
         try {
             vsCodeState.isRecommendationsActive = true
-            if (this.isNewSession) {
-                const isAutoTrigger = context.triggerKind === InlineCompletionTriggerKind.Automatic
-                if (isAutoTrigger && !CodeSuggestionsState.instance.isSuggestionsEnabled()) {
-                    // return early when suggestions are disabled with auto trigger
-                    return []
-                }
-
-                // tell the tutorial that completions has been triggered
-                await this.inlineTutorialAnnotation.triggered(context.triggerKind)
-                TelemetryHelper.instance.setInvokeSuggestionStartTime()
-                TelemetryHelper.instance.setTriggerType(context.triggerKind)
-
-                // make service requests if it's a new session
-                await this.recommendationService.getAllRecommendations(
-                    this.languageClient,
-                    document,
-                    position,
-                    context,
-                    token
-                )
+            getLogger().debug(`provideInlineCompletionItems triggered`)
+            const isAutoTrigger = context.triggerKind === InlineCompletionTriggerKind.Automatic
+            if (isAutoTrigger && !CodeSuggestionsState.instance.isSuggestionsEnabled()) {
+                // return early when suggestions are disabled with auto trigger
+                return []
             }
+
+            // tell the tutorial that completions has been triggered
+            await this.inlineTutorialAnnotation.triggered(context.triggerKind)
+            TelemetryHelper.instance.setInvokeSuggestionStartTime()
+            TelemetryHelper.instance.setTriggerType(context.triggerKind)
+
+            await this.recommendationService.getAllRecommendations(
+                this.languageClient,
+                document,
+                position,
+                context,
+                token
+            )
             // get active item from session for displaying
             const items = this.sessionManager.getActiveRecommendation()
             const session = this.sessionManager.getActiveSession()

--- a/packages/amazonq/src/app/inline/sessionManager.ts
+++ b/packages/amazonq/src/app/inline/sessionManager.ts
@@ -55,10 +55,7 @@ export class SessionManager {
     }
 
     public getActiveRecommendation(): InlineCompletionItemWithReferences[] {
-        if (!this.activeSession) {
-            return []
-        }
-        return this.activeSession.suggestions
+        return this.activeSession?.suggestions ?? []
     }
 
     public get acceptedSuggestionCount(): number {

--- a/packages/amazonq/src/app/inline/sessionManager.ts
+++ b/packages/amazonq/src/app/inline/sessionManager.ts
@@ -17,7 +17,6 @@ interface CodeWhispererSession {
 
 export class SessionManager {
     private activeSession?: CodeWhispererSession
-    private activeIndex: number = 0
     private _acceptedSuggestionCount: number = 0
 
     constructor() {}
@@ -35,7 +34,6 @@ export class SessionManager {
             requestStartTime,
             firstCompletionDisplayLatency,
         }
-        this.activeIndex = 0
     }
 
     public closeSession() {
@@ -56,23 +54,6 @@ export class SessionManager {
         this.activeSession.suggestions = [...this.activeSession.suggestions, ...suggestions]
     }
 
-    public incrementActiveIndex() {
-        const suggestionCount = this.activeSession?.suggestions?.length
-        if (!suggestionCount) {
-            return
-        }
-        this.activeIndex === suggestionCount - 1 ? suggestionCount - 1 : this.activeIndex++
-    }
-
-    public decrementActiveIndex() {
-        this.activeIndex === 0 ? 0 : this.activeIndex--
-    }
-
-    /*
-        We have to maintain the active suggestion index ourselves because VS Code doesn't expose which suggestion it's currently showing
-        In order to keep track of the right suggestion state, and for features such as reference tracker, this hack is still needed
-     */
-
     public getActiveRecommendation(): InlineCompletionItemWithReferences[] {
         if (!this.activeSession) {
             return []
@@ -90,6 +71,5 @@ export class SessionManager {
 
     public clear() {
         this.activeSession = undefined
-        this.activeIndex = 0
     }
 }

--- a/packages/amazonq/src/app/inline/sessionManager.ts
+++ b/packages/amazonq/src/app/inline/sessionManager.ts
@@ -74,27 +74,10 @@ export class SessionManager {
      */
 
     public getActiveRecommendation(): InlineCompletionItemWithReferences[] {
-        let suggestionCount = this.activeSession?.suggestions.length
-        if (!suggestionCount) {
+        if (!this.activeSession) {
             return []
         }
-        if (suggestionCount === 1 && this.activeSession?.isRequestInProgress) {
-            suggestionCount += 1
-        }
-
-        const activeSuggestion = this.activeSession?.suggestions[this.activeIndex]
-        if (!activeSuggestion) {
-            return []
-        }
-        const items = [activeSuggestion]
-        // to make the total number of suggestions match the actual number
-        for (let i = 1; i < suggestionCount; i++) {
-            items.push({
-                ...activeSuggestion,
-                insertText: `${i}`,
-            })
-        }
-        return items
+        return this.activeSession.suggestions
     }
 
     public get acceptedSuggestionCount(): number {

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -230,46 +230,6 @@ describe('InlineCompletionManager', () => {
                 assert(registerProviderStub.calledTwice) // Once in constructor, once after rejection
             })
         })
-
-        describe('previous command', () => {
-            it('should register and handle previous command correctly', async () => {
-                const prevCommandCall = registerCommandStub
-                    .getCalls()
-                    .find((call) => call.args[0] === 'editor.action.inlineSuggest.showPrevious')
-
-                assert(prevCommandCall, 'Previous command should be registered')
-
-                if (prevCommandCall) {
-                    const handler = prevCommandCall.args[1]
-                    await handler()
-
-                    assert(executeCommandStub.calledWith('editor.action.inlineSuggest.hide'))
-                    assert(disposableStub.calledOnce)
-                    assert(registerProviderStub.calledTwice)
-                    assert(executeCommandStub.calledWith('editor.action.inlineSuggest.trigger'))
-                }
-            })
-        })
-
-        describe('next command', () => {
-            it('should register and handle next command correctly', async () => {
-                const nextCommandCall = registerCommandStub
-                    .getCalls()
-                    .find((call) => call.args[0] === 'editor.action.inlineSuggest.showNext')
-
-                assert(nextCommandCall, 'Next command should be registered')
-
-                if (nextCommandCall) {
-                    const handler = nextCommandCall.args[1]
-                    await handler()
-
-                    assert(executeCommandStub.calledWith('editor.action.inlineSuggest.hide'))
-                    assert(disposableStub.calledOnce)
-                    assert(registerProviderStub.calledTwice)
-                    assert(executeCommandStub.calledWith('editor.action.inlineSuggest.trigger'))
-                }
-            })
-        })
     })
 
     describe('AmazonQInlineCompletionItemProvider', () => {

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -320,30 +320,12 @@ describe('InlineCompletionManager', () => {
                     assert(getAllRecommendationsStub.calledOnce)
                     assert.deepStrictEqual(items, mockSuggestions)
                 }),
-                it('should not call recommendation service for existing sessions', async () => {
-                    provider = new AmazonQInlineCompletionItemProvider(
-                        languageClient,
-                        recommendationService,
-                        mockSessionManager,
-                        inlineTutorialAnnotation,
-                        false
-                    )
-                    const items = await provider.provideInlineCompletionItems(
-                        mockDocument,
-                        mockPosition,
-                        mockContext,
-                        mockToken
-                    )
-                    assert(getAllRecommendationsStub.notCalled)
-                    assert.deepStrictEqual(items, mockSuggestions)
-                }),
                 it('should handle reference if there is any', async () => {
                     provider = new AmazonQInlineCompletionItemProvider(
                         languageClient,
                         recommendationService,
                         mockSessionManager,
-                        inlineTutorialAnnotation,
-                        false
+                        inlineTutorialAnnotation
                     )
                     await provider.provideInlineCompletionItems(mockDocument, mockPosition, mockContext, mockToken)
                     assert(setInlineReferenceStub.calledOnce)
@@ -360,8 +342,7 @@ describe('InlineCompletionManager', () => {
                         languageClient,
                         recommendationService,
                         mockSessionManager,
-                        inlineTutorialAnnotation,
-                        true
+                        inlineTutorialAnnotation
                     )
                     getActiveRecommendationStub.returns([
                         {
@@ -391,8 +372,7 @@ describe('InlineCompletionManager', () => {
                         languageClient,
                         recommendationService,
                         mockSessionManager,
-                        inlineTutorialAnnotation,
-                        true
+                        inlineTutorialAnnotation
                     )
                     const expectedText = 'this is my text'
                     getActiveRecommendationStub.returns([
@@ -415,8 +395,7 @@ describe('InlineCompletionManager', () => {
                         languageClient,
                         recommendationService,
                         mockSessionManager,
-                        inlineTutorialAnnotation,
-                        true
+                        inlineTutorialAnnotation
                     )
                     getActiveRecommendationStub.returns([])
                     const messageShown = new Promise((resolve) =>
@@ -449,8 +428,7 @@ describe('InlineCompletionManager', () => {
                         languageClient,
                         recommendationService,
                         mockSessionManager,
-                        inlineTutorialAnnotation,
-                        false
+                        inlineTutorialAnnotation
                     )
                     const p1 = provider.provideInlineCompletionItems(mockDocument, mockPosition, mockContext, mockToken)
                     const p2 = provider.provideInlineCompletionItems(mockDocument, mockPosition, mockContext, mockToken)

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -20,12 +20,7 @@ import { AmazonQInlineCompletionItemProvider, InlineCompletionManager } from '..
 import { RecommendationService } from '../../../../../src/app/inline/recommendationService'
 import { SessionManager } from '../../../../../src/app/inline/sessionManager'
 import { createMockDocument, createMockTextEditor, getTestWindow, installFakeClock } from 'aws-core-vscode/test'
-import {
-    noInlineSuggestionsMsg,
-    ReferenceHoverProvider,
-    ReferenceInlineProvider,
-    ReferenceLogViewProvider,
-} from 'aws-core-vscode/codewhisperer'
+import { noInlineSuggestionsMsg, ReferenceHoverProvider, ReferenceLogViewProvider } from 'aws-core-vscode/codewhisperer'
 import { InlineGeneratingMessage } from '../../../../../src/app/inline/inlineGeneratingMessage'
 import { LineTracker } from '../../../../../src/app/inline/stateTracker/lineTracker'
 import { InlineTutorialAnnotation } from '../../../../../src/app/inline/tutorials/inlineTutorialAnnotation'
@@ -238,7 +233,6 @@ describe('InlineCompletionManager', () => {
             let provider: AmazonQInlineCompletionItemProvider
             let getAllRecommendationsStub: sinon.SinonStub
             let recommendationService: RecommendationService
-            let setInlineReferenceStub: sinon.SinonStub
             let inlineTutorialAnnotation: InlineTutorialAnnotation
 
             beforeEach(() => {
@@ -246,7 +240,6 @@ describe('InlineCompletionManager', () => {
                 const activeStateController = new InlineGeneratingMessage(lineTracker)
                 inlineTutorialAnnotation = new InlineTutorialAnnotation(lineTracker, mockSessionManager)
                 recommendationService = new RecommendationService(mockSessionManager, activeStateController)
-                setInlineReferenceStub = sandbox.stub(ReferenceInlineProvider.instance, 'setInlineReference')
 
                 mockSessionManager = {
                     getActiveSession: getActiveSessionStub,
@@ -288,14 +281,6 @@ describe('InlineCompletionManager', () => {
                         inlineTutorialAnnotation
                     )
                     await provider.provideInlineCompletionItems(mockDocument, mockPosition, mockContext, mockToken)
-                    assert(setInlineReferenceStub.calledOnce)
-                    assert(
-                        setInlineReferenceStub.calledWithExactly(
-                            mockPosition.line,
-                            mockSuggestions[0].insertText,
-                            fakeReferences
-                        )
-                    )
                 }),
                 it('should add a range to the completion item when missing', async function () {
                     provider = new AmazonQInlineCompletionItemProvider(

--- a/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
@@ -111,13 +111,6 @@ describe('RecommendationService', () => {
                 ...expectedRequestArgs,
                 partialResultToken: mockPartialResultToken,
             })
-
-            // Verify session management
-            const items = sessionManager.getActiveRecommendation()
-            assert.deepStrictEqual(items, [mockInlineCompletionItemOne, { insertText: '1' } as InlineCompletionItem])
-            sessionManager.incrementActiveIndex()
-            const items2 = sessionManager.getActiveRecommendation()
-            assert.deepStrictEqual(items2, [mockInlineCompletionItemTwo, { insertText: '1' } as InlineCompletionItem])
         })
     })
 })


### PR DESCRIPTION
## Problem
The current implementation overwrites the `editor.action.inlineSuggest.showPrevious` and `editor.action.inlineSuggest.showNext` commands to swap out the inlineProvider. These custom overwrites cause a few issues:
- forces us to maintain a ton of state [leads to bugs, some of which were observed in bug bash].
- causes the suggestions to "refresh" when going through them since we are re-instantiating the provider on "scrolls". 
- doesn't natively support "accept word"/"accept line". 

## Solution
- Remove the overwrite, remove reliance of `session` state. 
- Simplify implementation to use native VSC commands. 

## Fixed Bugs
- Scrolling through suggestions now works and doesn't "refresh". 
- Accept Word/Accept Line now work properly. 
- Significantly faster to scroll through suggestions. 
- Inline Reference Codelense no longer flashes when scrolling through suggestions. 

## Tests and Verification: 
Testing this change it feels significantly 'smoother'. 


https://github.com/user-attachments/assets/631ee822-3cab-46b5-a07c-b3d4b8eb7d3b



## Future Work
- with some more aggressive refactoring, and once telemetry is mostly in Flare, we can completely delete the sessionManager. 
- revisit reference codelense, and see if its the right choice. Maybe a message instead?

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
