### PR TITLE
feat(chat): Add ripgrep path and make it executable

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-09ac6888-de83-418b-afa7-d1cc58f687b2.json
+++ b/packages/amazonq/.changes/next-release/Feature-09ac6888-de83-418b-afa7-d1cc58f687b2.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "Add grepSearch dependency for agentic chat"
-}

--- a/packages/amazonq/.changes/next-release/Feature-09ac6888-de83-418b-afa7-d1cc58f687b2.json
+++ b/packages/amazonq/.changes/next-release/Feature-09ac6888-de83-418b-afa7-d1cc58f687b2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Add grepSearch dependency for agentic chat"
+}

--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -13,7 +13,7 @@ export interface AmazonQResourcePaths extends ResourcePaths {
      * Path to `rg` (or `rg.exe`) executable/binary.
      * Example: `"<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/rg"`
      */
-    rg: string
+    ripGrep: string
 }
 
 export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
@@ -27,8 +27,8 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
     protected override async postInstall(assetDirectory: string): Promise<void> {
         const resourcePaths = this.resourcePaths(assetDirectory)
         await fs.chmod(resourcePaths.node, 0o755)
-        if (await fs.exists(resourcePaths.rg)) {
-            await fs.chmod(resourcePaths.rg, 0o755)
+        if (await fs.exists(resourcePaths.ripGrep)) {
+            await fs.chmod(resourcePaths.ripGrep, 0o755)
         }
     }
 
@@ -37,7 +37,7 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
             return {
                 lsp: this.config.path ?? '',
                 node: getNodeExecutableName(),
-                rg: `ripgrep/${getRgExecutableName()}`,
+                ripGrep: `ripgrep/${getRgExecutableName()}`,
                 ui: this.config.ui ?? '',
             }
         }
@@ -47,7 +47,7 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
         return {
             lsp: path.join(assetDirectory, 'servers/aws-lsp-codewhisperer.js'),
             node: nodePath,
-            rg: rgPath,
+            ripGrep: rgPath,
             ui: path.join(assetDirectory, 'clients/amazonq-ui.js'),
         }
     }

--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -3,12 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fs, getNodeExecutableName, BaseLspInstaller, ResourcePaths } from 'aws-core-vscode/shared'
+import { fs, getNodeExecutableName, getRgExecutableName, BaseLspInstaller, ResourcePaths } from 'aws-core-vscode/shared'
 import path from 'path'
 import { ExtendedAmazonQLSPConfig, getAmazonQLspConfig } from './config'
 
 export interface AmazonQResourcePaths extends ResourcePaths {
     ui: string
+    /**
+     * Path to `rg` (or `rg.exe`) executable/binary.
+     * Example: `"<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/rg"`
+     */
+    rg: string
 }
 
 export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
@@ -22,6 +27,9 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
     protected override async postInstall(assetDirectory: string): Promise<void> {
         const resourcePaths = this.resourcePaths(assetDirectory)
         await fs.chmod(resourcePaths.node, 0o755)
+        if (await fs.exists(resourcePaths.rg)) {
+            await fs.chmod(resourcePaths.rg, 0o755)
+        }
     }
 
     protected override resourcePaths(assetDirectory?: string): AmazonQResourcePaths {
@@ -29,14 +37,17 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
             return {
                 lsp: this.config.path ?? '',
                 node: getNodeExecutableName(),
+                rg: `ripgrep/${getRgExecutableName()}`,
                 ui: this.config.ui ?? '',
             }
         }
 
         const nodePath = path.join(assetDirectory, `servers/${getNodeExecutableName()}`)
+        const rgPath = path.join(assetDirectory, `servers/ripgrep/${getRgExecutableName()}`)
         return {
             lsp: path.join(assetDirectory, 'servers/aws-lsp-codewhisperer.js'),
             node: nodePath,
+            rg: rgPath,
             ui: path.join(assetDirectory, 'clients/amazonq-ui.js'),
         }
     }

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -13,6 +13,10 @@ export function getNodeExecutableName(): string {
     return process.platform === 'win32' ? 'node.exe' : 'node'
 }
 
+export function getRgExecutableName(): string {
+    return process.platform === 'win32' ? 'rg.exe' : 'rg'
+}
+
 /**
  * Get a json payload that will be sent to the language server, who is waiting to know what the encryption key is.
  * Code reference: https://github.com/aws/language-servers/blob/7da212185a5da75a72ce49a1a7982983f438651a/client/vscode/src/credentialsActivation.ts#L77


### PR DESCRIPTION
## Problem
- AgenticChat will add a grepSearch tool which depends on ripgrep binary

## Solution
- Add ripgrep path and make it executable

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
