### PR TITLE
feat(amazonq): remove option to select multiple diffs

### DIFF
--- a/packages/amazonq/.changes/next-release/Removal-4bab219b-28df-44af-8b7f-6ea50dbb02a8.json
+++ b/packages/amazonq/.changes/next-release/Removal-4bab219b-28df-44af-8b7f-6ea50dbb02a8.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "/transform: remove option to select multiple diffs"
+}

--- a/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
+++ b/packages/amazonq/test/e2e/amazonq/transformByQ.test.ts
@@ -65,7 +65,7 @@ describe('Amazon Q Code Transformation', function () {
     })
 
     describe('Starting a transformation from chat', () => {
-        it('Can click through all user input forms for a Java upgrade', async () => {
+        it.only('Can click through all user input forms for a Java upgrade', async () => {
             sinon.stub(startTransformByQ, 'getValidSQLConversionCandidateProjects').resolves([])
             sinon.stub(GumbyController.prototype, 'validateLanguageUpgradeProjects' as keyof GumbyController).resolves([
                 {
@@ -123,29 +123,8 @@ describe('Amazon Q Code Transformation', function () {
                 formItemValues: skipTestsFormValues,
             })
 
-            // 3 additional chat messages (including message with 3rd form) get sent after 2nd form submitted; wait for all of them
-            await tab.waitForEvent(() => tab.getChatItems().length > 9, {
-                waitTimeoutInMs: 5000,
-                waitIntervalInMs: 1000,
-            })
-            const multipleDiffsForm = tab.getChatItems().pop()
-            assert.strictEqual(
-                multipleDiffsForm?.formItems?.[0]?.id ?? undefined,
-                'GumbyTransformOneOrMultipleDiffsForm'
-            )
-
-            const oneOrMultipleDiffsFormItemValues = {
-                GumbyTransformOneOrMultipleDiffsForm: 'One diff',
-            }
-            const oneOrMultipleDiffsFormValues: Record<string, string> = { ...oneOrMultipleDiffsFormItemValues }
-            tab.clickCustomFormButton({
-                id: 'gumbyTransformOneOrMultipleDiffsFormConfirm',
-                text: 'Confirm',
-                formItemValues: oneOrMultipleDiffsFormValues,
-            })
-
             // 2 additional chat messages get sent after 3rd form submitted; wait for both of them
-            await tab.waitForEvent(() => tab.getChatItems().length > 11, {
+            await tab.waitForEvent(() => tab.getChatItems().length > 8, {
                 waitTimeoutInMs: 5000,
                 waitIntervalInMs: 1000,
             })
@@ -172,7 +151,7 @@ describe('Amazon Q Code Transformation', function () {
             tab.addChatMessage({ prompt: '/dummy/path/to/jdk8' })
 
             // 2 additional chat messages get sent after JDK path submitted; wait for both of them
-            await tab.waitForEvent(() => tab.getChatItems().length > 13, {
+            await tab.waitForEvent(() => tab.getChatItems().length > 10, {
                 waitTimeoutInMs: 5000,
                 waitIntervalInMs: 1000,
             })
@@ -194,7 +173,7 @@ describe('Amazon Q Code Transformation', function () {
                 text: 'View summary',
             })
 
-            await tab.waitForEvent(() => tab.getChatItems().length > 14, {
+            await tab.waitForEvent(() => tab.getChatItems().length > 11, {
                 waitTimeoutInMs: 5000,
                 waitIntervalInMs: 1000,
             })

--- a/packages/amazonq/test/unit/amazonqGumby/transformationResultsHandler.test.ts
+++ b/packages/amazonq/test/unit/amazonqGumby/transformationResultsHandler.test.ts
@@ -5,18 +5,12 @@
 import assert from 'assert'
 import sinon from 'sinon'
 import { DiffModel, AddedChangeNode, ModifiedChangeNode } from 'aws-core-vscode/codewhisperer/node'
-import { DescriptionContent } from 'aws-core-vscode/codewhisperer'
 import path from 'path'
 import { getTestResourceFilePath } from './amazonQGumbyUtil'
 import { fs } from 'aws-core-vscode/shared'
 import { createTestWorkspace } from 'aws-core-vscode/test'
 
 describe('DiffModel', function () {
-    let parsedTestDescriptions: DescriptionContent
-    beforeEach(async () => {
-        parsedTestDescriptions = JSON.parse(await fs.readFileText(getTestResourceFilePath('resources/files/diff.json')))
-    })
-
     afterEach(() => {
         sinon.restore()
     })
@@ -34,18 +28,12 @@ describe('DiffModel', function () {
 
             return true
         })
-        testDiffModel.parseDiff(
-            getTestResourceFilePath('resources/files/addedFile.diff'),
-            workspacePath,
-            parsedTestDescriptions.content[0],
-            1
-        )
+        testDiffModel.parseDiff(getTestResourceFilePath('resources/files/addedFile.diff'), workspacePath)
 
         assert.strictEqual(
             testDiffModel.patchFileNodes[0].patchFilePath,
             getTestResourceFilePath('resources/files/addedFile.diff')
         )
-        assert(testDiffModel.patchFileNodes[0].label.includes(parsedTestDescriptions.content[0].name))
         const change = testDiffModel.patchFileNodes[0].children[0]
 
         assert.strictEqual(change instanceof AddedChangeNode, true)
@@ -64,16 +52,13 @@ describe('DiffModel', function () {
 
         testDiffModel.parseDiff(
             getTestResourceFilePath('resources/files/modifiedFile.diff'),
-            workspaceFolder.uri.fsPath,
-            parsedTestDescriptions.content[0],
-            1
+            workspaceFolder.uri.fsPath
         )
 
         assert.strictEqual(
             testDiffModel.patchFileNodes[0].patchFilePath,
             getTestResourceFilePath('resources/files/modifiedFile.diff')
         )
-        assert(testDiffModel.patchFileNodes[0].label.includes(parsedTestDescriptions.content[0].name))
         const change = testDiffModel.patchFileNodes[0].children[0]
 
         assert.strictEqual(change instanceof ModifiedChangeNode, true)
@@ -92,9 +77,7 @@ describe('DiffModel', function () {
 
         testDiffModel.parseDiff(
             getTestResourceFilePath('resources/files/modifiedFile.diff'),
-            workspaceFolder.uri.fsPath,
-            undefined,
-            1
+            workspaceFolder.uri.fsPath
         )
 
         assert.strictEqual(

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -367,15 +367,11 @@ export class GumbyController {
                     this.transformationFinished({
                         message: CodeWhispererConstants.jobCancelledChatMessage,
                         tabID: message.tabID,
-                        includeStartNewTransformationButton: true,
                     })
                 })
                 break
             case ButtonActions.CONFIRM_SKIP_TESTS_FORM:
                 await this.handleSkipTestsSelection(message)
-                break
-            case ButtonActions.CONFIRM_SELECTIVE_TRANSFORMATION_FORM:
-                await this.handleOneOrMultipleDiffs(message)
                 break
             case ButtonActions.CONFIRM_SQL_CONVERSION_TRANSFORMATION_FORM:
                 await this.handleUserSQLConversionProjectSelection(message)
@@ -441,25 +437,6 @@ export class GumbyController {
                 userChoice: skipTestsSelection,
             })
             this.messenger.sendSkipTestsSelectionMessage(skipTestsSelection, message.tabID)
-            await this.messenger.sendOneOrMultipleDiffsPrompt(message.tabID)
-        })
-    }
-
-    private async handleOneOrMultipleDiffs(message: any) {
-        await telemetry.codeTransform_submitSelection.run(async () => {
-            const oneOrMultipleDiffsSelection = message.formSelectedValues['GumbyTransformOneOrMultipleDiffsForm']
-            if (oneOrMultipleDiffsSelection === CodeWhispererConstants.multipleDiffsMessage) {
-                transformByQState.setMultipleDiffs(true)
-            } else {
-                transformByQState.setMultipleDiffs(false)
-            }
-
-            telemetry.record({
-                codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
-                userChoice: oneOrMultipleDiffsSelection,
-            })
-
-            this.messenger.sendOneOrMultipleDiffsMessage(oneOrMultipleDiffsSelection, message.tabID)
             this.promptJavaHome('source', message.tabID)
             // TO-DO: delete line above and uncomment line below when releasing CSB
             // await this.messenger.sendCustomDependencyVersionMessage(message.tabID)
@@ -618,7 +595,6 @@ export class GumbyController {
             this.transformationFinished({
                 message: CodeWhispererConstants.jobCancelledChatMessage,
                 tabID: message.tabID,
-                includeStartNewTransformationButton: true,
             })
             return
         }
@@ -647,15 +623,11 @@ export class GumbyController {
         )
     }
 
-    private transformationFinished(data: {
-        message: string | undefined
-        tabID: string
-        includeStartNewTransformationButton: boolean
-    }) {
+    private transformationFinished(data: { message: string | undefined; tabID: string }) {
         this.resetTransformationChatFlow()
         // at this point job is either completed, partially_completed, cancelled, or failed
         if (data.message) {
-            this.messenger.sendJobFinishedMessage(data.tabID, data.message, data.includeStartNewTransformationButton)
+            this.messenger.sendJobFinishedMessage(data.tabID, data.message)
         }
     }
 
@@ -779,7 +751,6 @@ export class GumbyController {
             this.transformationFinished({
                 tabID: message.tabID,
                 message: (err as Error).message,
-                includeStartNewTransformationButton: true,
             })
         }
 

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -157,47 +157,6 @@ export class Messenger {
         )
     }
 
-    public async sendOneOrMultipleDiffsPrompt(tabID: string) {
-        const formItems: ChatItemFormItem[] = []
-        formItems.push({
-            id: 'GumbyTransformOneOrMultipleDiffsForm',
-            type: 'select',
-            title: CodeWhispererConstants.selectiveTransformationFormTitle,
-            mandatory: true,
-            options: [
-                {
-                    value: CodeWhispererConstants.oneDiffMessage,
-                    label: CodeWhispererConstants.oneDiffMessage,
-                },
-                {
-                    value: CodeWhispererConstants.multipleDiffsMessage,
-                    label: CodeWhispererConstants.multipleDiffsMessage,
-                },
-            ],
-        })
-
-        this.dispatcher.sendAsyncEventProgress(
-            new AsyncEventProgressMessage(tabID, {
-                inProgress: true,
-                message: CodeWhispererConstants.userPatchDescriptionChatMessage(
-                    transformByQState.getTargetJDKVersion() ?? ''
-                ),
-            })
-        )
-
-        this.dispatcher.sendChatPrompt(
-            new ChatPrompt(
-                {
-                    message: 'Q Code Transformation',
-                    formItems: formItems,
-                },
-                'TransformOneOrMultipleDiffsForm',
-                tabID,
-                false
-            )
-        )
-    }
-
     public async sendLanguageUpgradeProjectPrompt(projects: TransformationCandidateProject[], tabID: string) {
         const projectFormOptions: { value: any; label: string }[] = []
         const detectedJavaVersions = new Array<JDKVersion | undefined>()
@@ -501,16 +460,14 @@ export class Messenger {
         this.dispatcher.sendCommandMessage(new SendCommandMessage(message.command, message.tabID, message.eventId))
     }
 
-    public sendJobFinishedMessage(tabID: string, message: string, includeStartNewTransformationButton: boolean = true) {
+    public sendJobFinishedMessage(tabID: string, message: string) {
         const buttons: ChatItemButton[] = []
-        if (includeStartNewTransformationButton) {
-            buttons.push({
-                keepCardAfterClick: false,
-                text: CodeWhispererConstants.startTransformationButtonText,
-                id: ButtonActions.CONFIRM_START_TRANSFORMATION_FLOW,
-                disabled: false,
-            })
-        }
+        buttons.push({
+            keepCardAfterClick: false,
+            text: CodeWhispererConstants.startTransformationButtonText,
+            id: ButtonActions.CONFIRM_START_TRANSFORMATION_FLOW,
+            disabled: false,
+        })
 
         if (transformByQState.isPartiallySucceeded() || transformByQState.isSucceeded()) {
             buttons.push({
@@ -595,11 +552,6 @@ export class Messenger {
 
     public sendSkipTestsSelectionMessage(skipTestsSelection: string, tabID: string) {
         const message = `Okay, I will ${skipTestsSelection.toLowerCase()} when building your project.`
-        this.dispatcher.sendChatMessage(new ChatMessage({ message, messageType: 'ai-prompt' }, tabID))
-    }
-
-    public sendOneOrMultipleDiffsMessage(selectiveTransformationSelection: string, tabID: string) {
-        const message = `Okay, I will create ${selectiveTransformationSelection.toLowerCase()} with my proposed changes.`
         this.dispatcher.sendChatMessage(new ChatMessage({ message, messageType: 'ai-prompt' }, tabID))
     }
 

--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
@@ -18,7 +18,6 @@ export enum ButtonActions {
     CONFIRM_SQL_CONVERSION_TRANSFORMATION_FORM = 'gumbySQLConversionTransformFormConfirm',
     CANCEL_TRANSFORMATION_FORM = 'gumbyTransformFormCancel', // shared between Language Upgrade & SQL Conversion
     CONFIRM_SKIP_TESTS_FORM = 'gumbyTransformSkipTestsFormConfirm',
-    CONFIRM_SELECTIVE_TRANSFORMATION_FORM = 'gumbyTransformOneOrMultipleDiffsFormConfirm',
     SELECT_SQL_CONVERSION_METADATA_FILE = 'gumbySQLConversionMetadataTransformFormConfirm',
     SELECT_CUSTOM_DEPENDENCY_VERSION_FILE = 'gumbyCustomDependencyVersionTransformFormConfirm',
     CONTINUE_TRANSFORMATION_FORM = 'gumbyTransformFormContinue',

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -699,11 +699,10 @@ export async function postTransformationJob() {
     }
 
     let chatMessage = transformByQState.getJobFailureErrorChatMessage()
-    const diffMessage = CodeWhispererConstants.diffMessage(transformByQState.getMultipleDiffs())
     if (transformByQState.isSucceeded()) {
-        chatMessage = CodeWhispererConstants.jobCompletedChatMessage(diffMessage)
+        chatMessage = CodeWhispererConstants.jobCompletedChatMessage
     } else if (transformByQState.isPartiallySucceeded()) {
-        chatMessage = CodeWhispererConstants.jobPartiallyCompletedChatMessage(diffMessage)
+        chatMessage = CodeWhispererConstants.jobPartiallyCompletedChatMessage
     }
 
     transformByQState.getChatControllers()?.transformationFinished.fire({
@@ -732,13 +731,13 @@ export async function postTransformationJob() {
     }
 
     if (transformByQState.isSucceeded()) {
-        void vscode.window.showInformationMessage(CodeWhispererConstants.jobCompletedNotification(diffMessage), {
+        void vscode.window.showInformationMessage(CodeWhispererConstants.jobCompletedNotification, {
             title: localizedText.ok,
         })
     } else if (transformByQState.isPartiallySucceeded()) {
         void vscode.window
             .showInformationMessage(
-                CodeWhispererConstants.jobPartiallyCompletedNotification(diffMessage),
+                CodeWhispererConstants.jobPartiallyCompletedNotification,
                 CodeWhispererConstants.amazonQFeedbackText
             )
             .then((choice) => {

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -22,23 +22,6 @@ export const AWSTemplateKeyWords = ['AWSTemplateFormatVersion', 'Resources', 'AW
 
 export const AWSTemplateCaseInsensitiveKeyWords = ['cloudformation', 'cfn', 'template', 'description']
 
-const patchDescriptions: { [key: string]: string } = {
-    'Prepare minimal upgrade to Java 17':
-        'This diff patch covers the set of upgrades for Springboot, JUnit, and PowerMockito frameworks in Java 17.',
-    'Prepare minimal upgrade to Java 21':
-        'This diff patch covers the set of upgrades for Springboot, JUnit, and PowerMockito frameworks in Java 21.',
-    'Popular Enterprise Specifications and Application Frameworks upgrade':
-        'This diff patch covers the set of upgrades for Jakarta EE 10, Hibernate 6.2, and Micronaut 3.',
-    'HTTP Client Utilities, Apache Commons Utilities, and Web Frameworks':
-        'This diff patch covers the set of upgrades for Apache HTTP Client 5, Apache Commons utilities (Collections, IO, Lang, Math), and Struts 6.0.',
-    'Testing Tools and Frameworks upgrade':
-        'This diff patch covers the set of upgrades for ArchUnit, Mockito, TestContainers, and Cucumber, in addition to the Jenkins plugins and the Maven Wrapper.',
-    'Miscellaneous Processing Documentation upgrade':
-        'This diff patch covers a diverse set of upgrades spanning ORMs, XML processing, API documentation, and more.',
-    'Deprecated API replacement, dependency upgrades, and formatting':
-        'This diff patch replaces deprecated APIs, makes additional dependency version upgrades, and formats code changes.',
-}
-
 export const JsonConfigFileNamingConvention = new Set([
     'app.json',
     'appsettings.json',
@@ -669,27 +652,13 @@ export const enterJavaHomePlaceholder = 'Enter the path to your Java installatio
 
 export const openNewTabPlaceholder = 'Open a new tab to chat with Q'
 
-export const diffMessage = (multipleDiffs: boolean) => {
-    return multipleDiffs
-        ? 'You can review the diffs to see my proposed changes and accept or reject them. You will be able to accept changes from one diff at a time. If you reject changes in one diff, you will not be able to view or accept changes in the other diffs.'
-        : 'You can review the diff to see my proposed changes and accept or reject them.'
-}
+export const jobCompletedChatMessage = `I completed your transformation. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the changes I'm proposing.`
 
-export const jobCompletedChatMessage = (multipleDiffsString: string) => {
-    return `I completed your transformation. ${multipleDiffsString} The transformation summary has details about the changes I'm proposing.`
-}
+export const jobCompletedNotification = `Amazon Q transformed your code. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the changes.`
 
-export const jobCompletedNotification = (multipleDiffsString: string) => {
-    return `Amazon Q transformed your code. ${multipleDiffsString} The transformation summary has details about the changes.`
-}
+export const jobPartiallyCompletedChatMessage = `I transformed part of your code. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the files I updated and the errors that prevented a complete transformation.`
 
-export const jobPartiallyCompletedChatMessage = (multipleDiffsString: string) => {
-    return `I transformed part of your code. ${multipleDiffsString} The transformation summary has details about the files I updated and the errors that prevented a complete transformation.`
-}
-
-export const jobPartiallyCompletedNotification = (multipleDiffsString: string) => {
-    return `Amazon Q transformed part of your code. ${multipleDiffsString} The transformation summary has details about the files I updated and the errors that prevented a complete transformation.`
-}
+export const jobPartiallyCompletedNotification = `Amazon Q transformed part of your code. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the files I updated and the errors that prevented a complete transformation.`
 
 export const noPomXmlFoundChatMessage = `I couldn\'t find a project that I can upgrade. I couldn\'t find a pom.xml file in any of your open projects, nor could I find any embedded SQL statements. Currently, I can upgrade Java 8, 11, or 17 projects built on Maven, or Oracle SQL to PostgreSQL statements in Java projects. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
@@ -727,24 +696,7 @@ export const viewProposedChangesNotification =
 
 export const changesAppliedChatMessageOneDiff = 'I applied the changes to your project.'
 
-export const changesAppliedChatMessageMultipleDiffs = (
-    currentPatchIndex: number,
-    totalPatchFiles: number,
-    description: string | undefined
-) =>
-    description
-        ? `I applied the changes in diff patch ${currentPatchIndex + 1} of ${totalPatchFiles} to your project. ${patchDescriptions[description]}`
-        : 'I applied the changes to your project.'
-
 export const changesAppliedNotificationOneDiff = 'Amazon Q applied the changes to your project'
-
-export const changesAppliedNotificationMultipleDiffs = (currentPatchIndex: number, totalPatchFiles: number) => {
-    if (totalPatchFiles === 1) {
-        return 'Amazon Q applied the changes to your project.'
-    } else {
-        return `Amazon Q applied the changes in diff patch ${currentPatchIndex + 1} of ${totalPatchFiles} to your project.`
-    }
-}
 
 export const noOpenProjectsFoundChatMessage = `I couldn\'t find a project that I can upgrade. Currently, I support Java 8, Java 11, Java 17, and Java 21 projects built on Maven. Make sure your project is open in the IDE. For more information, see the [Amazon Q documentation](${codeTransformPrereqDoc}).`
 
@@ -804,20 +756,14 @@ export const chooseProjectSchemaFormMessage = 'To continue, choose the project a
 
 export const skipUnitTestsFormTitle = 'Choose to skip unit tests'
 
-export const selectiveTransformationFormTitle = 'Choose how to receive proposed changes'
-
 export const skipUnitTestsFormMessage =
     'I will build your project using `mvn clean test` by default. If you would like me to build your project without running unit tests, I will use `mvn clean test-compile`.'
 
 export const runUnitTestsMessage = 'Run unit tests'
 
-export const oneDiffMessage = 'One diff'
-
 export const doNotSkipUnitTestsBuildCommand = 'clean test'
 
 export const skipUnitTestsMessage = 'Skip unit tests'
-
-export const multipleDiffsMessage = 'Multiple diffs'
 
 export const skipUnitTestsBuildCommand = 'clean test-compile'
 

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -66,16 +66,6 @@ export type CrossFileStrategy = 'opentabs' | 'codemap' | 'bm25' | 'default'
 
 export type SupplementalContextStrategy = CrossFileStrategy | UtgStrategy | 'empty'
 
-export type PatchInfo = {
-    name: string
-    filename: string
-    isSuccessful: boolean
-}
-
-export type DescriptionContent = {
-    content: PatchInfo[]
-}
-
 export interface CodeWhispererSupplementalContext {
     isUtg: boolean
     isProcessTimeout: boolean
@@ -757,8 +747,6 @@ export class TransformByQState {
 
     private targetJDKVersion: JDKVersion | undefined = undefined
 
-    private produceMultipleDiffs: boolean = false
-
     private customBuildCommand: string = ''
 
     private sourceDB: DB | undefined = undefined
@@ -853,10 +841,6 @@ export class TransformByQState {
 
     public getLinesOfCodeSubmitted() {
         return this.linesOfCodeSubmitted
-    }
-
-    public getMultipleDiffs() {
-        return this.produceMultipleDiffs
     }
 
     public getPreBuildLogFilePath() {
@@ -1035,10 +1019,6 @@ export class TransformByQState {
         this.linesOfCodeSubmitted = lines
     }
 
-    public setMultipleDiffs(produceMultipleDiffs: boolean) {
-        this.produceMultipleDiffs = produceMultipleDiffs
-    }
-
     public setStartTime(time: string) {
         this.startTime = time
     }
@@ -1181,7 +1161,6 @@ export class TransformByQState {
         this.buildLog = ''
         this.customBuildCommand = ''
         this.intervalId = undefined
-        this.produceMultipleDiffs = false
     }
 }
 

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -347,10 +347,6 @@ export async function zipCode(
             getLogger().info(`CodeTransformation: source code files size = ${sourceFilesSize}`)
         }
 
-        if (transformByQState.getMultipleDiffs() && zipManifest instanceof ZipManifest) {
-            zipManifest.transformCapabilities.push('SELECTIVE_TRANSFORMATION_V1')
-        }
-
         if (
             transformByQState.getTransformationType() === TransformationType.SQL_CONVERSION &&
             zipManifest instanceof ZipManifest
@@ -788,7 +784,7 @@ async function processClientInstructions(jobId: string, clientInstructionsPath: 
     await extractOriginalProjectSources(destinationPath)
     getLogger().info(`CodeTransformation: copied project to ${destinationPath}`)
     const diffModel = new DiffModel()
-    diffModel.parseDiff(clientInstructionsPath, path.join(destinationPath, 'sources'), undefined, 1, true)
+    diffModel.parseDiff(clientInstructionsPath, path.join(destinationPath, 'sources'), true)
     // show user the diff.patch
     const doc = await vscode.workspace.openTextDocument(clientInstructionsPath)
     await vscode.window.showTextDocument(doc, { viewColumn: vscode.ViewColumn.One })

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -10,13 +10,7 @@ import { parsePatch, applyPatches, ParsedDiff } from 'diff'
 import path from 'path'
 import vscode from 'vscode'
 import { ExportIntent } from '@amzn/codewhisperer-streaming'
-import {
-    TransformByQReviewStatus,
-    transformByQState,
-    PatchInfo,
-    DescriptionContent,
-    TransformationType,
-} from '../../models/model'
+import { TransformByQReviewStatus, transformByQState, TransformationType } from '../../models/model'
 import { ExportResultArchiveStructure, downloadExportResultArchive } from '../../../shared/utilities/download'
 import { getLogger } from '../../../shared/logger/logger'
 import { telemetry } from '../../../shared/telemetry/telemetry'
@@ -119,11 +113,9 @@ export class PatchFileNode {
     readonly patchFilePath: string
     children: ProposedChangeNode[] = []
 
-    constructor(description: PatchInfo | undefined = undefined, patchFilePath: string) {
+    constructor(patchFilePath: string) {
         this.patchFilePath = patchFilePath
-        this.label = description
-            ? `${description.name} (${description.isSuccessful ? 'Success' : 'Failure'})`
-            : path.basename(patchFilePath)
+        this.label = path.basename(patchFilePath)
     }
 }
 
@@ -164,13 +156,7 @@ export class DiffModel {
      * @param pathToWorkspace Path to the project that was transformed
      * @returns List of nodes containing the paths of files that were modified, added, or removed
      */
-    public parseDiff(
-        pathToDiff: string,
-        pathToWorkspace: string,
-        diffDescription: PatchInfo | undefined,
-        totalDiffPatches: number,
-        isIntermediateBuild: boolean = false
-    ): PatchFileNode {
+    public parseDiff(pathToDiff: string, pathToWorkspace: string, isIntermediateBuild: boolean = false): PatchFileNode {
         this.patchFileNodes = []
         const diffContents = fs.readFileSync(pathToDiff, 'utf8')
 
@@ -214,8 +200,7 @@ export class DiffModel {
                 }
             },
         })
-        const patchFileNode = new PatchFileNode(diffDescription, pathToDiff)
-        patchFileNode.label = `Patch ${this.currentPatchIndex + 1} of ${totalDiffPatches}: ${patchFileNode.label}`
+        const patchFileNode = new PatchFileNode(pathToDiff)
         patchFileNode.children = changedFiles.flatMap((file) => {
             /* ex. file.oldFileName = 'a/src/java/com/project/component/MyFile.java'
              * ex. file.newFileName = 'b/src/java/com/project/component/MyFile.java'
@@ -331,7 +316,6 @@ export class ProposedTransformationExplorer {
 
         let patchFiles: string[] = []
         let singlePatchFile: string = ''
-        let patchFilesDescriptions: DescriptionContent | undefined = undefined
 
         const reset = async () => {
             await setContext('gumby.transformationProposalReviewInProgress', false)
@@ -446,45 +430,9 @@ export class ProposedTransformationExplorer {
                 const zip = new AdmZip(pathToArchive)
                 zip.extractAllTo(pathContainingArchive)
                 const files = fs.readdirSync(path.join(pathContainingArchive, ExportResultArchiveStructure.PathToPatch))
-                if (files.length === 1) {
-                    singlePatchFile = path.join(
-                        pathContainingArchive,
-                        ExportResultArchiveStructure.PathToPatch,
-                        files[0]
-                    )
-                } else {
-                    const jsonFile = files.find((file) => file.endsWith('.json'))
-                    if (!jsonFile) {
-                        throw new Error('Expected JSON file not found')
-                    }
-                    const filePath = path.join(
-                        pathContainingArchive,
-                        ExportResultArchiveStructure.PathToPatch,
-                        jsonFile
-                    )
-                    const jsonData = fs.readFileSync(filePath, 'utf-8')
-                    patchFilesDescriptions = JSON.parse(jsonData)
-                }
-                if (patchFilesDescriptions !== undefined) {
-                    for (const patchInfo of patchFilesDescriptions.content) {
-                        patchFiles.push(
-                            path.join(
-                                pathContainingArchive,
-                                ExportResultArchiveStructure.PathToPatch,
-                                patchInfo.filename
-                            )
-                        )
-                    }
-                } else {
-                    patchFiles.push(singlePatchFile)
-                }
-                // Because multiple patches are returned once the ZIP is downloaded, we want to show the first one to start
-                diffModel.parseDiff(
-                    patchFiles[0],
-                    transformByQState.getProjectPath(),
-                    patchFilesDescriptions ? patchFilesDescriptions.content[0] : undefined,
-                    patchFiles.length
-                )
+                singlePatchFile = path.join(pathContainingArchive, ExportResultArchiveStructure.PathToPatch, files[0])
+                patchFiles.push(singlePatchFile)
+                diffModel.parseDiff(patchFiles[0], transformByQState.getProjectPath())
 
                 await setContext('gumby.reviewState', TransformByQReviewStatus.InReview)
                 transformDataProvider.refresh()
@@ -548,51 +496,16 @@ export class ProposedTransformationExplorer {
                 telemetry.record({
                     codeTransformSessionId: CodeTransformTelemetryState.instance.getSessionId(),
                     codeTransformJobId: transformByQState.getJobId(),
-                    userChoice: `acceptChanges-${patchFilesDescriptions?.content[diffModel.currentPatchIndex].name}`,
+                    userChoice: 'acceptChanges',
                 })
             })
-            if (transformByQState.getMultipleDiffs()) {
-                void vscode.window.showInformationMessage(
-                    CodeWhispererConstants.changesAppliedNotificationMultipleDiffs(
-                        diffModel.currentPatchIndex,
-                        patchFiles.length
-                    )
-                )
-            } else {
-                void vscode.window.showInformationMessage(CodeWhispererConstants.changesAppliedNotificationOneDiff)
-            }
-
-            // We do this to ensure that the changesAppliedChatMessage is only sent to user when they accept the first diff.patch
+            void vscode.window.showInformationMessage(CodeWhispererConstants.changesAppliedNotificationOneDiff)
             transformByQState.getChatControllers()?.transformationFinished.fire({
-                message: CodeWhispererConstants.changesAppliedChatMessageMultipleDiffs(
-                    diffModel.currentPatchIndex,
-                    patchFiles.length,
-                    patchFilesDescriptions
-                        ? patchFilesDescriptions.content[diffModel.currentPatchIndex].name
-                        : undefined
-                ),
+                message: CodeWhispererConstants.changesAppliedChatMessageOneDiff,
                 tabID: ChatSessionManager.Instance.getSession().tabID,
-                includeStartNewTransformationButton: diffModel.currentPatchIndex === patchFiles.length - 1,
             })
-
-            // Load the next patch file
-            diffModel.currentPatchIndex++
-            if (diffModel.currentPatchIndex < patchFiles.length) {
-                const nextPatchFile = patchFiles[diffModel.currentPatchIndex]
-                const nextPatchFileDescription = patchFilesDescriptions
-                    ? patchFilesDescriptions.content[diffModel.currentPatchIndex]
-                    : undefined
-                diffModel.parseDiff(
-                    nextPatchFile,
-                    transformByQState.getProjectPath(),
-                    nextPatchFileDescription,
-                    patchFiles.length
-                )
-                transformDataProvider.refresh()
-            } else {
-                // All patches have been applied, reset the state
-                await reset()
-            }
+            // reset after applying the patch
+            await reset()
         })
 
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.rejectChanges', async () => {


### PR DESCRIPTION
## Problem

Prompting users to select one or multiple diffs is a very infrequently used feature.


## Solution

Remove it.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
