### PR TITLE
fix(amazonq): remove target JDK path prompt

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-636765f1-2278-4a2d-b512-7c63ecc2ce67.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-636765f1-2278-4a2d-b512-7c63ecc2ce67.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/transform: avoid prompting user for target JDK path unnecessarily"
+}

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -688,13 +688,17 @@ export class GumbyController {
                 const pathToJavaHome = extractPath(data.message)
                 if (pathToJavaHome) {
                     transformByQState.setSourceJavaHome(pathToJavaHome)
+                    // TO-DO: delete line below and comment block below when releasing CSB
+                    await this.prepareLanguageUpgradeProject(data.tabID)
                     // if source and target JDK versions are the same, just re-use the source JAVA_HOME and start the build
+                    /*
                     if (transformByQState.getTargetJDKVersion() === transformByQState.getSourceJDKVersion()) {
                         transformByQState.setTargetJavaHome(pathToJavaHome)
                         await this.prepareLanguageUpgradeProject(data.tabID)
                     } else {
                         this.promptJavaHome('target', data.tabID)
                     }
+                    */
                 } else {
                     this.messenger.sendUnrecoverableErrorResponse('invalid-java-home', data.tabID)
                 }

--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -688,7 +688,7 @@ export class GumbyController {
                 const pathToJavaHome = extractPath(data.message)
                 if (pathToJavaHome) {
                     transformByQState.setSourceJavaHome(pathToJavaHome)
-                    // TO-DO: delete line below and comment block below when releasing CSB
+                    // TO-DO: delete line below and uncomment the block below when releasing CSB
                     await this.prepareLanguageUpgradeProject(data.tabID)
                     // if source and target JDK versions are the same, just re-use the source JAVA_HOME and start the build
                     /*


### PR DESCRIPTION
## Problem

/transform was unnecessarily prompting users for their target JDK paths in some cases.

## Solution

Remove the prompt.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
