### PR TITLE
feat(amazonq): Command to clear extension cache

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -805,6 +805,11 @@
             {
                 "command": "aws.amazonq.walkthrough.show",
                 "title": "%AWS.amazonq.welcomeWalkthrough%"
+            },
+            {
+                "command": "aws.amazonq.clearCache",
+                "title": "%AWS.amazonq.clearCache%",
+                "category": "%AWS.amazonq.title%"
             }
         ],
         "keybindings": [

--- a/packages/amazonq/src/commands.ts
+++ b/packages/amazonq/src/commands.ts
@@ -9,7 +9,11 @@
 import * as vscode from 'vscode'
 import { Auth } from 'aws-core-vscode/auth'
 import { Commands } from 'aws-core-vscode/shared'
+import { clearCacheDeclaration } from './util/clearCache'
 
 export function registerCommands(context: vscode.ExtensionContext) {
-    context.subscriptions.push(Commands.register('_aws.amazonq.auth.autoConnect', Auth.instance.tryAutoConnect))
+    context.subscriptions.push(
+        Commands.register('_aws.amazonq.auth.autoConnect', Auth.instance.tryAutoConnect),
+        clearCacheDeclaration.register()
+    )
 }

--- a/packages/amazonq/src/util/clearCache.ts
+++ b/packages/amazonq/src/util/clearCache.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthUtil } from 'aws-core-vscode/codewhisperer'
+import { Commands, globals } from 'aws-core-vscode/shared'
+import vscode from 'vscode'
+
+/**
+ * The purpose of this module is to provide a util to clear all extension cache so that it has a clean state
+ */
+
+/**
+ * Clears "all" cache of the extension, effectively putting the user in a "net new" state.
+ *
+ * NOTE: This is a best attempt. There may be state like a file in the filesystem which is not deleted.
+ *       We should aim to add all state clearing in to this method.
+ */
+async function clearCache() {
+    // Check a final time if they want to clear their cache
+    const doContinue = await vscode.window
+        .showInformationMessage(
+            'This will wipe your Amazon Q extension state, then reload your VS Code window. This operation is not dangerous. ',
+            { modal: true },
+            'Continue'
+        )
+        .then((value) => {
+            return value === 'Continue'
+        })
+    if (!doContinue) {
+        return
+    }
+
+    // SSO cache persists on disk, this should indirectly delete it
+    const conn = AuthUtil.instance.conn
+    if (conn) {
+        await AuthUtil.instance.auth.deleteConnection(conn)
+    }
+
+    await globals.globalState.clear()
+
+    // Make the IDE reload so all new changes take effect
+    void vscode.commands.executeCommand('workbench.action.reloadWindow')
+}
+export const clearCacheDeclaration = Commands.declare({ id: 'aws.amazonq.clearCache' }, () => clearCache)

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -328,6 +328,7 @@
     "AWS.amazonq.title": "Amazon Q",
     "AWS.amazonq.chat": "Chat",
     "AWS.amazonq.openChat": "Open Chat",
+    "AWS.amazonq.clearCache": "Clear extension cache",
     "AWS.amazonq.context.folders.title": "Folders",
     "AWS.amazonq.context.folders.description": "Add all files in a folder to context",
     "AWS.amazonq.context.files.title": "Files",


### PR DESCRIPTION
## Problem

We need a way to clear `globalState` since it looks like some users are getting in to a bad corrputed state where things stop working.

Uninstalling the extension does not clear state, it is intentionally designed that way by vscode, as we don't want to wipe states on extension updates.

## Solution:

This creates a new command "Amazon Q: Clear extension cache" which clears the cache and reloads the window.

There is safety modal which pops up right before clearing after the command is selected.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
