### PR TITLE
fix(amazonq): fix cache watcher on token file to avoid logout after SSO connection migration

### DIFF
--- a/packages/amazonq/src/util/clearCache.ts
+++ b/packages/amazonq/src/util/clearCache.ts
@@ -32,10 +32,9 @@ async function clearCache() {
         return
     }
 
-    // SSO cache persists on disk, this should indirectly delete it
-    const conn = AuthUtil.instance.conn
-    if (conn) {
-        await AuthUtil.instance.auth.deleteConnection(conn)
+    // SSO cache persists on disk, this should log out
+    if (AuthUtil.instance.isConnected()) {
+        await AuthUtil.instance.logout()
     }
 
     await globals.globalState.clear()

--- a/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
@@ -9,7 +9,7 @@ import { Position, CancellationToken, InlineCompletionItem } from 'vscode'
 import assert from 'assert'
 import { RecommendationService } from '../../../../../src/app/inline/recommendationService'
 import { SessionManager } from '../../../../../src/app/inline/sessionManager'
-import { createMockDocument } from 'aws-core-vscode/test'
+import { createMockDocument, createTestAuthUtil } from 'aws-core-vscode/test'
 import { LineTracker } from '../../../../../src/app/inline/stateTracker/lineTracker'
 import { InlineGeneratingMessage } from '../../../../../src/app/inline/inlineGeneratingMessage'
 
@@ -17,6 +17,11 @@ describe('RecommendationService', () => {
     let languageClient: LanguageClient
     let sendRequestStub: sinon.SinonStub
     let sandbox: sinon.SinonSandbox
+    let sessionManager: SessionManager
+    let lineTracker: LineTracker
+    let activeStateController: InlineGeneratingMessage
+    let service: RecommendationService
+
     const mockDocument = createMockDocument()
     const mockPosition = { line: 0, character: 0 } as Position
     const mockContext = { triggerKind: 1, selectedCompletionInfo: undefined }
@@ -29,12 +34,8 @@ describe('RecommendationService', () => {
         insertText: 'ItemTwo',
     } as InlineCompletionItem
     const mockPartialResultToken = 'some-random-token'
-    const sessionManager = new SessionManager()
-    const lineTracker = new LineTracker()
-    const activeStateController = new InlineGeneratingMessage(lineTracker)
-    const service = new RecommendationService(sessionManager, activeStateController)
 
-    beforeEach(() => {
+    beforeEach(async () => {
         sandbox = sinon.createSandbox()
 
         sendRequestStub = sandbox.stub()
@@ -42,6 +43,13 @@ describe('RecommendationService', () => {
         languageClient = {
             sendRequest: sendRequestStub,
         } as unknown as LanguageClient
+
+        await createTestAuthUtil()
+
+        sessionManager = new SessionManager()
+        lineTracker = new LineTracker()
+        activeStateController = new InlineGeneratingMessage(lineTracker)
+        service = new RecommendationService(sessionManager, activeStateController)
     })
 
     afterEach(() => {

--- a/packages/core/src/auth/auth2.ts
+++ b/packages/core/src/auth/auth2.ts
@@ -41,7 +41,8 @@ import { LanguageClient } from 'vscode-languageclient'
 import { getLogger } from '../shared/logger/logger'
 import { ToolkitError } from '../shared/errors'
 import { useDeviceFlow } from './sso/ssoAccessTokenProvider'
-import { getCacheFileWatcher } from './sso/cache'
+import { getCacheDir, getCacheFileWatcher, getFlareCacheFileName } from './sso/cache'
+import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 
 export const notificationTypes = {
     updateBearerToken: new RequestType<UpdateCredentialsParams, ResponseMessage, Error>(
@@ -77,7 +78,7 @@ export type TokenSource = IamIdentityCenterSsoTokenSource | AwsBuilderIdSsoToken
  * Handles auth requests to the Identity Server in the Amazon Q LSP.
  */
 export class LanguageClientAuth {
-    readonly #ssoCacheWatcher = getCacheFileWatcher()
+    readonly #ssoCacheWatcher = getCacheFileWatcher(getCacheDir(), getFlareCacheFileName(VSCODE_EXTENSION_ID.amazonq))
 
     constructor(
         private readonly client: LanguageClient,

--- a/packages/core/src/auth/sso/cache.ts
+++ b/packages/core/src/auth/sso/cache.ts
@@ -45,8 +45,8 @@ export function getCache(directory = getCacheDir()): SsoCache {
     }
 }
 
-export function getCacheFileWatcher(directory = getCacheDir()) {
-    const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(directory, '*.json'))
+export function getCacheFileWatcher(directory = getCacheDir(), file = '*.json') {
+    const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(directory, file))
     globals.context.subscriptions.push(watcher)
     return watcher
 }
@@ -157,4 +157,20 @@ export function getRegistrationCacheFile(ssoCacheDir: string, key: RegistrationK
 
     const suffix = `${key.region}${key.scopes && key.scopes.length > 0 ? `-${hash(key.startUrl, key.scopes)}` : ''}`
     return path.join(ssoCacheDir, `aws-toolkit-vscode-client-id-${suffix}.json`)
+}
+
+/**
+ * Returns the cache file name that Flare identity server uses for SSO token and registration
+ *
+ * @param key - The key to use for the new registration cache file.
+ * See https://github.com/aws/language-servers/blob/c10819ea2c25ce564c75fb43a6792f3c919b757a/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.ts
+ * @returns File name of the Flare cache file
+ */
+export function getFlareCacheFileName(key: string) {
+    const hash = (str: string) => {
+        const hasher = crypto.createHash('sha1')
+        return hasher.update(str).digest('hex')
+    }
+
+    return hash(key) + '.json'
 }


### PR DESCRIPTION
## Problem
The current cache file watcher is triggered on every `*.json` file change in the cache folder. When migrating old auth SSO connections to Flare, there is a race condition. If the old connection is migrated (meaning that the old token file deletes) after the file watcher is instantiated, the file watcher `delete` event will trigger and logout the user

## Solution
The Flare auth cache file watcher will only listen to events for the Flare token .json file. This way, when we delete the old token .json file, there is no logout event triggered

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
