### PR TITLE
fix(amazonq): register commands before invocation

### DIFF
--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -27,7 +27,6 @@ import {
     showLearnMore,
     showSsoSignIn,
     showFreeTierLimit,
-    updateReferenceLog,
     showIntroduction,
     reconnect,
     openSecurityIssuePanel,
@@ -62,7 +61,6 @@ import {
 } from './service/diagnosticsProvider'
 import { SecurityPanelViewProvider, openEditorAtRange } from './views/securityPanelViewProvider'
 import { Commands, registerCommandErrorHandler, registerDeclaredCommands } from '../shared/vscode/commands2'
-import { refreshStatusBar } from './service/statusBar'
 import { AuthUtil } from './util/authUtil'
 import { ImportAdderProvider } from './service/importAdderProvider'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
@@ -235,10 +233,6 @@ export async function activate(context: ExtContext): Promise<void> {
         showLearnMore.register(),
         // show free tier limit
         showFreeTierLimit.register(),
-        // update reference log instance
-        updateReferenceLog.register(),
-        // refresh codewhisperer status bar
-        refreshStatusBar.register(),
         // generate code fix
         generateFix.register(client, context),
         // regenerate code fix


### PR DESCRIPTION
## Problem
Commands `updateReferenceLog` and `refreshStatusBar` are not yet registered when invoked in `AuthUtil`

## Solution
Register the commands before `activateAmazonqLsp`, instead of in `activateCodeWhisperer`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
