### PR TITLE
fix(customizations): Fix bug where customizations were always registered as new

### DIFF
--- a/packages/core/src/codewhisperer/util/customizationUtil.ts
+++ b/packages/core/src/codewhisperer/util/customizationUtil.ts
@@ -89,7 +89,14 @@ export const onProfileChangedListener: (event: ProfileChangedEvent) => any = asy
  */
 export const getNewCustomizations = (availableCustomizations: Customization[]) => {
     const persistedCustomizations = getPersistedCustomizations()
-    return availableCustomizations.filter((c) => !persistedCustomizations.map((p) => p.arn).includes(c.arn))
+    const newCustomizations = availableCustomizations.filter(
+        (c) =>
+            !persistedCustomizations
+                .flat()
+                .map((p) => p.arn)
+                .includes(c.arn)
+    )
+    return newCustomizations
 }
 
 export async function notifyNewCustomizations() {

--- a/packages/core/src/test/codewhisperer/customizationUtil.test.ts
+++ b/packages/core/src/test/codewhisperer/customizationUtil.test.ts
@@ -1,0 +1,42 @@
+import * as sinon from 'sinon'
+import * as assert from 'assert'
+import * as customizationModule from '../../../src/codewhisperer/util/customizationUtil'
+
+describe('getNewCustomizations', () => {
+    let getPersistedCustomizationsStub: sinon.SinonStub
+
+    const availableCustomizations = [
+        { arn: 'arn1', name: 'custom1' },
+        { arn: 'arn2', name: 'custom2' },
+    ]
+
+    const persistedCustomizations = [[{ arn: 'arn1', name: 'custom1' }], [{ arn: 'arn2', name: 'custom2' }]]
+
+    beforeEach(() => {
+        getPersistedCustomizationsStub = sinon.stub(customizationModule, 'getPersistedCustomizations')
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    it('returns new customizations that are not in persisted customizations', () => {
+        const customizations = [...availableCustomizations, { arn: 'arn3', name: 'custom3' }]
+
+        getPersistedCustomizationsStub.returns(persistedCustomizations)
+
+        const result = customizationModule.getNewCustomizations(customizations)
+
+        assert.deepEqual(result, [{ arn: 'arn3', name: 'custom3' }])
+        sinon.assert.calledOnce(getPersistedCustomizationsStub)
+    })
+
+    it('returns empty array when all available customizations are persisted', () => {
+        getPersistedCustomizationsStub.returns(persistedCustomizations)
+
+        const result = customizationModule.getNewCustomizations(availableCustomizations)
+
+        assert.deepEqual(result.length, 0)
+        sinon.assert.calledOnce(getPersistedCustomizationsStub)
+    })
+})


### PR DESCRIPTION
## Problem
All cached customizations are always marked as new, so a notification for new customizations always appears when switching profiles.

## Solution
Fix the bug by flattening the cached customization array and add some unit tests

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
