### PR TITLE
config(amazonq): remove .acds file extension from abap language

### DIFF
--- a/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/packages/core/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -153,7 +153,6 @@ export class RuntimeLanguageContext {
             psm1: 'powershell',
             r: 'r',
             abap: 'abap',
-            acds: 'abap',
         })
         this.languageSingleLineCommentPrefixMap = createConstantMap<CodewhispererLanguage, string>({
             c: '// ',


### PR DESCRIPTION
## Problem
Team decides to remove `.acds` and only allow `.abap` as the file extension of `abap` language

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
