### PR TITLE
fix(workspace): remove non-flare workspace lsp

### DIFF
--- a/packages/amazonq/.changes/next-release/Removal-951c2b6a-c6ce-45df-95d0-381ca51b935f.json
+++ b/packages/amazonq/.changes/next-release/Removal-951c2b6a-c6ce-45df-95d0-381ca51b935f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Disable local workspace LSP"
+}

--- a/packages/amazonq/src/app/chat/activation.ts
+++ b/packages/amazonq/src/app/chat/activation.ts
@@ -6,21 +6,13 @@
 import * as vscode from 'vscode'
 import { ExtensionContext } from 'vscode'
 import { telemetry } from 'aws-core-vscode/telemetry'
-import { AuthUtil, CodeWhispererSettings } from 'aws-core-vscode/codewhisperer'
-import { Commands, placeholder, funcUtil } from 'aws-core-vscode/shared'
+import { AuthUtil } from 'aws-core-vscode/codewhisperer'
+import { Commands, placeholder } from 'aws-core-vscode/shared'
 import * as amazonq from 'aws-core-vscode/amazonq'
 
 export async function activate(context: ExtensionContext) {
     const appInitContext = amazonq.DefaultAmazonQAppInitContext.instance
     await amazonq.TryChatCodeLensProvider.register(appInitContext.onDidChangeAmazonQVisibility.event)
-
-    const setupLsp = funcUtil.debounce(async () => {
-        void amazonq.LspController.instance.trySetupLsp(context, {
-            startUrl: AuthUtil.instance.startUrl,
-            maxIndexSize: CodeWhispererSettings.instance.getMaxIndexSize(),
-            isVectorIndexEnabled: false,
-        })
-    }, 5000)
 
     context.subscriptions.push(
         amazonq.focusAmazonQChatWalkthrough.register(),
@@ -37,7 +29,7 @@ export async function activate(context: ExtensionContext) {
         void vscode.env.openExternal(vscode.Uri.parse(amazonq.amazonQHelpUrl))
     })
 
-    void setupLsp()
+    //void setupLsp()
     void setupAuthNotification()
 }
 

--- a/packages/amazonq/src/app/chat/activation.ts
+++ b/packages/amazonq/src/app/chat/activation.ts
@@ -29,7 +29,6 @@ export async function activate(context: ExtensionContext) {
         void vscode.env.openExternal(vscode.Uri.parse(amazonq.amazonQHelpUrl))
     })
 
-    //void setupLsp()
     void setupAuthNotification()
 }
 


### PR DESCRIPTION
## Problem
The workspace LSP has been merged into the Amazon Q LSP (Flare). There is no need to keep the non-flare workspace LSP, it will consume both CPU and memory once it starts to index. This will make non agentic chat experience not having `@file` or `@workspace ` but at this point we want customers to use agentic chat. As such CPU and memory usage problem is of higher priority.

## Solution
remove: disable workspace lsp

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
