### PR TITLE
fix(amazonq): throw if no region profiles are available

### DIFF
--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -177,9 +177,17 @@ export class RegionProfileManager {
             }
         }
 
-        // Only throw error if all regions fail
-        if (failedRegions.length === endpoints.size) {
-            throw new Error(`Failed to list profiles for all regions: ${failedRegions.join(', ')}`)
+        // Throw error if any regional API calls failed and no profiles are available
+        if (failedRegions.length > 0 && availableProfiles.length === 0) {
+            throw new ToolkitError(`Failed to list Q Developer profiles for regions: ${failedRegions.join(', ')}`, {
+                code: 'ListQDeveloperProfilesFailed',
+            })
+        }
+
+        // Throw an error if all listAvailableProfile calls succeeded, but user has no Q developer profiles
+        // This is not an expected state
+        if (failedRegions.length === 0 && availableProfiles.length === 0) {
+            throw new ToolkitError('This user has no Q Developer profiles', { code: 'QDeveloperProfileNotFound' })
         }
 
         this._profiles = availableProfiles


### PR DESCRIPTION
Duplicate PR of https://github.com/aws/aws-toolkit-vscode/pull/7357 into Flare branch

## Problem
When ListRegionProfile call throttles for a subset of regions, we currently do not throw, but instead return the available profiles in the regions where the call succeeded. However, if that list is empty (no profiles in that region), we return an empty list. This breaks the UI, and causes a state that is not recoverable

## Solution
Throw an error in the scenario where availableProfiles is empty. This triggers a retry state in the UI, making the state recoverable.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
