### PR TITLE
refactor(clearcache): Delete the LSP cache dir

### DIFF
--- a/packages/amazonq/src/util/clearCache.ts
+++ b/packages/amazonq/src/util/clearCache.ts
@@ -4,7 +4,7 @@
  */
 
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
-import { Commands, globals } from 'aws-core-vscode/shared'
+import { Commands, fs, globals, LanguageServerResolver } from 'aws-core-vscode/shared'
 import vscode from 'vscode'
 
 /**
@@ -39,6 +39,9 @@ async function clearCache() {
     }
 
     await globals.globalState.clear()
+
+    // Clear the Language Server Cache
+    await fs.delete(LanguageServerResolver.defaultDir(), { recursive: true, force: true })
 
     // Make the IDE reload so all new changes take effect
     void vscode.commands.executeCommand('workbench.action.reloadWindow')


### PR DESCRIPTION
Sometimes users MAY modify the LSP cache dir for reasons like development.

We have a feature to clear cache, but right now it does not clear the LSP cache.
Now we will additionally clear the LSP cache when the user runs the command `Amazon Q: Clear extension cache`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
