### PR TITLE
fix(amazonq): handle existing Flare connection when migrating SSO connections

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
@@ -250,9 +250,9 @@ describe('AuthUtil', async function () {
 
             sinon.stub(mementoUtils, 'getEnvironmentSpecificMemento').returns(memento)
             sinon.stub(cache, 'getCacheDir').returns(cacheDir)
-            
+
             mockLspAuth = (auth as any).lspAuth
-            mockLspAuth.getSsoToken.resolves(undefined) 
+            mockLspAuth.getSsoToken.resolves(undefined)
 
             fromTokenFile = cache.getTokenCacheFile(cacheDir, 'profile1')
             const registrationKey = {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -403,8 +403,8 @@ export class AuthUtil implements IAuthProvider {
 
         if (!profiles) {
             return
-        } 
-        
+        }
+
         try {
             // Try go get token from LSP auth. If available, skip migration and delete old auth profile
             const token = await this.lspAuth.getSsoToken(

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -21,6 +21,7 @@ export type LogTopic =
     | 'nextEditPrediction'
     | 'resourceCache'
     | 'telemetry'
+    | 'amazonqAuth'
 
 class ErrorLog {
     constructor(


### PR DESCRIPTION
## Problem
Auth migration to LSP is not handled gracefully when a user downgrades and upgrades to auth on LSP multiple times, causing users to be logged out if they upgrade a second time

## Solution
In the auth migration script, call the LSP identity server to check if a token is available. If the token is available, don't migrate the auth connection. If no token is available, migrate.

Added unit tests for the case.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
