### PR TITLE
fix(sso): increase SSO timeout

### DIFF
--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -36,6 +36,7 @@ import { StandardRetryStrategy, defaultRetryDecider } from '@smithy/middleware-r
 import { AuthenticationFlow } from './model'
 import { toSnakeCase } from '../../shared/utilities/textUtilities'
 import { getUserAgent, withTelemetryContext } from '../../shared/telemetry/util'
+import { oneSecond } from '../../shared/datetime'
 
 export class OidcClient {
     public constructor(
@@ -124,7 +125,9 @@ export class OidcClient {
             requestHandler: {
                 // This field may have a bug: https://github.com/aws/aws-sdk-js-v3/issues/6271
                 // If the bug is real but is fixed, then we can probably remove this field and just have no timeout by default
-                requestTimeout: 5000,
+                //
+                // Also, we bump this higher due to ticket V1761315147, so that SSO does not timeout
+                requestTimeout: oneSecond * 12,
             },
         })
 


### PR DESCRIPTION
## Problem:

In ticket V1761315147 it was being reported that createToken could take 9 seconds. This would mean that the SSO client API request would time out

## Solution:

Bump the timeout to 12 seconds as specified in V1761315147



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
