### PR TITLE
fix(amazonq): show notification when user switches tabs

### DIFF
--- a/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
+++ b/packages/core/src/amazonq/webview/ui/quickActions/handler.ts
@@ -308,6 +308,12 @@ export class QuickActionHandler {
         if (gumbyTabId !== undefined) {
             this.mynahUI.selectTab(gumbyTabId, eventId || '')
             this.connector.onTabChange(gumbyTabId)
+            this.mynahUI.notify({
+                duration: 5000,
+                title: 'Q CodeTransformation',
+                content:
+                    "Switched to the existing /transform tab; click 'Start a new transformation' below to run another transformation",
+            })
             return
         }
 


### PR DESCRIPTION
## Problem

When users have a /transform tab open, then open a new tab and type /transform, we open the existing /transform tab but don't show a notification like IntelliJ does.

## Solution

Add notification in top right.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
