### PR TITLE
fix(telemetry): add result parameter when emitting telemetry

### DIFF
--- a/packages/core/src/codewhisperer/util/telemetryHelper.ts
+++ b/packages/core/src/codewhisperer/util/telemetryHelper.ts
@@ -659,6 +659,7 @@ export class TelemetryHelper {
             codewhispererSessionId: session.sessionId,
             codewhispererTriggerType: session.triggerType,
             credentialStartUrl: AuthUtil.instance.connection?.startUrl,
+            result: 'Succeeded',
         })
     }
     public sendCodeScanEvent(languageId: string, jobId: string) {


### PR DESCRIPTION
## Problem
Users are seeing `telemetry: invalid Metric: "codewhisperer_clientComponentLatency" emitted without the `result` property, which is always required. Consider using `.run()` instead of `.emit()`, which will set these properties automatically. See https://github.com/aws/aws-toolkit-vscode/blob/master/docs/telemetry.md#guidelines`

## Solution
Add result attribute when emitting the metric

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
