### PR TITLE
feat(lsp): forward chatOptionsUpdate to ui

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -53,6 +53,8 @@ import {
     CancellationTokenSource,
     chatUpdateNotificationType,
     ChatUpdateParams,
+    chatOptionsUpdateType,
+    ChatOptionsUpdateParams,
 } from '@aws/language-server-runtimes/protocol'
 import { v4 as uuidv4 } from 'uuid'
 import * as vscode from 'vscode'
@@ -483,6 +485,13 @@ export function registerMessageListeners(
     languageClient.onNotification(chatUpdateNotificationType.method, (params: ChatUpdateParams) => {
         void provider.webview?.postMessage({
             command: chatUpdateNotificationType.method,
+            params: params,
+        })
+    })
+
+    languageClient.onNotification(chatOptionsUpdateType.method, (params: ChatOptionsUpdateParams) => {
+        void provider.webview?.postMessage({
+            command: chatOptionsUpdateType.method,
             params: params,
         })
     })


### PR DESCRIPTION
## Problem

`chatOptionsUpdate` notifications are not forwarded to UI.

This is needed to persist previously selected model in new tabs.


## Solution

Forward `chatOptionsUpdate` notifications to UI

Related PR: https://github.com/aws/language-server-runtimes/pull/530


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
