### PR TITLE
feat(amazonq): add mcp field to client capabilities

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -123,6 +123,7 @@ export async function startLanguageServer(
                 awsClientCapabilities: {
                     q: {
                         developerProfiles: true,
+                        mcp: true,
                     },
                     window: {
                         notifications: true,


### PR DESCRIPTION
## Problem
- client can decide to use MCP or not

## Solution
- add mcp field to client capabilities
- related server change: https://github.com/aws/language-servers/pull/1473

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
