### PR TITLE
fix(tests): "rejected promise not handled"

### DIFF
--- a/packages/amazonq/src/app/chat/activation.ts
+++ b/packages/amazonq/src/app/chat/activation.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import { ExtensionContext } from 'vscode'
 import { telemetry } from 'aws-core-vscode/telemetry'
 import { AuthUtil } from 'aws-core-vscode/codewhisperer'
-import { Commands, placeholder } from 'aws-core-vscode/shared'
+import { Commands, getLogger, placeholder } from 'aws-core-vscode/shared'
 import * as amazonq from 'aws-core-vscode/amazonq'
 
 export async function activate(context: ExtensionContext) {
@@ -67,7 +67,9 @@ async function setupAuthNotification() {
         const selection = await vscode.window.showWarningMessage('Start using Amazon Q', buttonAction)
 
         if (selection === buttonAction) {
-            void amazonq.focusAmazonQPanel.execute(placeholder, source)
+            amazonq.focusAmazonQPanel.execute(placeholder, source).catch((e) => {
+                getLogger().error('focusAmazonQPanel failed: %s', e)
+            })
         }
     }
 }

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -166,7 +166,9 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
         // Give time for the extension to finish initializing.
         globals.clock.setTimeout(async () => {
             CommonAuthWebview.authSource = ExtStartUpSources.firstStartUp
-            void focusAmazonQPanel.execute(placeholder, ExtStartUpSources.firstStartUp)
+            focusAmazonQPanel.execute(placeholder, ExtStartUpSources.firstStartUp).catch((e) => {
+                getLogger().error('focusAmazonQPanel failed: %s', e)
+            })
         }, 1000)
     }
 

--- a/packages/core/src/amazonq/auth/controller.ts
+++ b/packages/core/src/amazonq/auth/controller.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getLogger } from '../../shared/logger/logger'
 import { reconnect } from '../../codewhisperer/commands/basicCommands'
 import { amazonQChatSource } from '../../codewhisperer/commands/types'
 import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
@@ -27,7 +28,9 @@ export class AuthController {
     }
 
     private handleFullAuth() {
-        void focusAmazonQPanel.execute(placeholder, 'amazonQChat')
+        focusAmazonQPanel.execute(placeholder, 'amazonQChat').catch((e) => {
+            getLogger().error('focusAmazonQPanel failed: %s', e)
+        })
     }
 
     private handleReAuth() {

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -405,7 +405,9 @@ export const notifyNewCustomizationsCmd = Commands.declare(
 function focusQAfterDelay() {
     // this command won't work without a small delay after install
     globals.clock.setTimeout(() => {
-        void focusAmazonQPanel.execute(placeholder, 'startDelay')
+        focusAmazonQPanel.execute(placeholder, 'startDelay').catch((e) => {
+            getLogger().error('focusAmazonQPanel failed: %s', e)
+        })
     }, 1000)
 }
 
@@ -597,7 +599,10 @@ export const signoutCodeWhisperer = Commands.declare(
     (auth: AuthUtil) => async (_: VsCodeCommandArg, source: CodeWhispererSource) => {
         await auth.secondaryAuth.deleteConnection()
         SecurityIssueTreeViewProvider.instance.refresh()
-        return focusAmazonQPanel.execute(placeholder, source)
+        return focusAmazonQPanel.execute(placeholder, source).catch((e) => {
+            getLogger().error('focusAmazonQPanel failed: %s', e)
+            return undefined
+        })
     }
 )
 

--- a/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
+++ b/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
@@ -28,6 +28,7 @@ import { AuthUtil } from '../util/authUtil'
 import { submitFeedback } from '../../feedback/vue/submitFeedback'
 import { focusAmazonQPanel } from '../../codewhispererChat/commands/registerCommands'
 import { isWeb } from '../../shared/extensionGlobals'
+import { getLogger } from '../../shared/logger/logger'
 
 export function createAutoSuggestions(running: boolean): DataQuickPickItem<'autoSuggestions'> {
     const labelResume = localize('AWS.codewhisperer.resumeCodeWhispererNode.label', 'Resume Auto-Suggestions')
@@ -238,7 +239,10 @@ export function switchToAmazonQNode(): DataQuickPickItem<'openChatPanel'> {
         data: 'openChatPanel',
         label: 'Open Chat Panel',
         iconPath: getIcon('vscode-comment'),
-        onClick: () => focusAmazonQPanel.execute(placeholder, 'codewhispererQuickPick'),
+        onClick: () =>
+            focusAmazonQPanel.execute(placeholder, 'codewhispererQuickPick').catch((e) => {
+                getLogger().error('focusAmazonQPanel failed: %s', e)
+            }),
     }
 }
 
@@ -247,7 +251,9 @@ export function createSignIn(): DataQuickPickItem<'signIn'> {
     const icon = getIcon('vscode-account')
 
     let onClick = () => {
-        void focusAmazonQPanel.execute(placeholder, 'codewhispererQuickPick')
+        focusAmazonQPanel.execute(placeholder, 'codewhispererQuickPick').catch((e) => {
+            getLogger().error('focusAmazonQPanel failed: %s', e)
+        })
     }
     if (isWeb()) {
         // TODO: nkomonen, call a Command instead

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -267,7 +267,9 @@ export class AuthUtil {
         } catch (err) {
             if (err instanceof ProfileNotFoundError) {
                 // Expected that connection would be deleted by conn.getToken()
-                void focusAmazonQPanel.execute(placeholder, 'profileNotFoundSignout')
+                focusAmazonQPanel.execute(placeholder, 'profileNotFoundSignout').catch((e) => {
+                    getLogger().error('focusAmazonQPanel failed: %s', e)
+                })
             }
             throw err
         }


### PR DESCRIPTION
## Problem:

    rejected promise not handled within 1 second:
    Error: command 'aws.amazonq.focusChat' not found

## Solution:
Don't use `void` to ignore rejected promises.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
