### PR TITLE
fix: do not depend on node binary to start LSP

### DIFF
--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -95,12 +95,11 @@ export function createServerOptions({
     warnThresholds?: { cpu?: number; memory?: number }
 }) {
     return async () => {
-        const bin = executable[0]
         const args = [...executable.slice(1), serverModule, ...execArgv]
         if (isDebugInstance()) {
             args.unshift('--inspect=6080')
         }
-        const lspProcess = new ChildProcess(bin, args, { warnThresholds })
+        const lspProcess = new ChildProcess(process.execPath, args, { warnThresholds })
 
         // this is a long running process, awaiting it will never resolve
         void lspProcess.run()


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
