### PR TITLE
ci: only publish amazonq as "latest" release

### DIFF
--- a/buildspec/release/50githubrelease.yml
+++ b/buildspec/release/50githubrelease.yml
@@ -36,10 +36,13 @@ phases:
             - echo "posting $VERSION with sha384 hash $HASH to GitHub"
             - PKG_DISPLAY_NAME=$(grep -m 1 displayName packages/${TARGET_EXTENSION}/package.json | grep -o '[a-zA-z][^\"]\+' | tail -n1)
             - RELEASE_MESSAGE="${PKG_DISPLAY_NAME} for VS Code $VERSION"
+            # Only set amazonq as "latest" release. This ensures https://api.github.com/repos/aws/aws-toolkit-vscode/releases/latest
+            # consistently points to the amazonq artifact, instead of being "random".
+            - LATEST="$([ "$TARGET_EXTENSION" = amazonq ] && echo '--latest' || echo '--latest=false' )"
             - |
                 if [ "$STAGE" = "prod" ]; then
                   # note: the tag arg passed here should match what is in 10changeversion.yml
-                  gh release create --repo $REPO --title "$PKG_DISPLAY_NAME $VERSION" --notes "$RELEASE_MESSAGE" -- "${TARGET_EXTENSION}/v${VERSION}" "$UPLOAD_TARGET" "$HASH_UPLOAD_TARGET"
+                  gh release create "$LATEST" --repo $REPO --title "$PKG_DISPLAY_NAME $VERSION" --notes "$RELEASE_MESSAGE" -- "${TARGET_EXTENSION}/v${VERSION}" "$UPLOAD_TARGET" "$HASH_UPLOAD_TARGET"
                 else
                   echo "SKIPPED (stage=${STAGE}): 'gh release create --repo $REPO'"
                 fi


### PR DESCRIPTION
Problem:
The `browser_download_url` in https://api.github.com/repos/aws/aws-toolkit-vscode/releases/latest points to a random artifact depending on whether toolkit or amazonq was the last release to publish.

Solution:
Modify the deploy logic to only set "latest" for "amazonq", never "toolkit".



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
