### PR TITLE
NEP: feature flag & bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
             ],
             "dependencies": {
                 "@types/node": "^22.7.5",
+                "jaro-winkler": "^0.2.8",
                 "vscode-nls": "^5.2.0",
                 "vscode-nls-dev": "^4.0.4"
             },
@@ -24,6 +25,7 @@
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
+                "@types/jaro-winkler": "^0.2.4",
                 "@types/vscode": "^1.68.0",
                 "@types/vscode-webview": "^1.57.1",
                 "@types/webpack-env": "^1.18.5",
@@ -13390,6 +13392,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/jaro-winkler": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@types/jaro-winkler/-/jaro-winkler-0.2.4.tgz",
+            "integrity": "sha512-TNVu6vL0Z3h+hYcW78IRloINA0y0MTVJ1PFVtVpBSgk+ejmaH5aVfcVghzNXZ0fa6gXe4zapNMQtMGWOJKTLig==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/js-yaml": {
             "version": "4.0.5",
             "dev": true,
@@ -19334,6 +19343,12 @@
             "optionalDependencies": {
                 "@pkgjs/parseargs": "^0.11.0"
             }
+        },
+        "node_modules/jaro-winkler": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/jaro-winkler/-/jaro-winkler-0.2.8.tgz",
+            "integrity": "sha512-yr+mElb6dWxA1mzFu0+26njV5DWAQRNTi5pB6fFMm79zHrfAs3d0qjhe/IpZI4AHIUJkzvu5QXQRWOw2O0GQyw==",
+            "license": "MIT"
         },
         "node_modules/jest-worker": {
             "version": "27.5.1",
@@ -25608,6 +25623,7 @@
                 "http2": "^3.3.6",
                 "i18n-ts": "^1.0.5",
                 "immutable": "^4.3.0",
+                "jaro-winkler": "^0.2.8",
                 "jose": "5.4.1",
                 "js-yaml": "^4.1.0",
                 "jsonc-parser": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
                 "prettier": "^3.3.3",
                 "prettier-plugin-sh": "^0.14.0",
                 "pretty-quick": "^4.0.0",
-                "ts-node": "^10.9.2",
+                "ts-node": "^10.9.1",
                 "typescript": "^5.0.4",
                 "webpack": "^5.95.0",
                 "webpack-cli": "^5.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
                 "prettier": "^3.3.3",
                 "prettier-plugin-sh": "^0.14.0",
                 "pretty-quick": "^4.0.0",
-                "ts-node": "^10.9.1",
+                "ts-node": "^10.9.2",
                 "typescript": "^5.0.4",
                 "webpack": "^5.95.0",
                 "webpack-cli": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",
+        "@types/jaro-winkler": "^0.2.4",
         "@types/vscode": "^1.68.0",
         "@types/vscode-webview": "^1.57.1",
         "@types/webpack-env": "^1.18.5",
@@ -74,6 +75,7 @@
     },
     "dependencies": {
         "@types/node": "^22.7.5",
+        "jaro-winkler": "^0.2.8",
         "vscode-nls": "^5.2.0",
         "vscode-nls-dev": "^4.0.4"
     }

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -831,16 +831,6 @@
                 "linux": "meta+alt+i"
             },
             {
-                "command": "aws.amazonq.inline.acceptEdit",
-                "key": "tab",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "aws.amazonq.inline.rejectEdit",
-                "key": "escape",
-                "when": "editorTextFocus"
-            },
-            {
                 "command": "aws.amazonq.inline.debugAcceptEdit",
                 "key": "ctrl+alt+a",
                 "mac": "cmd+alt+a",
@@ -932,6 +922,16 @@
                 "command": "aws.amazonq.inline.waitForUserDecisionRejectAll",
                 "key": "escape",
                 "when": "editorTextFocus && aws.codewhisperer.connected && amazonq.inline.codelensShortcutEnabled"
+            },
+            {
+                "command": "aws.amazonq.inline.acceptEdit",
+                "key": "tab",
+                "when": "editorTextFocus && amazonq.editSuggestionActive"
+            },
+            {
+                "command": "aws.amazonq.inline.rejectEdit",
+                "key": "escape",
+                "when": "editorTextFocus && amazonq.editSuggestionActive"
             }
         ],
         "icons": {

--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -146,7 +146,6 @@ export class EditDecorationManager {
         this.currentRemovedCodeDecorations = []
         this.acceptHandler = undefined
         this.rejectHandler = undefined
-        // Clear context to allow normal Tab key behavior
         void setContext('amazonq.editSuggestionActive' as any, false)
     }
 

--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -311,8 +311,9 @@ export async function displaySvgDecoration(
                 },
                 totalSessionDisplayTime: Date.now() - session.requestStartTime,
                 firstCompletionDisplayLatency: session.firstCompletionDisplayLatency,
-                addedCharacterCount: addedCharacterCount,
-                deletedCharacterCount: deletedCharacterCount,
+                // TODO: Update LogInlineCompletionSessionResultsParams interface to include these properties
+                // addedCharacterCount: addedCharacterCount,
+                // deletedCharacterCount: deletedCharacterCount,
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
         },
@@ -344,8 +345,9 @@ export async function displaySvgDecoration(
                         discarded: false,
                     },
                 },
-                addedCharacterCount: addedCharacterCount,
-                deletedCharacterCount: deletedCharacterCount,
+                // TODO: Update LogInlineCompletionSessionResultsParams interface to include these properties
+                // addedCharacterCount: addedCharacterCount,
+                // deletedCharacterCount: deletedCharacterCount,
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
         },

--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -126,8 +126,6 @@ export class EditDecorationManager {
         // Highlight removed lines with red background
         this.currentRemovedCodeDecorations = this.highlightRemovedLines(editor, originalCode, newCode)
         editor.setDecorations(this.removedCodeDecorationType, this.currentRemovedCodeDecorations)
-
-        // Register command handlers for accept/reject
     }
 
     /**
@@ -286,43 +284,11 @@ export async function displaySvgDecoration(
                 // deletedCharacterCount: deletedCharacterCount,
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
-            decorationManager.dispose()
-            const params: LogInlineCompletionSessionResultsParams = {
-                sessionId: session.sessionId,
-                completionSessionResult: {
-                    [item.itemId]: {
-                        seen: true,
-                        accepted: true,
-                        discarded: false,
-                    },
-                },
-                totalSessionDisplayTime: Date.now() - session.requestStartTime,
-                firstCompletionDisplayLatency: session.firstCompletionDisplayLatency,
-                // TODO: Update LogInlineCompletionSessionResultsParams interface to include these properties
-                // addedCharacterCount: addedCharacterCount,
-                // deletedCharacterCount: deletedCharacterCount,
-            }
-            languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
         },
         () => {
             // Handle reject
             getLogger().info('Edit suggestion rejected')
             decorationManager.clearDecorations(editor)
-            const params: LogInlineCompletionSessionResultsParams = {
-                sessionId: session.sessionId,
-                completionSessionResult: {
-                    [item.itemId]: {
-                        seen: true,
-                        accepted: false,
-                        discarded: false,
-                    },
-                },
-                // TODO: Update LogInlineCompletionSessionResultsParams interface to include these properties
-                // addedCharacterCount: addedCharacterCount,
-                // deletedCharacterCount: deletedCharacterCount,
-            }
-            languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
-            decorationManager.dispose()
             const params: LogInlineCompletionSessionResultsParams = {
                 sessionId: session.sessionId,
                 completionSessionResult: {

--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -300,6 +300,21 @@ export async function displaySvgDecoration(
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
             decorationManager.dispose()
+            const params: LogInlineCompletionSessionResultsParams = {
+                sessionId: session.sessionId,
+                completionSessionResult: {
+                    [item.itemId]: {
+                        seen: true,
+                        accepted: true,
+                        discarded: false,
+                    },
+                },
+                totalSessionDisplayTime: Date.now() - session.requestStartTime,
+                firstCompletionDisplayLatency: session.firstCompletionDisplayLatency,
+                addedCharacterCount: addedCharacterCount,
+                deletedCharacterCount: deletedCharacterCount,
+            }
+            languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
         },
         () => {
             // Handle reject
@@ -320,6 +335,19 @@ export async function displaySvgDecoration(
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
             decorationManager.dispose()
+            const params: LogInlineCompletionSessionResultsParams = {
+                sessionId: session.sessionId,
+                completionSessionResult: {
+                    [item.itemId]: {
+                        seen: true,
+                        accepted: false,
+                        discarded: false,
+                    },
+                },
+                addedCharacterCount: addedCharacterCount,
+                deletedCharacterCount: deletedCharacterCount,
+            }
+            languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
         },
         originalCode,
         newCode

--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -100,7 +100,8 @@ export class EditDecorationManager {
         onAccept: () => void,
         onReject: () => void,
         originalCode: string,
-        newCode: string
+        newCode: string,
+        removedHighlights?: vscode.DecorationOptions[]
     ): void {
         // Clear any existing decorations
         this.clearDecorations(editor)
@@ -120,8 +121,13 @@ export class EditDecorationManager {
         // Apply image decoration
         editor.setDecorations(this.imageDecorationType, [this.currentImageDecoration])
 
-        // Highlight removed lines with red background
-        this.currentRemovedCodeDecorations = this.highlightRemovedLines(editor, originalCode, newCode)
+        // Highlight removed parts with red background - use provided highlights if available
+        if (removedHighlights && removedHighlights.length > 0) {
+            this.currentRemovedCodeDecorations = removedHighlights
+        } else {
+            // Fall back to line-level highlights if no char-level highlights provided
+            this.currentRemovedCodeDecorations = this.highlightRemovedLines(editor, originalCode, newCode)
+        }
         editor.setDecorations(this.removedCodeDecorationType, this.currentRemovedCodeDecorations)
 
         // Register command handlers for accept/reject

--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getLogger } from 'aws-core-vscode/shared'
+import { getLogger, setContext } from 'aws-core-vscode/shared'
 import * as vscode from 'vscode'
 import { diffLines } from 'diff'
 import { LanguageClient } from 'vscode-languageclient'
@@ -18,6 +18,7 @@ export class EditDecorationManager {
     private currentRemovedCodeDecorations: vscode.DecorationOptions[] = []
     private acceptHandler: (() => void) | undefined
     private rejectHandler: (() => void) | undefined
+    private disposables: vscode.Disposable[] = []
 
     constructor() {
         this.imageDecorationType = vscode.window.createTextEditorDecorationType({
@@ -27,8 +28,6 @@ export class EditDecorationManager {
         this.removedCodeDecorationType = vscode.window.createTextEditorDecorationType({
             backgroundColor: 'rgba(255, 0, 0, 0.2)',
         })
-
-        this.registerCommandHandlers()
     }
 
     /**
@@ -104,7 +103,11 @@ export class EditDecorationManager {
         removedHighlights?: vscode.DecorationOptions[]
     ): void {
         // Clear any existing decorations
+        this.registerCommandHandlers()
         this.clearDecorations(editor)
+
+        // Set context to enable the Tab key handler
+        void setContext('amazonq.editSuggestionActive' as any, true)
 
         // Store handlers
         this.acceptHandler = onAccept
@@ -143,6 +146,8 @@ export class EditDecorationManager {
         this.currentRemovedCodeDecorations = []
         this.acceptHandler = undefined
         this.rejectHandler = undefined
+        // Clear context to allow normal Tab key behavior
+        void setContext('amazonq.editSuggestionActive' as any, false)
     }
 
     /**
@@ -150,24 +155,30 @@ export class EditDecorationManager {
      */
     public registerCommandHandlers(): void {
         // Register Tab key handler for accepting suggestion
-        vscode.commands.registerCommand('aws.amazonq.inline.acceptEdit', () => {
+        const acceptDisposable = vscode.commands.registerCommand('aws.amazonq.inline.acceptEdit', () => {
             if (this.acceptHandler) {
                 this.acceptHandler()
             }
         })
+        this.disposables.push(acceptDisposable)
 
         // Register Esc key handler for rejecting suggestion
-        vscode.commands.registerCommand('aws.amazonq.inline.rejectEdit', () => {
+        const rejectDisposable = vscode.commands.registerCommand('aws.amazonq.inline.rejectEdit', () => {
             if (this.rejectHandler) {
                 this.rejectHandler()
             }
         })
+        this.disposables.push(rejectDisposable)
     }
 
     /**
      * Disposes resources
      */
     public dispose(): void {
+        for (const disposable of this.disposables) {
+            disposable.dispose()
+        }
+        this.disposables = []
         this.imageDecorationType.dispose()
         this.removedCodeDecorationType.dispose()
     }
@@ -194,6 +205,51 @@ function replaceEditorContent(editor: vscode.TextEditor, newCode: string): void 
 }
 
 /**
+ * Calculates the end position of the actual edited content by finding the last changed part
+ */
+function getEndOfEditPosition(originalCode: string, newCode: string): vscode.Position {
+    const changes = diffLines(originalCode, newCode)
+    let lineOffset = 0
+
+    // Track the end position of the last added chunk
+    let lastChangeEndLine = 0
+    let lastChangeEndColumn = 0
+    let foundAddedContent = false
+
+    for (const part of changes) {
+        if (part.added) {
+            foundAddedContent = true
+
+            // Calculate lines in this added part
+            const lines = part.value.split('\n')
+            const linesCount = lines.length
+
+            // Update position to the end of this added chunk
+            lastChangeEndLine = lineOffset + linesCount - 1
+
+            // Get the length of the last line in this added chunk
+            lastChangeEndColumn = lines[linesCount - 1].length
+        }
+
+        // Update line offset (skip removed parts)
+        if (!part.removed) {
+            // Safely calculate line count from the part's value
+            const partLineCount = part.value.split('\n').length
+            lineOffset += partLineCount - 1
+        }
+    }
+
+    // If we found added content, return position at the end of the last addition
+    if (foundAddedContent) {
+        return new vscode.Position(lastChangeEndLine, lastChangeEndColumn)
+    }
+
+    // Fallback to current cursor position if no changes were found
+    const editor = vscode.window.activeTextEditor
+    return editor ? editor.selection.active : new vscode.Position(0, 0)
+}
+
+/**
  * Helper function to display SVG decorations
  */
 export async function displaySvgDecoration(
@@ -216,7 +272,16 @@ export async function displaySvgDecoration(
         () => {
             // Handle accept
             getLogger().info('Edit suggestion accepted')
+
+            // Calculate cursor position before replacing content
+            const endPosition = getEndOfEditPosition(originalCode, newCode)
+
+            // Replace content
             replaceEditorContent(editor, newCode)
+
+            // Move cursor to end of the actual changed content
+            editor.selection = new vscode.Selection(endPosition, endPosition)
+
             decorationManager.clearDecorations(editor)
             const params: LogInlineCompletionSessionResultsParams = {
                 sessionId: session.sessionId,
@@ -234,6 +299,7 @@ export async function displaySvgDecoration(
                 // deletedCharacterCount: deletedCharacterCount,
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
+            decorationManager.dispose()
         },
         () => {
             // Handle reject
@@ -253,6 +319,7 @@ export async function displaySvgDecoration(
                 // deletedCharacterCount: deletedCharacterCount,
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
+            decorationManager.dispose()
         },
         originalCode,
         newCode

--- a/packages/amazonq/src/app/inline/EditRendering/svgGenerator.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/svgGenerator.ts
@@ -14,7 +14,9 @@ export class SvgGenerationService {
     /**
      * Generates an SVG image representing a code diff
      * @param originalCode The original code
-     * @param udiff The unified diff content
+     * @param newCode The new code with editsss
+     * @param theme The editor theme information
+     * @param offSet The margin to add to the left of the image
      */
     public async generateDiffSvg(
         originalCode: string,
@@ -125,9 +127,9 @@ export class SvgGenerationService {
         const fontSize = theme.fontSize
         const headerFrontSize = Math.ceil(fontSize * 0.66)
         const lineHeight = theme.lingHeight
-        const foreground = theme.foreground || '#d4d4d4'
+        const foreground = theme.foreground
+        const bordeColor = 'rgba(212, 212, 212, 0.5)'
         const background = theme.background || '#1e1e1e'
-        const bordeColor = theme.foreground || '#d4d4d4'
         const diffRemoved = theme.diffRemoved || 'rgba(255, 0, 0, 0.2)'
         const diffAdded = 'rgba(72, 128, 72, 0.52)'
         return `
@@ -272,40 +274,52 @@ export class SvgGenerationService {
         diffAdded: string
         diffRemoved: string
     } {
+        // Define default dark theme colors
+        const darkThemeColors = {
+            foreground: 'rgba(212, 212, 212, 1)',
+            background: 'rgba(30, 30, 30, 1)',
+            diffAdded: 'rgba(231, 245, 231, 0.2)',
+            diffRemoved: 'rgba(255, 0, 0, 0.2)',
+        }
+
+        // Define default light theme colors
+        const lightThemeColors = {
+            foreground: 'rgba(0, 0, 0, 1)',
+            background: 'rgba(255, 255, 255, 1)',
+            diffAdded: 'rgba(198, 239, 206, 0.2)',
+            diffRemoved: 'rgba(255, 199, 206, 0.5)',
+        }
+
         // Define colors for specific themes
         const themeColorMap: {
             [key: string]: { foreground: string; background: string; diffAdded: string; diffRemoved: string }
         } = {
-            'Default Dark+': {
-                foreground: '#d4d4d4',
-                background: '#1e1e1e',
-                diffAdded: 'rgba(231, 245, 231, 0.2)',
-                diffRemoved: 'rgba(255, 0, 0, 0.2)',
-            },
             Abyss: {
-                foreground: '#ffffff',
-                background: '#000c18',
+                foreground: 'rgba(255, 255, 255, 1)',
+                background: 'rgba(0, 12, 24, 1)',
                 diffAdded: 'rgba(0, 255, 0, 0.2)',
                 diffRemoved: 'rgba(255, 0, 0, 0.3)',
             },
             Red: {
-                foreground: '#ff0000',
-                background: '#330000',
+                foreground: 'rgba(255, 0, 0, 1)',
+                background: 'rgba(51, 0, 0, 1)',
                 diffAdded: 'rgba(255, 100, 100, 0.2)',
                 diffRemoved: 'rgba(255, 0, 0, 0.5)',
             },
             // Add more themes as needed
         }
 
-        // Return colors for the current theme or default colors
-        return (
-            themeColorMap[themeName] || {
-                foreground: '#000000',
-                background: '#ffffff',
-                diffAdded: 'rgba(198, 239, 206, 0.2)',
-                diffRemoved: 'rgba(255, 199, 206, 0.5)',
-            }
-        )
+        // Check if theme name contains "dark" or "light"
+        const themeNameLower = themeName.toLowerCase()
+
+        if (themeNameLower.includes('dark')) {
+            return darkThemeColors
+        } else if (themeNameLower.includes('light')) {
+            return lightThemeColors
+        }
+
+        // Return colors for the specific theme or default to light theme
+        return themeColorMap[themeName] || lightThemeColors
     }
 
     private calculatePosition(

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -40,7 +40,7 @@ import { InlineGeneratingMessage } from './inlineGeneratingMessage'
 import { LineTracker } from './stateTracker/lineTracker'
 import { InlineTutorialAnnotation } from './tutorials/inlineTutorialAnnotation'
 import { TelemetryHelper } from './telemetryHelper'
-import { getLogger } from 'aws-core-vscode/shared'
+import { Experiments, getLogger } from 'aws-core-vscode/shared'
 import { debounce, messageUtils } from 'aws-core-vscode/utils'
 import { showEdits } from './EditRendering/imageRenderer'
 import { NextEditPredictionPanel } from './webViewPanel'
@@ -246,11 +246,15 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
             const cursorPosition = document.validatePosition(position)
             for (const item of items) {
                 if (item.isInlineEdit) {
-                    const panel = NextEditPredictionPanel.getInstance()
-                    panel.updateContent(item.insertText as string)
-                    void showEdits(item, editor, session, this.languageClient)
-                    getLogger('nextEditPrediction').info('Received edit!')
-                    return []
+                    // Check if Next Edit Prediction feature flag is enabled
+                    if (Experiments.instance.isExperimentEnabled('amazonqLSPNEP')) {
+                        const panel = NextEditPredictionPanel.getInstance()
+                        panel.updateContent(item.insertText as string)
+                        void showEdits(item, editor, session, this.languageClient)
+                        getLogger('nextEditPrediction').info('Received edit!')
+                        return []
+                    }
+                    // If NEP is disabled, handle as regular completion
                 }
 
                 item.command = {

--- a/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
@@ -210,6 +210,7 @@ describe('RecommendationService', () => {
             await service.getAllRecommendations(languageClient, mockDocument, mockPosition, mockContext, mockToken)
 
             // Verify recordCompletionRequest was called
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             sinon.assert.calledOnce(cursorUpdateManager.recordCompletionRequest as sinon.SinonStub)
         })
 
@@ -271,7 +272,7 @@ describe('RecommendationService', () => {
             sendRequestStub.rejects(testError)
 
             // Stub the UI methods to avoid errors
-            const showGeneratingStub = sandbox.stub(activeStateController, 'showGenerating').resolves()
+            // const showGeneratingStub = sandbox.stub(activeStateController, 'showGenerating').resolves()
             const hideGeneratingStub = sandbox.stub(activeStateController, 'hideGenerating')
 
             // Call the method

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -580,7 +580,8 @@
         "xml2js": "^0.6.1",
         "yaml-cfn": "^0.3.2",
         "@svgdotjs/svg.js": "^3.0.16",
-        "svgdom": "^0.1.0"
+        "svgdom": "^0.1.0",
+        "jaro-winkler": "^0.2.8"
     },
     "overrides": {
         "webfont": {

--- a/packages/core/src/shared/settings-toolkit.gen.ts
+++ b/packages/core/src/shared/settings-toolkit.gen.ts
@@ -45,7 +45,8 @@ export const toolkitSettings = {
         "amazonqLSP": {},
         "amazonqLSPInline": {},
         "amazonqLSPInlineChat": {},
-        "amazonqChatLSP": {}
+        "amazonqChatLSP": {},
+        "amazonqLSPNEP": {}
     },
     "aws.resources.enabledResources": {},
     "aws.lambda.recentlyUploaded": {},

--- a/packages/core/src/shared/vscode/setContext.ts
+++ b/packages/core/src/shared/vscode/setContext.ts
@@ -29,6 +29,7 @@ export type contextKey =
     | 'aws.toolkit.amazonqInstall.dismissed'
     | 'aws.stepFunctions.isWorkflowStudioFocused'
     | 'aws.toolkit.notifications.show'
+    | 'aws.amazonq.editSuggestionActive'
     // Deprecated/legacy names. New keys should start with "aws.".
     | 'codewhisperer.activeLine'
     | 'gumby.isPlanAvailable'

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -262,6 +262,10 @@
                         "amazonqChatLSP": {
                             "type": "boolean",
                             "default": true
+                        },
+                        "amazonqLSPNEP": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
1. Added a feature flag `amazonqLSPNEP` for NEP.
Configure the settings.json like:
```
"aws.experiments": {
        "amazonqLSP": true,
        "amazonqLSPInline": true, // optional: enables inline completion from flare
        "amazonqLSPChat": true, // optional: enables chat from flare
        "amazonqLSPNEP": true, // optional: enables next edit prediction
    },
```
2. Fixed some UI/UX bugs:
- Color theme matches IDE light/dark theme
- Cursor move to the end of edit once accepted
- Added conditions to the accept/reject commands so tab/esc works outside of NEP context. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
