### PR TITLE
fix(lsp): handle ShowDocumentParams.external

### DIFF
--- a/packages/core/src/shared/utilities/vsCodeUtils.ts
+++ b/packages/core/src/shared/utilities/vsCodeUtils.ts
@@ -215,8 +215,11 @@ export function reloadWindowPrompt(message: string): void {
  * if user dismisses the vscode confirmation prompt.
  */
 export async function openUrl(url: vscode.Uri, source?: string): Promise<boolean> {
+    // Avoid PII in URL.
+    const truncatedUrl = `${url.scheme}${url.authority}${url.path}${url.fragment.substring(20)}`
+
     return telemetry.aws_openUrl.run(async (span) => {
-        span.record({ url: url.toString(), source })
+        span.record({ url: truncatedUrl, source })
         const didOpen = await vscode.env.openExternal(url)
         if (!didOpen) {
             throw new CancellationError('user')


### PR DESCRIPTION
## Problem

LSP server can't open URLs, because the LSP client does not correctly handle `ShowDocumentParams.external` requests.
LSP spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#showDocumentParams

## Solution

When `ShowDocumentParams.external` is true, open the URL in a web browser instead of as a editor document.

Also: avoid PII in openUrl metric.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
