### PR TITLE
fix(amazonq): Revert "feat(amazonq): add the mcp field to client capa…

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -123,7 +123,6 @@ export async function startLanguageServer(
                 awsClientCapabilities: {
                     q: {
                         developerProfiles: true,
-                        mcp: true,
                     },
                     window: {
                         notifications: true,


### PR DESCRIPTION
## Problem
- not expose MCP feature before public release

## Solution
- reverts commit 6cbe787cbd1132bdea0de1b0d5edc5d329953087.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
