### PR TITLE
feat(amazonq): Bundle LSP with the extension as fallback.  

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-d6714581-799f-49dc-bb63-f08d461e9bde.json
+++ b/packages/amazonq/.changes/next-release/Feature-d6714581-799f-49dc-bb63-f08d461e9bde.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Launch LSP with bundled artifacts as fallback"
+}

--- a/packages/amazonq/src/lsp/activation.ts
+++ b/packages/amazonq/src/lsp/activation.ts
@@ -11,7 +11,6 @@ import { lspSetupStage, ToolkitError, messages, getLogger } from 'aws-core-vscod
 export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     try {
         await lspSetupStage('all', async () => {
-            throw Error(`Q Install failed!`)
             const installResult = await new AmazonQLspInstaller().resolve()
             await lspSetupStage('launch', async () => await startLanguageServer(ctx, installResult.resourcePaths))
         })

--- a/packages/amazonq/src/lsp/activation.ts
+++ b/packages/amazonq/src/lsp/activation.ts
@@ -16,7 +16,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
         })
     } catch (err) {
         const e = err as ToolkitError
-        getLogger('amazonqLsp').warn(`Failed to start downloaded LSP ${e.message}. Starting with bundled LSP...`)
+        getLogger('amazonqLsp').warn(`Failed to start downloaded LSP, falling back to bundled LSP: ${e.message}`)
         try {
             await lspSetupStage('all', async () => {
                 await lspSetupStage('launch', async () => await startLanguageServer(ctx, getBundledResourcePaths(ctx)))

--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -45,7 +45,7 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
     ) {
         const lspDir = Uri.file(LanguageServerResolver.defaultDir())
         const dist = Uri.joinPath(globals.context.extensionUri, 'dist')
-        const bundledResources = Uri.joinPath(globals.context.extensionUri, 'resources', 'language-server')
+        const bundledResources = Uri.joinPath(globals.context.extensionUri, 'resources/language-server')
         let resourcesRoots = [lspDir, dist]
         if (this.mynahUIPath?.startsWith(globals.context.extensionUri.fsPath)) {
             getLogger('amazonqLsp').info(`Using bundled webview resources ${bundledResources.fsPath}`)

--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -44,8 +44,8 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
     ) {
         const lspDir = Uri.file(LanguageServerResolver.defaultDir())
         const dist = Uri.joinPath(globals.context.extensionUri, 'dist')
-
-        const resourcesRoots = [lspDir, dist]
+        const bundledResources = Uri.joinPath(globals.context.extensionUri, 'resources', 'language-server')
+        const resourcesRoots = [lspDir, dist, bundledResources]
 
         /**
          * if the mynah chat client is defined, then make sure to add it to the resource roots, otherwise

--- a/packages/amazonq/src/lsp/chat/webviewProvider.ts
+++ b/packages/amazonq/src/lsp/chat/webviewProvider.ts
@@ -19,6 +19,7 @@ import {
     AmazonQPromptSettings,
     LanguageServerResolver,
     amazonqMark,
+    getLogger,
 } from 'aws-core-vscode/shared'
 import { AuthUtil, RegionProfile } from 'aws-core-vscode/codewhisperer'
 import { featureConfig } from 'aws-core-vscode/amazonq'
@@ -45,8 +46,11 @@ export class AmazonQChatViewProvider implements WebviewViewProvider {
         const lspDir = Uri.file(LanguageServerResolver.defaultDir())
         const dist = Uri.joinPath(globals.context.extensionUri, 'dist')
         const bundledResources = Uri.joinPath(globals.context.extensionUri, 'resources', 'language-server')
-        const resourcesRoots = [lspDir, dist, bundledResources]
-
+        let resourcesRoots = [lspDir, dist]
+        if (this.mynahUIPath?.startsWith(globals.context.extensionUri.fsPath)) {
+            getLogger('amazonqLsp').info(`Using bundled webview resources ${bundledResources.fsPath}`)
+            resourcesRoots = [bundledResources, dist]
+        }
         /**
          * if the mynah chat client is defined, then make sure to add it to the resource roots, otherwise
          * it will 401 when trying to load

--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -36,7 +36,7 @@ export function isValidConfigSection(section: unknown): section is ConfigSection
 }
 
 export const defaultAmazonQLspConfig: ExtendedAmazonQLSPConfig = {
-    manifestUrl: 'https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json',
+    manifestUrl: 'https://aws-language-servers-gamma.amazonaws.com/qAgenticChatServer/0/manifest.json',
     supportedVersions: '1.*.*',
     id: 'AmazonQ', // used across IDEs for identifying global storage/local disk locations. Do not change.
     suppressPromptPrefix: 'amazonQ',

--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -36,7 +36,7 @@ export function isValidConfigSection(section: unknown): section is ConfigSection
 }
 
 export const defaultAmazonQLspConfig: ExtendedAmazonQLSPConfig = {
-    manifestUrl: 'https://aws-language-servers-gamma.amazonaws.com/qAgenticChatServer/0/manifest.json',
+    manifestUrl: 'https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json',
     supportedVersions: '1.*.*',
     id: 'AmazonQ', // used across IDEs for identifying global storage/local disk locations. Do not change.
     suppressPromptPrefix: 'amazonQ',

--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -61,7 +61,7 @@ export function getBundledResourcePaths(ctx: vscode.ExtensionContext): AmazonQRe
     return {
         lsp: path.join(assetDirectory, 'servers', 'aws-lsp-codewhisperer.js'),
         node: process.execPath,
-        ripGrep: process.platform === 'win32' ? 'rg.exe' : 'rg',
+        ripGrep: '',
         ui: path.join(assetDirectory, 'clients', 'amazonq-ui.js'),
     }
 }

--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -61,7 +61,7 @@ export function getBundledResourcePaths(ctx: vscode.ExtensionContext): AmazonQRe
     return {
         lsp: path.join(assetDirectory, 'servers', 'aws-lsp-codewhisperer.js'),
         node: process.execPath,
-        ripGrep: '',
+        ripGrep: process.platform === 'win32' ? 'rg.exe' : 'rg',
         ui: path.join(assetDirectory, 'clients', 'amazonq-ui.js'),
     }
 }

--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import vscode from 'vscode'
 import { fs, getNodeExecutableName, getRgExecutableName, BaseLspInstaller, ResourcePaths } from 'aws-core-vscode/shared'
 import path from 'path'
 import { ExtendedAmazonQLSPConfig, getAmazonQLspConfig } from './config'
@@ -53,4 +54,14 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
     }
 
     protected override downloadMessageOverride: string | undefined = 'Updating Amazon Q plugin'
+}
+
+export function getBundledResourcePaths(ctx: vscode.ExtensionContext): AmazonQResourcePaths {
+    const assetDirectory = vscode.Uri.joinPath(ctx.extensionUri, 'resources', 'language-server').fsPath
+    return {
+        lsp: path.join(assetDirectory, 'aws-lsp-codewhisperer.js'),
+        node: process.execPath,
+        ripGrep: '',
+        ui: path.join(assetDirectory, 'amazonq-ui.js'),
+    }
 }

--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -59,9 +59,9 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
 export function getBundledResourcePaths(ctx: vscode.ExtensionContext): AmazonQResourcePaths {
     const assetDirectory = vscode.Uri.joinPath(ctx.extensionUri, 'resources', 'language-server').fsPath
     return {
-        lsp: path.join(assetDirectory, 'aws-lsp-codewhisperer.js'),
+        lsp: path.join(assetDirectory, 'servers', 'aws-lsp-codewhisperer.js'),
         node: process.execPath,
         ripGrep: '',
-        ui: path.join(assetDirectory, 'amazonq-ui.js'),
+        ui: path.join(assetDirectory, 'clients', 'amazonq-ui.js'),
     }
 }

--- a/scripts/lspArtifact.ts
+++ b/scripts/lspArtifact.ts
@@ -1,0 +1,171 @@
+import * as https from 'https'
+import * as fs from 'fs'
+import * as crypto from 'crypto'
+import * as path from 'path'
+import * as os from 'os'
+import AdmZip from 'adm-zip'
+
+interface ManifestContent {
+    filename: string
+    url: string
+    hashes: string[]
+    bytes: number
+}
+
+interface ManifestTarget {
+    platform: string
+    arch: string
+    contents: ManifestContent[]
+}
+
+interface ManifestVersion {
+    serverVersion: string
+    isDelisted: boolean
+    targets: ManifestTarget[]
+}
+
+interface Manifest {
+    versions: ManifestVersion[]
+}
+async function verifyFileHash(filePath: string, expectedHash: string): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+        const hash = crypto.createHash('sha384')
+        const stream = fs.createReadStream(filePath)
+
+        stream.on('data', (data) => {
+            hash.update(data)
+        })
+
+        stream.on('end', () => {
+            const fileHash = hash.digest('hex')
+            // Remove 'sha384:' prefix from expected hash if present
+            const expectedHashValue = expectedHash.replace('sha384:', '')
+            resolve(fileHash === expectedHashValue)
+        })
+
+        stream.on('error', reject)
+    })
+}
+
+async function ensureDirectoryExists(dirPath: string): Promise<void> {
+    if (!fs.existsSync(dirPath)) {
+        await fs.promises.mkdir(dirPath, { recursive: true })
+    }
+}
+
+export async function downloadLanguageServer(): Promise<void> {
+    const tempDir = path.join(os.tmpdir(), 'amazonq-download-temp')
+    const resourcesDir = path.join(__dirname, '../packages/amazonq/resources/language-server')
+
+    // clear previous cached language server
+    try {
+        fs.rmdirSync(resourcesDir, { recursive: true })
+    } catch (e) {
+        throw Error(`Failed to clean up language server`)
+    }
+
+    await ensureDirectoryExists(tempDir)
+    await ensureDirectoryExists(resourcesDir)
+
+    return new Promise((resolve, reject) => {
+        const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json'
+
+        https
+            .get(manifestUrl, (res) => {
+                let data = ''
+
+                res.on('data', (chunk) => {
+                    data += chunk
+                })
+
+                res.on('end', async () => {
+                    try {
+                        const manifest: Manifest = JSON.parse(data)
+
+                        const latestVersion = manifest.versions
+                            .filter((v) => !v.isDelisted)
+                            .sort((a, b) => b.serverVersion.localeCompare(a.serverVersion))[0]
+
+                        if (!latestVersion) {
+                            throw new Error('No valid version found in manifest')
+                        }
+
+                        const darwinArm64Target = latestVersion.targets.find(
+                            (t) => t.platform === 'darwin' && t.arch === 'arm64'
+                        )
+
+                        if (!darwinArm64Target) {
+                            throw new Error('No darwin arm64 target found')
+                        }
+
+                        for (const content of darwinArm64Target.contents) {
+                            const fileName = content.filename
+                            const fileUrl = content.url
+                            const expectedHash = content.hashes[0]
+                            const tempFilePath = path.join(tempDir, fileName)
+
+                            console.log(`Downloading ${fileName} from ${fileUrl} ...`)
+
+                            await new Promise((downloadResolve, downloadReject) => {
+                                https
+                                    .get(fileUrl, (fileRes) => {
+                                        const fileStream = fs.createWriteStream(tempFilePath)
+                                        fileRes.pipe(fileStream)
+
+                                        fileStream.on('finish', () => {
+                                            fileStream.close()
+                                            downloadResolve(void 0)
+                                        })
+
+                                        fileStream.on('error', (err) => {
+                                            fs.unlink(tempFilePath, () => {})
+                                            downloadReject(err)
+                                        })
+                                    })
+                                    .on('error', (err) => {
+                                        fs.unlink(tempFilePath, () => {})
+                                        downloadReject(err)
+                                    })
+                            })
+
+                            console.log(`Verifying hash for ${fileName}...`)
+                            const isHashValid = await verifyFileHash(tempFilePath, expectedHash)
+
+                            if (!isHashValid) {
+                                fs.unlinkSync(tempFilePath)
+                                throw new Error(`Hash verification failed for ${fileName}`)
+                            }
+
+                            console.log(`Extracting ${fileName}...`)
+                            const zip = new AdmZip(tempFilePath)
+                            zip.extractAllTo(resourcesDir, true) // true for overwrite
+
+                            // Clean up temp file
+                            fs.unlinkSync(tempFilePath)
+                            console.log(`Successfully processed ${fileName}`)
+                        }
+
+                        // Clean up temp directory
+                        fs.rmdirSync(tempDir)
+                        fs.rmdirSync(path.join(resourcesDir, 'indexing'), { recursive: true })
+                        fs.rmSync(path.join(resourcesDir, 'node'))
+                        console.log('Download and extraction completed successfully')
+                        resolve()
+                    } catch (err) {
+                        // Clean up temp directory on error
+                        if (fs.existsSync(tempDir)) {
+                            fs.rmdirSync(tempDir, { recursive: true })
+                        }
+                        reject(err)
+                    }
+                })
+            })
+            .on('error', (err) => {
+                // Clean up temp directory on error
+                if (fs.existsSync(tempDir)) {
+                    fs.rmdirSync(tempDir, { recursive: true })
+                }
+                reject(err)
+            })
+    })
+}

--- a/scripts/lspArtifact.ts
+++ b/scripts/lspArtifact.ts
@@ -103,6 +103,7 @@ export async function downloadLanguageServer(): Promise<void> {
                             const fileUrl = content.url
                             const expectedHash = content.hashes[0]
                             const tempFilePath = path.join(tempDir, fileName)
+                            const fileFolderName = content.filename.replace('.zip', '')
 
                             console.log(`Downloading ${fileName} from ${fileUrl} ...`)
 
@@ -138,7 +139,7 @@ export async function downloadLanguageServer(): Promise<void> {
 
                             console.log(`Extracting ${fileName}...`)
                             const zip = new AdmZip(tempFilePath)
-                            zip.extractAllTo(resourcesDir, true) // true for overwrite
+                            zip.extractAllTo(path.join(resourcesDir, fileFolderName), true) // true for overwrite
 
                             // Clean up temp file
                             fs.unlinkSync(tempFilePath)
@@ -147,8 +148,8 @@ export async function downloadLanguageServer(): Promise<void> {
 
                         // Clean up temp directory
                         fs.rmdirSync(tempDir)
-                        fs.rmdirSync(path.join(resourcesDir, 'indexing'), { recursive: true })
-                        fs.rmSync(path.join(resourcesDir, 'node'))
+                        fs.rmdirSync(path.join(resourcesDir, 'servers', 'indexing'), { recursive: true })
+                        fs.rmSync(path.join(resourcesDir, 'servers', 'node'))
                         console.log('Download and extraction completed successfully')
                         resolve()
                     } catch (err) {

--- a/scripts/lspArtifact.ts
+++ b/scripts/lspArtifact.ts
@@ -151,7 +151,14 @@ export async function downloadLanguageServer(): Promise<void> {
                         // Clean up temp directory
                         fs.rmdirSync(tempDir)
                         fs.rmdirSync(path.join(resourcesDir, 'servers', 'indexing'), { recursive: true })
+                        fs.rmdirSync(path.join(resourcesDir, 'servers', 'ripgrep'), { recursive: true })
                         fs.rmSync(path.join(resourcesDir, 'servers', 'node'))
+                        if (!fs.existsSync(path.join(resourcesDir, 'servers', 'aws-lsp-codewhisperer.js'))) {
+                            throw new Error(`Extracting aws-lsp-codewhisperer.js failure`)
+                        }
+                        if (!fs.existsSync(path.join(resourcesDir, 'clients', 'amazonq-ui.js'))) {
+                            throw new Error(`Extracting amazonq-ui.js failure`)
+                        }
                         console.log('Download and extraction completed successfully')
                         resolve()
                     } catch (err) {

--- a/scripts/lspArtifact.ts
+++ b/scripts/lspArtifact.ts
@@ -59,9 +59,11 @@ export async function downloadLanguageServer(): Promise<void> {
 
     // clear previous cached language server
     try {
-        fs.rmdirSync(resourcesDir, { recursive: true })
+        if (fs.existsSync(resourcesDir)) {
+            fs.rmdirSync(resourcesDir, { recursive: true })
+        }
     } catch (e) {
-        throw Error(`Failed to clean up language server`)
+        throw Error(`Failed to clean up language server ${resourcesDir}`)
     }
 
     await ensureDirectoryExists(tempDir)

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -20,6 +20,7 @@
 import * as child_process from 'child_process' // eslint-disable-line no-restricted-imports
 import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import * as path from 'path'
+import { downloadLanguageServer } from './lspArtifact'
 
 function parseArgs() {
     // Invoking this script with argument "foo":
@@ -105,7 +106,7 @@ function getVersionSuffix(feature: string, debug: boolean): string {
     return `${debugSuffix}${featureSuffix}${commitSuffix}`
 }
 
-function main() {
+async function main() {
     const args = parseArgs()
     // It is expected that this will package from a packages/{subproject} folder.
     // There is a base config in packages/
@@ -155,6 +156,10 @@ function main() {
         }
 
         nodefs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, undefined, '    '))
+
+        // add language server fallback
+        await downloadLanguageServer()
+
         child_process.execFileSync(
             'vsce',
             [

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -157,8 +157,10 @@ async function main() {
 
         nodefs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, undefined, '    '))
 
-        // add language server fallback
-        await downloadLanguageServer()
+        // add language server bundle
+        if (packageJson.name === 'amazon-q-vscode') {
+            await downloadLanguageServer()
+        }
 
         child_process.execFileSync(
             'vsce',


### PR DESCRIPTION
## Problem
The LSP start failure because 
1. node binary is blocked because of firewall
2. chat UI js file is blocked because of firewall or anti virus
3. lsp js file is broken post download because of security mechanism

## Solution
1. Bundle the JS LSP with the amazonq package.
2. Re-start LSP wth the bundled JS files if and only if downloaded LSP does not work!
3. Use the VS Code vended node to start the bundled LSP.


This was tested by 
1. Generated the vsix, which is now 20MB.
2. Disconnect from internet, remove local LSP caches
3. Install the new vsix
4. Webview of chat should load.

also tested by manually corrupting the aws-lsp-codewhisperer.js


Limitations:
1. The indexing library function will not work because it is missing.
2. rg is not in the bundle

Ref: https://github.com/aws/aws-toolkit-jetbrains/pull/5772

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
