### PR TITLE
fix(amazonq): Add proxy configuration support with SSL Cert Validation

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -213,6 +213,12 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "amazonQ.proxy.certificateAuthority": {
+                    "type": "string",
+                    "markdownDescription": "%AWS.configuration.description.amazonq.proxy.certificateAuthority%",
+                    "default": null,
+                    "scope": "application"
                 }
             }
         },

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -34,6 +34,7 @@ import {
     Experiments,
     isSageMaker,
     isAmazonLinux2,
+    ProxyUtil,
 } from 'aws-core-vscode/shared'
 import { ExtStartUpSources } from 'aws-core-vscode/telemetry'
 import { VSCODE_EXTENSION_ID } from 'aws-core-vscode/utils'
@@ -119,6 +120,10 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     const extContext = {
         extensionContext: context,
     }
+
+    // Configure proxy settings early
+    ProxyUtil.configureProxyForLanguageServer()
+
     // This contains every lsp agnostic things (auth, security scan, code scan)
     await activateCodeWhisperer(extContext as ExtContext)
     if (

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -98,7 +98,7 @@
     "AWS.configuration.description.amazonq.workspaceIndexIgnoreFilePatterns": "File patterns to ignore when indexing your workspace files",
     "AWS.configuration.description.amazonq.workspaceIndexCacheDirPath": "The path to the directory that contains the cache of the index of your workspace files",
     "AWS.configuration.description.amazonq.ignoredSecurityIssues": "Specifies a list of code issue identifiers that Amazon Q should ignore when reviewing your workspace. Each item in the array should be a unique string identifier for a specific code issue. This allows you to suppress notifications for known issues that you've assessed and determined to be false positives or not applicable to your project. Use this setting with caution, as it may cause you to miss important security alerts.",
-    "AWS.command.apig.copyUrl": "Copy URL",
+    "AWS.configuration.description.amazonq.proxy.certificateAuthority": "Path to a Certificate Authority (PEM file) for SSL/TLS verification when using a proxy.",
     "AWS.command.apig.invokeRemoteRestApi": "Invoke in the cloud",
     "AWS.command.apig.invokeRemoteRestApi.cn": "Invoke on Amazon",
     "AWS.appBuilder.explorerTitle": "Application Builder",

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -39,6 +39,7 @@ export {
     CodewhispererUserDecision,
     CodewhispererSecurityScan,
 } from './telemetry/telemetry.gen'
+export { ProxyUtil } from './utilities/proxyUtil'
 export { randomUUID } from './crypto'
 export * from './environmentVariables'
 export * from './vscode/setContext'

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -21,6 +21,7 @@ export type LogTopic =
     | 'nextEditPrediction'
     | 'resourceCache'
     | 'telemetry'
+    | 'proxyUtil'
 
 class ErrorLog {
     constructor(

--- a/packages/core/src/shared/settings-amazonq.gen.ts
+++ b/packages/core/src/shared/settings-amazonq.gen.ts
@@ -36,7 +36,8 @@ export const amazonqSettings = {
     "amazonQ.workspaceIndexMaxFileSize": {},
     "amazonQ.workspaceIndexCacheDirPath": {},
     "amazonQ.workspaceIndexIgnoreFilePatterns": {},
-    "amazonQ.ignoredSecurityIssues": {}
+    "amazonQ.ignoredSecurityIssues": {},
+    "amazonQ.proxy.certificateAuthority": {}
 }
 
 export default amazonqSettings

--- a/packages/core/src/shared/utilities/proxyUtil.ts
+++ b/packages/core/src/shared/utilities/proxyUtil.ts
@@ -39,7 +39,7 @@ export class ProxyUtil {
     private static getProxyConfiguration(): ProxyConfig {
         const httpConfig = vscode.workspace.getConfiguration('http')
         const proxyUrl = httpConfig.get<string>('proxy')
-        this.logger.debug(`Proxy URL: ${proxyUrl}`)
+        this.logger.debug(`Proxy URL Setting in VSCode Settings: ${proxyUrl}`)
 
         const amazonQConfig = vscode.workspace.getConfiguration('amazonQ')
         const proxySettings = amazonQConfig.get<{
@@ -60,6 +60,8 @@ export class ProxyUtil {
 
         // Always enable experimental proxy support for better handling of both explicit and transparent proxies
         process.env.EXPERIMENTAL_HTTP_PROXY_SUPPORT = 'true'
+        // Add OpenSSL certificate store support
+        process.env.NODE_OPTIONS = '--use-openssl-ca'
 
         // Set proxy environment variables
         if (proxyUrl) {

--- a/packages/core/src/shared/utilities/proxyUtil.ts
+++ b/packages/core/src/shared/utilities/proxyUtil.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode from 'vscode'
+import { getLogger } from '../logger/logger'
+
+interface ProxyConfig {
+    proxyUrl: string | undefined
+    certificateAuthority: string | undefined
+}
+
+/**
+ * Utility class for handling proxy configuration
+ */
+export class ProxyUtil {
+    private static readonly logger = getLogger('proxyUtil')
+
+    /**
+     * Sets proxy environment variables based on VS Code settings for use with the Flare Language Server
+     *
+     * See documentation here for setting the environement variables which are inherited by Flare LS process:
+     * https://github.com/aws/language-server-runtimes/blob/main/runtimes/docs/proxy.md
+     */
+    public static configureProxyForLanguageServer(): void {
+        try {
+            const proxyConfig = this.getProxyConfiguration()
+
+            this.setProxyEnvironmentVariables(proxyConfig)
+        } catch (err) {
+            this.logger.error(`Failed to configure proxy: ${err}`)
+        }
+    }
+
+    /**
+     * Gets proxy configuration from VS Code settings
+     */
+    private static getProxyConfiguration(): ProxyConfig {
+        const httpConfig = vscode.workspace.getConfiguration('http')
+        const proxyUrl = httpConfig.get<string>('proxy')
+        this.logger.debug(`Proxy URL: ${proxyUrl}`)
+
+        const amazonQConfig = vscode.workspace.getConfiguration('amazonQ')
+        const proxySettings = amazonQConfig.get<{
+            certificateAuthority?: string
+        }>('proxy', {})
+
+        return {
+            proxyUrl,
+            certificateAuthority: proxySettings.certificateAuthority,
+        }
+    }
+
+    /**
+     * Sets environment variables based on proxy configuration
+     */
+    private static setProxyEnvironmentVariables(config: ProxyConfig): void {
+        const proxyUrl = config.proxyUrl
+
+        // Always enable experimental proxy support for better handling of both explicit and transparent proxies
+        process.env.EXPERIMENTAL_HTTP_PROXY_SUPPORT = 'true'
+
+        // Set proxy environment variables
+        if (proxyUrl) {
+            process.env.HTTPS_PROXY = proxyUrl
+            process.env.HTTP_PROXY = proxyUrl
+            this.logger.debug(`Set proxy environment variables: ${proxyUrl}`)
+        }
+
+        // Set certificate bundle environment variables if configured
+        if (config.certificateAuthority) {
+            process.env.NODE_EXTRA_CA_CERTS = config.certificateAuthority
+            process.env.AWS_CA_BUNDLE = config.certificateAuthority
+            this.logger.debug(`Set certificate bundle path: ${config.certificateAuthority}`)
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Amazon Q For VS Code has lost proxy support following the release of Agentic Chat (1.63.0) due to a fundamental architectural change. Previously, API calls were executed in VS Code's Extension Host process, which automatically handled proxy settings. Now, these calls are made through a separate Flare Language Server process that doesn't inherit VS Code's proxy configurations.

Key Issues:
- VS Code's built-in proxy handling doesn't propagate to the Flare process
- Environment variables required for proxy support aren't being passed to the Flare Language Server

## Solution
- Enabled Flare's experimental proxy support by setting `EXPERIMENTAL_HTTP_PROXY_SUPPORT=true`. See: https://github.com/aws/language-server-runtimes/blob/main/runtimes/docs/proxy.md
- Implemented `ProxyUtil` class to configure proxy settings before Flare Language Server starts
- Added `amazonQ.proxy.certificateAuthority` setting, allowing customers to conveniently set the path to their custom Certificate Authority (CA) .pem file directly in VS Code settings. This eliminates the need to set the `NODE_EXTRA_CA_CERTS` environment variable via CLI, providing a more user-friendly way to configure custom CA certificates for proxy connections.
- Reads VS Code's `http.proxy` setting and sets corresponding environment variables
- Configures certificate paths for both system and custom CA bundles



TODO: Potentially update [public documentation](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/general-troubleshoot.html#general-troubleshoot-firewall) with new settings field

<img width="666" alt="Screenshot 2025-06-04 at 4 45 44 PM" src="https://github.com/user-attachments/assets/2d1505d7-4184-4b34-afa7-63e9be715999" />



## Testing

Tested using [mitmproxy](https://docs.mitmproxy.org/stable/overview/installation/)

### Scenario 1: Explicit HTTP Proxy

- First test with adding the proxy to the VSC settings and disabling `EXPERIMENTAL_HTTP_PROXY_SUPPORT` (Request fails as expected)
- Then test  with adding the proxy to the VSC settings and enabling `EXPERIMENTAL_HTTP_PROXY_SUPPORT` (Request succeeds as expected due to automatically locating the certificate store from the OS)


https://github.com/user-attachments/assets/38f3fc28-5ff1-4c5e-b303-222399a5357f




### Scenario 1: Transparent HTTP Proxy

- Turn on proxy
-  First test with disabled `EXPERIMENTAL_HTTP_PROXY_SUPPORT` and no explicit HTTP proxy config added (Request fails as expected)
- Then test with enabled `EXPERIMENTAL_HTTP_PROXY_SUPPORT` and no explicit HTTP proxy config added (Request succeeds as expected due to automatically locating the certificate store from the OS)


https://github.com/user-attachments/assets/6d54d98c-683a-430d-8f65-f8f7e7dc2ad6

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
