### PR TITLE
feat(lambda): Add handler for upcoming Lambda URI

### DIFF
--- a/packages/core/src/lambda/activation.ts
+++ b/packages/core/src/lambda/activation.ts
@@ -24,6 +24,7 @@ import { liveTailRegistry, liveTailCodeLensProvider } from '../awsService/cloudW
 import { getFunctionLogGroupName } from '../awsService/cloudWatchLogs/activation'
 import { ToolkitError, isError } from '../shared/errors'
 import { LogStreamFilterResponse } from '../awsService/cloudWatchLogs/wizard/liveTailLogStreamSubmenu'
+import { registerLambdaUriHandler } from './uriHandlers'
 
 /**
  * Activates Lambda components.
@@ -116,6 +117,8 @@ export async function activate(context: ExtContext): Promise<void> {
                     throw err
                 }
             }
-        })
+        }),
+
+        registerLambdaUriHandler()
     )
 }

--- a/packages/core/src/lambda/uriHandlers.ts
+++ b/packages/core/src/lambda/uriHandlers.ts
@@ -1,0 +1,39 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as nls from 'vscode-nls'
+
+import { SearchParams } from '../shared/vscode/uriHandler'
+import { showMessage } from '../shared/utilities/messages'
+import globals from '../shared/extensionGlobals'
+
+const localize = nls.loadMessageBundle()
+
+export function registerLambdaUriHandler() {
+    async function openFunctionHandler(params: ReturnType<typeof parseOpenParams>) {
+        await showMessage(
+            'warn',
+            localize(
+                'AWS.lambda.uriUnavailable',
+                'The URI handler you are attempting to open is not handled in this version of the toolkit, try installing the latest version'
+            )
+        )
+    }
+
+    return vscode.Disposable.from(
+        globals.uriHandler.onPath('/lambda/load-function', openFunctionHandler, parseOpenParams)
+    )
+}
+function parseOpenParams(query: SearchParams) {
+    return {
+        functionName: query.getOrThrow(
+            'functionName',
+            localize('AWS.lambda.open.missingName', 'A function name must be provided')
+        ),
+        region: query.getOrThrow('region', localize('AWS.lambda.open.missingRegion', 'A region must be provided')),
+        isCfn: query.get('isCfn'),
+    }
+}

--- a/packages/core/src/lambda/uriHandlers.ts
+++ b/packages/core/src/lambda/uriHandlers.ts
@@ -7,20 +7,24 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 
 import { SearchParams } from '../shared/vscode/uriHandler'
-import { showMessage } from '../shared/utilities/messages'
+import { showConfirmationMessage } from '../shared/utilities/messages'
 import globals from '../shared/extensionGlobals'
+import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 
 const localize = nls.loadMessageBundle()
 
 export function registerLambdaUriHandler() {
     async function openFunctionHandler(params: ReturnType<typeof parseOpenParams>) {
-        await showMessage(
-            'warn',
-            localize(
+        const response = await showConfirmationMessage({
+            prompt: localize(
                 'AWS.lambda.uriUnavailable',
-                'The URI handler you are attempting to open is not handled in this version of the toolkit, try installing the latest version'
-            )
-        )
+                'The URI you are attempting to access is not in this version of the Toolkit'
+            ),
+            confirm: localize('AWS.installLatest', 'Install latest'),
+        })
+        if (response) {
+            await vscode.commands.executeCommand('extension.open', VSCODE_EXTENSION_ID.awstoolkit)
+        }
     }
 
     return vscode.Disposable.from(

--- a/packages/core/src/lambda/uriHandlers.ts
+++ b/packages/core/src/lambda/uriHandlers.ts
@@ -31,7 +31,8 @@ export function registerLambdaUriHandler() {
         globals.uriHandler.onPath('/lambda/load-function', openFunctionHandler, parseOpenParams)
     )
 }
-function parseOpenParams(query: SearchParams) {
+
+export function parseOpenParams(query: SearchParams) {
     return {
         functionName: query.getOrThrow(
             'functionName',

--- a/packages/core/src/test/lambda/uriHandlers.test.ts
+++ b/packages/core/src/test/lambda/uriHandlers.test.ts
@@ -1,0 +1,36 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { SearchParams } from '../../shared/vscode/uriHandler'
+import { parseOpenParams } from '../../lambda/uriHandlers'
+import { globals } from '../../shared'
+
+describe('Lambda URI Handler', function () {
+    describe('load-function', function () {
+        it('registers for "/lambda/load-function"', function () {
+            assert.throws(() => globals.uriHandler.onPath('/lambda/load-function', () => {}))
+        })
+
+        it('parses parameters', function () {
+            let query = new SearchParams({
+                functionName: 'example',
+            })
+            assert.throws(() => parseOpenParams(query), /A region must be provided/)
+            query = new SearchParams({
+                region: 'example',
+            })
+            assert.throws(() => parseOpenParams(query), /A function name must be provided/)
+
+            const valid = {
+                functionName: 'example',
+                region: 'example',
+                isCfn: 'false',
+            }
+            query = new SearchParams(valid)
+            assert.deepEqual(parseOpenParams(query), valid)
+        })
+    })
+})


### PR DESCRIPTION
## Problem
The Lambda team plans to add a URI handler to act as an entrypoint to the toolkit from a URL. This will be fully available in an upcoming toolkit release, but customers who don't have that version will not get the benefit of the handler.

## Solution
Add a handler ahead of time telling customers to update to the latest version. This way, customers who have an older version with this change will be notified that the functionality they are trying to use is in a newer version. This should help customers from becoming confused when they open a link and an older version says it is not handled.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
