### PR TITLE
bug: ISSUE-7452: Fix EC2 Workspace Connect for Any OS

### DIFF
--- a/packages/core/src/awsService/ec2/model.ts
+++ b/packages/core/src/awsService/ec2/model.ts
@@ -43,10 +43,10 @@ export interface Ec2RemoteEnv extends VscodeRemoteConnection {
     ssmSession: StartSessionResponse
 }
 
-export type Ec2OS = 'Amazon Linux' | 'Ubuntu' | 'macOS'
 interface RemoteUser {
-    os: Ec2OS
+    os: string
     name: string
+    home: string
 }
 
 export class Ec2Connecter implements vscode.Disposable {
@@ -215,7 +215,7 @@ export class Ec2Connecter implements vscode.Disposable {
             await startVscodeRemote(
                 remoteEnv.SessionProcess,
                 remoteEnv.hostname,
-                '/',
+                remoteUser.home,
                 remoteEnv.vscPath,
                 remoteUser.name
             )
@@ -298,14 +298,9 @@ export class Ec2Connecter implements vscode.Disposable {
     }
 
     /** Removes old key(s) that we added to the remote ~/.ssh/authorized_keys file. */
-    public async tryCleanKeys(
-        instanceId: string,
-        hintComment: string,
-        hostOS: Ec2OS,
-        remoteAuthorizedKeysPath: string
-    ) {
+    public async tryCleanKeys(instanceId: string, hintComment: string, remoteAuthorizedKeysPath: string) {
         try {
-            const deleteExistingKeyCommand = getRemoveLinesCommand(hintComment, hostOS, remoteAuthorizedKeysPath)
+            const deleteExistingKeyCommand = getRemoveLinesCommand(hintComment, remoteAuthorizedKeysPath)
             await this.sendCommandAndWait(instanceId, deleteExistingKeyCommand)
         } catch (e) {
             getLogger().warn(`ec2: failed to clean keys: %O`, e)
@@ -326,26 +321,61 @@ export class Ec2Connecter implements vscode.Disposable {
         const sshPubKey = await sshKeyPair.getPublicKey()
         const hintComment = '#AWSToolkitForVSCode'
 
-        const remoteAuthorizedKeysPath = `/home/${remoteUser.name}/.ssh/authorized_keys`
+        const remoteSshPath = `${remoteUser.home}/.ssh`
+        const remoteAuthorizedKeysPath = `${remoteSshPath}/authorized_keys`
+        const user = shellQuote(remoteUser.name)
+        const sshPath = shellQuote(remoteSshPath)
+        const authorizedKeysPath = shellQuote(remoteAuthorizedKeysPath)
+        const prepareAuthorizedKeysCommand = [
+            `group=$(id -gn ${user})`,
+            `mkdir -p ${sshPath}`,
+            `chown ${user}:"$group" ${sshPath}`,
+            `chmod 700 ${sshPath}`,
+            `touch ${authorizedKeysPath}`,
+            `chown ${user}:"$group" ${authorizedKeysPath}`,
+            `chmod 600 ${authorizedKeysPath}`,
+        ].join(' && ')
+        const keyEntry = [sshPubKey.replace(/\r?\n/g, ''), hintComment].join(' ')
+        const writeKeyCommand = `printf '%s\\n' ${shellQuote(keyEntry)} >> ${authorizedKeysPath}`
 
-        const appendStr = (s: string) => `echo "${s}" >> ${remoteAuthorizedKeysPath}`
-        const writeKeyCommand = appendStr([sshPubKey.replace('\n', ''), hintComment].join(' '))
-
-        await this.tryCleanKeys(selection.instanceId, hintComment, remoteUser.os, remoteAuthorizedKeysPath)
+        await this.sendCommandAndWait(selection.instanceId, prepareAuthorizedKeysCommand)
+        await this.tryCleanKeys(selection.instanceId, hintComment, remoteAuthorizedKeysPath)
         await this.sendCommandAndWait(selection.instanceId, writeKeyCommand)
     }
 
     public async getRemoteUser(instanceId: string): Promise<RemoteUser> {
         const os = await this.ssm.getTargetPlatformName(instanceId)
+        let name: string
         if (os === 'Amazon Linux') {
-            return { name: 'ec2-user', os }
+            name = 'ec2-user'
+        } else if (os === 'Ubuntu') {
+            name = 'ubuntu'
+        } else {
+            const input = await vscode.window.showInputBox({
+                prompt: `Unrecognized OS "${os}". Enter the username for instance ${instanceId}:`,
+            })
+            name = input?.trim() ?? ''
+            if (!name) {
+                throw new ToolkitError(`Unrecognized OS name ${os} on instance ${instanceId}`, { code: 'UnknownEc2OS' })
+            }
         }
 
-        if (os === 'Ubuntu') {
-            return { name: 'ubuntu', os }
+        if (!/^[a-z_][a-z0-9._-]*\$?$/i.test(name)) {
+            throw new ToolkitError(`Invalid username ${name} for instance ${instanceId}`, { code: 'UnknownEc2User' })
         }
 
-        throw new ToolkitError(`Unrecognized OS name ${os} on instance ${instanceId}`, { code: 'UnknownEc2OS' })
+        const home = (
+            await this.ssm.sendCommandAndWaitForOutput(instanceId, 'AWS-RunShellScript', {
+                commands: [`getent passwd ${shellQuote(name)} | cut -d: -f6`],
+            })
+        ).trim()
+        if (!home.startsWith('/') || home.includes('\n')) {
+            throw new ToolkitError(`Unable to find a home directory for user ${name} on instance ${instanceId}`, {
+                code: 'UnknownEc2User',
+            })
+        }
+
+        return { name, os, home }
     }
 }
 
@@ -355,14 +385,13 @@ export class Ec2Connecter implements vscode.Disposable {
  * @param filepath filepath (as string) to target with the command.
  * @returns bash command to remove lines from file.
  */
-export function getRemoveLinesCommand(pattern: string, hostOS: Ec2OS, filepath: string): string {
+export function getRemoveLinesCommand(pattern: string, filepath: string): string {
     if (pattern.includes('/')) {
         throw new ToolkitError(`ec2: cannot match pattern containing '/', given: ${pattern}`)
     }
-    // Linux allows not passing extension to -i, whereas macOS requires zero length extension.
-    return `sed -i${isLinux(hostOS) ? '' : " ''"} /${pattern}/d ${filepath}`
+    return `sed -i.bak '/${pattern}/d' ${shellQuote(filepath)} && rm -f ${shellQuote(`${filepath}.bak`)}`
 }
 
-function isLinux(os: Ec2OS): boolean {
-    return os === 'Amazon Linux' || os === 'Ubuntu'
+function shellQuote(value: string): string {
+    return `'${value.replace(/'/g, `'"'"'`)}'`
 }

--- a/packages/core/src/shared/clients/ssm.ts
+++ b/packages/core/src/shared/clients/ssm.ts
@@ -14,6 +14,8 @@ import {
     InstanceInformation,
     SendCommandCommand,
     SendCommandCommandOutput,
+    GetCommandInvocationCommand,
+    GetCommandInvocationCommandOutput,
     waitUntilCommandExecuted,
     SessionState,
     paginateDescribeInstanceInformation,
@@ -100,6 +102,19 @@ export class SsmClient extends ClientWrapper<SSMClient> {
         } catch (err) {
             throw new ToolkitError(`Failed in sending command to target ${target}`, { cause: err as Error })
         }
+    }
+
+    public async sendCommandAndWaitForOutput(
+        target: string,
+        documentName: string,
+        parameters: Record<string, string[]>
+    ): Promise<string> {
+        const response = await this.sendCommandAndWait(target, documentName, parameters)
+        const invocation = (await this.makeRequest(GetCommandInvocationCommand, {
+            CommandId: response.Command!.CommandId!,
+            InstanceId: target,
+        })) as GetCommandInvocationCommandOutput
+        return invocation.StandardOutputContent ?? ''
     }
 
     public async getInstanceAgentPingStatus(target: string): Promise<string> {

--- a/packages/core/src/test/awsService/ec2/model.test.ts
+++ b/packages/core/src/test/awsService/ec2/model.test.ts
@@ -16,10 +16,11 @@ import { assertNoTelemetryMatch, createTestWorkspaceFolder } from '../../testUti
 import { fs } from '../../../shared'
 import path from 'path'
 import { ChildProcess } from '../../../shared/utilities/processUtils'
-import { isMac, isWin } from '../../../shared/vscode/env'
+import { isWin } from '../../../shared/vscode/env'
 import { inspect } from '../../../shared/utilities/collectionUtils'
 import { assertLogsContain } from '../../globalSetup.test'
 import { InstanceStateName } from '@aws-sdk/client-ec2'
+import { getTestWindow } from '../../shared/vscode/window'
 
 describe('Ec2ConnectClient', function () {
     let client: Ec2Connecter
@@ -158,8 +159,15 @@ describe('Ec2ConnectClient', function () {
             }
 
             const keys = await SshKeyPair.getSshKeyPair('key', 30000)
-            await client.sendSshKeyToInstance(testSelection, keys, { name: 'test-user', os: 'Amazon Linux' })
+            await client.sendSshKeyToInstance(testSelection, keys, {
+                name: 'test-user',
+                os: 'Amazon Linux',
+                home: '/srv/test user',
+            })
             sinon.assert.calledWith(sendCommandStub, testSelection.instanceId, 'AWS-RunShellScript')
+            assert.match(sendCommandStub.firstCall.args[2].commands[0], /mkdir -p '\/srv\/test user\/\.ssh'/)
+            assert.match(sendCommandStub.firstCall.args[2].commands[0], /chmod 700/)
+            assert.match(sendCommandStub.firstCall.args[2].commands[0], /chmod 600/)
             sinon.restore()
         })
 
@@ -172,7 +180,11 @@ describe('Ec2ConnectClient', function () {
             }
             const testWorkspaceFolder = await createTestWorkspaceFolder()
             const keys = await SshKeyPair.getSshKeyPair('key', 60000)
-            await client.sendSshKeyToInstance(testSelection, keys, { name: 'test-user', os: 'Amazon Linux' })
+            await client.sendSshKeyToInstance(testSelection, keys, {
+                name: 'test-user',
+                os: 'Amazon Linux',
+                home: '/home/test-user',
+            })
             const privKey = await fs.readFileText(keys.getPrivateKeyPath())
             assertNoTelemetryMatch(privKey)
             sinon.restore()
@@ -184,35 +196,73 @@ describe('Ec2ConnectClient', function () {
 
     describe('getRemoteUser', async function () {
         let getTargetPlatformNameStub: sinon.SinonStub<[target: string], Promise<string>>
+        let getCommandOutputStub: sinon.SinonStub
 
-        before(async function () {
+        beforeEach(function () {
             getTargetPlatformNameStub = sinon.stub(SsmClient.prototype, 'getTargetPlatformName')
+            getCommandOutputStub = sinon.stub(SsmClient.prototype, 'sendCommandAndWaitForOutput')
         })
 
-        after(async function () {
+        afterEach(function () {
             sinon.restore()
         })
 
-        it('identifies the user for ubuntu as ubuntu', async function () {
+        it('identifies the user and home for ubuntu', async function () {
             getTargetPlatformNameStub.resolves('Ubuntu')
+            getCommandOutputStub.resolves('/home/ubuntu\n')
             const remoteUser = await client.getRemoteUser('testInstance')
-            assert.strictEqual(remoteUser.name, 'ubuntu')
+            assert.deepStrictEqual(remoteUser, { name: 'ubuntu', os: 'Ubuntu', home: '/home/ubuntu' })
+            sinon.assert.calledWith(
+                getCommandOutputStub,
+                'testInstance',
+                'AWS-RunShellScript',
+                sinon.match({ commands: ["getent passwd 'ubuntu' | cut -d: -f6"] })
+            )
         })
 
-        it('identifies the user for amazon linux as ec2-user', async function () {
+        it('identifies the user and home for amazon linux', async function () {
             getTargetPlatformNameStub.resolves('Amazon Linux')
+            getCommandOutputStub.resolves('/home/ec2-user\n')
             const remoteUser = await client.getRemoteUser('testInstance')
-            assert.strictEqual(remoteUser.name, 'ec2-user')
+            assert.deepStrictEqual(remoteUser, {
+                name: 'ec2-user',
+                os: 'Amazon Linux',
+                home: '/home/ec2-user',
+            })
         })
 
-        it('throws error when not given known OS', async function () {
+        it('uses the selected user and its actual home for an unknown OS', async function () {
             getTargetPlatformNameStub.resolves('ThisIsNotARealOs!')
-            try {
-                await client.getRemoteUser('testInstance')
-                assert.ok(false)
-            } catch (exception) {
-                assert.ok(true)
-            }
+            getCommandOutputStub.resolves('/srv/workspaces/developer\n')
+            getTestWindow().onDidShowInputBox((input) => input.acceptValue(' developer '))
+            const remoteUser = await client.getRemoteUser('testInstance')
+            assert.deepStrictEqual(remoteUser, {
+                name: 'developer',
+                os: 'ThisIsNotARealOs!',
+                home: '/srv/workspaces/developer',
+            })
+        })
+
+        it('rejects an unknown user without a valid home directory', async function () {
+            getTargetPlatformNameStub.resolves('Debian')
+            getCommandOutputStub.resolves('')
+            getTestWindow().onDidShowInputBox((input) => input.acceptValue('missing-user'))
+            await assert.rejects(client.getRemoteUser('testInstance'), { code: 'UnknownEc2User' })
+        })
+
+        for (const unsafeUsername of ['-root', 'user name', 'user\nname', 'user`id`', 'user$(id)', 'user\\name']) {
+            it(`rejects unsafe username ${JSON.stringify(unsafeUsername)} before running a command`, async function () {
+                getTargetPlatformNameStub.resolves('Debian')
+                getTestWindow().onDidShowInputBox((input) => input.acceptValue(unsafeUsername))
+                await assert.rejects(client.getRemoteUser('testInstance'), { code: 'UnknownEc2User' })
+                sinon.assert.notCalled(getCommandOutputStub)
+            })
+        }
+
+        it('cancels when an unknown OS username is not selected', async function () {
+            getTargetPlatformNameStub.resolves('Debian')
+            getTestWindow().onDidShowInputBox((input) => input.hide())
+            await assert.rejects(client.getRemoteUser('testInstance'), { code: 'UnknownEc2OS' })
         })
     })
 
@@ -225,9 +275,9 @@ describe('Ec2ConnectClient', function () {
                 region: 'test-region',
             }
 
-            await client.tryCleanKeys(testSelection.instanceId, 'hint', 'macOS', 'path/to/keys')
+            await client.tryCleanKeys(testSelection.instanceId, 'hint', 'path/to/keys')
             sendCommandStub.calledWith(testSelection.instanceId, 'AWS-RunShellScript', {
-                commands: [getRemoveLinesCommand('hint', 'macOS', 'path/to/keys')],
+                commands: [getRemoveLinesCommand('hint', 'path/to/keys')],
             })
             sinon.assert.calledWith(sendCommandStub, testSelection.instanceId, 'AWS-RunShellScript')
             sinon.restore()
@@ -243,9 +293,9 @@ describe('Ec2ConnectClient', function () {
                 region: 'test-region',
             }
 
-            await client.tryCleanKeys(testSelection.instanceId, 'hint', 'macOS', 'path/to/keys')
+            await client.tryCleanKeys(testSelection.instanceId, 'hint', 'path/to/keys')
             sinon.assert.calledWith(sendCommandStub, testSelection.instanceId, 'AWS-RunShellScript', {
-                commands: [getRemoveLinesCommand('hint', 'macOS', 'path/to/keys')],
+                commands: [getRemoveLinesCommand('hint', 'path/to/keys')],
             })
             sinon.restore()
             assertLogsContain('failed to clean keys', false, 'warn')
@@ -268,8 +318,6 @@ describe('getRemoveLinesCommand', async function () {
         if (isWin()) {
             this.skip()
         }
-        // For the test, we only need to distinguish mac and linux
-        const hostOS = isMac() ? 'macOS' : 'Amazon Linux'
         const lines = ['line1', 'line2 pattern', 'line3', 'line4 pattern', 'line5', 'line6 pattern', 'line7']
         const expected = ['line1', 'line3', 'line5', 'line7']
 
@@ -278,32 +326,25 @@ describe('getRemoveLinesCommand', async function () {
         const textFile = path.join(tempPath.uri.fsPath, 'test.txt')
         const originalContent = lineToStr(lines)
         await fs.writeFile(textFile, originalContent)
-        const [command, ...args] = getRemoveLinesCommand('pattern', hostOS, textFile).split(' ')
-        const process = new ChildProcess(command, args, { collect: true })
+        const command = getRemoveLinesCommand('pattern', textFile)
+        const process = new ChildProcess('/bin/sh', ['-c', command], { collect: true })
         const result = await process.run()
-        assert.strictEqual(
-            result.exitCode,
-            0,
-            `Ran command '${command} ${args.join(' ')}' and failed with result ${inspect(result)}`
-        )
+        assert.strictEqual(result.exitCode, 0, `Ran command '${command}' and failed with result ${inspect(result)}`)
 
         const newContent = await fs.readFileText(textFile)
         assert.notStrictEqual(newContent, originalContent)
         assert.strictEqual(newContent, lineToStr(expected))
     })
 
-    it('includes empty extension on macOS only', async function () {
-        const macCommand = getRemoveLinesCommand('pattern', 'macOS', 'test.txt')
-        const alCommand = getRemoveLinesCommand('pattern', 'Amazon Linux', 'test.txt')
-        const ubuntuCommand = getRemoveLinesCommand('pattern', 'Ubuntu', 'test.txt')
-
-        assert.ok(macCommand.includes("''"))
-        assert.ok(!alCommand.includes("''"))
-        assert.strictEqual(ubuntuCommand, alCommand)
+    it('uses a portable backup suffix and quotes the path', async function () {
+        assert.strictEqual(
+            getRemoveLinesCommand('pattern', '/home/user name/.ssh/authorized_keys'),
+            "sed -i.bak '/pattern/d' '/home/user name/.ssh/authorized_keys' && rm -f '/home/user name/.ssh/authorized_keys.bak'"
+        )
     })
 
     it('throws when given invalid pattern', function () {
-        assert.throws(() => getRemoveLinesCommand('pat/tern', 'macOS', 'test.txt'))
+        assert.throws(() => getRemoveLinesCommand('pat/tern', 'test.txt'))
     })
 })
 


### PR DESCRIPTION
## Problem

EC2 Workspace Connect only recognized Amazon Linux and Ubuntu. Other Linux distributions failed before users could select the SSH account. The connection code also assumed that every account lived under `/home/<username>`, did not create a missing `.ssh/authorized_keys`, and opened `/` as the remote folder.

## Solution

1. Keep the existing defaults for Amazon Linux and Ubuntu.
2. Prompt for an SSH username when Systems Manager reports another operating system.
3. Validate the username before using it in a remote shell command.
4. Resolve the selected account's real home directory from the instance through Systems Manager and fail closed if it is missing or invalid.
5. Create the account's `.ssh` directory and `authorized_keys` file when needed, set ownership to the selected account, and enforce permissions `700` and `600`.
6. Remove the previous Toolkit key with a quoted, GNU and BSD compatible `sed -i.bak` command, remove the backup, and append the new public key with shell safe quoting.
7. Open the resolved home directory instead of `/` in VS Code Remote SSH.
8. Add Systems Manager command output support through `GetCommandInvocation`.

## Tests

1. EC2 model unit suite: 26 passing. This covers Amazon Linux, Ubuntu, an unknown OS with a custom user and nonstandard home, missing homes, cancellation, unsafe usernames, SSH file setup, permissions, and portable key cleanup.
2. Core lint suite: 3 passing, including ESLint and git secrets checks.
3. Core TypeScript compilation: passed.
4. Core webpack build: passed with the repository's existing optional dependency warnings.

## Validation scope

The automated tests mock Systems Manager responses and execute the generated key cleanup command locally. No live EC2 instance matrix was available in this local remediation run. A target without `getent`, `sed`, or the permissions required by `AWS-RunShellScript` fails closed instead of writing to a guessed path.

## License

I confirm that my contribution is made under the terms of the Apache 2.0 license.
