### PR TITLE
feat(amazonq): enable agentic workflow

### DIFF
--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messenger.ts
@@ -739,7 +739,7 @@ dependencyManagement:
     - identifier: "com.example:library1"
       targetVersion: "2.1.0"
       versionProperty: "library1.version"  # Optional
-      originType: "FIRST_PARTY" # or "THIRD_PARTY"  # Optional
+      originType: "FIRST_PARTY" # or "THIRD_PARTY"
     - identifier: "com.example:library2"
       targetVersion: "3.0.0"
       originType: "THIRD_PARTY"

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -677,7 +677,7 @@ export async function postTransformationJob() {
 
     let chatMessage = transformByQState.getJobFailureErrorChatMessage()
     if (transformByQState.isSucceeded()) {
-        chatMessage = CodeWhispererConstants.jobCompletedChatMessage
+        chatMessage = CodeWhispererConstants.jobCompletedChatMessage(transformByQState.getTargetJDKVersion() ?? '')
     } else if (transformByQState.isPartiallySucceeded()) {
         chatMessage = CodeWhispererConstants.jobPartiallyCompletedChatMessage
     }
@@ -708,9 +708,12 @@ export async function postTransformationJob() {
     }
 
     if (transformByQState.isSucceeded()) {
-        void vscode.window.showInformationMessage(CodeWhispererConstants.jobCompletedNotification, {
-            title: localizedText.ok,
-        })
+        void vscode.window.showInformationMessage(
+            CodeWhispererConstants.jobCompletedNotification(transformByQState.getTargetJDKVersion() ?? ''),
+            {
+                title: localizedText.ok,
+            }
+        )
     } else if (transformByQState.isPartiallySucceeded()) {
         void vscode.window
             .showInformationMessage(

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -655,9 +655,11 @@ export const enterJavaHomePlaceholder = 'Enter the path to your Java installatio
 
 export const openNewTabPlaceholder = 'Open a new tab to chat with Q'
 
-export const jobCompletedChatMessage = `I completed your transformation. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the changes I'm proposing.`
+export const jobCompletedChatMessage = (version: string) =>
+    `I completed your transformation. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the changes I'm proposing. If you want to upgrade additional libraries and other dependencies, run /transform with the transformed code and specify ${version} as the source and target version.`
 
-export const jobCompletedNotification = `Amazon Q transformed your code. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the changes.`
+export const jobCompletedNotification = (version: string) =>
+    `Amazon Q transformed your code. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the changes. If you want to upgrade additional libraries and other dependencies, run /transform with the transformed code and specify ${version} as the source and target version.`
 
 export const jobPartiallyCompletedChatMessage = `I transformed part of your code. You can review the diff to see my proposed changes and accept or reject them. The transformation summary has details about the files I updated and the errors that prevented a complete transformation.`
 

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -676,8 +676,8 @@ export class ZipManifest {
     version: string = '1.0'
     hilCapabilities: string[] = ['HIL_1pDependency_VersionUpgrade']
     // TO-DO: add 'CLIENT_SIDE_BUILD' here when releasing
-    // TO-DO: add something like AGENTIC_PLAN_V1 here when BE allowlists everyone
-    transformCapabilities: string[] = ['EXPLAINABILITY_V1']
+    transformCapabilities: string[] = ['EXPLAINABILITY_V1', 'SELECTIVE_TRANSFORMATION_V2']
+    noInteractiveMode: boolean = true
     customBuildCommand: string = 'clean test'
     requestedConversions?: {
         sqlConversion?: {

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -392,6 +392,8 @@ dependencyManagement:
             const manifestText = manifestBuffer.toString('utf8')
             const manifest = JSON.parse(manifestText)
             assert.strictEqual(manifest.customBuildCommand, CodeWhispererConstants.skipUnitTestsBuildCommand)
+            assert.strictEqual(manifest.noInteractiveMode, true)
+            assert.strictEqual(manifest.transformCapabilities.includes('SELECTIVE_TRANSFORMATION_V2'), true)
         })
     })
 


### PR DESCRIPTION
## Problem

We have a new "agentic workflow" that uses agents to customize transformations.

## Solution

Enable it by passing in a new value via the manifest.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
