### PR TITLE
feat: pass isInlineEdit as true to LogInlineCompletionSessionResultsParams for NEP

### DIFF
--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -284,9 +284,7 @@ export async function displaySvgDecoration(
     originalCodeHighlightRanges: Array<{ line: number; start: number; end: number }>,
     session: CodeWhispererSession,
     languageClient: LanguageClient,
-    item: InlineCompletionItemWithReferences,
-    addedCharacterCount: number,
-    deletedCharacterCount: number
+    item: InlineCompletionItemWithReferences
 ) {
     const originalCode = editor.document.getText()
 
@@ -320,8 +318,7 @@ export async function displaySvgDecoration(
                 },
                 totalSessionDisplayTime: Date.now() - session.requestStartTime,
                 firstCompletionDisplayLatency: session.firstCompletionDisplayLatency,
-                // addedCharacterCount: addedCharacterCount,
-                // deletedCharacterCount: deletedCharacterCount,
+                isInlineEdit: true,
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
         },
@@ -338,8 +335,7 @@ export async function displaySvgDecoration(
                         discarded: false,
                     },
                 },
-                // addedCharacterCount: addedCharacterCount,
-                // deletedCharacterCount: deletedCharacterCount,
+                isInlineEdit: true,
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
         },

--- a/packages/amazonq/src/app/inline/EditRendering/imageRenderer.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/imageRenderer.ts
@@ -24,14 +24,8 @@ export async function showEdits(
         const svgGenerationService = new SvgGenerationService()
         // Generate your SVG image with the file contents
         const currentFile = editor.document.uri.fsPath
-        const {
-            svgImage,
-            startLine,
-            newCode,
-            origionalCodeHighlightRange,
-            addedCharacterCount,
-            deletedCharacterCount,
-        } = await svgGenerationService.generateDiffSvg(currentFile, item.insertText as string)
+        const { svgImage, startLine, newCode, origionalCodeHighlightRange } =
+            await svgGenerationService.generateDiffSvg(currentFile, item.insertText as string)
 
         if (svgImage) {
             // display the SVG image
@@ -43,9 +37,7 @@ export async function showEdits(
                 origionalCodeHighlightRange,
                 session,
                 languageClient,
-                item,
-                addedCharacterCount,
-                deletedCharacterCount
+                item
             )
         } else {
             getLogger('nextEditPrediction').error('SVG image generation returned an empty result.')

--- a/packages/amazonq/src/app/inline/EditRendering/svgGenerator.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/svgGenerator.ts
@@ -5,7 +5,6 @@
 
 import { diffChars } from 'diff'
 import * as vscode from 'vscode'
-import { applyUnifiedDiff } from './diffUtils'
 import { ToolkitError, getLogger, isWeb } from 'aws-core-vscode/shared'
 import { diffUtilities } from 'aws-core-vscode/shared'
 
@@ -30,8 +29,6 @@ export class SvgGenerationService {
         startLine: number
         newCode: string
         origionalCodeHighlightRange: Range[]
-        addedCharacterCount: number
-        deletedCharacterCount: number
     }> {
         const textDoc = await vscode.workspace.openTextDocument(filePath)
         const originalCode = textDoc.getText()
@@ -39,7 +36,6 @@ export class SvgGenerationService {
             logger.error(`udiff format error`)
             throw new ToolkitError('udiff format erro')
         }
-        const { addedCharacterCount, deletedCharacterCount } = applyUnifiedDiff(originalCode, udiff)
         const newCode = await diffUtilities.getPatchedCode(filePath, udiff)
         const modifiedLines = diffUtilities.getModifiedLinesFromUnifiedDiff(udiff)
         // eslint-disable-next-line aws-toolkits/no-json-stringify-in-log
@@ -54,8 +50,6 @@ export class SvgGenerationService {
                 startLine: 0,
                 newCode: newCode,
                 origionalCodeHighlightRange: [{ line: 0, start: 0, end: 0 }],
-                addedCharacterCount: 0,
-                deletedCharacterCount: 0,
             }
         }
         const { createSVGWindow } = await import('svgdom')
@@ -108,8 +102,6 @@ export class SvgGenerationService {
             startLine: editStartLine,
             newCode: newCode,
             origionalCodeHighlightRange: highlightRanges.removedRanges,
-            addedCharacterCount,
-            deletedCharacterCount,
         }
     }
 


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
