### PR TITLE
feat(amazonq): add MCP server support

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-57661731-6180-4157-a04b-d3a8b50aa1a8.json
+++ b/packages/amazonq/.changes/next-release/Feature-57661731-6180-4157-a04b-d3a8b50aa1a8.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Add MCP Server Support"
+}

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -123,6 +123,7 @@ export async function startLanguageServer(
                 awsClientCapabilities: {
                     q: {
                         developerProfiles: true,
+                        mcp: true,
                     },
                     window: {
                         notifications: true,


### PR DESCRIPTION
## Problem
- we are missing `mcp: true` flag

## Solution
- add back `mcp: true` flag to enable mcp server support




---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
