### PR TITLE
fix(amazonq): bundle flare version comparison using numbers 

### DIFF
--- a/scripts/lspArtifact.ts
+++ b/scripts/lspArtifact.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs'
 import * as crypto from 'crypto'
 import * as path from 'path'
 import * as os from 'os'
+import * as semver from 'semver'
 import AdmZip from 'adm-zip'
 
 interface ManifestContent {
@@ -54,21 +55,6 @@ async function ensureDirectoryExists(dirPath: string): Promise<void> {
     }
 }
 
-function compareVersions(v1: string, v2: string): number {
-    const parts1 = v1.split('.').map(Number)
-    const parts2 = v2.split('.').map(Number)
-
-    for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-        const part1 = parts1[i] || 0
-        const part2 = parts2[i] || 0
-
-        if (part1 > part2) return 1
-        if (part1 < part2) return -1
-    }
-
-    return 0
-}
-
 export async function downloadLanguageServer(): Promise<void> {
     const tempDir = path.join(os.tmpdir(), 'amazonq-download-temp')
     const resourcesDir = path.join(__dirname, '../packages/amazonq/resources/language-server')
@@ -102,7 +88,7 @@ export async function downloadLanguageServer(): Promise<void> {
 
                         const latestVersion = manifest.versions
                             .filter((v) => !v.isDelisted)
-                            .sort((a, b) => compareVersions(b.serverVersion, a.serverVersion))[0]
+                            .sort((a, b) => semver.compare(b.serverVersion, a.serverVersion))[0]
 
                         if (!latestVersion) {
                             throw new Error('No valid version found in manifest')


### PR DESCRIPTION
## Problem
String comparison says "1.11.0" < "1.9.0". We should compare numbers.

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
