### PR TITLE
fix(amazonq): Fixing issue with unable to get local issuer certificate

### DIFF
--- a/packages/core/src/shared/utilities/proxyUtil.ts
+++ b/packages/core/src/shared/utilities/proxyUtil.ts
@@ -57,12 +57,6 @@ export class ProxyUtil {
      */
     private static setProxyEnvironmentVariables(config: ProxyConfig): void {
         const proxyUrl = config.proxyUrl
-
-        // Always enable experimental proxy support for better handling of both explicit and transparent proxies
-        process.env.EXPERIMENTAL_HTTP_PROXY_SUPPORT = 'true'
-        // Add OpenSSL certificate store support
-        process.env.NODE_OPTIONS = '--use-openssl-ca'
-
         // Set proxy environment variables
         if (proxyUrl) {
             process.env.HTTPS_PROXY = proxyUrl


### PR DESCRIPTION
## Problem
- Start seeing "unable to get local issuer certificate" since 1.72, affecting server-side workspace context in Flare

## Solution
- Removing  openSSL and the Experiment flag set to true works fine.
- This should fix the current regression.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
