### PR TITLE
fix(amazonq): only show lines of code

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-665b0f02-d6fe-4cfc-ac52-564f35d12aa5.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-665b0f02-d6fe-4cfc-ac52-564f35d12aa5.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "/transform: only show lines of code statistic in plan"
-}

--- a/packages/amazonq/.changes/next-release/Bug Fix-665b0f02-d6fe-4cfc-ac52-564f35d12aa5.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-665b0f02-d6fe-4cfc-ac52-564f35d12aa5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "/transform: only show lines of code statistic in plan"
+}

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -595,9 +595,11 @@ export function getJobStatisticsHtml(jobStatistics: any) {
     htmlString += `<div style="flex: 1; margin-left: 20px; border: 1px solid #424750; border-radius: 8px; padding: 10px;">`
     // eslint-disable-next-line unicorn/no-array-for-each
     jobStatistics.forEach((stat: { name: string; value: string }) => {
-        htmlString += `<p style="margin-bottom: 4px"><img src="${getTransformationIcon(
-            stat.name
-        )}" style="vertical-align: middle;"> ${getFormattedString(stat.name)}: ${stat.value}</p>`
+        if (stat.name === 'linesOfCode') {
+            htmlString += `<p style="margin-bottom: 4px"><img src="${getTransformationIcon(
+                stat.name
+            )}" style="vertical-align: middle;"> ${getFormattedString(stat.name)}: ${stat.value}</p>`
+        }
     })
     htmlString += `</div>`
     return htmlString
@@ -647,8 +649,6 @@ export async function getTransformationPlan(jobId: string, profile: RegionProfil
             plan += `</div><br>`
         }
         plan += `</div><br>`
-        plan += `<p style="font-size: 18px; margin-bottom: 4px;"><b>Appendix</b><br><a href="#top" style="float: right; font-size: 14px;">Scroll to top <img src="${arrowIcon}" style="vertical-align: middle;"></a></p><br>`
-        plan = addTableMarkdown(plan, '-1', tableMapping) // ID of '-1' reserved for appendix table; only 1 table there
         return plan
     } catch (e: any) {
         const errorMessage = (e as Error).message


### PR DESCRIPTION
## Problem

Some plan statistics, such as files to be changed, incorrectly show as 0 currently.


## Solution

To avoid confusion, until the server-side fix happens, only show users the # of lines of code statistic, which works fine.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
