### PR TITLE
fix(amazonq): bring back experimental config

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -261,7 +261,7 @@
                         },
                         "amazonqLSPInlineChat": {
                             "type": "boolean",
-                            "default": true
+                            "default": false
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
