### PR TITLE
fix(amazonq): allow node to inherit proxy settings from VSC

### DIFF
--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -120,7 +120,7 @@ export async function getVSCodeSettings(): Promise<{ proxyUrl?: string; certific
             }
 
             const certPath = join(tempDir, 'vscode-ca-certs.pem')
-            const certContent = allCerts.join('')
+            const certContent = allCerts.join('\n')
 
             nodefs.writeFileSync(certPath, certContent)
             result.certificatePath = certPath

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -120,7 +120,7 @@ export async function getVSCodeSettings(): Promise<{ proxyUrl?: string; certific
             }
 
             const certPath = join(tempDir, 'vscode-ca-certs.pem')
-            const certContent = allCerts.join('\n')
+            const certContent = allCerts.join('')
 
             nodefs.writeFileSync(certPath, certContent)
             result.certificatePath = certPath

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -10,8 +10,7 @@ import { waitUntil } from '../../utilities/timeoutUtils'
 import { isDebugInstance } from '../../vscode/env'
 import { tmpdir } from 'os'
 import { join } from 'path'
-// eslint-disable-next-line no-restricted-imports
-import * as fs from 'fs'
+import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 import * as vscode from 'vscode'
 import * as tls from 'tls'
 
@@ -118,14 +117,14 @@ export function getVSCodeSettings(): { proxyUrl?: string; certificatePath?: stri
 
                 // Create a temporary file with certificates
                 const tempDir = join(tmpdir(), 'aws-toolkit-vscode')
-                if (!fs.existsSync(tempDir)) {
-                    fs.mkdirSync(tempDir, { recursive: true })
+                if (!nodefs.existsSync(tempDir)) {
+                    nodefs.mkdirSync(tempDir, { recursive: true })
                 }
 
                 const certPath = join(tempDir, 'vscode-ca-certs.pem')
                 const certContent = certs.join('\n')
 
-                fs.writeFileSync(certPath, certContent)
+                nodefs.writeFileSync(certPath, certContent)
                 result.certificatePath = certPath
                 logger.info(`Created certificate file at: ${certPath}`)
             }

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -102,7 +102,7 @@ export async function getVSCodeSettings(): Promise<{ proxyUrl?: string; certific
         }
 
         try {
-            const tls = await import('node:tls')
+            const tls = await import('tls')
 
             // @ts-ignore Get system certificates
             const systemCerts = tls.getCACertificates('system')

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -10,6 +10,7 @@ import { waitUntil } from '../../utilities/timeoutUtils'
 import { isDebugInstance } from '../../vscode/env'
 import { tmpdir } from 'os'
 import { join } from 'path'
+// eslint-disable-next-line no-restricted-imports
 import * as fs from 'fs'
 import * as vscode from 'vscode'
 import * as tls from 'tls'

--- a/packages/webpack.base.config.js
+++ b/packages/webpack.base.config.js
@@ -38,9 +38,6 @@ module.exports = (env = {}, argv = {}) => {
         externals: {
             vscode: 'commonjs vscode',
             vue: 'root Vue',
-            fs: 'commonjs fs',
-            path: 'commonjs path',
-            os: 'commonjs os',
             tls: 'commonjs tls',
         },
         resolve: {

--- a/packages/webpack.base.config.js
+++ b/packages/webpack.base.config.js
@@ -38,6 +38,10 @@ module.exports = (env = {}, argv = {}) => {
         externals: {
             vscode: 'commonjs vscode',
             vue: 'root Vue',
+            fs: 'commonjs fs',
+            path: 'commonjs path',
+            os: 'commonjs os',
+            tls: 'commonjs tls',
         },
         resolve: {
             extensions: ['.ts', '.js'],


### PR DESCRIPTION
## Problem
With the introduction of agentic chat, Amazon Q Developer now runs its language server (Flare) in a separate Node.js process outside of VS Code's control. This creates network connectivity issues in corporate environments:

The Node.js process doesn't inherit VS Code's proxy settings, causing connection failures behind corporate proxies

Corporate SSL certificates aren't trusted by the Node.js process, resulting in certificate validation errors

Proxy authentication (including Integrated Windows Authentication) doesn't work automatically

These issues prevent Amazon Q Developer from functioning in enterprise environments with strict network policies.

## Solution

This PR enables the Flare Language Server to inherit VS Code's Electron proxy settings and certificate trust store:

Added a getElectronSettings() function that extracts:

Proxy rules from Electron's session

Proxy bypass rules for local addresses

Trusted certificates from Electron's certificate store

Modified createServerOptions() to:

Apply Electron's proxy settings to the Node.js process environment

Pass trusted certificates to Node.js via NODE_EXTRA_CA_CERTS

Preserve proxy bypass rules via NO_PROXY

Simplified the proxy environment setup in baseLspInstaller.ts to focus on SSL verification settings

This approach ensures that the Node.js process uses the same proxy configuration and certificate trust store as VS Code, making Amazon Q Developer work transparently in corporate environments without requiring manual configuration.
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
