### PR TITLE
deps: bump @aws-toolkits/telemetry to 1.0.324

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.323",
+                "@aws-toolkits/telemetry": "^1.0.324",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -10879,9 +10879,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.323",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.323.tgz",
-            "integrity": "sha512-Wc6HE+l5iJm/3TYx8Y8pU99ffmq78FgDDVMKjYG9Mfr4cXO4PEkB6XOkiVwGYnrNOGWqyYNlnkBFJ32WJRfkKg==",
+            "version": "1.0.324",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.324.tgz",
+            "integrity": "sha512-O4K9Ip3ge+EdTITOhMNcVxp+DPxK/1JHm9XcDwg/5N3q9SbwQ7/WeVtTHkvgq+IiQGKjnJ/4Vuyw3/3h29K7ww==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.323",
+        "@aws-toolkits/telemetry": "^1.0.324",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",


### PR DESCRIPTION
## Problem
- Added new metrics in aws-toolkit-common package: https://github.com/aws/aws-toolkit-common/pull/1054
## Solution
- Consume latest version of aws-toolkit-common package

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
