### PR TITLE
ci: use windows-latest image for github CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -184,7 +184,7 @@ jobs:
     windows:
         needs: lint-commits
         name: test Windows
-        runs-on: windows-2019
+        runs-on: windows-latest
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
## Problem
- `windows-2019` image is being deprecated on 6/30/2025
    - See here: https://github.com/actions/runner-images/issues/12045

## Solution
- update to use `windows-latest` image for github CI

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
