### PR TITLE
fix(amazonq): improve typeahead experience

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -241,7 +241,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                     getLogger().debug(`Re-using suggestions that match user typed characters`)
                     return prevItemMatchingPrefix
                 }
-                getLogger().debug(`Auto rejecting previous suggestion in session`)
+                getLogger().debug(`Auto rejecting suggestions from previous session`)
                 // if no such suggestions, report the previous suggestion as Reject
                 const params: LogInlineCompletionSessionResultsParams = {
                     sessionId: prevSessionId,

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -208,10 +208,41 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                 return []
             }
 
-            // report suggestion state for previous suggestions if they exist
-            const prevSessionId = this.sessionManager.getActiveSession()?.sessionId
+            // handling previous session
+            const prevSession = this.sessionManager.getActiveSession()
+            const prevSessionId = prevSession?.sessionId
             const prevItemId = this.sessionManager.getActiveRecommendation()?.[0]?.itemId
-            if (prevSessionId && prevItemId) {
+            const prevStartPosition = prevSession?.startPosition
+            const editor = window.activeTextEditor
+            if (prevSession && prevSessionId && prevItemId && prevStartPosition) {
+                const prefix = document.getText(new Range(prevStartPosition, position))
+                const prevItemMatchingPrefix = []
+                for (const item of this.sessionManager.getActiveRecommendation()) {
+                    const text = typeof item.insertText === 'string' ? item.insertText : item.insertText.value
+                    if (text.startsWith(prefix) && position.isAfterOrEqual(prevStartPosition)) {
+                        item.command = {
+                            command: 'aws.amazonq.acceptInline',
+                            title: 'On acceptance',
+                            arguments: [
+                                prevSessionId,
+                                item,
+                                editor,
+                                prevSession?.requestStartTime,
+                                position.line,
+                                prevSession?.firstCompletionDisplayLatency,
+                            ],
+                        }
+                        item.range = new Range(prevStartPosition, position)
+                        prevItemMatchingPrefix.push(item as InlineCompletionItem)
+                    }
+                }
+                // re-use previous suggestions as long as new typed prefix matches
+                if (prevItemMatchingPrefix.length > 0) {
+                    getLogger().debug(`Re-using suggestions that match user typed characters`)
+                    return prevItemMatchingPrefix
+                }
+                getLogger().debug(`Auto rejecting previous suggestion in session`)
+                // if no such suggestions, report the previous suggestion as Reject
                 const params: LogInlineCompletionSessionResultsParams = {
                     sessionId: prevSessionId,
                     completionSessionResult: {
@@ -242,7 +273,6 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
             const items = this.sessionManager.getActiveRecommendation()
             const itemId = this.sessionManager.getActiveRecommendation()?.[0]?.itemId
             const session = this.sessionManager.getActiveSession()
-            const editor = window.activeTextEditor
 
             // Show message to user when manual invoke fails to produce results.
             if (items.length === 0 && context.triggerKind === InlineCompletionTriggerKind.Invoke) {

--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -66,6 +66,7 @@ export class RecommendationService {
                 firstResult.sessionId,
                 firstResult.items,
                 requestStartTime,
+                position,
                 firstCompletionDisplayLatency
             )
 

--- a/packages/amazonq/src/app/inline/sessionManager.ts
+++ b/packages/amazonq/src/app/inline/sessionManager.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import * as vscode from 'vscode'
 import { InlineCompletionItemWithReferences } from '@aws/language-server-runtimes-types'
 
 // TODO: add more needed data to the session interface
@@ -13,6 +13,7 @@ interface CodeWhispererSession {
     isRequestInProgress: boolean
     requestStartTime: number
     firstCompletionDisplayLatency?: number
+    startPosition: vscode.Position
 }
 
 export class SessionManager {
@@ -25,6 +26,7 @@ export class SessionManager {
         sessionId: string,
         suggestions: InlineCompletionItemWithReferences[],
         requestStartTime: number,
+        startPosition: vscode.Position,
         firstCompletionDisplayLatency?: number
     ) {
         this.activeSession = {
@@ -32,6 +34,7 @@ export class SessionManager {
             suggestions,
             isRequestInProgress: true,
             requestStartTime,
+            startPosition,
             firstCompletionDisplayLatency,
         }
     }


### PR DESCRIPTION
## Problem
In the inline flare branch, the typeahead experience is bad because even when user typed matching characters after seeing a suggestion, we are still re-fetching the new suggestions, which causes the cached suggestion to disappear and new suggestion re-appear.

## Solution
Use the previous suggestion from last invocation if what user typed matches the suggestion prefix.


https://github.com/user-attachments/assets/8c039a80-edd9-4687-9f2c-fb646707b79c



This also aligns the experience in prod plugins without Flare inline.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
