### PR TITLE
docs(amazonq): Improved the local LSP setup documentation with more information

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -26,9 +26,7 @@ sequenceDiagram
 
 ## Language Server Debugging
 
-1. Clone https://github.com/aws/language-servers.git and set it up in the same workspace as this project by cmd+shift+p and "add folder to workspace" and selecting the language-servers folder that you just cloned. Your VS code folder structure should look like  below.
-
-    
+1. Clone https://github.com/aws/language-servers.git and set it up in the same workspace as this project by cmd+shift+p and "add folder to workspace" and selecting the language-servers folder that you just cloned. Your VS code folder structure should look like below.
 
     ```
     /aws-toolkit-vscode
@@ -45,7 +43,7 @@ sequenceDiagram
     npm run package
     ```
     to get the project setup
-3. Enable the lsp experiment:
+3. You need to open VScode user settings (Cmd+Shift+P and Search "Open User Settings (JSON)") and add the lines below at the bottom of the settings to enable the lsp experiment:
     ```
     "aws.experiments": {
       "amazonqLSP": true,
@@ -54,7 +52,7 @@ sequenceDiagram
     }
     ```
 4. Uncomment the `__AMAZONQLSP_PATH` and `__AMAZONQLSP_UI` variables in the `amazonq/.vscode/launch.json` extension configuration
-5. Use the `Launch LSP with Debugging` configuration and set breakpoints in VSCode or the language server
+5. Use the `Launch LSP with Debugging` configuration and set breakpoints in VSCode or the language server, Once you run "Launch LSP with Debugging" a new window should start, wait for the plugin to show up there. Then go to the run menu again and run "Attach to Language Server (amazonq)" after this you should be able to add breakpoints in the LSP code.
 6. (Optional): Enable `"amazonq.trace.server": "on"` or `"amazonq.trace.server": "verbose"` in your VSCode settings to view detailed log messages sent to/from the language server. These log messages will show up in the "Amazon Q Language Server" output channel
 
 ## Amazon Q Inline Activation


### PR DESCRIPTION
## Problem
The documentation was incomplete for setting up the LSP locally for testing. 

## Solution
Added the required information.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
