### PR TITLE
fix(accessanalyzer): update cfn-policy-validator and tf-policy-validator versions

### DIFF
--- a/packages/core/src/awsService/accessanalyzer/vue/iamPolicyChecks.vue
+++ b/packages/core/src/awsService/accessanalyzer/vue/iamPolicyChecks.vue
@@ -15,10 +15,10 @@
                         <p>Install Python 3.6+</p>
                     </li>
                     <li>
-                        <code> pip install cfn-policy-validator==0.0.34 </code>
+                        <code> pip install cfn-policy-validator==0.0.36 </code>
                     </li>
                     <li>
-                        <code> pip install tf-policy-validator==0.0.8 </code>
+                        <code> pip install tf-policy-validator==0.0.9 </code>
                     </li>
                     <li>
                         <p>Provide IAM Roles Credentials</p>

--- a/packages/toolkit/.changes/next-release/Feature-2fdc05d7-db85-4a4f-8af5-ec729fade8fd.json
+++ b/packages/toolkit/.changes/next-release/Feature-2fdc05d7-db85-4a4f-8af5-ec729fade8fd.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "AccessAnalyzer: CheckNoPublicAccess custom policy check supports additional resource types."
+}


### PR DESCRIPTION
 ## Problem
`cfn-policy-validator` dependency was updated (https://github.com/awslabs/aws-cloudformation-iam-policy-validator/releases/tag/v0.0.36)
`tf-policy-validator` dependency was updated (https://github.com/awslabs/terraform-iam-policy-validator/releases/tag/v0.0.9)

## Solution
Update the dependency version to 0.0.36 from 0.0.34 and 0.0.9 from 0.0.8 in the accessanalyzer integration.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
