### PR TITLE
fix(amazonq): increase node memory size to 8G

### DIFF
--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -96,7 +96,7 @@ export function createServerOptions({
 }) {
     return async () => {
         const bin = executable[0]
-        const args = [...executable.slice(1), serverModule, ...execArgv]
+        const args = [...executable.slice(1), '--max-old-space-size=8196', serverModule, ...execArgv]
         if (isDebugInstance()) {
             args.unshift('--inspect=6080')
         }


### PR DESCRIPTION
## Problem
- large repo has OOM exception when init
```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 0xb9bbf0 node::Abort() [Amazon Q Helper (Workspace Context)]
 2: 0xaa27ee  [Amazon Q Helper (Workspace Context)]
 3: 0xd734a0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [Amazon Q Helper (Workspace Context)]
 4: 0xd73847 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [Amazon Q Helper (Workspace Context)]
 5: 0xf50c55  [Amazon Q Helper (Workspace Context)]
 6: 0xf6312d v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [Amazon Q Helper (Workspace Context)]
 7: 0xf3d81e v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [Amazon Q Helper (Workspace Context)]
 8: 0xf3ebe7 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [Amazon Q Helper (Workspace Context)]
 9: 0xf1fdea v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [Amazon Q Helper (Workspace Context)]
10: 0x12e505f v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [Amazon Q Helper (Workspace Context)]
11: 0x1711cb9  [Amazon Q Helper (Workspace Context)]
[Info  - 7:59:05 PM] Connection to server got closed. Server will restart.
[Info  - 7:59:05 PM] Error occurred during chat request: Error: Connection got disposed.
[Info  - 7:59:05 PM] Last result from langauge server: undefined
```

## Solution
- increase node memory size to 8G
- tested with a local build
```
2025-06-18 04:59:37.485 [info] Command: (not started) [/opt/vsc-sysroot/lib/ld-linux-x86-64.so.2 --library-path /opt/vsc-sysroot/lib/ /home/isalan/.cache/aws/toolkits/language-servers/AmazonQ/1.13.0/servers/node --max-old-space-size=8196 /home/isalan/.cache/aws/toolkits/language-servers/AmazonQ/1.13.0/servers/aws-lsp-codewhisperer.js --nolazy --preserve-symlinks --stdio --pre-init-encryption --set-credentials-encryption-key]
```

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
