### PR TITLE
fix(amazonq): Q opens the history tabs automatically after plugin launch

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-541466ab-cebc-4f12-bbc6-6cdedad9eafe.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-541466ab-cebc-4f12-bbc6-6cdedad9eafe.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Resolve missing chat options in Amazon Q chat interface."
+}

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -169,6 +169,7 @@ export function registerMessageListeners(
                         languageClient.info(
                             `[VSCode Client] Chat options flags: mcpServers=${pendingChatOptions?.mcpServers}, history=${pendingChatOptions?.history}, export=${pendingChatOptions?.export}, quickActions=[${quickActionsDisplay}]`
                         )
+                        languageClient.sendNotification(message.command, message.params)
                     } catch (err) {
                         languageClient.error(
                             `[VSCode Client] Failed to send CHAT_OPTIONS after "aws/chat/ready" event: ${(err as Error).message}`


### PR DESCRIPTION
## Problem
- Right now, Q does not open the history tabs automatically after VSC Reload or restart

## Solution
- This PR fixes the above issue

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
