### PR TITLE
feat(amazonq): support select images as context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15033,20 +15033,23 @@
             }
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.26",
+            "version": "0.1.47",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.47.tgz",
+            "integrity": "sha512-Pu6UnAImpweLMcAmhNdw/NrajB25Ymzp1Om1V9NEVQJRMO/KJCDiErmbOYTYBXvgNoR10kObqiL1P/Tk/Fpu3g==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.22"
+                "@aws/language-server-runtimes-types": "^0.1.41"
             }
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.97",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.97.tgz",
-            "integrity": "sha512-Wzt09iC5YTVRJmmW6DwunBFSR0mV+cHjDwJ5iic1sEvXlI9CnrxlEjfn09crkVQ2XZj3dNJHoLQPptH+AEQfNg==",
+            "version": "0.2.99",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.99.tgz",
+            "integrity": "sha512-WLMEHhWDgsJW2FAYDX6bxQ7NvR47I9H63SXIDbCEnZQdC9/OnKBdl0IJ8bWYQ256xaI9QVof7/YUXFSzNfV7DA==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.39",
+                "@aws/language-server-runtimes-types": "^0.1.41",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/api-logs": "^0.200.0",
                 "@opentelemetry/core": "^2.0.0",
@@ -15073,10 +15076,11 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.39",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.39.tgz",
-            "integrity": "sha512-HjZ9tYcs++vcSyNwCcGLC8k1nvdWTD7XRa6sI71OYwFzJvyMa4/BY7Womq/kmyuD/IB6MRVvuRdgYQxuU1mSGA==",
+            "version": "0.1.41",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.41.tgz",
+            "integrity": "sha512-Ejupyj9560P6wQ9d9miSkgmEOUEczuc7mrFA727KmwXzp8yocNKonecdAn4r+CBxuPcbOaXDdyywK08cvAruig==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"
@@ -30068,9 +30072,9 @@
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
                 "@aws/chat-client": "^0.1.4",
-                "@aws/chat-client-ui-types": "^0.1.24",
-                "@aws/language-server-runtimes": "^0.2.97",
-                "@aws/language-server-runtimes-types": "^0.1.39",
+                "@aws/chat-client-ui-types": "^0.1.47",
+                "@aws/language-server-runtimes": "^0.2.99",
+                "@aws/language-server-runtimes-types": "^0.1.41",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",

--- a/packages/amazonq/.changes/next-release/Feature-a93aa3b3-83cd-45bb-81d9-4ad25e783300.json
+++ b/packages/amazonq/.changes/next-release/Feature-a93aa3b3-83cd-45bb-81d9-4ad25e783300.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "support adding image context from file system"
+	"description": "Added image support to Amazon Q chat, users can now upload images from their local file system"
 }

--- a/packages/amazonq/.changes/next-release/Feature-a93aa3b3-83cd-45bb-81d9-4ad25e783300.json
+++ b/packages/amazonq/.changes/next-release/Feature-a93aa3b3-83cd-45bb-81d9-4ad25e783300.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "support adding image context from file system"
+}

--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -486,7 +486,7 @@ export function registerMessageListeners(
             defaultUri: params.defaultUri ? vscode.Uri.parse(params.defaultUri) : undefined,
             title: params.title,
         })
-        const urisString = uris?.map((uri) => uri.toString())
+        const urisString = uris?.map((uri) => uri.fsPath)
         return { uris: urisString || [] }
     })
 

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -163,6 +163,7 @@ export async function startLanguageServer(
                     q: {
                         developerProfiles: true,
                         pinnedContextEnabled: true,
+                        imageContextEnabled: true,
                         mcp: true,
                         reroute: true,
                         modelSelection: true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -470,9 +470,9 @@
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
         "@aws/chat-client": "^0.1.4",
-        "@aws/chat-client-ui-types": "^0.1.24",
-        "@aws/language-server-runtimes": "^0.2.97",
-        "@aws/language-server-runtimes-types": "^0.1.39",
+        "@aws/chat-client-ui-types": "^0.1.47",
+        "@aws/language-server-runtimes": "^0.2.99",
+        "@aws/language-server-runtimes-types": "^0.1.41",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",


### PR DESCRIPTION
## Problem
WebView emit event to open system file dialog to use the VSC api to open file dialog, and the event need to be handled by extension

## Solution
1. Register the request between WebView and language server by adding `case OPEN_FILE_DIALOG`
2. Add handling for event when language server request to open system file dialog, which is defined in `languageClient.onRequest(ShowOpenDialogRequestType.method, async (params: ShowOpenDialogParams)`

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
