### PR TITLE
fix(amazonq): add jitter for validation call of profiles 

### DIFF
--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -285,35 +285,39 @@ export class RegionProfileManager {
         if (!previousSelected) {
             return
         }
-        // Comment these out until we have a better way to deal with throttling issue, currently service can only take 1 tps
+
         // cross-validation
-        // this.getProfiles()
-        //     .then(async (profiles) => {
-        //         const r = profiles.find((it) => it.arn === previousSelected.arn)
-        //         if (!r) {
-        //             telemetry.amazonq_profileState.emit({
-        //                 source: 'reload',
-        //                 amazonQProfileRegion: 'not-set',
-        //                 reason: 'profile could not be selected',
-        //                 result: 'Failed',
-        //             })
+        const jitterInSec = Math.floor(Math.random() * 6)
+        const jitterInMs = jitterInSec * 1000
+        setTimeout(async () => {
+            this.getProfiles()
+                .then(async (profiles) => {
+                    const r = profiles.find((it) => it.arn === previousSelected.arn)
+                    if (!r) {
+                        telemetry.amazonq_profileState.emit({
+                            source: 'reload',
+                            amazonQProfileRegion: 'not-set',
+                            reason: 'profile could not be selected',
+                            result: 'Failed',
+                        })
 
-        //             await this.invalidateProfile(previousSelected.arn)
-        //             RegionProfileManager.logger.warn(
-        //                 `invlaidating ${previousSelected.name} profile, arn=${previousSelected.arn}`
-        //             )
-        //         }
-        //     })
-        //     .catch((e) => {
-        //         telemetry.amazonq_profileState.emit({
-        //             source: 'reload',
-        //             amazonQProfileRegion: 'not-set',
-        //             reason: (e as Error).message,
-        //             result: 'Failed',
-        //         })
-        //     })
+                        await this.invalidateProfile(previousSelected.arn)
+                        RegionProfileManager.logger.warn(
+                            `invlaidating ${previousSelected.name} profile, arn=${previousSelected.arn}`
+                        )
+                    }
+                })
+                .catch((e) => {
+                    telemetry.amazonq_profileState.emit({
+                        source: 'reload',
+                        amazonQProfileRegion: 'not-set',
+                        reason: (e as Error).message,
+                        result: 'Failed',
+                    })
+                })
 
-        await this.switchRegionProfile(previousSelected, 'reload')
+            await this.switchRegionProfile(previousSelected, 'reload')
+        }, jitterInMs)
     }
 
     private loadPersistedRegionProfle(): { [label: string]: RegionProfile } {

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -286,7 +286,10 @@ export class RegionProfileManager {
             return
         }
 
+        await this.switchRegionProfile(previousSelected, 'reload')
+
         // cross-validation
+        // jitter of 0 ~ 5 second
         const jitterInSec = Math.floor(Math.random() * 6)
         const jitterInMs = jitterInSec * 1000
         setTimeout(async () => {
@@ -315,8 +318,6 @@ export class RegionProfileManager {
                         result: 'Failed',
                     })
                 })
-
-            await this.switchRegionProfile(previousSelected, 'reload')
         }, jitterInMs)
     }
 

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -285,32 +285,33 @@ export class RegionProfileManager {
         if (!previousSelected) {
             return
         }
+        // Comment these out until we have a better way to deal with throttling issue, currently service can only take 1 tps
         // cross-validation
-        this.getProfiles()
-            .then(async (profiles) => {
-                const r = profiles.find((it) => it.arn === previousSelected.arn)
-                if (!r) {
-                    telemetry.amazonq_profileState.emit({
-                        source: 'reload',
-                        amazonQProfileRegion: 'not-set',
-                        reason: 'profile could not be selected',
-                        result: 'Failed',
-                    })
+        // this.getProfiles()
+        //     .then(async (profiles) => {
+        //         const r = profiles.find((it) => it.arn === previousSelected.arn)
+        //         if (!r) {
+        //             telemetry.amazonq_profileState.emit({
+        //                 source: 'reload',
+        //                 amazonQProfileRegion: 'not-set',
+        //                 reason: 'profile could not be selected',
+        //                 result: 'Failed',
+        //             })
 
-                    await this.invalidateProfile(previousSelected.arn)
-                    RegionProfileManager.logger.warn(
-                        `invlaidating ${previousSelected.name} profile, arn=${previousSelected.arn}`
-                    )
-                }
-            })
-            .catch((e) => {
-                telemetry.amazonq_profileState.emit({
-                    source: 'reload',
-                    amazonQProfileRegion: 'not-set',
-                    reason: (e as Error).message,
-                    result: 'Failed',
-                })
-            })
+        //             await this.invalidateProfile(previousSelected.arn)
+        //             RegionProfileManager.logger.warn(
+        //                 `invlaidating ${previousSelected.name} profile, arn=${previousSelected.arn}`
+        //             )
+        //         }
+        //     })
+        //     .catch((e) => {
+        //         telemetry.amazonq_profileState.emit({
+        //             source: 'reload',
+        //             amazonQProfileRegion: 'not-set',
+        //             reason: (e as Error).message,
+        //             result: 'Failed',
+        //         })
+        //     })
 
         await this.switchRegionProfile(previousSelected, 'reload')
     }


### PR DESCRIPTION
…

## Problem
- to reduce # of service calls within short time duration and result in throttling error thrown
- 


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
