### PR TITLE
fix(amazonq): migrate process.env proxy setting handling to proxyUtil.ts

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-a06c2136-a87a-41af-9304-454bc77aaecc.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-a06c2136-a87a-41af-9304-454bc77aaecc.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Added automatic system certificate detection and VSCode proxy settings support"
+}

--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -122,7 +122,7 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     }
 
     // Configure proxy settings early
-    ProxyUtil.configureProxyForLanguageServer()
+    await ProxyUtil.configureProxyForLanguageServer()
 
     // This contains every lsp agnostic things (auth, security scan, code scan)
     await activateCodeWhisperer(extContext as ExtContext)

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -4,7 +4,7 @@
  */
 
 import { ToolkitError } from '../../errors'
-import { Logger, getLogger } from '../../logger/logger'
+import { Logger } from '../../logger/logger'
 import { ChildProcess } from '../../utilities/processUtils'
 import { waitUntil } from '../../utilities/timeoutUtils'
 import { isDebugInstance } from '../../vscode/env'
@@ -87,14 +87,12 @@ export function createServerOptions({
     serverModule,
     execArgv,
     warnThresholds,
-    env,
 }: {
     encryptionKey: Buffer
     executable: string[]
     serverModule: string
     execArgv: string[]
     warnThresholds?: { cpu?: number; memory?: number }
-    env?: Record<string, string>
 }) {
     return async () => {
         const bin = executable[0]
@@ -103,18 +101,7 @@ export function createServerOptions({
             args.unshift('--inspect=6080')
         }
 
-        // Merge environment variables
-        const processEnv = { ...process.env }
-        if (env) {
-            Object.assign(processEnv, env)
-        }
-
-        const lspProcess = new ChildProcess(bin, args, {
-            warnThresholds,
-            spawnOptions: {
-                env: processEnv,
-            },
-        })
+        const lspProcess = new ChildProcess(bin, args, { warnThresholds })
 
         // this is a long running process, awaiting it will never resolve
         void lspProcess.run()

--- a/packages/core/src/shared/lsp/utils/platform.ts
+++ b/packages/core/src/shared/lsp/utils/platform.ts
@@ -8,10 +8,6 @@ import { Logger, getLogger } from '../../logger/logger'
 import { ChildProcess } from '../../utilities/processUtils'
 import { waitUntil } from '../../utilities/timeoutUtils'
 import { isDebugInstance } from '../../vscode/env'
-import { tmpdir } from 'os'
-import { join } from 'path'
-import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
-import * as vscode from 'vscode'
 
 export function getNodeExecutableName(): string {
     return process.platform === 'win32' ? 'node.exe' : 'node'
@@ -85,53 +81,6 @@ export async function validateNodeExe(nodePath: string[], lsp: string, args: str
     }
 }
 
-/**
- * Gets proxy settings and certificates from VS Code
- */
-export async function getVSCodeSettings(): Promise<{ proxyUrl?: string; certificatePath?: string }> {
-    const result: { proxyUrl?: string; certificatePath?: string } = {}
-    const logger = getLogger('amazonqLsp')
-
-    try {
-        // Get proxy settings from VS Code configuration
-        const httpConfig = vscode.workspace.getConfiguration('http')
-        const proxy = httpConfig.get<string>('proxy')
-        if (proxy) {
-            result.proxyUrl = proxy
-            logger.info(`Using proxy from VS Code settings: ${proxy}`)
-        }
-    } catch (err) {
-        logger.error(`Failed to get VS Code settings: ${err}`)
-        return result
-    }
-    try {
-        const tls = await import('tls')
-        // @ts-ignore Get system certificates
-        const systemCerts = tls.getCACertificates('system')
-        // @ts-ignore Get any existing extra certificates
-        const extraCerts = tls.getCACertificates('extra')
-        const allCerts = [...systemCerts, ...extraCerts]
-        if (allCerts && allCerts.length > 0) {
-            logger.info(`Found ${allCerts.length} certificates in system's trust store`)
-
-            const tempDir = join(tmpdir(), 'aws-toolkit-vscode')
-            if (!nodefs.existsSync(tempDir)) {
-                nodefs.mkdirSync(tempDir, { recursive: true })
-            }
-
-            const certPath = join(tempDir, 'vscode-ca-certs.pem')
-            const certContent = allCerts.join('\n')
-
-            nodefs.writeFileSync(certPath, certContent)
-            result.certificatePath = certPath
-            logger.info(`Created certificate file at: ${certPath}`)
-        }
-    } catch (err) {
-        logger.error(`Failed to extract certificates: ${err}`)
-    }
-    return result
-}
-
 export function createServerOptions({
     encryptionKey,
     executable,
@@ -158,31 +107,6 @@ export function createServerOptions({
         const processEnv = { ...process.env }
         if (env) {
             Object.assign(processEnv, env)
-        }
-
-        // Get settings from VS Code
-        const settings = await getVSCodeSettings()
-        const logger = getLogger('amazonqLsp')
-
-        // Add proxy settings to the Node.js process
-        if (settings.proxyUrl) {
-            processEnv.HTTPS_PROXY = settings.proxyUrl
-        }
-
-        // Add certificate path if available
-        if (settings.certificatePath) {
-            processEnv.NODE_EXTRA_CA_CERTS = settings.certificatePath
-            logger.info(`Using certificate file: ${settings.certificatePath}`)
-        }
-
-        // Get SSL verification settings
-        const httpConfig = vscode.workspace.getConfiguration('http')
-        const strictSSL = httpConfig.get<boolean>('proxyStrictSSL', true)
-
-        // Handle SSL certificate verification
-        if (!strictSSL) {
-            processEnv.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-            logger.info('SSL verification disabled via VS Code settings')
         }
 
         const lspProcess = new ChildProcess(bin, args, {

--- a/packages/core/src/shared/utilities/proxyUtil.ts
+++ b/packages/core/src/shared/utilities/proxyUtil.ts
@@ -90,6 +90,7 @@ export class ProxyUtil {
         if (!strictSSL) {
             process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
             this.logger.info('SSL verification disabled via VS Code settings')
+            return // No need to set CA certs when SSL verification is disabled
         }
 
         // Set certificate bundle environment variables if user configured


### PR DESCRIPTION
## Problem
Previous fix was separate from the existing proxyUtil.ts handling.

## Solution
Logic has been moved form platform.ts to proxyUtil.ts to have all process.env handling in one place. 
also added fetching for NO_PROXY settings from vsc
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
