### PR TITLE
fix(amazonq): fix for amazon q app initialization failure on sagemaker

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-sagemaker-al2-support.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-sagemaker-al2-support.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Improved Amazon Linux 2 support with better SageMaker environment detection"
+}

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -38,6 +38,7 @@ import {
     isAmazonLinux2,
     getClientId,
     extensionVersion,
+    isSageMaker,
 } from 'aws-core-vscode/shared'
 import { processUtils } from 'aws-core-vscode/shared'
 import { activate } from './chat/activation'
@@ -53,11 +54,24 @@ import { InlineChatTutorialAnnotation } from '../app/inline/tutorials/inlineChat
 const localize = nls.loadMessageBundle()
 const logger = getLogger('amazonqLsp.lspClient')
 
-export const glibcLinker: string = process.env.VSCODE_SERVER_CUSTOM_GLIBC_LINKER || ''
-export const glibcPath: string = process.env.VSCODE_SERVER_CUSTOM_GLIBC_PATH || ''
-
 export function hasGlibcPatch(): boolean {
-    return glibcLinker.length > 0 && glibcPath.length > 0
+    // Skip GLIBC patching for SageMaker environments
+    if (isSageMaker()) {
+        getLogger('amazonqLsp').info('SageMaker environment detected in hasGlibcPatch, skipping GLIBC patching')
+        return false // Return false to ensure SageMaker doesn't try to use GLIBC patching
+    }
+
+    // Check for environment variables (for CDM)
+    const glibcLinker = process.env.VSCODE_SERVER_CUSTOM_GLIBC_LINKER || ''
+    const glibcPath = process.env.VSCODE_SERVER_CUSTOM_GLIBC_PATH || ''
+
+    if (glibcLinker.length > 0 && glibcPath.length > 0) {
+        getLogger('amazonqLsp').info('GLIBC patching environment variables detected')
+        return true
+    }
+
+    // No environment variables, no patching needed
+    return false
 }
 
 export async function startLanguageServer(
@@ -82,9 +96,24 @@ export async function startLanguageServer(
     const traceServerEnabled = Settings.instance.isSet(`${clientId}.trace.server`)
     let executable: string[] = []
     // apply the GLIBC 2.28 path to node js runtime binary
-    if (isAmazonLinux2() && hasGlibcPatch()) {
-        executable = [glibcLinker, '--library-path', glibcPath, resourcePaths.node]
-        getLogger('amazonqLsp').info(`Patched node runtime with GLIBC to ${executable}`)
+    if (isSageMaker()) {
+        // SageMaker doesn't need GLIBC patching
+        getLogger('amazonqLsp').info('SageMaker environment detected, skipping GLIBC patching')
+        executable = [resourcePaths.node]
+    } else if (isAmazonLinux2() && hasGlibcPatch()) {
+        // Use environment variables if available (for CDM)
+        if (process.env.VSCODE_SERVER_CUSTOM_GLIBC_LINKER && process.env.VSCODE_SERVER_CUSTOM_GLIBC_PATH) {
+            executable = [
+                process.env.VSCODE_SERVER_CUSTOM_GLIBC_LINKER,
+                '--library-path',
+                process.env.VSCODE_SERVER_CUSTOM_GLIBC_PATH,
+                resourcePaths.node,
+            ]
+            getLogger('amazonqLsp').info(`Patched node runtime with GLIBC using env vars to ${executable}`)
+        } else {
+            // No environment variables, use the node executable directly
+            executable = [resourcePaths.node]
+        }
     } else {
         executable = [resourcePaths.node]
     }

--- a/packages/core/src/shared/extensionUtilities.ts
+++ b/packages/core/src/shared/extensionUtilities.ts
@@ -171,11 +171,30 @@ export function isCloud9(flavor: 'classic' | 'codecatalyst' | 'any' = 'any'): bo
 }
 
 /**
+ * Checks if the current environment has SageMaker-specific environment variables
+ * @returns true if SageMaker environment variables are detected
+ */
+function hasSageMakerEnvVars(): boolean {
+    return (
+        process.env.SAGEMAKER_APP_TYPE !== undefined ||
+        process.env.SAGEMAKER_INTERNAL_IMAGE_URI !== undefined ||
+        process.env.STUDIO_LOGGING_DIR?.includes('/var/log/studio') === true
+    )
+}
+
+/**
  *
  * @param appName to identify the proper SM instance
  * @returns true if the current system is SageMaker(SMAI or SMUS)
  */
 export function isSageMaker(appName: 'SMAI' | 'SMUS' = 'SMAI'): boolean {
+    // Check for SageMaker-specific environment variables first
+    if (hasSageMakerEnvVars() || process.env.SERVICE_NAME === sageMakerUnifiedStudio) {
+        getLogger().debug('SageMaker environment detected via environment variables')
+        return true
+    }
+
+    // Fall back to app name checks
     switch (appName) {
         case 'SMAI':
             return vscode.env.appName === sageMakerAppname


### PR DESCRIPTION
## Problem
GlibC paths are undefined and not available for SageMaker instances running in containers even thought their compute is Amazon linux 2. With no GlibC paths language server is not starting.

## Solution
- Skipping GlibC path check for sagemaker instances
- Increasing checks for sagemaker instances

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
