### PR TITLE
config(amazonq): temporarily disable cursor update manager before ove…

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -251,19 +251,19 @@ async function setupInline(
     // Create and start the CursorUpdateManager with the provider from InlineManager
     const cursorUpdateManager = new CursorUpdateManager(client, inlineCompletionProvider)
 
+    // TODO: Comment [CursorUpdateManager] out for now before NEP feature works sufficiently stable
     // Start the CursorUpdateManager
-    await cursorUpdateManager.start()
+    // await cursorUpdateManager.start()
 
     // Track cursor position changes
-    const cursorUpdateDisposable = vscode.window.onDidChangeTextEditorSelection(
-        (e: vscode.TextEditorSelectionChangeEvent) => {
-            if (e.textEditor === vscode.window.activeTextEditor) {
-                cursorUpdateManager.updatePosition(e.selections[0].active, e.textEditor.document.uri.toString())
-            }
-        }
-    )
-
-    toDispose.push(cursorUpdateDisposable)
+    // const cursorUpdateDisposable = vscode.window.onDidChangeTextEditorSelection(
+    //     (e: vscode.TextEditorSelectionChangeEvent) => {
+    //         if (e.textEditor === vscode.window.activeTextEditor) {
+    //             cursorUpdateManager.updatePosition(e.selections[0].active, e.textEditor.document.uri.toString())
+    //         }
+    //     }
+    // )
+    // toDispose.push(cursorUpdateDisposable)
 
     activeInlineChat(extensionContext, client, encryptionKey, inlineChatTutorialAnnotation)
 


### PR DESCRIPTION
…ral NEP experience is stable

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
