### PR TITLE
fix(amazonq): Remove setSystemCertificates from proxyUtil

### DIFF
--- a/packages/core/src/shared/utilities/proxyUtil.ts
+++ b/packages/core/src/shared/utilities/proxyUtil.ts
@@ -5,9 +5,6 @@
 
 import vscode from 'vscode'
 import { getLogger } from '../logger/logger'
-import { tmpdir } from 'os'
-import { join } from 'path'
-import * as nodefs from 'fs' // eslint-disable-line no-restricted-imports
 
 interface ProxyConfig {
     proxyUrl: string | undefined
@@ -73,9 +70,6 @@ export class ProxyUtil {
         // Always enable experimental proxy support for better handling of both explicit and transparent proxies
         process.env.EXPERIMENTAL_HTTP_PROXY_SUPPORT = 'true'
 
-        // Load built-in bundle and system OS trust store
-        process.env.NODE_OPTIONS = '--use-system-ca'
-
         const proxyUrl = config.proxyUrl
         // Set proxy environment variables
         if (proxyUrl) {
@@ -104,41 +98,6 @@ export class ProxyUtil {
             process.env.NODE_EXTRA_CA_CERTS = config.certificateAuthority
             process.env.AWS_CA_BUNDLE = config.certificateAuthority
             this.logger.debug(`Set certificate bundle path: ${config.certificateAuthority}`)
-        } else {
-            // Fallback to system certificates if no custom CA is configured
-            await this.setSystemCertificates()
-        }
-    }
-
-    /**
-     * Sets system certificates as fallback when no custom CA is configured
-     */
-    private static async setSystemCertificates(): Promise<void> {
-        try {
-            const tls = await import('tls')
-            // @ts-ignore Get system certificates
-            const systemCerts = tls.getCACertificates('system')
-            // @ts-ignore Get any existing extra certificates
-            const extraCerts = tls.getCACertificates('extra')
-            const allCerts = [...systemCerts, ...extraCerts]
-            if (allCerts && allCerts.length > 0) {
-                this.logger.debug(`Found ${allCerts.length} certificates in system's trust store`)
-
-                const tempDir = join(tmpdir(), 'aws-toolkit-vscode')
-                if (!nodefs.existsSync(tempDir)) {
-                    nodefs.mkdirSync(tempDir, { recursive: true })
-                }
-
-                const certPath = join(tempDir, 'vscode-ca-certs.pem')
-                const certContent = allCerts.join('\n')
-
-                nodefs.writeFileSync(certPath, certContent)
-                process.env.NODE_EXTRA_CA_CERTS = certPath
-                process.env.AWS_CA_BUNDLE = certPath
-                this.logger.debug(`Set system certificate bundle path: ${certPath}`)
-            }
-        } catch (err) {
-            this.logger.error(`Failed to extract system certificates: ${err}`)
         }
     }
 }


### PR DESCRIPTION
## Problem
We enabled experimental proxy support in FLARE in [this PR](https://github.com/aws/aws-toolkit-vscode/pull/7556). The ProxyConfigManager within FLARE gathers and injects OS CAs. See [here](https://github.com/tsmithsz/language-server-runtimes/blob/main/runtimes/runtimes/util/standalone/experimentalProxyUtil.ts#L124). 

The current `setSystemCertificates()` call also extracts system certificates and sets `NODE_EXTRA_CA_CERTS/AWS_CA_BUNDLE`. This duplicates and can even override our custom logic, leading to unpredictable CA bundles.


## Solution

- Remove redundant `setSystemCertificates()` method from proxy util.

All certificate loading now flows through a single code path (`ProxyConfigManager.getCertificates()`), eliminating conflicts and ensuring consistent OS CA handling.


## Testing

- Tested using MITM Proxy in local capture mode


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
