### PR TITLE
fix(amazonq): connect chat history to VSCode workspace file

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -164,6 +164,7 @@ export async function startLanguageServer(
                         developerProfiles: true,
                         pinnedContextEnabled: true,
                         mcp: true,
+                        workspaceFilePath: vscode.workspace.workspaceFile?.fsPath,
                     },
                     window: {
                         notifications: true,


### PR DESCRIPTION
## Problem
- When a user adds or removes folders from the workspace, or save an unnamed workspace to a named workspace, chat history gets lost

## Solution
- https://github.com/aws/language-servers/pull/1767

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
