### PR TITLE
fix(amazonq): Remove incompatible Node 18 flag

### DIFF
--- a/packages/core/src/shared/utilities/proxyUtil.ts
+++ b/packages/core/src/shared/utilities/proxyUtil.ts
@@ -73,9 +73,6 @@ export class ProxyUtil {
         // Always enable experimental proxy support for better handling of both explicit and transparent proxies
         process.env.EXPERIMENTAL_HTTP_PROXY_SUPPORT = 'true'
 
-        // Load built-in bundle and system OS trust store
-        process.env.NODE_OPTIONS = '--use-system-ca'
-
         const proxyUrl = config.proxyUrl
         // Set proxy environment variables
         if (proxyUrl) {


### PR DESCRIPTION
## Problem


Recently added the `process.env.NODE_OPTIONS = '--use-system-ca'`. This caused issues when downloading the LSP:

```
2025-06-26 14:48:04.633 [error] amazonqLsp.lspClient: failed to run basic "node -e" test (exitcode=9): PID 48382: [/Users/tsmithsz/Library/Caches/aws/toolkits/language-servers/AmazonQ/1.16.0/servers/node -e console.log("ok " + process.version)]
2025-06-26 14:48:04.634 [warning] telemetry: invalid Metric:  "languageServer_setup" emitted with missing fields: id
2025-06-26 14:48:04.634 [debug] telemetry: languageServer_setup {
  Metadata: {
    missingFields: 'id',
    metricId: '4fb062f4-ac6d-4da5-8c36-a32425d58260',
    traceId: '95908c07-fa81-49a9-9356-45f2f3739888',
    parentId: '840adbe9-3e9b-47e5-86a2-970f10e53828',
    languageServerSetupStage: 'launch',
    duration: '900',
    result: 'Failed',
    reason: 'FailedToRunNode',
    reasonDesc: 'FailedToRunNode: amazonqLsp: failed to run basic "node -e" test (exitcode=9): PID 48382: [/Users/x/x/x/aws/x/x/x/x/x/x -e console.log("ok " + process.version)]',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'Milliseconds',
  Passive: true
}
````
This is because this flag requires Node v23+.  The Flare runtime uses an older version (Node 18). 

## Solution

- Remove this flag. We can skip setting this since Flare is handling certificate discovery.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
