### PR TITLE
fix(amazonq): typo amazonq.editSuggestionActive -> aws.amazonq.editSuggestionActive

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -945,12 +945,12 @@
             {
                 "command": "aws.amazonq.inline.acceptEdit",
                 "key": "tab",
-                "when": "editorTextFocus && amazonq.editSuggestionActive"
+                "when": "editorTextFocus && aws.amazonq.editSuggestionActive"
             },
             {
                 "command": "aws.amazonq.inline.rejectEdit",
                 "key": "escape",
-                "when": "editorTextFocus && amazonq.editSuggestionActive"
+                "when": "editorTextFocus && aws.amazonq.editSuggestionActive"
             }
         ],
         "icons": {

--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -133,7 +133,7 @@ export class EditDecorationManager {
     ): void {
         this.clearDecorations(editor)
 
-        void setContext('amazonq.editSuggestionActive' as any, true)
+        void setContext('aws.amazonq.editSuggestionActive' as any, true)
 
         this.acceptHandler = onAccept
         this.rejectHandler = onReject
@@ -163,7 +163,7 @@ export class EditDecorationManager {
         this.currentRemovedCodeDecorations = []
         this.acceptHandler = undefined
         this.rejectHandler = undefined
-        void setContext('amazonq.editSuggestionActive' as any, false)
+        void setContext('aws.amazonq.editSuggestionActive' as any, false)
     }
 
     /**


### PR DESCRIPTION

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
