### PR TITLE
fix(amazonq): revert unneeded changes

### DIFF
--- a/packages/core/src/testLint/gitSecrets.test.ts
+++ b/packages/core/src/testLint/gitSecrets.test.ts
@@ -115,7 +115,6 @@ ${mySecretAccessKey}
     })
 
     it('ensures no git secrets are found', function () {
-        this.timeout(10000)
         const result = runCmd([gitSecrets, '--scan'], { cwd: toolkitProjectDir })
         assert.strictEqual(result.status, 0, `Failure output: ${result.stderr.toString()}`)
     })


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
