### PR TITLE
fix(amazonq): remove the depedency of the CDN js script.

### DIFF
--- a/packages/core/scripts/build/copyFiles.ts
+++ b/packages/core/scripts/build/copyFiles.ts
@@ -31,6 +31,11 @@ const tasks: CopyTask[] = [
     { target: path.join('src', 'testFixtures') },
     { target: 'src/auth/sso/vue' },
 
+    // Vue.js for webviews
+    {
+        target: path.join('../../node_modules', 'vue', 'dist', 'vue.global.prod.js'),
+        destination: path.join('libs', 'vue.min.js'),
+    },
     // SSM
     {
         target: path.join('../../node_modules', 'aws-ssm-document-language-service', 'dist', 'server.js'),

--- a/packages/core/src/login/webview/commonAuthViewProvider.ts
+++ b/packages/core/src/login/webview/commonAuthViewProvider.ts
@@ -148,6 +148,10 @@ export class CommonAuthViewProvider implements WebviewViewProvider {
         const entrypoint =
             serverHostname !== undefined ? Uri.parse(serverHostname).with({ path: `/${this.source}` }) : scriptUri
 
+        // Get Vue.js from dist/libs directory
+        const vueUri = Uri.joinPath(assetsPath, 'dist', 'libs', 'vue.min.js')
+        const vueScript = webview.asWebviewUri(vueUri)
+
         return `
             <!DOCTYPE html>
             <html lang="en">
@@ -158,7 +162,7 @@ export class CommonAuthViewProvider implements WebviewViewProvider {
                     <title>Base View Extension</title>
                 </head>
                 <body>
-                    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/3.4.4/vue.global.prod.min.js"></script>  
+                    <script src="${vueScript.toString()}"></script>  
                     <script>
                         const vscode = acquireVsCodeApi();
                     </script>


### PR DESCRIPTION
1. update the commonAuthViewProvider to use the locally bundled vue.js, instead of to load the vue.js from CDN.
2. this going to resolve the customer request that When customer is trying to login to IDC via Q they are hitting a URL which is not part of the whitelist urls as per [documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/firewall.html)

## Problem
Customers complain about need to whitelist the `cdnjs.cloudflare.com` which doesn't listed in the https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/firewall.html

## Solution
update the commonAuthViewProvider to use the locally bundled vue.js, instead of to load the vue.js from CDN.

verified the amazon Q auth view still working as expected after this change. 
<img width="287" alt="image" src="https://github.com/user-attachments/assets/54676527-857c-4ae3-8a07-77f91990161e" />


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
