### PR TITLE
fix(amazonq): save previously-used JDK path

### DIFF
--- a/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/messenger/messengerUtils.ts
@@ -37,7 +37,7 @@ export enum GumbyCommands {
 
 export default class MessengerUtils {
     static createJavaHomePrompt = (jdkVersion: JDKVersion | undefined): string => {
-        let javaHomePrompt = `${CodeWhispererConstants.enterJavaHomeChatMessage} ${jdkVersion}. \n`
+        let javaHomePrompt = `${CodeWhispererConstants.enterJavaHomeChatMessage} ${jdkVersion}.\n\n`
         if (os.platform() === 'win32') {
             javaHomePrompt += CodeWhispererConstants.windowsJavaHomeHelpChatMessage
         } else if (os.platform() === 'darwin') {

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -754,6 +754,8 @@ export class TransformByQState {
 
     private targetJDKVersion: JDKVersion | undefined = undefined
 
+    private jdkVersionToPath: Map<JDKVersion, string> = new Map()
+
     private customBuildCommand: string = ''
 
     private sourceDB: DB | undefined = undefined
@@ -874,6 +876,14 @@ export class TransformByQState {
         return this.targetJDKVersion
     }
 
+    public getPathFromJdkVersion(version: JDKVersion | undefined) {
+        if (version) {
+            return this.jdkVersionToPath.get(version)
+        } else {
+            return undefined
+        }
+    }
+
     public getSourceDB() {
         return this.sourceDB
     }
@@ -952,6 +962,12 @@ export class TransformByQState {
 
     public getTargetJavaHome() {
         return this.targetJavaHome
+    }
+
+    public setJdkVersionToPath(jdkVersion: JDKVersion | undefined, path: string) {
+        if (jdkVersion) {
+            this.jdkVersionToPath.set(jdkVersion, path)
+        }
     }
 
     public getChatControllers() {


### PR DESCRIPTION
## Problem

It can be annoying for users to have to enter the previously-used JDK paths every time they use `/transform`.

## Solution

Save the previously-used JDK paths and display them to the user for ease of access.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
