### PR TITLE
fix(amazonq): do not trigger inline completion when user delete code

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-8d48cfa7-278f-4b38-8121-0738bb0841b1.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-8d48cfa7-278f-4b38-8121-0738bb0841b1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Stop auto inline completion when deleting code"
+}


### PR DESCRIPTION
## Problem
Before we migrate inline completion to LSP, we do not auto trigger when user delete code.

## Solution

In the `provideInlineCompletion` callback that VS Code invokes, we check if this document has a very recent deletion event, if there is, do not make auto trigger. This is a best effort estimate of recent deletion because the `provideInlineCompletion` callback does not indicate the source input that triggered itself, we have to listen to document deletion events that almost happens at the same time.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
