### PR TITLE
fix(amazonq): Adding modelSelection feature flag

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -164,6 +164,7 @@ export async function startLanguageServer(
                         developerProfiles: true,
                         pinnedContextEnabled: true,
                         mcp: true,
+                        modelSelection: true,
                         workspaceFilePath: vscode.workspace.workspaceFile?.fsPath,
                     },
                     window: {


### PR DESCRIPTION
## Problem
- Model selection feature flag is not enabled.

## Solution
- Sent `modelSelection: true` as part of awsClientCapabilities.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
