### PR TITLE
fix(toolkit): handle isCn when region is not initialized to fix extension activation failure

### DIFF
--- a/packages/core/src/shared/extensionUtilities.ts
+++ b/packages/core/src/shared/extensionUtilities.ts
@@ -194,7 +194,13 @@ export function isSageMaker(appName: 'SMAI' | 'SMUS' = 'SMAI'): boolean {
 }
 
 export function isCn(): boolean {
-    return getComputeRegion()?.startsWith('cn') ?? false
+    try {
+        return getComputeRegion()?.startsWith('cn') ?? false
+    } catch (e) {
+        // If compute region isn't initialized yet, assume we're not in a CN region
+        getLogger().debug('isCn called before compute region initialized, defaulting to false')
+        return false
+    }
 }
 
 /**


### PR DESCRIPTION
## Problem
With updating Toolkit version to latest in SMUS CodeEditor Spaces, observing Toolkit throws an error as attached in screenshot below with error message
```
Attempted to get compute region without initializing
```
<img width="2039" alt="image" src="https://github.com/user-attachments/assets/a53e8fdc-bf7b-4c96-98fa-78c6db819a72" />

## Solution
- Issue is due to getComputeRegion() invoked first before compute region is initialized
- hence solution is to Make `isCn()` resilient to uninitialized state and return a default value
- Tested with a local debug artifact in SMUS CodeEditor space, toolkit activation completed and working
- 
<img width="1886" alt="image" src="https://github.com/user-attachments/assets/988c208c-3fe8-4530-a477-3e8704f1f598" />


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
