### PR TITLE
fix(amazonq): Prompt re-authenticate if auto trigger failed with expired token

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-da82b914-41c2-4003-8691-73f9ec62cc68.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-da82b914-41c2-4003-8691-73f9ec62cc68.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Prompt re-authenticate if auto trigger failed with expired token"
+}

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -319,6 +319,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                 position,
                 context,
                 token,
+                isAutoTrigger,
                 getAllRecommendationsOptions
             )
             // get active item from session for displaying

--- a/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
@@ -138,7 +138,14 @@ describe('RecommendationService', () => {
 
             sendRequestStub.resolves(mockFirstResult)
 
-            await service.getAllRecommendations(languageClient, mockDocument, mockPosition, mockContext, mockToken)
+            await service.getAllRecommendations(
+                languageClient,
+                mockDocument,
+                mockPosition,
+                mockContext,
+                mockToken,
+                true
+            )
 
             // Verify sendRequest was called with correct parameters
             assert(sendRequestStub.calledOnce)
@@ -172,7 +179,14 @@ describe('RecommendationService', () => {
             sendRequestStub.onFirstCall().resolves(mockFirstResult)
             sendRequestStub.onSecondCall().resolves(mockSecondResult)
 
-            await service.getAllRecommendations(languageClient, mockDocument, mockPosition, mockContext, mockToken)
+            await service.getAllRecommendations(
+                languageClient,
+                mockDocument,
+                mockPosition,
+                mockContext,
+                mockToken,
+                true
+            )
 
             // Verify sendRequest was called with correct parameters
             assert(sendRequestStub.calledTwice)
@@ -204,7 +218,14 @@ describe('RecommendationService', () => {
 
             sendRequestStub.resolves(mockFirstResult)
 
-            await service.getAllRecommendations(languageClient, mockDocument, mockPosition, mockContext, mockToken)
+            await service.getAllRecommendations(
+                languageClient,
+                mockDocument,
+                mockPosition,
+                mockContext,
+                mockToken,
+                true
+            )
 
             // Verify recordCompletionRequest was called
             // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -232,10 +253,18 @@ describe('RecommendationService', () => {
             const { showGeneratingStub, hideGeneratingStub } = setupUITest()
 
             // Call with showUi: false option
-            await service.getAllRecommendations(languageClient, mockDocument, mockPosition, mockContext, mockToken, {
-                showUi: false,
-                emitTelemetry: true,
-            })
+            await service.getAllRecommendations(
+                languageClient,
+                mockDocument,
+                mockPosition,
+                mockContext,
+                mockToken,
+                true,
+                {
+                    showUi: false,
+                    emitTelemetry: true,
+                }
+            )
 
             // Verify UI methods were not called
             sinon.assert.notCalled(showGeneratingStub)
@@ -248,7 +277,14 @@ describe('RecommendationService', () => {
             const { showGeneratingStub, hideGeneratingStub } = setupUITest()
 
             // Call with default options (showUi: true)
-            await service.getAllRecommendations(languageClient, mockDocument, mockPosition, mockContext, mockToken)
+            await service.getAllRecommendations(
+                languageClient,
+                mockDocument,
+                mockPosition,
+                mockContext,
+                mockToken,
+                true
+            )
 
             // Verify UI methods were called
             sinon.assert.calledOnce(showGeneratingStub)
@@ -284,6 +320,7 @@ describe('RecommendationService', () => {
                     mockPosition,
                     mockContext,
                     mockToken,
+                    true,
                     options
                 )
 


### PR DESCRIPTION
## Problem
As inline completion was moved to Flare LSP, one previous design of inline completion: Show re-auth prompt when access denied, was not migrated. 

## Solution
Prompt re-authenticate if auto trigger failed with expired token.
This is not new code, I just borrowed old code path. Link is added in the comments. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
