### PR TITLE
fix(amazonq): nep edits might be rendered as completion in ghost text

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -265,6 +265,9 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                 const prefix = document.getText(new Range(prevStartPosition, position))
                 const prevItemMatchingPrefix = []
                 for (const item of this.sessionManager.getActiveRecommendation()) {
+                    if (item.isInlineEdit) {
+                        break
+                    }
                     const text = typeof item.insertText === 'string' ? item.insertText : item.insertText.value
                     if (text.startsWith(prefix) && position.isAfterOrEqual(prevStartPosition)) {
                         item.command = {


### PR DESCRIPTION
## Problem

<img width="833" alt="image" src="https://github.com/user-attachments/assets/e11adc34-ed8e-4278-a4ef-8c75efdf5d6c" />



## Solution

- Temporarily dont use "cache" previous session suggestion for "Edits". 
- The real fix is #7605 which is to make render the cache suggestion correctly but we need more validation and testing.



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
