### PR TITLE
fix(amazonq): remove profile validation

### DIFF
--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -287,38 +287,6 @@ export class RegionProfileManager {
         }
 
         await this.switchRegionProfile(previousSelected, 'reload')
-
-        // cross-validation
-        // jitter of 0 ~ 5 second
-        const jitterInSec = Math.floor(Math.random() * 6)
-        const jitterInMs = jitterInSec * 1000
-        setTimeout(async () => {
-            this.getProfiles()
-                .then(async (profiles) => {
-                    const r = profiles.find((it) => it.arn === previousSelected.arn)
-                    if (!r) {
-                        telemetry.amazonq_profileState.emit({
-                            source: 'reload',
-                            amazonQProfileRegion: 'not-set',
-                            reason: 'profile could not be selected',
-                            result: 'Failed',
-                        })
-
-                        await this.invalidateProfile(previousSelected.arn)
-                        RegionProfileManager.logger.warn(
-                            `invlaidating ${previousSelected.name} profile, arn=${previousSelected.arn}`
-                        )
-                    }
-                })
-                .catch((e) => {
-                    telemetry.amazonq_profileState.emit({
-                        source: 'reload',
-                        amazonQProfileRegion: 'not-set',
-                        reason: (e as Error).message,
-                        result: 'Failed',
-                    })
-                })
-        }, jitterInMs)
     }
 
     private loadPersistedRegionProfle(): { [label: string]: RegionProfile } {


### PR DESCRIPTION
## Problem

VS Code extension startup was delayed by ~5 seconds due to profile validation logic that used jittered API calls to avoid rate limiting. This cross-validation checked if restored profiles were still valid but caused poor user experience during plugin loading.


Related PR:
- https://github.com/aws/aws-toolkit-vscode/pull/7534

## Solution

Removed the profile cross-validation code in restoreRegionProfile() to eliminate startup delays. This trades off immediate detection of admin-deleted profiles (rare edge case) for faster plugin loading that benefits all users daily.


## Testing

Generate plugin build and tested. Saw latency improvements of ~2-3s in plugin load time


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
