### PR TITLE
feat(amazonq): disable generating message while waiting for inline suggestion

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-78cd26f7-38b9-4363-8fde-20008c088cc2.json
+++ b/packages/amazonq/.changes/next-release/Feature-78cd26f7-38b9-4363-8fde-20008c088cc2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "disable generating message while waiting for inline suggestion"
+}

--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -25,7 +25,8 @@ export interface GetAllRecommendationsOptions {
 export class RecommendationService {
     constructor(
         private readonly sessionManager: SessionManager,
-        private readonly inlineGeneratingMessage: InlineGeneratingMessage,
+        // uncomment the below line to re-enable generating message
+        // private readonly inlineGeneratingMessage: InlineGeneratingMessage,
         private cursorUpdateRecorder?: ICursorUpdateRecorder
     ) {}
     /**
@@ -65,7 +66,8 @@ export class RecommendationService {
         try {
             // Show UI indicators only if UI is enabled
             if (options.showUi) {
-                await this.inlineGeneratingMessage.showGenerating(context.triggerKind)
+                // uncomment the below line to re-enable generating message
+                // await this.inlineGeneratingMessage.showGenerating(context.triggerKind)
                 await statusBar.setLoading()
             }
 
@@ -149,7 +151,8 @@ export class RecommendationService {
         } finally {
             // Remove all UI indicators if UI is enabled
             if (options.showUi) {
-                this.inlineGeneratingMessage.hideGenerating()
+                // uncomment the below line to re-enable generating message
+                // this.inlineGeneratingMessage.hideGenerating()
                 void statusBar.refreshStatusBar() // effectively "stop loading"
             }
         }

--- a/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/recommendationService.test.ts
@@ -274,7 +274,7 @@ describe('RecommendationService', () => {
         })
 
         it('should show UI indicators when showUi option is true (default)', async () => {
-            const { showGeneratingStub, hideGeneratingStub } = setupUITest()
+            // const { showGeneratingStub, hideGeneratingStub } = setupUITest()
 
             // Call with default options (showUi: true)
             await service.getAllRecommendations(
@@ -287,8 +287,8 @@ describe('RecommendationService', () => {
             )
 
             // Verify UI methods were called
-            sinon.assert.calledOnce(showGeneratingStub)
-            sinon.assert.calledOnce(hideGeneratingStub)
+            // sinon.assert.calledOnce(showGeneratingStub)
+            // sinon.assert.calledOnce(hideGeneratingStub)
             sinon.assert.calledOnce(statusBarStub.setLoading)
             sinon.assert.calledOnce(statusBarStub.refreshStatusBar)
         })


### PR DESCRIPTION
## Problem

disable generating message while waiting for inline suggestion

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
