### PR TITLE
feat(amazonq): adding isInlineEdit to LogInlineCompletionSessionResultsParams for EDITS telemetry

### DIFF
--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -315,6 +315,7 @@ export async function displaySvgDecoration(
                 },
                 totalSessionDisplayTime: Date.now() - session.requestStartTime,
                 firstCompletionDisplayLatency: session.firstCompletionDisplayLatency,
+                isInlineEdit: true,
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
             if (inlineCompletionProvider) {
@@ -343,6 +344,7 @@ export async function displaySvgDecoration(
                         discarded: false,
                     },
                 },
+                isInlineEdit: true,
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
         },


### PR DESCRIPTION
## Problem

adding isInlineEdit to LogInlineCompletionSessionResultsParams for EDITS telemetry: 
https://github.com/aws/language-servers/blob/main/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts#L910


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
