### PR TITLE
fix(lambda): Revert update to function upload directory selection wizard

### DIFF
--- a/packages/core/src/lambda/commands/editLambda.ts
+++ b/packages/core/src/lambda/commands/editLambda.ts
@@ -12,7 +12,6 @@ import {
     getFunctionInfo,
     getLambdaDetails,
     getTempLocation,
-    lambdaEdits,
     lambdaTempPath,
     setFunctionInfo,
 } from '../utils'
@@ -138,7 +137,6 @@ export async function editLambdaCommand(functionNode: LambdaFunctionNode) {
 export async function editLambda(lambda: LambdaFunction, onActivation?: boolean) {
     return await telemetry.lambda_quickEditFunction.run(async () => {
         telemetry.record({ source: onActivation ? 'workspace' : 'explorer' })
-        const { name, region, configuration } = lambda
         const downloadLocation = getTempLocation(lambda.name, lambda.region)
         const downloadLocationName = vscode.workspace.asRelativePath(downloadLocation, true)
 
@@ -200,9 +198,6 @@ export async function editLambda(lambda: LambdaFunction, onActivation?: boolean)
             await openLambdaFile(lambdaLocation)
             watchForUpdates(lambda, vscode.Uri.file(downloadLocation))
         }
-
-        const newEdit = { location: downloadLocationName, region, functionName: name, configuration }
-        lambdaEdits.push(newEdit)
 
         return downloadLocation
     })

--- a/packages/core/src/lambda/utils.ts
+++ b/packages/core/src/lambda/utils.ts
@@ -202,23 +202,3 @@ export function getTempRegionLocation(region: string) {
 export function getTempLocation(functionName: string, region: string) {
     return path.join(getTempRegionLocation(region), functionName)
 }
-
-type LambdaEdit = {
-    location: string
-    functionName: string
-    region: string
-    configuration?: Lambda.FunctionConfiguration
-}
-
-// Array to keep the list of functions that are being edited.
-export const lambdaEdits: LambdaEdit[] = []
-
-// Given a particular function and region, it returns the full LambdaEdit object
-export function getLambdaEditFromNameRegion(name: string, functionRegion: string) {
-    return lambdaEdits.find(({ functionName, region }) => functionName === name && region === functionRegion)
-}
-
-// Given a particular localPath, it returns the full LambdaEdit object
-export function getLambdaEditFromLocation(functionLocation: string) {
-    return lambdaEdits.find(({ location }) => location === functionLocation)
-}

--- a/packages/core/src/test/lambda/commands/editLambda.test.ts
+++ b/packages/core/src/test/lambda/commands/editLambda.test.ts
@@ -75,7 +75,6 @@ describe('editLambda', function () {
         sinon.replace(require('../../../lambda/commands/editLambda'), 'promptDeploy', promptDeployStub)
 
         // Other stubs
-        sinon.stub(utils, 'lambdaEdits').value([])
         sinon.stub(utils, 'getLambdaDetails').returns({ fileName: 'index.js', functionName: 'test-function' })
         sinon.stub(fs, 'readdir').resolves([])
         sinon.stub(fs, 'delete').resolves()

--- a/packages/core/src/test/lambda/utils.test.ts
+++ b/packages/core/src/test/lambda/utils.test.ts
@@ -12,9 +12,6 @@ import {
     getFunctionInfo,
     setFunctionInfo,
     compareCodeSha,
-    lambdaEdits,
-    getLambdaEditFromNameRegion,
-    getLambdaEditFromLocation,
 } from '../../lambda/utils'
 import { LambdaFunction } from '../../lambda/commands/uploadLambda'
 import { DefaultLambdaClient } from '../../shared/clients/lambdaClient'
@@ -185,50 +182,6 @@ describe('lambda utils', function () {
 
             const result = await compareCodeSha(mockLambda)
             assert.strictEqual(result, false)
-        })
-    })
-
-    describe('lambdaEdits array functions', function () {
-        beforeEach(function () {
-            lambdaEdits.length = 0
-            lambdaEdits.push(
-                {
-                    location: '/tmp/func1',
-                    functionName: 'func1',
-                    region: 'us-east-1',
-                },
-                {
-                    location: '/tmp/func2',
-                    functionName: 'func2',
-                    region: 'us-west-2',
-                }
-            )
-        })
-
-        describe('getLambdaEditFromNameRegion', function () {
-            it('finds edit by name and region', function () {
-                const result = getLambdaEditFromNameRegion('func1', 'us-east-1')
-                assert.strictEqual(result?.functionName, 'func1')
-                assert.strictEqual(result?.region, 'us-east-1')
-            })
-
-            it('returns undefined when not found', function () {
-                const result = getLambdaEditFromNameRegion('nonexistent', 'us-east-1')
-                assert.strictEqual(result, undefined)
-            })
-        })
-
-        describe('getLambdaEditFromLocation', function () {
-            it('finds edit by location', function () {
-                const result = getLambdaEditFromLocation('/tmp/func2')
-                assert.strictEqual(result?.functionName, 'func2')
-                assert.strictEqual(result?.location, '/tmp/func2')
-            })
-
-            it('returns undefined when not found', function () {
-                const result = getLambdaEditFromLocation('/tmp/nonexistent')
-                assert.strictEqual(result, undefined)
-            })
         })
     })
 })

--- a/packages/toolkit/.changes/next-release/Bug Fix-70bf4138-7b79-4fc1-8e6a-0637f0058da6.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-70bf4138-7b79-4fc1-8e6a-0637f0058da6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Lambda upload from directory doesn't allow selection of directory"
+}


### PR DESCRIPTION
fixes #7618

## Problem
Introduced in #7601 is a bug where choosing to upload a Lambda function from a directory would not allow the user to actually select the directory. In the directory selection window, the button to select is disabled. This was an inadvertent change when adding new functionality.

## Solution
Revert the breaking change. In addition to switching `canSelectFolders` to `true` and `canSelectFiles` to `false`, I have reverted the other changes in the upload flow that were added in the original PR. This is because these changes added another flow to the upload modal that doesn't fit with all the other added functionality, and just increases the complexity of the code without much benefit. Because this was the only place that used the `lambdaEdits` array from the `utils`, I removed that as well.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
