### PR TITLE
docs(amazonq): improve LSP documentation

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -25,6 +25,7 @@ sequenceDiagram
 ```
 
 ## Language Server Debugging
+If you want to connect a local version of language-servers to aws-toolkit-vscode, follow these steps:
 
 1. Clone https://github.com/aws/language-servers.git and set it up in the same workspace as this project by cmd+shift+p and "add folder to workspace" and selecting the language-servers folder that you just cloned. Your VS code folder structure should look like below.
 
@@ -54,6 +55,43 @@ sequenceDiagram
 4. Uncomment the `__AMAZONQLSP_PATH` and `__AMAZONQLSP_UI` variables in the `amazonq/.vscode/launch.json` extension configuration
 5. Use the `Launch LSP with Debugging` configuration and set breakpoints in VSCode or the language server, Once you run "Launch LSP with Debugging" a new window should start, wait for the plugin to show up there. Then go to the run menu again and run "Attach to Language Server (amazonq)" after this you should be able to add breakpoints in the LSP code.
 6. (Optional): Enable `"amazonq.trace.server": "on"` or `"amazonq.trace.server": "verbose"` in your VSCode settings to view detailed log messages sent to/from the language server. These log messages will show up in the "Amazon Q Language Server" output channel
+
+### Breakpoints Work-Around
+If the breakpoints in your language-servers project remain greyed out and do not trigger when you run `Launch LSP with Debugging`, your debugger may be attaching to the language server before it has launched. You can follow the work-around below to avoid this problem. If anyone fixes this issue, please remove this section.
+1. Set your breakpoints and click `Launch LSP with Debugging`
+2. Once the debugging session has started, click `Launch LSP with Debugging` again, then `Cancel` on any pop-ups that appear
+3. On the debug panel, click `Attach to Language Server (amazonq)` next to the red stop button
+4. Click `Launch LSP with Debugging` again, then `Cancel` on any pop-ups that appear
+
+## Language Server Runtimes Debugging
+If you want to connect a local version of language-server-runtimes to aws-toolkit-vscode, follow these steps:
+
+1. Clone https://github.com/aws/language-server-runtimes.git and set it up in the same workspace as this project by cmd+shift+p and "add folder to workspace" and selecting the language-server-runtimes folder that you just cloned. Your VS code folder structure should look like below.
+
+    ```
+    /aws-toolkit-vscode
+    /toolkit
+    /core
+    /amazonq
+    /language-server-runtimes
+    ```
+2. Inside of the language-server-runtimes project run:
+    ```
+    npm install
+    npm run compile
+    cd runtimes
+    npm run prepub
+    cd out
+    npm link
+    cd ../../types
+    npm link
+    ```
+    If you get an error running `npm run prepub`, you can instead run `npm run prepub:copyFiles` to skip cleaning and testing.
+3. Inside of aws-toolkit-vscode run:
+    ```
+    npm install
+    npm link @aws/language-server-runtimes @aws/language-server-runtimes-types
+    ```
 
 ## Amazon Q Inline Activation
 


### PR DESCRIPTION
## Problem
The LSP documentation is currently missing instructions for connecting a local version of language-server-runtimes to aws-toolkit-vscode. It is also missing information about a work-around for setting breakpoints in a local version of language-servers.

## Solution
- Add instructions describing how to set up a local version of language-server-runtimes and connect it to aws-toolkit-vscode
- Add instructions describing how to work around a breakpoint bug when debugging with a local version of language-servers.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
