### PR TITLE
fix(amazonq): improve feedback experience and min char limit

### DIFF
--- a/packages/core/src/feedback/vue/submitFeedback.ts
+++ b/packages/core/src/feedback/vue/submitFeedback.ts
@@ -41,6 +41,10 @@ export class FeedbackWebview extends VueWebview {
             return 'Choose a reaction (smile/frown)'
         }
 
+        if (message.comment.length < 188) {
+            return 'Please add atleast 100 characters in the template describing your issue.'
+        }
+
         if (this.commentData) {
             message.comment = `${message.comment}\n\n${this.commentData}`
         }

--- a/packages/core/src/feedback/vue/submitFeedback.vue
+++ b/packages/core/src/feedback/vue/submitFeedback.vue
@@ -34,6 +34,26 @@
                             >.</em
                         >
                     </div>
+                    <div style="margin-top: 10px">
+                        <em>For helpful feedback, please include:</em>
+                        <ul style="margin-top: 5px; margin-bottom: 5px">
+                            <li>
+                                <em><strong>Issue:</strong> A brief summary of the issue or suggestion</em>
+                            </li>
+                            <li>
+                                <em
+                                    ><strong>Reproduction Steps:</strong> Clear steps to reproduce the issue (if
+                                    applicable)</em
+                                >
+                            </li>
+                            <li>
+                                <em
+                                    ><strong>Expected vs. Actual:</strong> What you expected and what actually
+                                    happened</em
+                                >
+                            </li>
+                        </ul>
+                    </div>
                     <br />
                     <div>
                         <em>
@@ -66,7 +86,16 @@ const client = WebviewClientFactory.create<FeedbackWebview>()
 export default defineComponent({
     data() {
         return {
-            comment: '',
+            comment: `Issue:
+
+Reproduction Steps:
+1. 
+2. 
+3. 
+
+Expected Behavior: 
+
+Actual Behavior: `,
             sentiment: '',
             isSubmitting: false,
             error: '',

--- a/packages/core/src/test/feedback/commands/submitFeedbackListener.test.ts
+++ b/packages/core/src/test/feedback/commands/submitFeedbackListener.test.ts
@@ -10,9 +10,14 @@ import { FeedbackWebview } from '../../../feedback/vue/submitFeedback'
 import sinon from 'sinon'
 import { waitUntil } from '../../../shared'
 
-const comment = 'comment'
+const comment =
+    'This is a detailed feedback comment that meets the minimum length requirement. ' +
+    'It includes specific information about the issue, steps to reproduce, expected behavior, and actual behavior. ' +
+    'This comment is long enough to pass the 188 character validation rule.'
 const sentiment = 'Positive'
 const message = { command: 'submitFeedback', comment: comment, sentiment: sentiment }
+const shortComment = 'This is a short comment'
+const shortMessage = { command: 'submitFeedback', comment: shortComment, sentiment: sentiment }
 
 describe('submitFeedbackListener', function () {
     let mockTelemetry: TelemetryService
@@ -46,6 +51,15 @@ describe('submitFeedbackListener', function () {
             const webview = new FeedbackWebview(mockTelemetry, productName)
             const result = await webview.submit(message)
             assert.strictEqual(result, expectedError)
+        })
+
+        it(`validates ${productName} feedback comment length is at least 188 characters`, async function () {
+            const postStub = sinon.stub()
+            mockTelemetry.postFeedback = postStub
+            const webview = new FeedbackWebview(mockTelemetry, productName)
+            const result = await webview.submit(shortMessage)
+            assert.strictEqual(result, 'Please add atleast 100 characters in the template describing your issue.')
+            assert.strictEqual(postStub.called, false, 'postFeedback should not be called for short comments')
         })
     }
 })


### PR DESCRIPTION
## Problem
Feedback forms were coming empty and with no useful data. Mostly a UI change.


## Solution
Added char limits and starting templates so that we can get meaningful messages out of this.
![image](https://github.com/user-attachments/assets/18431020-3519-41a6-bb6f-47a1367d3da6)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
