### PR TITLE
config(amazonq): nep only auto trigger on acceptance if there is nextToken

### DIFF
--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -318,7 +318,8 @@ export async function displaySvgDecoration(
                 isInlineEdit: true,
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
-            if (inlineCompletionProvider) {
+            // Only auto trigger on acceptance if there is a nextToken
+            if (inlineCompletionProvider && session.editsStreakPartialResultToken) {
                 await inlineCompletionProvider.provideInlineCompletionItems(
                     editor.document,
                     endPosition,


### PR DESCRIPTION
…Token

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
