### PR TITLE
fix(amazonq): generateCompletion pagination is invoked in blocking context

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-ab23e716-ee5c-47cd-8b6a-545dd6c7bda7.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-ab23e716-ee5c-47cd-8b6a-545dd6c7bda7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "fix increased latency due to inline completion API is called in a blocking manner"
+}


### PR DESCRIPTION
## Problem
GenerateCompletion will wait until "ALL" pages are finished and then return. It's supposed to return the first response immediately when it arrives and push/update the remaining suggestions afterward.


## Solution
Revert partial unintended changes made in https://github.com/aws/aws-toolkit-vscode/commit/9bd9d997cf46c37218fd76ea7dfb1aa09b4bd66d#diff-5d07606815c684624bb1c126f4e0da3df22fb2b89be24564d203a8b78fd3c1adL92-L107

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
