### PR TITLE
deps: bump @aws-toolkits/telemetry to 1.0.328

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "vscode-nls-dev": "^4.0.4"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.326",
+                "@aws-toolkits/telemetry": "^1.0.328",
                 "@playwright/browser-chromium": "^1.43.1",
                 "@stylistic/eslint-plugin": "^2.11.0",
                 "@types/he": "^1.2.3",
@@ -15008,10 +15008,11 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.326",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.326.tgz",
-            "integrity": "sha512-4PpnljGgERDJpdAJdBHKb9eaDhq8ktYiWoYS/mCG2ojplGvEP/ymzfzPJ6apUErT3iu74+md1x5JL8h7N7/ZFA==",
+            "version": "1.0.328",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.328.tgz",
+            "integrity": "sha512-DenImMbYXCqyh8ofX6nh8IINHRXlELdi3BycvEefy0By6hEUao+BuW92SLfbqJ7Z+BgRrwminI91au5aGe9RHA==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^6.12.6",
                 "cross-spawn": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "skippedTestReport": "ts-node ./scripts/skippedTestReport.ts ./packages/amazonq/test/e2e/"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.326",
+        "@aws-toolkits/telemetry": "^1.0.328",
         "@playwright/browser-chromium": "^1.43.1",
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/he": "^1.2.3",


### PR DESCRIPTION
## Problem
- added new metric in aws-toolkit-common: https://github.com/aws/aws-toolkit-common/pull/1063

## Solution
- Consume latest version of aws-toolkit-common package

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
