### PR TITLE
fix(amazonq): update Q profile and customizations on language-servers crash restart

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -1325,25 +1325,39 @@
                     "fontCharacter": "\\f1de"
                 }
             },
-            "aws-schemas-registry": {
+            "aws-sagemaker-code-editor": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1df"
                 }
             },
-            "aws-schemas-schema": {
+            "aws-sagemaker-jupyter-lab": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e0"
                 }
             },
-            "aws-stepfunctions-preview": {
+            "aws-schemas-registry": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e1"
+                }
+            },
+            "aws-schemas-schema": {
+                "description": "AWS Contributed Icon",
+                "default": {
+                    "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
+                    "fontCharacter": "\\f1e2"
+                }
+            },
+            "aws-stepfunctions-preview": {
+                "description": "AWS Contributed Icon",
+                "default": {
+                    "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
+                    "fontCharacter": "\\f1e3"
                 }
             }
         },

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -223,6 +223,55 @@ async function initializeAuth(client: LanguageClient): Promise<AmazonQLspAuth> {
     return auth
 }
 
+async function initializeLanguageServerConfiguration(client: LanguageClient, context: string = 'startup') {
+    const logger = getLogger('amazonqLsp')
+
+    if (AuthUtil.instance.isConnectionValid()) {
+        logger.info(`[${context}] Connection valid, initializing language server configuration`)
+
+        try {
+            // Send profile configuration
+            logger.info(`[${context}] Sending profile configuration to language server`)
+            await sendProfileToLsp(client)
+            logger.info(`[${context}] Profile configuration sent successfully`)
+
+            // Send customization configuration
+            logger.info(`[${context}] Sending customization configuration to language server`)
+            await pushConfigUpdate(client, {
+                type: 'customization',
+                customization: getSelectedCustomization(),
+            })
+            logger.info(`[${context}] Customization configuration sent successfully`)
+        } catch (error) {
+            logger.error(`[${context}] Failed to initialize language server configuration: ${error}`)
+            throw error
+        }
+    } else {
+        logger.warn(
+            `[${context}] Connection invalid, skipping language server configuration - this will cause authentication failures`
+        )
+        const activeConnection = AuthUtil.instance.auth.activeConnection
+        const connectionState = activeConnection
+            ? AuthUtil.instance.auth.getConnectionState(activeConnection)
+            : 'no-connection'
+        logger.warn(`[${context}] Connection state: ${connectionState}`)
+    }
+}
+
+async function sendProfileToLsp(client: LanguageClient) {
+    const logger = getLogger('amazonqLsp')
+    const profileArn = AuthUtil.instance.regionProfileManager.activeRegionProfile?.arn
+
+    logger.debug(`Sending profile to LSP: ${profileArn || 'undefined'}`)
+
+    await pushConfigUpdate(client, {
+        type: 'profile',
+        profileArn: profileArn,
+    })
+
+    logger.debug(`Profile sent to LSP successfully`)
+}
+
 async function onLanguageServerReady(
     extensionContext: vscode.ExtensionContext,
     auth: AmazonQLspAuth,
@@ -254,14 +303,7 @@ async function onLanguageServerReady(
     // We manually push the cached values the first time since event handlers, which should push, may not have been setup yet.
     // Execution order is weird and should be fixed in the flare implementation.
     // TODO: Revisit if we need this if we setup the event handlers properly
-    if (AuthUtil.instance.isConnectionValid()) {
-        await sendProfileToLsp(client)
-
-        await pushConfigUpdate(client, {
-            type: 'customization',
-            customization: getSelectedCustomization(),
-        })
-    }
+    await initializeLanguageServerConfiguration(client, 'startup')
 
     toDispose.push(
         inlineManager,
@@ -355,13 +397,6 @@ async function onLanguageServerReady(
         // Set this inside onReady so that it only triggers on subsequent language server starts (not the first)
         onServerRestartHandler(client, auth)
     )
-
-    async function sendProfileToLsp(client: LanguageClient) {
-        await pushConfigUpdate(client, {
-            type: 'profile',
-            profileArn: AuthUtil.instance.regionProfileManager.activeRegionProfile?.arn,
-        })
-    }
 }
 
 /**
@@ -381,8 +416,21 @@ function onServerRestartHandler(client: LanguageClient, auth: AmazonQLspAuth) {
         // TODO: Port this metric override to common definitions
         telemetry.languageServer_crash.emit({ id: 'AmazonQ' })
 
-        // Need to set the auth token in the again
-        await auth.refreshConnection(true)
+        const logger = getLogger('amazonqLsp')
+        logger.info('[crash-recovery] Language server crash detected, reinitializing authentication')
+
+        try {
+            // Send bearer token
+            logger.info('[crash-recovery] Refreshing connection and sending bearer token')
+            await auth.refreshConnection(true)
+            logger.info('[crash-recovery] Bearer token sent successfully')
+
+            // Send profile and customization configuration
+            await initializeLanguageServerConfiguration(client, 'crash-recovery')
+            logger.info('[crash-recovery] Language server configuration reinitialized successfully')
+        } catch (error) {
+            logger.error(`[crash-recovery] Failed to reinitialize after crash: ${error}`)
+        }
     })
 }
 

--- a/packages/amazonq/src/lsp/config.ts
+++ b/packages/amazonq/src/lsp/config.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode'
-import { DevSettings, getServiceEnvVarConfig, BaseLspInstaller } from 'aws-core-vscode/shared'
+import { DevSettings, getServiceEnvVarConfig, BaseLspInstaller, getLogger } from 'aws-core-vscode/shared'
 import { LanguageClient } from 'vscode-languageclient'
 import {
     DidChangeConfigurationNotification,
@@ -68,23 +68,31 @@ export function toAmazonQLSPLogLevel(logLevel: vscode.LogLevel): LspLogLevel {
  * push the given config.
  */
 export async function pushConfigUpdate(client: LanguageClient, config: QConfigs) {
+    const logger = getLogger('amazonqLsp')
+
     switch (config.type) {
         case 'profile':
+            logger.debug(`Pushing profile configuration: ${config.profileArn || 'undefined'}`)
             await client.sendRequest(updateConfigurationRequestType.method, {
                 section: 'aws.q',
                 settings: { profileArn: config.profileArn },
             })
+            logger.debug(`Profile configuration pushed successfully`)
             break
         case 'customization':
+            logger.debug(`Pushing customization configuration: ${config.customization || 'undefined'}`)
             client.sendNotification(DidChangeConfigurationNotification.type.method, {
                 section: 'aws.q',
                 settings: { customization: config.customization },
             })
+            logger.debug(`Customization configuration pushed successfully`)
             break
         case 'logLevel':
+            logger.debug(`Pushing log level configuration`)
             client.sendNotification(DidChangeConfigurationNotification.type.method, {
                 section: 'aws.logLevel',
             })
+            logger.debug(`Log level configuration pushed successfully`)
             break
     }
 }

--- a/packages/amazonq/test/unit/amazonq/lsp/client.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/client.test.ts
@@ -1,0 +1,263 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import sinon from 'sinon'
+import { LanguageClient } from 'vscode-languageclient'
+import { AuthUtil } from 'aws-core-vscode/codewhisperer'
+import { AmazonQLspAuth } from '../../../../src/lsp/auth'
+
+// These tests verify the behavior of the authentication functions
+// Since the actual functions are module-level and use real dependencies,
+// we test the expected behavior through mock implementations
+
+describe('Language Server Client Authentication', function () {
+    let sandbox: sinon.SinonSandbox
+    let mockClient: any
+    let mockAuth: any
+    let authUtilStub: sinon.SinonStub
+    let loggerStub: any
+    let getLoggerStub: sinon.SinonStub
+    let pushConfigUpdateStub: sinon.SinonStub
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+
+        // Mock LanguageClient
+        mockClient = {
+            sendRequest: sandbox.stub().resolves(),
+            sendNotification: sandbox.stub(),
+            onDidChangeState: sandbox.stub(),
+        }
+
+        // Mock AmazonQLspAuth
+        mockAuth = {
+            refreshConnection: sandbox.stub().resolves(),
+        }
+
+        // Mock AuthUtil
+        authUtilStub = sandbox.stub(AuthUtil, 'instance').get(() => ({
+            isConnectionValid: sandbox.stub().returns(true),
+            regionProfileManager: {
+                activeRegionProfile: { arn: 'test-profile-arn' },
+            },
+            auth: {
+                getConnectionState: sandbox.stub().returns('valid'),
+                activeConnection: { id: 'test-connection' },
+            },
+        }))
+
+        // Create logger stub
+        loggerStub = {
+            info: sandbox.stub(),
+            debug: sandbox.stub(),
+            warn: sandbox.stub(),
+            error: sandbox.stub(),
+        }
+
+        // Clear all relevant module caches
+        const sharedModuleId = require.resolve('aws-core-vscode/shared')
+        const configModuleId = require.resolve('../../../../src/lsp/config')
+        delete require.cache[sharedModuleId]
+        delete require.cache[configModuleId]
+
+        // Create getLogger stub
+        getLoggerStub = sandbox.stub().returns(loggerStub)
+
+        // Create a mock shared module with stubbed getLogger
+        const mockSharedModule = {
+            getLogger: getLoggerStub,
+        }
+
+        // Override the require cache with our mock
+        require.cache[sharedModuleId] = {
+            id: sharedModuleId,
+            filename: sharedModuleId,
+            loaded: true,
+            parent: undefined,
+            children: [],
+            exports: mockSharedModule,
+            paths: [],
+        } as any
+
+        // Mock pushConfigUpdate
+        pushConfigUpdateStub = sandbox.stub().resolves()
+        const mockConfigModule = {
+            pushConfigUpdate: pushConfigUpdateStub,
+        }
+
+        require.cache[configModuleId] = {
+            id: configModuleId,
+            filename: configModuleId,
+            loaded: true,
+            parent: undefined,
+            children: [],
+            exports: mockConfigModule,
+            paths: [],
+        } as any
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    describe('initializeLanguageServerConfiguration behavior', function () {
+        it('should initialize configuration when connection is valid', async function () {
+            // Test the expected behavior of the function
+            const mockInitializeFunction = async (client: LanguageClient, context: string) => {
+                const { getLogger } = require('aws-core-vscode/shared')
+                const { pushConfigUpdate } = require('../../../../src/lsp/config')
+                const logger = getLogger('amazonqLsp')
+
+                if (AuthUtil.instance.isConnectionValid()) {
+                    logger.info(`[${context}] Connection valid, initializing language server configuration`)
+
+                    // Send profile configuration
+                    logger.info(`[${context}] Sending profile configuration to language server`)
+                    await pushConfigUpdate(client, {
+                        type: 'profile',
+                        profileArn: AuthUtil.instance.regionProfileManager.activeRegionProfile?.arn,
+                    })
+                    logger.info(`[${context}] Profile configuration sent successfully`)
+
+                    // Send customization configuration
+                    logger.info(`[${context}] Sending customization configuration to language server`)
+                    await pushConfigUpdate(client, {
+                        type: 'customization',
+                        customization: 'test-customization',
+                    })
+                    logger.info(`[${context}] Customization configuration sent successfully`)
+                } else {
+                    logger.warn(`[${context}] Connection invalid, skipping configuration`)
+                }
+            }
+
+            await mockInitializeFunction(mockClient as any, 'startup')
+
+            // Verify logging
+            assert(loggerStub.info.calledWith('[startup] Connection valid, initializing language server configuration'))
+            assert(loggerStub.info.calledWith('[startup] Sending profile configuration to language server'))
+            assert(loggerStub.info.calledWith('[startup] Profile configuration sent successfully'))
+            assert(loggerStub.info.calledWith('[startup] Sending customization configuration to language server'))
+            assert(loggerStub.info.calledWith('[startup] Customization configuration sent successfully'))
+
+            // Verify pushConfigUpdate was called twice
+            assert.strictEqual(pushConfigUpdateStub.callCount, 2)
+
+            // Verify profile configuration
+            assert(
+                pushConfigUpdateStub.calledWith(mockClient, {
+                    type: 'profile',
+                    profileArn: 'test-profile-arn',
+                })
+            )
+
+            // Verify customization configuration
+            assert(
+                pushConfigUpdateStub.calledWith(mockClient, {
+                    type: 'customization',
+                    customization: 'test-customization',
+                })
+            )
+        })
+
+        it('should log warning when connection is invalid', async function () {
+            // Mock invalid connection
+            authUtilStub.get(() => ({
+                isConnectionValid: sandbox.stub().returns(false),
+                auth: {
+                    getConnectionState: sandbox.stub().returns('invalid'),
+                    activeConnection: { id: 'test-connection' },
+                },
+            }))
+
+            const mockInitializeFunction = async (client: LanguageClient, context: string) => {
+                const { getLogger } = require('aws-core-vscode/shared')
+                const logger = getLogger('amazonqLsp')
+
+                if (AuthUtil.instance.isConnectionValid()) {
+                    // Should not reach here
+                } else {
+                    logger.warn(
+                        `[${context}] Connection invalid, skipping language server configuration - this will cause authentication failures`
+                    )
+                    const activeConnection = AuthUtil.instance.auth.activeConnection
+                    const connectionState = activeConnection
+                        ? AuthUtil.instance.auth.getConnectionState(activeConnection)
+                        : 'no-connection'
+                    logger.warn(`[${context}] Connection state: ${connectionState}`)
+                }
+            }
+
+            await mockInitializeFunction(mockClient as any, 'crash-recovery')
+
+            // Verify warning logs
+            assert(
+                loggerStub.warn.calledWith(
+                    '[crash-recovery] Connection invalid, skipping language server configuration - this will cause authentication failures'
+                )
+            )
+            assert(loggerStub.warn.calledWith('[crash-recovery] Connection state: invalid'))
+
+            // Verify pushConfigUpdate was not called
+            assert.strictEqual(pushConfigUpdateStub.callCount, 0)
+        })
+    })
+
+    describe('crash recovery handler behavior', function () {
+        it('should reinitialize authentication after crash', async function () {
+            const mockCrashHandler = async (client: LanguageClient, auth: AmazonQLspAuth) => {
+                const { getLogger } = require('aws-core-vscode/shared')
+                const { pushConfigUpdate } = require('../../../../src/lsp/config')
+                const logger = getLogger('amazonqLsp')
+
+                logger.info('[crash-recovery] Language server crash detected, reinitializing authentication')
+
+                try {
+                    logger.info('[crash-recovery] Refreshing connection and sending bearer token')
+                    await auth.refreshConnection(true)
+                    logger.info('[crash-recovery] Bearer token sent successfully')
+
+                    // Mock the configuration initialization
+                    if (AuthUtil.instance.isConnectionValid()) {
+                        await pushConfigUpdate(client, {
+                            type: 'profile',
+                            profileArn: AuthUtil.instance.regionProfileManager.activeRegionProfile?.arn,
+                        })
+                    }
+
+                    logger.info('[crash-recovery] Language server configuration reinitialized successfully')
+                } catch (error) {
+                    logger.error(`[crash-recovery] Failed to reinitialize after crash: ${error}`)
+                }
+            }
+
+            await mockCrashHandler(mockClient as any, mockAuth as any)
+
+            // Verify crash recovery logging
+            assert(
+                loggerStub.info.calledWith(
+                    '[crash-recovery] Language server crash detected, reinitializing authentication'
+                )
+            )
+            assert(loggerStub.info.calledWith('[crash-recovery] Refreshing connection and sending bearer token'))
+            assert(loggerStub.info.calledWith('[crash-recovery] Bearer token sent successfully'))
+            assert(
+                loggerStub.info.calledWith('[crash-recovery] Language server configuration reinitialized successfully')
+            )
+
+            // Verify auth.refreshConnection was called
+            assert(mockAuth.refreshConnection.calledWith(true))
+
+            // Verify profile configuration was sent
+            assert(
+                pushConfigUpdateStub.calledWith(mockClient, {
+                    type: 'profile',
+                    profileArn: 'test-profile-arn',
+                })
+            )
+        })
+    })
+})

--- a/packages/amazonq/test/unit/amazonq/lsp/config.test.ts
+++ b/packages/amazonq/test/unit/amazonq/lsp/config.test.ts
@@ -77,3 +77,149 @@ describe('getAmazonQLspConfig', () => {
         delete process.env.__AMAZONQLSP_UI
     }
 })
+
+describe('pushConfigUpdate', () => {
+    let sandbox: sinon.SinonSandbox
+    let mockClient: any
+    let loggerStub: any
+    let getLoggerStub: sinon.SinonStub
+    let pushConfigUpdate: any
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+
+        // Mock LanguageClient
+        mockClient = {
+            sendRequest: sandbox.stub().resolves(),
+            sendNotification: sandbox.stub(),
+        }
+
+        // Create logger stub
+        loggerStub = {
+            debug: sandbox.stub(),
+        }
+
+        // Clear all relevant module caches
+        const configModuleId = require.resolve('../../../../src/lsp/config')
+        const sharedModuleId = require.resolve('aws-core-vscode/shared')
+        delete require.cache[configModuleId]
+        delete require.cache[sharedModuleId]
+
+        // Create getLogger stub and store reference for test verification
+        getLoggerStub = sandbox.stub().returns(loggerStub)
+
+        // Create a mock shared module with stubbed getLogger
+        const mockSharedModule = {
+            getLogger: getLoggerStub,
+        }
+
+        // Override the require cache with our mock
+        require.cache[sharedModuleId] = {
+            id: sharedModuleId,
+            filename: sharedModuleId,
+            loaded: true,
+            parent: undefined,
+            children: [],
+            exports: mockSharedModule,
+            paths: [],
+        } as any
+
+        // Now require the module - it should use our mocked getLogger
+        const configModule = require('../../../../src/lsp/config')
+        pushConfigUpdate = configModule.pushConfigUpdate
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    it('should send profile configuration with logging', async () => {
+        const config = {
+            type: 'profile' as const,
+            profileArn: 'test-profile-arn',
+        }
+
+        await pushConfigUpdate(mockClient, config)
+
+        // Verify logging
+        assert(loggerStub.debug.calledWith('Pushing profile configuration: test-profile-arn'))
+        assert(loggerStub.debug.calledWith('Profile configuration pushed successfully'))
+
+        // Verify client call
+        assert(mockClient.sendRequest.calledOnce)
+        assert(
+            mockClient.sendRequest.calledWith(sinon.match.string, {
+                section: 'aws.q',
+                settings: { profileArn: 'test-profile-arn' },
+            })
+        )
+    })
+
+    it('should send customization configuration with logging', async () => {
+        const config = {
+            type: 'customization' as const,
+            customization: 'test-customization-arn',
+        }
+
+        await pushConfigUpdate(mockClient, config)
+
+        // Verify logging
+        assert(loggerStub.debug.calledWith('Pushing customization configuration: test-customization-arn'))
+        assert(loggerStub.debug.calledWith('Customization configuration pushed successfully'))
+
+        // Verify client call
+        assert(mockClient.sendNotification.calledOnce)
+        assert(
+            mockClient.sendNotification.calledWith(sinon.match.string, {
+                section: 'aws.q',
+                settings: { customization: 'test-customization-arn' },
+            })
+        )
+    })
+
+    it('should handle undefined profile ARN', async () => {
+        const config = {
+            type: 'profile' as const,
+            profileArn: undefined,
+        }
+
+        await pushConfigUpdate(mockClient, config)
+
+        // Verify logging with undefined
+        assert(loggerStub.debug.calledWith('Pushing profile configuration: undefined'))
+        assert(loggerStub.debug.calledWith('Profile configuration pushed successfully'))
+    })
+
+    it('should handle undefined customization ARN', async () => {
+        const config = {
+            type: 'customization' as const,
+            customization: undefined,
+        }
+
+        await pushConfigUpdate(mockClient, config)
+
+        // Verify logging with undefined
+        assert(loggerStub.debug.calledWith('Pushing customization configuration: undefined'))
+        assert(loggerStub.debug.calledWith('Customization configuration pushed successfully'))
+    })
+
+    it('should send logLevel configuration with logging', async () => {
+        const config = {
+            type: 'logLevel' as const,
+        }
+
+        await pushConfigUpdate(mockClient, config)
+
+        // Verify logging
+        assert(loggerStub.debug.calledWith('Pushing log level configuration'))
+        assert(loggerStub.debug.calledWith('Log level configuration pushed successfully'))
+
+        // Verify client call
+        assert(mockClient.sendNotification.calledOnce)
+        assert(
+            mockClient.sendNotification.calledWith(sinon.match.string, {
+                section: 'aws.logLevel',
+            })
+        )
+    })
+})


### PR DESCRIPTION
## Problem

Investigation revealed that when the language server crashed and automatically restarted, the crash recovery mechanism only sent bearer tokens but failed to send profile configuration, leaving the language server stuck in PENDING_Q_PROFILE state.

## Solution

Fixed the incomplete crash recovery mechanism by:
• **Enhanced crash recovery handler** to send both bearer token AND profile configuration during language server restart
• **Added comprehensive logging** with context tags ([startup], [crash-recovery]) for future debugging
• **Created centralized authentication function** to prevent code duplication between startup and crash recovery paths
• **Added debug logging** to pushConfigUpdate and sendProfileToLsp functions to track configuration values

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
