### PR TITLE
test(lambda): Remove duplicate code in Lambda tests

### DIFF
--- a/packages/core/src/test/lambda/utils.test.ts
+++ b/packages/core/src/test/lambda/utils.test.ts
@@ -13,7 +13,6 @@ import {
     setFunctionInfo,
     compareCodeSha,
 } from '../../lambda/utils'
-import { LambdaFunction } from '../../lambda/commands/uploadLambda'
 import { DefaultLambdaClient } from '../../shared/clients/lambdaClient'
 import { fs } from '../../shared/fs/fs'
 import { tempDirPath } from '../../shared/filesystemUtilities'
@@ -117,16 +116,6 @@ describe('lambda utils', function () {
     })
 
     describe('setFunctionInfo', function () {
-        let mockLambda: LambdaFunction
-
-        beforeEach(function () {
-            mockLambda = {
-                name: 'test-function',
-                region: 'us-east-1',
-                configuration: { FunctionName: 'test-function' },
-            }
-        })
-
         afterEach(function () {
             sinon.restore()
         })
@@ -151,16 +140,6 @@ describe('lambda utils', function () {
     })
 
     describe('compareCodeSha', function () {
-        let mockLambda: LambdaFunction
-
-        beforeEach(function () {
-            mockLambda = {
-                name: 'test-function',
-                region: 'us-east-1',
-                configuration: { FunctionName: 'test-function' },
-            }
-        })
-
         afterEach(function () {
             sinon.restore()
         })


### PR DESCRIPTION
## Problem
Duplicate code linter was finding errors in the `utils` tests for Lambda

## Solution
Remove duplicate code (now relying on already existing `mockLambda`)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
