### PR TITLE
fix(amazonq): Reduce plugin start-up latency

### DIFF
--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Auth, AuthUtils, CredentialsStore, LoginManager, initializeAuth } from 'aws-core-vscode/auth'
+import { AuthUtils, CredentialsStore, LoginManager, initializeAuth } from 'aws-core-vscode/auth'
 import { activate as activateCodeWhisperer, shutdown as shutdownCodeWhisperer } from 'aws-core-vscode/codewhisperer'
 import { makeEndpointsProvider, registerGenericCommands } from 'aws-core-vscode'
 import { CommonAuthWebview } from 'aws-core-vscode/login'
@@ -44,7 +44,6 @@ import * as vscode from 'vscode'
 import { registerCommands } from './commands'
 import { focusAmazonQPanel } from 'aws-core-vscode/codewhispererChat'
 import { activate as activateAmazonqLsp } from './lsp/activation'
-import { activate as activateInlineCompletion } from './app/inline/activation'
 import { hasGlibcPatch } from './lsp/client'
 
 export const amazonQContextPrefix = 'amazonq'
@@ -126,16 +125,10 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
 
     // This contains every lsp agnostic things (auth, security scan, code scan)
     await activateCodeWhisperer(extContext as ExtContext)
-    if (
-        (Experiments.instance.get('amazonqLSP', true) || Auth.instance.isInternalAmazonUser()) &&
-        (!isAmazonLinux2() || hasGlibcPatch())
-    ) {
-        // start the Amazon Q LSP for internal users first
-        // for AL2, start LSP if glibc patch is found
+
+    if (!isAmazonLinux2() || hasGlibcPatch()) {
+        // Activate Amazon Q LSP for everyone unless they're using AL2 without the glibc patch
         await activateAmazonqLsp(context)
-    }
-    if (!Experiments.instance.get('amazonqLSPInline', true)) {
-        await activateInlineCompletion()
     }
 
     // Generic extension commands

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -634,6 +634,12 @@ const registerToolkitApiCallbackOnce = once(() => {
 export const registerToolkitApiCallback = Commands.declare(
     { id: 'aws.amazonq.refreshConnectionCallback' },
     () => async (toolkitApi?: any) => {
+        // Early return if already registered to avoid duplicate work
+        if (_toolkitApi) {
+            getLogger().debug('Toolkit API callback already registered, skipping')
+            return
+        }
+
         // While the Q/CW exposes an API for the Toolkit to register callbacks on auth changes,
         // we need to do it manually here because the Toolkit would have been unable to call
         // this API if the Q/CW extension started afterwards (and this code block is running).

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -77,7 +77,7 @@ export class RegionProfileManager {
                         result: undefined,
                     },
                 },
-                { timeout: 15000, interval: 1500, truthy: true }
+                { timeout: 15000, interval: 500, truthy: true }
             )
         }
 

--- a/packages/core/src/shared/featureConfig.ts
+++ b/packages/core/src/shared/featureConfig.ts
@@ -55,6 +55,9 @@ export const featureDefinitions = new Map<FeatureName, FeatureContext>([
 
 export class FeatureConfigProvider {
     private featureConfigs = new Map<string, FeatureContext>()
+    private fetchPromise: Promise<void> | undefined = undefined
+    private lastFetchTime = 0
+    private readonly minFetchInterval = 5000 // 5 seconds minimum between fetches
 
     static #instance: FeatureConfigProvider
 
@@ -123,6 +126,28 @@ export class FeatureConfigProvider {
             return
         }
 
+        // Debounce multiple concurrent calls
+        const now = performance.now()
+        if (this.fetchPromise && now - this.lastFetchTime < this.minFetchInterval) {
+            getLogger().debug('amazonq: Debouncing feature config fetch')
+            return this.fetchPromise
+        }
+
+        if (this.fetchPromise) {
+            return this.fetchPromise
+        }
+
+        this.lastFetchTime = now
+        this.fetchPromise = this._fetchFeatureConfigsInternal()
+
+        try {
+            await this.fetchPromise
+        } finally {
+            this.fetchPromise = undefined
+        }
+    }
+
+    private async _fetchFeatureConfigsInternal(): Promise<void> {
         getLogger().debug('amazonq: Fetching feature configs')
         try {
             const response = await this.listFeatureEvaluations()

--- a/packages/core/src/shared/utilities/resourceCache.ts
+++ b/packages/core/src/shared/utilities/resourceCache.ts
@@ -60,6 +60,21 @@ export abstract class CachedResource<V> {
     abstract resourceProvider(): Promise<V>
 
     async getResource(): Promise<V> {
+        // Check cache without locking first
+        const quickCheck = this.readCacheOrDefault()
+        if (quickCheck.resource.result && !quickCheck.resource.locked) {
+            const duration = now() - quickCheck.resource.timestamp
+            if (duration < this.expirationInMilli) {
+                logger.debug(
+                    `cache hit (fast path), duration(%sms) is less than expiration(%sms), returning cached value: %s`,
+                    duration,
+                    this.expirationInMilli,
+                    this.key
+                )
+                return quickCheck.resource.result
+            }
+        }
+
         const cachedValue = await this.tryLoadResourceAndLock()
         const resource = cachedValue?.resource
 


### PR DESCRIPTION
## Problem

Performance analysis of the Amazon Q extension revealed significant startup latency issues, with the extension taking over 9 seconds to fully initialize. A detailed timing analysis identified several critical bottlenecks in the startup sequence, particularly around resource caching, LSP initialization, and feature configuration. These bottlenecks negatively impact user experience during IDE startup and extension activation.


## Solution

- **File:** [extension.ts](https://github.com/aws/aws-toolkit-vscode/pull/7673/files#diff-864d212c3cfe80d9fd863446a284ac78f32841f4a2473fc045eb44da2125ef34)
    - Call `activateAmazonqLsp` for everyone unless that person is using AL2 and they do not have glibc patch
    - Remove `activateInlineCompletion` since it is for the old inline completion
- **File:** [basicCommands.ts](https://github.com/aws/aws-toolkit-vscode/pull/7673/files#diff-3e5188bbea2cb8eee63d6c55b0bc903477762c8ed20016f062214accfa84ce02)
     - Added early return check to avoid duplicate registrations
- **File:** [regionProfileManager.ts](https://github.com/aws/aws-toolkit-vscode/pull/7673/files#diff-f5716036a70a8b212e9dae829ec09e33731f181c173a3f2b9ad9d361d51af14b)
     - Reduced polling interval from 1500ms to 500ms
- **File:** [featureConfig.ts](https://github.com/aws/aws-toolkit-vscode/pull/7673/files#diff-36d7708a6fdc6ffbcd86fa4ed20b2a0a0d3f02706afea263e81fe3bd8cba9a35)
     - Added debouncing mechanism to prevent duplicate API calls
     - Added time-based throttling with 5-second minimum interval
- **File:** [resourceCache.ts](https://github.com/aws/aws-toolkit-vscode/pull/7673/files#diff-6d4c5c28f1db15fcd36776b0a2331e9e96eeb53d2c64b0612a93241ea04a8b7c)
     - Added fast-path cache check to avoid locking for fresh cache hits


## Testing

Performance testing was conducted to measure the impact of the optimizations on Amazon Q extension startup time. Tests were performed on both a test package workspace and an empty workspace, with multiple runs to ensure consistency.

### Test Results
**Production Build (Latest):**

- Tests Package: 8.1s, 9.7s, 8.8s, 9.7s (Average: 9.1s)

- Empty Workspace: 8.9s, 10.1s, 10.0s, 8.8s (Average: 9.5s)

**Optimized Build (This PR):**

- Tests Package: 6.7s, 7.6s, 7.5s, 8.9s (Average: 7.7s)

- Empty Workspace: 6.9s, 7.6s, 6.8s, 7.6s (Average: 7.2s)

**Performance Improvement**
- Tests Package: 15.4% faster startup (9.1s → 7.7s)

- Empty Workspace: 24.2% faster startup (9.5s → 7.2s)

- Overall Average: 19.8% improvement in startup time

The optimizations show consistent performance gains across different workspace types. The reduced startup time enhances user experience by making the extension more responsive during IDE initialization.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
