### PR TITLE
fix(sagemaker): Fix race-condition with multiple remote spaces trying to reconnect

### DIFF
--- a/packages/core/resources/sagemaker_connect
+++ b/packages/core/resources/sagemaker_connect
@@ -9,13 +9,16 @@ _get_ssm_session_info() {
 
     local url_to_get_session_info="http://localhost:${local_endpoint_port}/get_session?connection_identifier=${aws_resource_arn}&credentials_type=${credentials_type}"
 
+    # Generate unique temporary file name to avoid conflicts
+    local temp_file="/tmp/ssm_session_response_$$_$(date +%s%N).json"
+
     # Use curl with --write-out to capture HTTP status
-    response=$(curl -s -w "%{http_code}" -o /tmp/ssm_session_response.json "$url_to_get_session_info")
+    response=$(curl -s -w "%{http_code}" -o "$temp_file" "$url_to_get_session_info")
     http_status="${response: -3}"
-    session_json=$(cat /tmp/ssm_session_response.json)
+    session_json=$(cat "$temp_file")
     
     # Clean up temporary file
-    rm -f /tmp/ssm_session_response.json
+    rm -f "$temp_file"
 
     if [[ "$http_status" -ne 200 ]]; then
         echo "Error: Failed to get SSM session info. HTTP status: $http_status"
@@ -40,16 +43,21 @@ _get_ssm_session_info_async() {
     local url_base="http://localhost:${local_endpoint_port}/get_session_async"
     local url_to_get_session_info="${url_base}?connection_identifier=${aws_resource_arn}&credentials_type=${credentials_type}&request_id=${request_id}"
 
+    # Generate unique temporary file name to avoid conflicts
+    local temp_file="/tmp/ssm_session_response_$$_$(date +%s%N).json"
+
     local max_retries=60
     local retry_interval=5
     local attempt=1
 
     while (( attempt <= max_retries )); do
-        response=$(curl -s -w "%{http_code}" -o /tmp/ssm_session_response.json "$url_to_get_session_info")
+        response=$(curl -s -w "%{http_code}" -o "$temp_file" "$url_to_get_session_info")
         http_status="${response: -3}"
-        session_json=$(cat /tmp/ssm_session_response.json)
+        session_json=$(cat "$temp_file")
 
         if [[ "$http_status" -eq 200 ]]; then
+            # Clean up temporary file on success
+            rm -f "$temp_file"
             export SSM_SESSION_JSON="$session_json"
             return 0
         elif [[ "$http_status" -eq 202 || "$http_status" -eq 204 ]]; then
@@ -59,10 +67,14 @@ _get_ssm_session_info_async() {
         else
             echo "Error: Failed to get SSM session info. HTTP status: $http_status"
             echo "Response: $session_json"
+            # Clean up temporary file on error
+            rm -f "$temp_file"
             exit 1
         fi
     done
 
+    # Clean up temporary file on timeout
+    rm -f "$temp_file"
     echo "Error: Timed out after $max_retries attempts waiting for session to be ready."
     exit 1
 }

--- a/packages/core/src/awsService/sagemaker/detached-server/utils.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/utils.ts
@@ -18,6 +18,10 @@ export { open }
 export const mappingFilePath = join(os.homedir(), '.aws', '.sagemaker-space-profiles')
 const tempFilePath = `${mappingFilePath}.tmp`
 
+// Simple file lock to prevent concurrent writes
+let isWriting = false
+const writeQueue: Array<() => Promise<void>> = []
+
 /**
  * Reads the local endpoint info file (default or via env) and returns pid & port.
  * @throws Error if the file is missing, invalid JSON, or missing fields
@@ -100,14 +104,45 @@ export async function readMapping() {
 }
 
 /**
+ * Processes the write queue to ensure only one write operation happens at a time.
+ */
+async function processWriteQueue() {
+    if (isWriting || writeQueue.length === 0) {
+        return
+    }
+
+    isWriting = true
+    try {
+        while (writeQueue.length > 0) {
+            const writeOperation = writeQueue.shift()!
+            await writeOperation()
+        }
+    } finally {
+        isWriting = false
+    }
+}
+
+/**
  * Writes the mapping to a temp file and atomically renames it to the target path.
+ * Uses a queue to prevent race conditions when multiple requests try to write simultaneously.
  */
 export async function writeMapping(mapping: SpaceMappings) {
-    try {
-        const json = JSON.stringify(mapping, undefined, 2)
-        await fs.writeFile(tempFilePath, json)
-        await fs.rename(tempFilePath, mappingFilePath)
-    } catch (err) {
-        throw new Error(`Failed to write mapping file: ${err instanceof Error ? err.message : String(err)}`)
-    }
+    return new Promise<void>((resolve, reject) => {
+        const writeOperation = async () => {
+            try {
+                // Generate unique temp file name to avoid conflicts
+                const uniqueTempPath = `${tempFilePath}.${process.pid}.${Date.now()}`
+
+                const json = JSON.stringify(mapping, undefined, 2)
+                await fs.writeFile(uniqueTempPath, json)
+                await fs.rename(uniqueTempPath, mappingFilePath)
+                resolve()
+            } catch (err) {
+                reject(new Error(`Failed to write mapping file: ${err instanceof Error ? err.message : String(err)}`))
+            }
+        }
+
+        writeQueue.push(writeOperation)
+        processWriteQueue().catch(reject)
+    })
 }


### PR DESCRIPTION
## Problem
- When reconnecting to multiple SageMaker Spaces (either via deeplink or from within the VS Code extension), a **race condition** occurs when writing to shared temporary files. This can cause the local SageMaker server to crash due to concurrent access.

## Solution
- For connections initiated from the VS Code extension, we generate **unique temporary files** to read the response json.
- For deeplink-based reconnections, we introduce a **queue** to process session requests sequentially.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
