### PR TITLE
fix(amazonq): should check if partialResultToken is empty for EDITS trigger on acceptance

### DIFF
--- a/packages/amazonq/src/app/inline/sessionManager.ts
+++ b/packages/amazonq/src/app/inline/sessionManager.ts
@@ -77,8 +77,8 @@ export class SessionManager {
         this._acceptedSuggestionCount += 1
     }
 
-    public updateActiveEditsStreakToken(partialResultToken?: number | string) {
-        if (!this.activeSession || !partialResultToken) {
+    public updateActiveEditsStreakToken(partialResultToken: number | string) {
+        if (!this.activeSession) {
             return
         }
         this.activeSession.editsStreakPartialResultToken = partialResultToken


### PR DESCRIPTION

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
