### PR TITLE
fix(amazonq): remove feature flag for CodeReview tool, update change logs

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-a0140eaf-abe8-43ae-9ea1-f0b1afcbc962.json
+++ b/packages/amazonq/.changes/next-release/Feature-a0140eaf-abe8-43ae-9ea1-f0b1afcbc962.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "QCodeReview tool will update CodeIssues panel along with quick action - `/review`"
-}

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -168,7 +168,6 @@ export async function startLanguageServer(
                         reroute: true,
                         modelSelection: true,
                         workspaceFilePath: vscode.workspace.workspaceFile?.fsPath,
-                        qCodeReviewInChat: true,
                     },
                     window: {
                         notifications: true,


### PR DESCRIPTION
## Problem

- Removing feature flag for Code Review tool
- Removed change logs for the above too

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
