### PR TITLE
fix(amazonq): skip edit suggestion if applyDiff fail

### DIFF
--- a/packages/amazonq/src/app/inline/EditRendering/imageRenderer.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/imageRenderer.ts
@@ -29,6 +29,7 @@ export async function showEdits(
         const { svgImage, startLine, newCode, origionalCodeHighlightRange } =
             await svgGenerationService.generateDiffSvg(currentFile, item.insertText as string)
 
+        // TODO: To investigate why it fails and patch [generateDiffSvg]
         if (newCode.length === 0) {
             getLogger('nextEditPrediction').warn('not able to apply provided edit suggestion, skip rendering')
             return

--- a/packages/amazonq/src/app/inline/EditRendering/imageRenderer.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/imageRenderer.ts
@@ -29,6 +29,11 @@ export async function showEdits(
         const { svgImage, startLine, newCode, origionalCodeHighlightRange } =
             await svgGenerationService.generateDiffSvg(currentFile, item.insertText as string)
 
+        if (newCode.length === 0) {
+            getLogger('nextEditPrediction').warn('not able to apply provided edit suggestion, skip rendering')
+            return
+        }
+
         if (svgImage) {
             // display the SVG image
             await displaySvgDecoration(


### PR DESCRIPTION
## Problem

applyDiff may fail and the consequence is the `newCode` to update become empty string, thus deleting all users' code.


## Before

https://github.com/user-attachments/assets/6524bae2-1374-452d-bb4e-3ec6f865c258






## After



https://github.com/user-attachments/assets/75d5ed7a-6940-4432-a8d9-73c485afb2c3



## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
