### PR TITLE
feat(amazonq): added logs of toolkit to the same disk file too

### DIFF
--- a/packages/amazonq/src/extension.ts
+++ b/packages/amazonq/src/extension.ts
@@ -45,6 +45,7 @@ import { registerCommands } from './commands'
 import { focusAmazonQPanel } from 'aws-core-vscode/codewhispererChat'
 import { activate as activateAmazonqLsp } from './lsp/activation'
 import { hasGlibcPatch } from './lsp/client'
+import { RotatingLogChannel } from './lsp/rotatingLogChannel'
 
 export const amazonQContextPrefix = 'amazonq'
 
@@ -103,7 +104,12 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     globals.manifestPaths.endpoints = context.asAbsolutePath(join('resources', 'endpoints.json'))
     globals.regionProvider = RegionProvider.fromEndpointsProvider(makeEndpointsProvider())
 
-    const qLogChannel = vscode.window.createOutputChannel('Amazon Q Logs', { log: true })
+    // Create rotating log channel for all Amazon Q logs
+    const qLogChannel = new RotatingLogChannel(
+        'Amazon Q Logs',
+        context,
+        vscode.window.createOutputChannel('Amazon Q Logs', { log: true })
+    )
     await activateLogger(context, amazonQContextPrefix, qLogChannel)
     globals.logOutputChannel = qLogChannel
     globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
@@ -111,6 +117,8 @@ export async function activateAmazonQCommon(context: vscode.ExtensionContext, is
     if (homeDirLogs.length > 0) {
         getLogger().error('fs.init: invalid env vars found: %O', homeDirLogs)
     }
+
+    getLogger().info('Rotating logger has been setup')
 
     await activateTelemetry(context, globals.awsContext, Settings.instance, 'Amazon Q For VS Code')
 


### PR DESCRIPTION
## Problem
LSP logs were being forwarded to the disk log. 

## Solution
Added extension logs also to set that would get printed on the disk.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
