### PR TITLE
feat(auth): Display second quickpick for SSO linked IAM profiles

### DIFF
--- a/packages/toolkit/.changes/next-release/Feature-852d6637-ac3c-4b7f-b846-649d23da87e3.json
+++ b/packages/toolkit/.changes/next-release/Feature-852d6637-ac3c-4b7f-b846-649d23da87e3.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Improved connection actions for SSO"
+}


### PR DESCRIPTION
## Problem
For customers using SSO with IAM Identity Center, the select connection quickpick looks like this:
<img width="611" height="228" alt="Screenshot 2025-07-18 at 12 06 22 PM" src="https://github.com/user-attachments/assets/b7ef8eaf-d853-4dc4-8e51-12ba9c9e35da" />
In this screenshot, I have 2 profiles configured to be using IdC, as well as 2 profiles using access keys at the bottom. In addition, there are the `PowerUserAccess` IAM credentials that are associated with my SSO profiles, although it's not clear which one. It is also not clear to me that in order to be properly set up to use Toolkit features, I must select the IAM credential sourced from the IdC. This is backed up by data from the recently launched Console to IDE project (mostly launched in #7601) that shows that when entering the quickpick through the introduced URI handler, many customers fail with an error of `CredentialsProviderError: Profile <profile identifier> was not found.` This error is a result of clicking the IdC profile when not logged in.


## Solution
To make it more clear that the user needs to select an IAM credential, this PR introduces a second quick pick that appears after the user has selected the IdC profile. The select connection quickpick now looks like this:
<img width="605" height="224" alt="Screenshot 2025-07-18 at 12 18 25 PM" src="https://github.com/user-attachments/assets/7a8cdb0c-7c91-41a7-b0eb-ce2912b58e18" />
The update is that an IAM IdC profile with a linked role now displays that information. Upon clicking that option, a new quickpick appears:
<img width="611" height="92" alt="Screenshot 2025-07-18 at 12 20 09 PM" src="https://github.com/user-attachments/assets/c20479b4-bf8d-4229-bc31-7690f36df148" />
Selecting this IAM credential does activate the correct profile and allows users to continue as if they'd selected it in the first quick pick.

This change is only based in the UI, and does not affect how these linkages are calculated.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
