### PR TITLE
fix(amazonq): match rotating logger level

### DIFF
--- a/packages/amazonq/src/lsp/rotatingLogChannel.ts
+++ b/packages/amazonq/src/lsp/rotatingLogChannel.ts
@@ -12,7 +12,6 @@ export class RotatingLogChannel implements vscode.LogOutputChannel {
     private fileStream: fs.WriteStream | undefined
     private originalChannel: vscode.LogOutputChannel
     private logger = getLogger('amazonqLsp')
-    private _logLevel: vscode.LogLevel = vscode.LogLevel.Info
     private currentFileSize = 0
     // eslint-disable-next-line @typescript-eslint/naming-convention
     private readonly MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
@@ -133,7 +132,7 @@ export class RotatingLogChannel implements vscode.LogOutputChannel {
     }
 
     get logLevel(): vscode.LogLevel {
-        return this._logLevel
+        return this.originalChannel.logLevel
     }
 
     get onDidChangeLogLevel(): vscode.Event<vscode.LogLevel> {

--- a/packages/amazonq/src/test/rotatingLogChannel.test.ts
+++ b/packages/amazonq/src/test/rotatingLogChannel.test.ts
@@ -161,4 +161,32 @@ describe('RotatingLogChannel', () => {
         assert.ok(content.includes('[WARN]'), 'Should include WARN level')
         assert.ok(content.includes('[ERROR]'), 'Should include ERROR level')
     })
+
+    it('delegates log level to the original channel', () => {
+        // Set up a mock output channel with a specific log level
+        const mockChannel = {
+            ...mockOutputChannel,
+            logLevel: vscode.LogLevel.Trace,
+        }
+
+        // Create a new log channel with the mock
+        const testLogChannel = new RotatingLogChannel('test-delegate', mockExtensionContext, mockChannel)
+
+        // Verify that the log level is delegated correctly
+        assert.strictEqual(
+            testLogChannel.logLevel,
+            vscode.LogLevel.Trace,
+            'Should delegate log level to original channel'
+        )
+
+        // Change the mock's log level
+        mockChannel.logLevel = vscode.LogLevel.Debug
+
+        // Verify that the change is reflected
+        assert.strictEqual(
+            testLogChannel.logLevel,
+            vscode.LogLevel.Debug,
+            'Should reflect changes to original channel log level'
+        )
+    })
 })


### PR DESCRIPTION
## Problem
When replacing the overall logger, log level gets overwritten. 

## Solution
Customized the logger level.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
