### PR TITLE
telemetry(lambda): nit to use sessionDuration correctly for debug duration

### DIFF
--- a/packages/core/src/lambda/remoteDebugging/ldkController.ts
+++ b/packages/core/src/lambda/remoteDebugging/ldkController.ts
@@ -729,7 +729,7 @@ export class RemoteDebugController {
                 )
                 return
             }
-            span.record({ duration: this.lastDebugStartTime === 0 ? 0 : Date.now() - this.lastDebugStartTime })
+            span.record({ sessionDuration: this.lastDebugStartTime === 0 ? 0 : Date.now() - this.lastDebugStartTime })
             try {
                 await vscode.window.withProgress(
                     {

--- a/packages/core/src/lambda/remoteDebugging/ldkController.ts
+++ b/packages/core/src/lambda/remoteDebugging/ldkController.ts
@@ -729,6 +729,7 @@ export class RemoteDebugController {
                 )
                 return
             }
+            // use sessionDuration to record debug duration
             span.record({ sessionDuration: this.lastDebugStartTime === 0 ? 0 : Date.now() - this.lastDebugStartTime })
             try {
                 await vscode.window.withProgress(


### PR DESCRIPTION
## Problem
This change has no customer facing impact.
duration -> sessionDuration (correct)
Previously this metrics is wrongly recorded to duration and got overwritten by the metrics wrapper

## Solution
Change to use sessionDuration correctly

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
