### PR TITLE
fix(amazonq): NPM script fixes for UI E2E Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "test": "npm run test -w packages/ --if-present",
         "testWeb": "npm run testWeb -w packages/ --if-present",
         "testE2E": "npm run testE2E -w packages/ --if-present",
-        "test:ui:prepare": "./node_modules/.bin/extest get-vscode -s ~/.vscode-test-resources -n && extest get-chromedriver -s ~/.vscode-test-resources -n",
+        "test:ui:setup": "./node_modules/.bin/extest get-vscode -s ~/.vscode-test-resources -n && extest get-chromedriver -s ~/.vscode-test-resources -n",
         "test:ui:install": "cd packages/amazonq && npm run package 2>&1 | grep -o 'VSIX Version: [^ ]*' | cut -d' ' -f3 | xargs -I{} bash -c 'cd ../../ && ./node_modules/.bin/extest install-vsix -f amazon-q-vscode-{}.vsix -e packages/amazonq/test/e2e_new/amazonq/resources -s ~/.vscode-test-resources'",
         "test:ui:run": "npm run testCompile && ./node_modules/.bin/extest run-tests -s ~/.vscode-test-resources -e packages/amazonq/test/e2e_new/amazonq/resources packages/amazonq/dist/test/e2e_new/amazonq/tests/*.js",
         "test:ui": "npm run test:ui:prepare && npm run test:ui:install && npm run test:ui:run",


### PR DESCRIPTION
## Problem
In my previous PR, the NPM script referenced the old e2e testing directory. This causes problems with our script that does not allow for multiple tests to be run at the same time and improper placement of resources and screenshot failures from tests.

## Solution
With this new PR and changes to the npm scripts, we properly reference the correct directories for our resource management and use regex to properly reference all of the .js files for the UI tests.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
