### PR TITLE
feat(stepfunctions) Start Execution launching Execution Details

### DIFF
--- a/packages/core/src/stepFunctions/vue/executeStateMachine/executeStateMachine.ts
+++ b/packages/core/src/stepFunctions/vue/executeStateMachine/executeStateMachine.ts
@@ -15,6 +15,7 @@ import { ExtContext } from '../../../shared/extensions'
 import { VueWebview } from '../../../webviews/main'
 import * as vscode from 'vscode'
 import { telemetry } from '../../../shared/telemetry/telemetry'
+import { ExecutionDetailProvider } from '../../executionDetails/executionDetailProvider'
 
 interface StateMachine {
     arn: string
@@ -61,6 +62,10 @@ export class ExecuteStateMachineWebview extends VueWebview {
                 stateMachineArn: this.stateMachine.arn,
                 input,
             })
+            await ExecutionDetailProvider.openExecutionDetails(
+                startExecResponse.executionArn!,
+                startExecResponse.startDate!.toString()
+            )
             this.logger.info('started execution for Step Functions State Machine')
             this.channel.appendLine(localize('AWS.stepFunctions.executeStateMachine.info.started', 'Execution started'))
             this.channel.appendLine(startExecResponse.executionArn || '')


### PR DESCRIPTION
## Problem
Currently Start Execution only outputs the execution arn to the output

## Solution
Adding a call to execution detail provider after starting an execution, launching the execution details webview ( Also works with express executions )

## Verification
![test8](https://github.com/user-attachments/assets/9c000d28-3563-42d0-aa93-5945ea4ba7c0)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
