### PR TITLE
fix(amazonq): point to the log file inside the folder

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -447,13 +447,15 @@ export function registerMessageListeners(
                     )
 
                     // Get the log directory path
-                    const logPath = globals.context.logUri?.fsPath
+                    const logFolderPath = globals.context.logUri?.fsPath
                     const result = { ...message.params, success: false }
 
-                    if (logPath) {
+                    if (logFolderPath) {
                         // Open the log directory in the OS file explorer directly
                         languageClient.info('[VSCode Client] Opening logs directory')
-                        await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(logPath))
+                        const path = require('path')
+                        const logFilePath = path.join(logFolderPath, 'Amazon Q Logs.log')
+                        await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(logFilePath))
                         result.success = true
                     } else {
                         // Fallback: show error if log path is not available


### PR DESCRIPTION
## Problem
Log folder was getting highlighted instead of the file. 

## Solution
Pointed to the file itself instead of the folder.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
