### PR TITLE
feat(amazonq): added show logs to the top menu bar dropdown

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -409,6 +409,11 @@
                     "group": "2_amazonQ@4"
                 },
                 {
+                    "command": "aws.amazonq.showLogs",
+                    "when": "view == aws.amazonq.AmazonQChatView",
+                    "group": "1_amazonQ@5"
+                },
+                {
                     "command": "aws.amazonq.reconnect",
                     "when": "(view == aws.amazonq.AmazonQChatView) && aws.codewhisperer.connectionExpired",
                     "group": "2_amazonQ@3"
@@ -633,6 +638,12 @@
             {
                 "command": "aws.amazonq.openReferencePanel",
                 "title": "%AWS.command.codewhisperer.openReferencePanel%",
+                "category": "%AWS.amazonq.title%",
+                "enablement": "aws.codewhisperer.connected"
+            },
+            {
+                "command": "aws.amazonq.showLogs",
+                "title": "%AWS.command.codewhisperer.showLogs%",
                 "category": "%AWS.amazonq.title%",
                 "enablement": "aws.codewhisperer.connected"
             },

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -275,6 +275,7 @@
     "AWS.command.codewhisperer.signout": "Sign Out",
     "AWS.command.codewhisperer.reconnect": "Reconnect",
     "AWS.command.codewhisperer.openReferencePanel": "Open Code Reference Log",
+    "AWS.command.codewhisperer.showLogs": "Show Logs",
     "AWS.command.q.selectRegionProfile": "Select Profile",
     "AWS.command.q.transform.acceptChanges": "Accept",
     "AWS.command.q.transform.rejectChanges": "Reject",

--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -23,6 +23,7 @@ import {
     enableCodeSuggestions,
     toggleCodeSuggestions,
     showReferenceLog,
+    showLogs,
     showSecurityScan,
     showLearnMore,
     showSsoSignIn,
@@ -299,6 +300,7 @@ export async function activate(context: ExtContext): Promise<void> {
         ),
         vscode.window.registerWebviewViewProvider(ReferenceLogViewProvider.viewType, ReferenceLogViewProvider.instance),
         showReferenceLog.register(),
+        showLogs.register(),
         showExploreAgentsView.register(),
         vscode.languages.registerCodeLensProvider(
             [...CodeWhispererConstants.platformLanguageIds],

--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -147,6 +147,32 @@ export const showReferenceLog = Commands.declare(
     }
 )
 
+export const showLogs = Commands.declare(
+    { id: 'aws.amazonq.showLogs', compositeKey: { 1: 'source' } },
+    () => async (_: VsCodeCommandArg, source: CodeWhispererSource) => {
+        if (_ !== placeholder) {
+            source = 'ellipsesMenu'
+        }
+
+        // Show warning message without buttons - just informational
+        void vscode.window.showWarningMessage(
+            'Log files may contain sensitive information such as account IDs, resource names, and other data. Be careful when sharing these logs.'
+        )
+
+        // Get the log directory path
+        const logFolderPath = globals.context.logUri?.fsPath
+        const path = require('path')
+        const logFilePath = path.join(logFolderPath, 'Amazon Q Logs.log')
+        if (logFilePath) {
+            // Open the log directory in the OS file explorer directly
+            await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(logFilePath))
+        } else {
+            // Fallback: show error if log path is not available
+            void vscode.window.showErrorMessage('Log location not available.')
+        }
+    }
+)
+
 export const showExploreAgentsView = Commands.declare(
     { id: 'aws.amazonq.exploreAgents', compositeKey: { 1: 'source' } },
     () => async (_: VsCodeCommandArg, source: CodeWhispererSource) => {


### PR DESCRIPTION
## Problem
Needed to add a new drop down show logs button at the top. Having just a web view button would lead to this functionality not work incase the LS doesnt work.

## Solution
Added the same show logs functionality in the top drop down.
<img width="933" height="448" alt="image" src="https://github.com/user-attachments/assets/00121f11-52b6-4aba-a183-4b2fd10c5c38" />


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
