### PR TITLE
fix(amazonq): disable SageMakerUnifiedStudio for show logs

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -410,7 +410,7 @@
                 },
                 {
                     "command": "aws.amazonq.showLogs",
-                    "when": "view == aws.amazonq.AmazonQChatView",
+                    "when": "!aws.isSageMakerUnifiedStudio",
                     "group": "1_amazonQ@5"
                 },
                 {
@@ -644,8 +644,7 @@
             {
                 "command": "aws.amazonq.showLogs",
                 "title": "%AWS.command.codewhisperer.showLogs%",
-                "category": "%AWS.amazonq.title%",
-                "enablement": "aws.codewhisperer.connected"
+                "category": "%AWS.amazonq.title%"
             },
             {
                 "command": "aws.amazonq.selectRegionProfile",


### PR DESCRIPTION
## Problem
Added another code setting for show logs.

## Solution
Added another code setting for show logs.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
