### PR TITLE
docs(amazonq): Documentation for setting up and running new UI E2E Tests w/ vscode-extension-tester

### DIFF
--- a/docs/TESTPLAN.md
+++ b/docs/TESTPLAN.md
@@ -41,7 +41,7 @@ The test suite has the following categories of tests:
 -   E2E Tests: **slow** tests
     -   Live in `src/testE2E`
     -   These tests are heavier than Integration tests.
-    -   Some E2E tests have a more complicated architecture, described in [TEST_E2E](./TEST_E2E.md)
+    -   Some E2E tests have a more complicated architecture, described in [UI_E2E_Test](./UI_E2E_Test.md)
 -   Performance Tests: **slow** tests
     -   Live in `src/testInteg/perf`.
     -   A subset of integration tests focused on catching performance regressions.

--- a/docs/UI_E2E_Test.md
+++ b/docs/UI_E2E_Test.md
@@ -9,6 +9,8 @@ UI tests use [vscode-extension-tester](https://github.com/redhat-developer/vscod
 npm run test:ui
 ```
 
+Note: All of these commands must be run at the root level aws-toolkit-vscode directory.
+
 ### Individual Commands
 
 #### `test:ui:prepare`
@@ -42,10 +44,6 @@ npm run test:ui:run
 
 -   Compiles test files with `npm run testCompile`
 -   Runs tests matching `packages/amazonq/dist/test/e2e_new/amazonq/tests/*.js`
-
-### E2E New Test Suite
-
-Modern UI testing framework located at `packages/amazonq/test/e2e_new/amazonq/`
 
 #### Directory Structure
 
@@ -120,12 +118,9 @@ describe('Feature Tests', () => {
 -   **Tests won't start**: Verify ChromeDriver/Chrome compatibility
 -   **Permission errors**: Check `~/.vscode-test-resources` permissions
 
-#### Debug and Reset
+#### Reset
 
 ```bash
-# Debug mode
-DEBUG=true npm run test:ui:run
-
 # Reset test environment
 rm -rf ~/.vscode-test-resources
 npm run test:ui:prepare

--- a/docs/UI_E2E_Test.md
+++ b/docs/UI_E2E_Test.md
@@ -1,0 +1,139 @@
+## UI Testing
+
+UI tests use [vscode-extension-tester](https://github.com/redhat-developer/vscode-extension-tester) to test the Amazon Q extension in a real VS Code environment.
+
+### Quick Start
+
+```bash
+# Run complete UI test suite
+npm run test:ui
+```
+
+### Individual Commands
+
+#### `test:ui:prepare`
+
+Downloads VS Code and ChromeDriver to `~/.vscode-test-resources`
+
+```bash
+npm run test:ui:prepare
+```
+
+#### `test:ui:install`
+
+Packages the Amazon Q extension and installs it for testing
+
+```bash
+npm run test:ui:install
+```
+
+-   Runs `npm run package` in amazonq directory
+-   Extracts version from build output
+-   Installs VSIX using `extest install-vsix`
+-   Sets up extension in test environment
+
+#### `test:ui:run`
+
+Compiles TypeScript and runs UI tests
+
+```bash
+npm run test:ui:run
+```
+
+-   Compiles test files with `npm run testCompile`
+-   Runs tests matching `packages/amazonq/dist/test/e2e_new/amazonq/tests/*.js`
+
+### E2E New Test Suite
+
+Modern UI testing framework located at `packages/amazonq/test/e2e_new/amazonq/`
+
+#### Directory Structure
+
+```
+packages/amazonq/test/e2e_new/amazonq/
+├── tests/            # Test files
+│   ├── chat.test.ts
+│   ├── pinContext.test.ts
+│   ├── quickActions.test.ts
+│   └── switchModel.test.ts
+├── helpers/          # Test helpers
+│   ├── pinContextHelper.ts
+│   ├── quickActionsHelper.ts
+│   └── switchModelHelper.ts
+├── utils/            # Testing utilities
+│   ├── authUtils.ts
+│   ├── cleanupUtils.ts
+│   ├── generalUtils.ts
+│   ├── setup.ts
+│   └── testContext.ts
+└── resources/        # Extension config
+    └── extensions.json
+```
+
+#### Test Categories
+
+-   **Chat** - Amazon Q chat functionality
+-   **Pin Context** - Context pinning features
+-   **Quick Actions** - Quick action commands
+-   **Switch Model** - Model switching functionality
+
+### Writing New Tests
+
+1. Create test files in `packages/amazonq/test/e2e_new/amazonq/tests/`
+2. Import utilities from `../utils/`
+3. Use helpers from `../helpers/`
+4. Follow existing patterns for setup/cleanup
+
+#### Example Test Structure
+
+```typescript
+import { describe, it, before, after } from 'mocha'
+import { setupTestContext, cleanupTestContext } from '../utils/setup'
+
+describe('Feature Tests', () => {
+    before(async () => {
+        await setupTestContext()
+    })
+
+    after(async () => {
+        await cleanupTestContext()
+    })
+
+    it('should test functionality', async () => {
+        // Test implementation
+    })
+})
+```
+
+### Prerequisites
+
+-   Node.js and npm
+-   VS Code extension development environment
+-   Chrome/Chromium browser
+
+### Troubleshooting
+
+#### Common Issues
+
+-   **VS Code download fails**: Check internet connection, retry `test:ui:prepare`
+-   **Extension install fails**: Ensure packaging succeeds
+-   **Tests won't start**: Verify ChromeDriver/Chrome compatibility
+-   **Permission errors**: Check `~/.vscode-test-resources` permissions
+
+#### Debug and Reset
+
+```bash
+# Debug mode
+DEBUG=true npm run test:ui:run
+
+# Reset test environment
+rm -rf ~/.vscode-test-resources
+npm run test:ui:prepare
+```
+
+### Test Development Tips
+
+-   Tests should be independent and run in any order
+-   Use existing utilities for common operations
+-   Clean up resources in `after` hooks
+-   Follow naming conventions from existing tests

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "test": "npm run test -w packages/ --if-present",
         "testWeb": "npm run testWeb -w packages/ --if-present",
         "testE2E": "npm run testE2E -w packages/ --if-present",
-        "test:ui:prepare": "./node_modules/.bin/extest get-vscode -s ~/.vscode-test-resources -n && extest get-chromedriver -s ~/.vscode-test-resources -n",
+        "test:ui:setup": "./node_modules/.bin/extest get-vscode -s ~/.vscode-test-resources -n && extest get-chromedriver -s ~/.vscode-test-resources -n",
         "test:ui:install": "cd packages/amazonq && npm run package 2>&1 | grep -o 'VSIX Version: [^ ]*' | cut -d' ' -f3 | xargs -I{} bash -c 'cd ../../ && ./node_modules/.bin/extest install-vsix -f amazon-q-vscode-{}.vsix -e packages/amazonq/test/e2e_new/amazonq/resources -s ~/.vscode-test-resources'",
         "test:ui:run": "npm run testCompile && ./node_modules/.bin/extest run-tests -s ~/.vscode-test-resources -e packages/amazonq/test/e2e_new/amazonq/resources packages/amazonq/dist/test/e2e_new/amazonq/tests/*.js",
         "test:ui": "npm run test:ui:prepare && npm run test:ui:install && npm run test:ui:run",


### PR DESCRIPTION
## Problem
The AWS Toolkit repository lacks documentation for the UI testing commands (test:ui:prepare, test:ui:install, test:ui:run, test:ui) and the new e2e_new testing suite. Contributors need clear guidance on how to run UI tests and understand the testing framework structure.

## Solution
Added comprehensive UI testing documentation covering:

- Command usage and workflow for the complete UI test suite

- Directory structure and organization of the e2e_new testing framework

- Guidelines for writing new UI tests with example code

- Troubleshooting common issues and debug techniques

- Prerequisites and setup requirements

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
