### PR TITLE
fix(amazonq): early stop pagination requests when user decision is made

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -164,6 +164,11 @@ export class InlineCompletionManager implements Disposable {
         const onInlineRejection = async () => {
             try {
                 vsCodeState.isCodeWhispererEditing = true
+                if (this.sessionManager.getActiveSession() === undefined) {
+                    return
+                }
+                const requestStartTime = this.sessionManager.getActiveSession()!.requestStartTime
+                const totalSessionDisplayTime = performance.now() - requestStartTime
                 await commands.executeCommand('editor.action.inlineSuggest.hide')
                 // TODO: also log the seen state for other suggestions in session
                 this.disposable.dispose()
@@ -185,6 +190,7 @@ export class InlineCompletionManager implements Disposable {
                             discarded: false,
                         },
                     },
+                    totalSessionDisplayTime: totalSessionDisplayTime,
                 }
                 this.languageClient.sendNotification(this.logSessionResultMessageName, params)
                 // clear session manager states once rejected

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -319,6 +319,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                             discarded: false,
                         },
                     },
+                    totalSessionDisplayTime: performance.now() - prevSession.requestStartTime,
                 }
                 this.languageClient.sendNotification(this.logSessionResultMessageName, params)
                 this.sessionManager.clear()

--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -15,7 +15,7 @@ import { SessionManager } from './sessionManager'
 import { AuthUtil, CodeWhispererStatusBarManager, vsCodeState } from 'aws-core-vscode/codewhisperer'
 import { TelemetryHelper } from './telemetryHelper'
 import { ICursorUpdateRecorder } from './cursorUpdateManager'
-import { globals, getLogger } from 'aws-core-vscode/shared'
+import { getLogger } from 'aws-core-vscode/shared'
 
 export interface GetAllRecommendationsOptions {
     emitTelemetry?: boolean
@@ -68,7 +68,7 @@ export class RecommendationService {
         if (options.editsStreakToken) {
             request = { ...request, partialResultToken: options.editsStreakToken }
         }
-        const requestStartTime = globals.clock.Date.now()
+        const requestStartTime = performance.now()
         const statusBar = CodeWhispererStatusBarManager.instance
 
         // Only track telemetry if enabled
@@ -117,7 +117,7 @@ export class RecommendationService {
             }
             TelemetryHelper.instance.setFirstSuggestionShowTime()
 
-            const firstCompletionDisplayLatency = globals.clock.Date.now() - requestStartTime
+            const firstCompletionDisplayLatency = performance.now() - requestStartTime
             this.sessionManager.startSession(
                 result.sessionId,
                 result.items,

--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -12,7 +12,7 @@ import {
 import { CancellationToken, InlineCompletionContext, Position, TextDocument } from 'vscode'
 import { LanguageClient } from 'vscode-languageclient'
 import { SessionManager } from './sessionManager'
-import { AuthUtil, CodeWhispererStatusBarManager } from 'aws-core-vscode/codewhisperer'
+import { AuthUtil, CodeWhispererStatusBarManager, vsCodeState } from 'aws-core-vscode/codewhisperer'
 import { TelemetryHelper } from './telemetryHelper'
 import { ICursorUpdateRecorder } from './cursorUpdateManager'
 import { globals, getLogger } from 'aws-core-vscode/shared'
@@ -183,6 +183,11 @@ export class RecommendationService {
                 request,
                 token
             )
+            // when pagination is in progress, but user has already accepted or rejected an inline completion
+            // then stop pagination
+            if (this.sessionManager.getActiveSession() === undefined || vsCodeState.isCodeWhispererEditing) {
+                break
+            }
             this.sessionManager.updateSessionSuggestions(result.items)
             nextToken = result.partialResultToken
         }


### PR DESCRIPTION
## Problem

When a paginated response is in flight, but the user already accepted or rejected a completion, the subsequent paginated requests should be cancelled.

This PR also fixes the `codewhispererTotalShownTime` being negative issue by using performance.now() across all timestamp computation. 


## Solution

This is not a user facing change.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
