### PR TITLE
fix(amazonq): fix line break format when getting the current text document

### DIFF
--- a/packages/amazonq/src/app/inline/EditRendering/svgGenerator.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/svgGenerator.ts
@@ -30,7 +30,7 @@ export class SvgGenerationService {
         origionalCodeHighlightRange: Range[]
     }> {
         const textDoc = await vscode.workspace.openTextDocument(filePath)
-        const originalCode = textDoc.getText()
+        const originalCode = textDoc.getText().replaceAll('\r\n', '\n')
         if (originalCode === '') {
             logger.error(`udiff format error`)
             throw new ToolkitError('udiff format error')

--- a/packages/core/src/shared/utilities/diffUtils.ts
+++ b/packages/core/src/shared/utilities/diffUtils.ts
@@ -25,7 +25,7 @@ import jaroWinkler from 'jaro-winkler'
  */
 export async function getPatchedCode(filePath: string, patch: string, snippetMode = false) {
     const document = await vscode.workspace.openTextDocument(filePath)
-    const fileContent = document.getText()
+    const fileContent = document.getText().replaceAll('\r\n', '\n')
     // Usage with the existing getPatchedCode function:
 
     let updatedPatch = patch


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
