### PR TITLE
fix(amazonq): Faster and more responsive auto trigger UX. 

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-7261a487-e80a-440f-b311-2688e256a886.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-7261a487-e80a-440f-b311-2688e256a886.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Faster and more responsive inline completion UX"
+}

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -976,6 +976,10 @@
                 "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected"
             },
             {
+                "command": "aws.amazonq.checkInlineSuggestionVisibility",
+                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected"
+            },
+            {
                 "command": "aws.amazonq.inline.invokeChat",
                 "win": "ctrl+i",
                 "mac": "cmd+i",

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -164,6 +164,11 @@ export class InlineCompletionManager implements Disposable {
         const onInlineRejection = async () => {
             try {
                 vsCodeState.isCodeWhispererEditing = true
+                if (this.sessionManager.getActiveSession() === undefined) {
+                    return
+                }
+                const requestStartTime = this.sessionManager.getActiveSession()!.requestStartTime
+                const totalSessionDisplayTime = performance.now() - requestStartTime
                 await commands.executeCommand('editor.action.inlineSuggest.hide')
                 // TODO: also log the seen state for other suggestions in session
                 this.disposable.dispose()
@@ -185,6 +190,7 @@ export class InlineCompletionManager implements Disposable {
                             discarded: false,
                         },
                     },
+                    totalSessionDisplayTime: totalSessionDisplayTime,
                 }
                 this.languageClient.sendNotification(this.logSessionResultMessageName, params)
                 // clear session manager states once rejected

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -319,6 +319,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                             discarded: false,
                         },
                     },
+                    totalSessionDisplayTime: performance.now() - prevSession.requestStartTime,
                 }
                 this.languageClient.sendNotification(this.logSessionResultMessageName, params)
                 this.sessionManager.clear()

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -222,8 +222,8 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         // this line is to force VS Code to re-render the inline completion
         // if it decides the inline completion can be shown
         await vscode.commands.executeCommand('editor.action.inlineSuggest.trigger')
-        // yield event loop to let backend state transition finish
-        await sleep(1)
+        // yield event loop to let backend state transition finish plus wait for vsc to render
+        await sleep(10)
         // run the command to detect if inline suggestion is really shown or not
         await vscode.commands.executeCommand(`aws.amazonq.checkInlineSuggestionVisibility`)
     }
@@ -316,7 +316,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                 if (prevItemMatchingPrefix.length > 0) {
                     logstr += `- not call LSP and reuse previous suggestions that match user typed characters
                     - duration between trigger to completion suggestion is displayed ${performance.now() - t0}`
-                    this.checkWhetherInlineCompletionWasShown()
+                    void this.checkWhetherInlineCompletionWasShown()
                     return prevItemMatchingPrefix
                 }
 
@@ -471,7 +471,7 @@ ${itemLog}
             this.sessionManager.updateCodeReferenceAndImports()
             // suggestions returned here will be displayed on screen
             logstr += `- duration between trigger to completion suggestion is displayed: ${performance.now() - t0}ms`
-            this.checkWhetherInlineCompletionWasShown()
+            void this.checkWhetherInlineCompletionWasShown()
             return itemsMatchingTypeahead as InlineCompletionItem[]
         } catch (e) {
             getLogger('amazonqLsp').error('Failed to provide completion items: %O', e)

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -228,6 +228,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         await vscode.commands.executeCommand(`aws.amazonq.checkInlineSuggestionVisibility`)
     }
 
+    // this method is automatically invoked by VS Code as user types
     async provideInlineCompletionItems(
         document: TextDocument,
         position: Position,

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import * as vscode from 'vscode'
 import {
     CancellationToken,
     InlineCompletionContext,
@@ -32,7 +32,6 @@ import {
     ImportAdderProvider,
     CodeSuggestionsState,
     vsCodeState,
-    inlineCompletionsDebounceDelay,
     noInlineSuggestionsMsg,
     getDiagnosticsDifferences,
     getDiagnosticsOfCurrentFile,
@@ -42,7 +41,7 @@ import { LineTracker } from './stateTracker/lineTracker'
 import { InlineTutorialAnnotation } from './tutorials/inlineTutorialAnnotation'
 import { TelemetryHelper } from './telemetryHelper'
 import { Experiments, getLogger, sleep } from 'aws-core-vscode/shared'
-import { debounce, messageUtils } from 'aws-core-vscode/utils'
+import { messageUtils } from 'aws-core-vscode/utils'
 import { showEdits } from './EditRendering/imageRenderer'
 import { ICursorUpdateRecorder } from './cursorUpdateManager'
 import { DocumentEventListener } from './documentEventListener'
@@ -214,13 +213,22 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
     ) {}
 
     private readonly logSessionResultMessageName = 'aws/logInlineCompletionSessionResults'
-    provideInlineCompletionItems = debounce(
-        this._provideInlineCompletionItems.bind(this),
-        inlineCompletionsDebounceDelay,
-        true
-    )
 
-    private async _provideInlineCompletionItems(
+    // Ideally use this API handleDidShowCompletionItem
+    // https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts#L83
+    // we need this because the returned items of provideInlineCompletionItems may not be actually rendered on screen
+    // if VS Code believes the user is actively typing then it will not show such item
+    async checkWhetherInlineCompletionWasShown() {
+        // this line is to force VS Code to re-render the inline completion
+        // if it decides the inline completion can be shown
+        await vscode.commands.executeCommand('editor.action.inlineSuggest.trigger')
+        // yield event loop to let backend state transition finish
+        await sleep(1)
+        // run the command to detect if inline suggestion is really shown or not
+        await vscode.commands.executeCommand(`aws.amazonq.checkInlineSuggestionVisibility`)
+    }
+
+    async provideInlineCompletionItems(
         document: TextDocument,
         position: Position,
         context: InlineCompletionContext,
@@ -307,17 +315,18 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                 if (prevItemMatchingPrefix.length > 0) {
                     logstr += `- not call LSP and reuse previous suggestions that match user typed characters
                     - duration between trigger to completion suggestion is displayed ${performance.now() - t0}`
+                    this.checkWhetherInlineCompletionWasShown()
                     return prevItemMatchingPrefix
                 }
-                getLogger().debug(`Auto rejecting suggestions from previous session`)
-                // if no such suggestions, report the previous suggestion as Reject
+
+                // if no such suggestions, report the previous suggestion as Reject or Discarded
                 const params: LogInlineCompletionSessionResultsParams = {
                     sessionId: prevSessionId,
                     completionSessionResult: {
                         [prevItemId]: {
-                            seen: true,
+                            seen: prevSession.displayed,
                             accepted: false,
-                            discarded: false,
+                            discarded: !prevSession.displayed,
                         },
                     },
                     totalSessionDisplayTime: performance.now() - prevSession.requestStartTime,
@@ -461,6 +470,7 @@ ${itemLog}
             this.sessionManager.updateCodeReferenceAndImports()
             // suggestions returned here will be displayed on screen
             logstr += `- duration between trigger to completion suggestion is displayed: ${performance.now() - t0}ms`
+            this.checkWhetherInlineCompletionWasShown()
             return itemsMatchingTypeahead as InlineCompletionItem[]
         } catch (e) {
             getLogger('amazonqLsp').error('Failed to provide completion items: %O', e)

--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -15,7 +15,7 @@ import { SessionManager } from './sessionManager'
 import { AuthUtil, CodeWhispererStatusBarManager, vsCodeState } from 'aws-core-vscode/codewhisperer'
 import { TelemetryHelper } from './telemetryHelper'
 import { ICursorUpdateRecorder } from './cursorUpdateManager'
-import { globals, getLogger } from 'aws-core-vscode/shared'
+import { getLogger } from 'aws-core-vscode/shared'
 
 export interface GetAllRecommendationsOptions {
     emitTelemetry?: boolean
@@ -68,7 +68,7 @@ export class RecommendationService {
         if (options.editsStreakToken) {
             request = { ...request, partialResultToken: options.editsStreakToken }
         }
-        const requestStartTime = globals.clock.Date.now()
+        const requestStartTime = performance.now()
         const statusBar = CodeWhispererStatusBarManager.instance
 
         // Only track telemetry if enabled
@@ -117,7 +117,7 @@ export class RecommendationService {
             }
             TelemetryHelper.instance.setFirstSuggestionShowTime()
 
-            const firstCompletionDisplayLatency = globals.clock.Date.now() - requestStartTime
+            const firstCompletionDisplayLatency = performance.now() - requestStartTime
             this.sessionManager.startSession(
                 result.sessionId,
                 result.items,

--- a/packages/amazonq/src/app/inline/recommendationService.ts
+++ b/packages/amazonq/src/app/inline/recommendationService.ts
@@ -12,7 +12,7 @@ import {
 import { CancellationToken, InlineCompletionContext, Position, TextDocument } from 'vscode'
 import { LanguageClient } from 'vscode-languageclient'
 import { SessionManager } from './sessionManager'
-import { AuthUtil, CodeWhispererStatusBarManager } from 'aws-core-vscode/codewhisperer'
+import { AuthUtil, CodeWhispererStatusBarManager, vsCodeState } from 'aws-core-vscode/codewhisperer'
 import { TelemetryHelper } from './telemetryHelper'
 import { ICursorUpdateRecorder } from './cursorUpdateManager'
 import { globals, getLogger } from 'aws-core-vscode/shared'
@@ -183,6 +183,11 @@ export class RecommendationService {
                 request,
                 token
             )
+            // when pagination is in progress, but user has already accepted or rejected an inline completion
+            // then stop pagination
+            if (this.sessionManager.getActiveSession() === undefined || vsCodeState.isCodeWhispererEditing) {
+                break
+            }
             this.sessionManager.updateSessionSuggestions(result.items)
             nextToken = result.partialResultToken
         }

--- a/packages/amazonq/src/app/inline/sessionManager.ts
+++ b/packages/amazonq/src/app/inline/sessionManager.ts
@@ -24,6 +24,8 @@ export interface CodeWhispererSession {
     // partialResultToken for the next trigger if user accepts an EDITS suggestion
     editsStreakPartialResultToken?: number | string
     triggerOnAcceptance?: boolean
+    // whether any suggestion in this session was displayed on screen
+    displayed: boolean
 }
 
 export class SessionManager {
@@ -49,6 +51,7 @@ export class SessionManager {
             startPosition,
             firstCompletionDisplayLatency,
             diagnosticsBeforeAccept,
+            displayed: false,
         }
         this._currentSuggestionIndex = 0
     }
@@ -125,6 +128,12 @@ export class SessionManager {
                 (this._currentSuggestionIndex - 1 + this.activeSession.suggestions.length) %
                 this.activeSession.suggestions.length
             this.updateCodeReferenceAndImports()
+        }
+    }
+
+    public checkInlineSuggestionVisibility() {
+        if (this.activeSession) {
+            this.activeSession.displayed = true
         }
     }
 

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -352,6 +352,10 @@ async function onLanguageServerReady(
             await vscode.commands.executeCommand('editor.action.inlineSuggest.showNext')
             sessionManager.onNextSuggestion()
         }),
+        // this is a workaround since handleDidShowCompletionItem is not public API
+        Commands.register('aws.amazonq.checkInlineSuggestionVisibility', async () => {
+            sessionManager.checkInlineSuggestionVisibility()
+        }),
         Commands.register({ id: 'aws.amazonq.invokeInlineCompletion', autoconnect: true }, async () => {
             await vscode.commands.executeCommand('editor.action.inlineSuggest.trigger')
         }),

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -378,7 +378,7 @@ describe('InlineCompletionManager', () => {
                     )
                     await messageShown
                 })
-            describe('debounce behavior', function () {
+            describe.skip('debounce behavior', function () {
                 let clock: ReturnType<typeof installFakeClock>
 
                 beforeEach(function () {

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -389,7 +389,7 @@ describe('InlineCompletionManager', () => {
                     clock.uninstall()
                 })
 
-                it('should only trigger once on rapid events', async () => {
+                it.skip('should only trigger once on rapid events', async () => {
                     provider = new AmazonQInlineCompletionItemProvider(
                         languageClient,
                         recommendationService,


### PR DESCRIPTION
## Problem
1. when intelliSense suggestion is surfaced, inline completion are not shown even if provideInlineCompletionItems have returned valid items.
2. provideInlineCompletionItems is unnecessarily debounced at 200ms which creates a user perceivable delay for inline completion UX. We already blocked concurrent API call. 
3. The items returned by provideInlineCompletionItems, even though they match the typeahead of the user's current editor (they can be presented), sometimes VS Code decides to not show them to avoid interrupting user's typing flow. This not show suggestion decision is not emitted as API callback or events, causing us to report the suggestion as Rejected but it should be Discard.

## Solution

1. Force the item to render by calling `editor.action.inlineSuggest.trigger` command.
<img width="589" height="374" alt="Screenshot 2025-07-24 at 7 45 12 PM" src="https://github.com/user-attachments/assets/f2723ab4-1d94-49e6-bae1-493c2af16bed" />

3. Remove the debounce

5. Use a specific command with when clause context to detect if a suggestion is shown or not.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
