### PR TITLE
fix(amazonq): skip EDITS suggestion if there is no change between current and new code suggestion

### DIFF
--- a/packages/amazonq/src/app/inline/EditRendering/imageRenderer.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/imageRenderer.ts
@@ -26,8 +26,10 @@ export async function showEdits(
         const svgGenerationService = new SvgGenerationService()
         // Generate your SVG image with the file contents
         const currentFile = editor.document.uri.fsPath
-        const { svgImage, startLine, newCode, origionalCodeHighlightRange } =
-            await svgGenerationService.generateDiffSvg(currentFile, item.insertText as string)
+        const { svgImage, startLine, newCode, originalCodeHighlightRange } = await svgGenerationService.generateDiffSvg(
+            currentFile,
+            item.insertText as string
+        )
 
         // TODO: To investigate why it fails and patch [generateDiffSvg]
         if (newCode.length === 0) {
@@ -42,7 +44,7 @@ export async function showEdits(
                 svgImage,
                 startLine,
                 newCode,
-                origionalCodeHighlightRange,
+                originalCodeHighlightRange,
                 session,
                 languageClient,
                 item,

--- a/packages/amazonq/test/unit/app/inline/EditRendering/imageRenderer.test.ts
+++ b/packages/amazonq/test/unit/app/inline/EditRendering/imageRenderer.test.ts
@@ -30,7 +30,7 @@ describe('showEdits', function () {
             svgImage: vscode.Uri.file('/path/to/generated.svg'),
             startLine: 5,
             newCode: 'console.log("Hello World");',
-            origionalCodeHighlightRange: [{ line: 5, start: 0, end: 10 }],
+            originalCodeHighlightRange: [{ line: 5, start: 0, end: 10 }],
             ...overrides,
         }
     }
@@ -167,7 +167,7 @@ describe('showEdits', function () {
             mockSvgResult.svgImage,
             mockSvgResult.startLine,
             mockSvgResult.newCode,
-            mockSvgResult.origionalCodeHighlightRange,
+            mockSvgResult.originalCodeHighlightRange,
             sessionStub,
             languageClientStub,
             itemStub


### PR DESCRIPTION
## Problem

Sometimes we see suggestion at the end of the page because there is no change from original code.


## Solution

skip EDITS suggestion if there is no change between current and new code suggestion

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
