### PR TITLE
feat(stepfunctions): Handling newExecution and editStateMachine 

### DIFF
--- a/packages/core/src/stepFunctions/commands/downloadStateMachineDefinition.ts
+++ b/packages/core/src/stepFunctions/commands/downloadStateMachineDefinition.ts
@@ -17,7 +17,7 @@ import { Result } from '../../shared/telemetry/telemetry'
 import { StateMachineNode } from '../explorer/stepFunctionsNodes'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { fs } from '../../shared/fs/fs'
-import { WorkflowStudioEditorProvider } from '../workflowStudio/workflowStudioEditorProvider'
+import { openWorkflowStudioWithDefinition } from '../utils'
 
 export async function downloadStateMachineDefinition(params: {
     outputChannel: vscode.OutputChannel
@@ -35,16 +35,7 @@ export async function downloadStateMachineDefinition(params: {
             })
 
         if (params.isPreviewAndRender) {
-            const doc = await vscode.workspace.openTextDocument({
-                language: 'asl',
-                content: stateMachineDetails.definition,
-            })
-
-            const textEditor = await vscode.window.showTextDocument(doc)
-            await WorkflowStudioEditorProvider.openWithWorkflowStudio(textEditor.document.uri, {
-                preserveFocus: true,
-                viewColumn: vscode.ViewColumn.Beside,
-            })
+            await openWorkflowStudioWithDefinition(stateMachineDetails.definition)
         } else {
             const wsPath = vscode.workspace.workspaceFolders
                 ? vscode.workspace.workspaceFolders[0].uri.fsPath

--- a/packages/core/src/stepFunctions/commands/downloadStateMachineDefinition.ts
+++ b/packages/core/src/stepFunctions/commands/downloadStateMachineDefinition.ts
@@ -35,7 +35,10 @@ export async function downloadStateMachineDefinition(params: {
             })
 
         if (params.isPreviewAndRender) {
-            await openWorkflowStudioWithDefinition(stateMachineDetails.definition)
+            await openWorkflowStudioWithDefinition(stateMachineDetails.definition, {
+                preserveFocus: true,
+                viewColumn: vscode.ViewColumn.Beside,
+            })
         } else {
             const wsPath = vscode.workspace.workspaceFolders
                 ? vscode.workspace.workspaceFolders[0].uri.fsPath

--- a/packages/core/src/stepFunctions/executionDetails/executionDetailProvider.ts
+++ b/packages/core/src/stepFunctions/executionDetails/executionDetailProvider.ts
@@ -35,7 +35,7 @@ export class ExecutionDetailProvider {
         const panel = vscode.window.createWebviewPanel(
             ExecutionDetailProvider.viewType,
             `Execution: ${executionArn.split(':').pop() || executionArn}`,
-            vscode.ViewColumn.Beside,
+            vscode.ViewColumn.One,
             {
                 enableScripts: true,
                 retainContextWhenHidden: true,

--- a/packages/core/src/stepFunctions/executionDetails/executionDetailProvider.ts
+++ b/packages/core/src/stepFunctions/executionDetails/executionDetailProvider.ts
@@ -96,6 +96,7 @@ export class ExecutionDetailProvider {
      * Initializes a WebView panel with execution details.
      * @param panel The WebView panel to initialize
      * @param executionArn The ARN of the execution to display
+     * @param startTime Optional start time for the execution
      */
     public async initializePanel(panel: vscode.WebviewPanel, executionArn: string, startTime?: string): Promise<void> {
         try {

--- a/packages/core/src/stepFunctions/messageHandlers/types.ts
+++ b/packages/core/src/stepFunctions/messageHandlers/types.ts
@@ -66,6 +66,8 @@ export enum Command {
     CLOSE_WFS = 'CLOSE_WFS',
     API_CALL = 'API_CALL',
     UNSUPPORTED_COMMAND = 'UNSUPPORTED_COMMAND',
+    START_EXECUTION = 'START_EXECUTION',
+    EDIT_STATE_MACHINE = 'EDIT_STATE_MACHINE',
 }
 
 export type FileWatchInfo = {

--- a/packages/core/src/stepFunctions/vue/executeStateMachine/executeStateMachine.ts
+++ b/packages/core/src/stepFunctions/vue/executeStateMachine/executeStateMachine.ts
@@ -16,6 +16,7 @@ import { VueWebview } from '../../../webviews/main'
 import * as vscode from 'vscode'
 import { telemetry } from '../../../shared/telemetry/telemetry'
 import { ExecutionDetailProvider } from '../../executionDetails/executionDetailProvider'
+import { showExecuteStateMachineWebview } from '../../utils'
 
 interface StateMachine {
     arn: string
@@ -88,18 +89,11 @@ export class ExecuteStateMachineWebview extends VueWebview {
     }
 }
 
-const Panel = VueWebview.compilePanel(ExecuteStateMachineWebview)
-
 export async function executeStateMachine(context: ExtContext, node: StateMachineNode): Promise<void> {
-    const wv = new Panel(context.extensionContext, context.outputChannel, {
+    await showExecuteStateMachineWebview({
         arn: node.details.stateMachineArn || '',
         name: node.details.name || '',
         region: node.regionCode,
-    })
-
-    await wv.show({
-        title: localize('AWS.executeStateMachine.title', 'Start Execution'),
-        cssFiles: ['executeStateMachine.css'],
     })
     telemetry.stepfunctions_executeStateMachineView.emit()
 }

--- a/packages/core/src/test/stepFunctions/utils.test.ts
+++ b/packages/core/src/test/stepFunctions/utils.test.ts
@@ -276,6 +276,7 @@ describe('parseExecutionArnForStateMachine', function () {
         const expressArn = 'arn:aws:states:us-east-1:123456789012:express:stateMachine:MyStateMachine:execution-name'
         const result = parseExecutionArnForStateMachine(expressArn)
 
+        assert.ok(result)
         assert.strictEqual(result.region, 'us-east-1')
         assert.strictEqual(result.stateMachineName, 'MyStateMachine')
         assert.strictEqual(result.stateMachineArn, 'arn:aws:states:us-east-1:123456789012:stateMachine:MyStateMachine')
@@ -285,6 +286,7 @@ describe('parseExecutionArnForStateMachine', function () {
         const standardArn = 'arn:aws:states:us-west-2:987654321098:stateMachine:TestMachine:execution-id'
         const result = parseExecutionArnForStateMachine(standardArn)
 
+        assert.ok(result)
         assert.strictEqual(result.region, 'us-west-2')
         assert.strictEqual(result.stateMachineName, 'TestMachine')
         assert.strictEqual(result.stateMachineArn, 'arn:aws:states:us-west-2:987654321098:stateMachine:TestMachine')
@@ -294,6 +296,7 @@ describe('parseExecutionArnForStateMachine', function () {
         const euArn = 'arn:aws:states:eu-west-1:555666777888:stateMachine:EuroMachine:exec-123'
         const result = parseExecutionArnForStateMachine(euArn)
 
+        assert.ok(result)
         assert.strictEqual(result.region, 'eu-west-1')
         assert.strictEqual(result.stateMachineName, 'EuroMachine')
         assert.strictEqual(result.stateMachineArn, 'arn:aws:states:eu-west-1:555666777888:stateMachine:EuroMachine')
@@ -304,6 +307,7 @@ describe('parseExecutionArnForStateMachine', function () {
             'arn:aws:states:ap-southeast-2:111222333444:stateMachine:My-State_Machine.Test:exec-456'
         const result = parseExecutionArnForStateMachine(arnWithSpecialName)
 
+        assert.ok(result)
         assert.strictEqual(result.region, 'ap-southeast-2')
         assert.strictEqual(result.stateMachineName, 'My-State_Machine.Test')
         assert.strictEqual(
@@ -316,6 +320,7 @@ describe('parseExecutionArnForStateMachine', function () {
         const differentAccountArn = 'arn:aws:states:us-central-1:999888777666:stateMachine:AccountTestMachine:exec-789'
         const result = parseExecutionArnForStateMachine(differentAccountArn)
 
+        assert.ok(result)
         assert.strictEqual(result.region, 'us-central-1')
         assert.strictEqual(result.stateMachineName, 'AccountTestMachine')
         assert.strictEqual(

--- a/packages/core/src/test/stepFunctions/utils.test.ts
+++ b/packages/core/src/test/stepFunctions/utils.test.ts
@@ -5,7 +5,14 @@
 
 import assert from 'assert'
 import * as vscode from 'vscode'
-import { isDocumentValid, isStepFunctionsRole } from '../../stepFunctions/utils'
+import {
+    isDocumentValid,
+    isStepFunctionsRole,
+    isInvalidJsonFile,
+    isInvalidYamlFile,
+    isExpressExecution,
+    parseExecutionArnForStateMachine,
+} from '../../stepFunctions/utils'
 import { IamRole } from '../../shared/clients/iam'
 
 describe('isStepFunctionsRole', function () {
@@ -117,5 +124,203 @@ describe('isDocumentValid', async function () {
         const isValid = await isDocumentValid(aslText, textDocument)
 
         assert.ok(!isValid)
+    })
+})
+
+describe('isInvalidJsonFile', function () {
+    it('returns false for valid JSON with ASL language ID', async function () {
+        const validJson = '{"StartAt": "Test", "States": {"Test": {"Type": "Pass", "End": true}}}'
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'asl',
+            content: validJson,
+        })
+
+        assert.strictEqual(isInvalidJsonFile(textDocument), false)
+    })
+
+    it('returns true for invalid JSON with ASL language ID', async function () {
+        const invalidJson = '{"StartAt": "Test", "States": {'
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'asl',
+            content: invalidJson,
+        })
+
+        assert.strictEqual(isInvalidJsonFile(textDocument), true)
+    })
+
+    it('returns false for empty content with ASL language ID', async function () {
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'asl',
+            content: '',
+        })
+
+        assert.strictEqual(isInvalidJsonFile(textDocument), false)
+    })
+
+    it('returns false for whitespace-only content with ASL language ID', async function () {
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'asl',
+            content: '   \n\t  ',
+        })
+
+        assert.strictEqual(isInvalidJsonFile(textDocument), false)
+    })
+
+    it('returns false for valid JSON with non-ASL language ID', async function () {
+        const validJson = '{"test": "value"}'
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'json',
+            content: validJson,
+        })
+
+        assert.strictEqual(isInvalidJsonFile(textDocument), false)
+    })
+
+    it('returns false for invalid JSON with non-ASL language ID', async function () {
+        const invalidJson = '{"test": invalid}'
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'json',
+            content: invalidJson,
+        })
+
+        assert.strictEqual(isInvalidJsonFile(textDocument), false)
+    })
+})
+
+describe('isInvalidYamlFile', function () {
+    it('returns false for valid YAML with ASL-YAML language ID', async function () {
+        const validYaml = 'StartAt: Test\nStates:\n  Test:\n    Type: Pass\n    End: true'
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'asl-yaml',
+            content: validYaml,
+        })
+
+        assert.strictEqual(isInvalidYamlFile(textDocument), false)
+    })
+
+    it('returns true for invalid YAML with ASL-YAML language ID', async function () {
+        const invalidYaml = 'StartAt: Test\nStates:\n  Test:\n    Type: Pass\n    End: true\n  - invalid list item'
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'asl-yaml',
+            content: invalidYaml,
+        })
+
+        assert.strictEqual(isInvalidYamlFile(textDocument), true)
+    })
+
+    it('returns false for empty content with ASL-YAML language ID', async function () {
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'asl-yaml',
+            content: '',
+        })
+
+        assert.strictEqual(isInvalidYamlFile(textDocument), false)
+    })
+
+    it('returns false for valid YAML with non-ASL-YAML language ID', async function () {
+        const validYaml = 'key: value\nlist:\n  - item1\n  - item2'
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'yaml',
+            content: validYaml,
+        })
+
+        assert.strictEqual(isInvalidYamlFile(textDocument), false)
+    })
+
+    it('returns false for invalid YAML with non-ASL-YAML language ID', async function () {
+        const invalidYaml = 'key: value\n  - invalid'
+        const textDocument = await vscode.workspace.openTextDocument({
+            language: 'yaml',
+            content: invalidYaml,
+        })
+
+        assert.strictEqual(isInvalidYamlFile(textDocument), false)
+    })
+})
+
+describe('isExpressExecution', function () {
+    it('returns true for express execution ARN', function () {
+        const expressArn = 'arn:aws:states:us-east-1:123456789012:express:stateMachine:MyStateMachine:execution-name'
+        assert.strictEqual(isExpressExecution(expressArn), true)
+    })
+
+    it('returns false for standard execution ARN', function () {
+        const standardArn = 'arn:aws:states:us-west-2:987654321098:stateMachine:TestMachine:execution-id'
+        assert.strictEqual(isExpressExecution(standardArn), false)
+    })
+
+    it('returns false for ARN with express format but different resource type', function () {
+        const arnWithDifferentType =
+            'arn:aws:states:us-east-1:123456789012:standard:stateMachine:MyStateMachine:execution-name'
+        assert.strictEqual(isExpressExecution(arnWithDifferentType), false)
+    })
+
+    it('returns false for malformed ARN with wrong segment count', function () {
+        const malformedArn = 'arn:aws:states:us-east-1:123456789012:stateMachine:execution-name'
+        assert.strictEqual(isExpressExecution(malformedArn), false)
+    })
+
+    it('returns false for empty string', function () {
+        assert.strictEqual(isExpressExecution(''), false)
+    })
+
+    it('returns false for ARN with correct segment count but no express type', function () {
+        const arnWithoutExpress =
+            'arn:aws:states:us-east-1:123456789012:other:stateMachine:MyStateMachine:execution-name'
+        assert.strictEqual(isExpressExecution(arnWithoutExpress), false)
+    })
+})
+
+describe('parseExecutionArnForStateMachine', function () {
+    it('parses express execution ARN correctly', function () {
+        const expressArn = 'arn:aws:states:us-east-1:123456789012:express:stateMachine:MyStateMachine:execution-name'
+        const result = parseExecutionArnForStateMachine(expressArn)
+
+        assert.strictEqual(result.region, 'us-east-1')
+        assert.strictEqual(result.stateMachineName, 'MyStateMachine')
+        assert.strictEqual(result.stateMachineArn, 'arn:aws:states:us-east-1:123456789012:stateMachine:MyStateMachine')
+    })
+
+    it('parses standard execution ARN correctly', function () {
+        const standardArn = 'arn:aws:states:us-west-2:987654321098:stateMachine:TestMachine:execution-id'
+        const result = parseExecutionArnForStateMachine(standardArn)
+
+        assert.strictEqual(result.region, 'us-west-2')
+        assert.strictEqual(result.stateMachineName, 'TestMachine')
+        assert.strictEqual(result.stateMachineArn, 'arn:aws:states:us-west-2:987654321098:stateMachine:TestMachine')
+    })
+
+    it('handles different regions correctly', function () {
+        const euArn = 'arn:aws:states:eu-west-1:555666777888:stateMachine:EuroMachine:exec-123'
+        const result = parseExecutionArnForStateMachine(euArn)
+
+        assert.strictEqual(result.region, 'eu-west-1')
+        assert.strictEqual(result.stateMachineName, 'EuroMachine')
+        assert.strictEqual(result.stateMachineArn, 'arn:aws:states:eu-west-1:555666777888:stateMachine:EuroMachine')
+    })
+
+    it('handles state machine names with hyphens and special characters', function () {
+        const arnWithSpecialName =
+            'arn:aws:states:ap-southeast-2:111222333444:stateMachine:My-State_Machine.Test:exec-456'
+        const result = parseExecutionArnForStateMachine(arnWithSpecialName)
+
+        assert.strictEqual(result.region, 'ap-southeast-2')
+        assert.strictEqual(result.stateMachineName, 'My-State_Machine.Test')
+        assert.strictEqual(
+            result.stateMachineArn,
+            'arn:aws:states:ap-southeast-2:111222333444:stateMachine:My-State_Machine.Test'
+        )
+    })
+
+    it('handles different account IDs correctly', function () {
+        const differentAccountArn = 'arn:aws:states:us-central-1:999888777666:stateMachine:AccountTestMachine:exec-789'
+        const result = parseExecutionArnForStateMachine(differentAccountArn)
+
+        assert.strictEqual(result.region, 'us-central-1')
+        assert.strictEqual(result.stateMachineName, 'AccountTestMachine')
+        assert.strictEqual(
+            result.stateMachineArn,
+            'arn:aws:states:us-central-1:999888777666:stateMachine:AccountTestMachine'
+        )
     })
 })

--- a/packages/core/src/test/stepFunctions/utils.test.ts
+++ b/packages/core/src/test/stepFunctions/utils.test.ts
@@ -15,6 +15,68 @@ import {
 } from '../../stepFunctions/utils'
 import { IamRole } from '../../shared/clients/iam'
 
+// Test Helpers
+async function createTextDocument(language: string, content: string): Promise<vscode.TextDocument> {
+    return await vscode.workspace.openTextDocument({
+        language,
+        content,
+    })
+}
+
+function createValidAsl(startAt: string = 'FirstMatchState', customStates?: any): string {
+    const defaultStates = {
+        FirstMatchState: {
+            Type: 'Task',
+            Resource: 'arn:aws:lambda:us-west-2:000000000000:function:OnFirstMatch',
+            End: true,
+        },
+    }
+
+    return JSON.stringify({
+        StartAt: startAt,
+        States: customStates || defaultStates,
+    })
+}
+
+function createInvalidAsl(): string {
+    return JSON.stringify({
+        StartAt: 'Does not exist',
+        States: {
+            FirstMatchState: {
+                Type: 'Task',
+                Resource: 'arn:aws:lambda:us-west-2:000000000000:function:OnFirstMatch',
+                End: true,
+            },
+        },
+    })
+}
+
+function createIamRoleWithPolicy(servicePrincipals: string[]): IamRole {
+    const baseRole: IamRole = {
+        Path: '',
+        RoleName: '',
+        RoleId: 'myRole',
+        Arn: 'arn:aws:iam::123456789012:role/myRole',
+        CreateDate: new Date(),
+    }
+
+    return {
+        ...baseRole,
+        AssumeRolePolicyDocument: JSON.stringify({
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Effect: 'Allow',
+                    Principal: {
+                        Service: servicePrincipals,
+                    },
+                    Action: ['sts:AssumeRole'],
+                },
+            ],
+        }),
+    }
+}
+
 describe('isStepFunctionsRole', function () {
     const baseIamRole: IamRole = {
         Path: '',
@@ -25,21 +87,7 @@ describe('isStepFunctionsRole', function () {
     }
 
     it('return true if the Step Functions service principal is in the AssumeRolePolicyDocument', function () {
-        const role: IamRole = {
-            ...baseIamRole,
-            AssumeRolePolicyDocument: JSON.stringify({
-                Version: '2012-10-17',
-                Statement: [
-                    {
-                        Effect: 'Allow',
-                        Principal: {
-                            Service: ['states.amazonaws.com'],
-                        },
-                        Action: ['sts:AssumeRole'],
-                    },
-                ],
-            }),
-        }
+        const role = createIamRoleWithPolicy(['states.amazonaws.com'])
         assert.ok(isStepFunctionsRole(role))
     })
 
@@ -48,81 +96,39 @@ describe('isStepFunctionsRole', function () {
     })
 
     it("returns false if the AssumeRolePolicyDocument does not contain Step Functions' service principal", () => {
-        const role: IamRole = {
-            ...baseIamRole,
-            AssumeRolePolicyDocument: JSON.stringify({
-                Version: '2012-10-17',
-                Statement: [
-                    {
-                        Effect: 'Allow',
-                        Principal: {
-                            Service: ['lambda.amazonaws.com'],
-                        },
-                        Action: ['sts:AssumeRole'],
-                    },
-                ],
-            }),
-        }
+        const role = createIamRoleWithPolicy(['lambda.amazonaws.com'])
         assert.ok(!isStepFunctionsRole(role))
     })
 })
 
 describe('isDocumentValid', async function () {
     it('returns true for valid ASL', async function () {
-        const aslText = `
-            {
-                "StartAt": "FirstMatchState",
-                "States": {
-                    "FirstMatchState": {
-                        "Type": "Task",
-                        "Resource": "arn:aws:lambda:us-west-2:000000000000:function:OnFirstMatch",
-                        "End": true
-                    }
-                }
-            } `
-
-        const textDocument = await vscode.workspace.openTextDocument({ language: 'asl' })
+        const aslText = createValidAsl()
+        const textDocument = await createTextDocument('asl', '')
 
         const isValid = await isDocumentValid(aslText, textDocument)
         assert.ok(isValid)
     })
 
     it('returns true for ASL with invalid arns', async function () {
-        const aslText = `
-            {
-                "StartAt": "FirstMatchState",
-                "States": {
-                    "FirstMatchState": {
-                        "Type": "Task",
-                        "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:OnFirstMatch",
-                        "End": true
-                    }
-                }
-            } `
-
-        const textDocument = await vscode.workspace.openTextDocument({ language: 'asl' })
+        const aslText = createValidAsl('FirstMatchState', {
+            FirstMatchState: {
+                Type: 'Task',
+                Resource: 'arn:aws:lambda:REGION:ACCOUNT_ID:function:OnFirstMatch',
+                End: true,
+            },
+        })
+        const textDocument = await createTextDocument('asl', '')
 
         const isValid = await isDocumentValid(aslText, textDocument)
         assert.ok(isValid)
     })
 
     it('returns false for invalid ASL', async function () {
-        const aslText = `
-            {
-                "StartAt": "Does not exist",
-                "States": {
-                    "FirstMatchState": {
-                        "Type": "Task",
-                        "Resource": "arn:aws:lambda:us-west-2:000000000000:function:OnFirstMatch",
-                        "End": true
-                    }
-                }
-            } `
-
-        const textDocument = await vscode.workspace.openTextDocument({ language: 'asl' })
+        const aslText = createInvalidAsl()
+        const textDocument = await createTextDocument('asl', '')
 
         const isValid = await isDocumentValid(aslText, textDocument)
-
         assert.ok(!isValid)
     })
 })
@@ -130,58 +136,40 @@ describe('isDocumentValid', async function () {
 describe('isInvalidJsonFile', function () {
     it('returns false for valid JSON with ASL language ID', async function () {
         const validJson = '{"StartAt": "Test", "States": {"Test": {"Type": "Pass", "End": true}}}'
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'asl',
-            content: validJson,
-        })
+        const textDocument = await createTextDocument('asl', validJson)
 
         assert.strictEqual(isInvalidJsonFile(textDocument), false)
     })
 
     it('returns true for invalid JSON with ASL language ID', async function () {
         const invalidJson = '{"StartAt": "Test", "States": {'
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'asl',
-            content: invalidJson,
-        })
+        const textDocument = await createTextDocument('asl', invalidJson)
 
         assert.strictEqual(isInvalidJsonFile(textDocument), true)
     })
 
     it('returns false for empty content with ASL language ID', async function () {
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'asl',
-            content: '',
-        })
+        const textDocument = await createTextDocument('asl', '')
 
         assert.strictEqual(isInvalidJsonFile(textDocument), false)
     })
 
     it('returns false for whitespace-only content with ASL language ID', async function () {
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'asl',
-            content: '   \n\t  ',
-        })
+        const textDocument = await createTextDocument('asl', '   \n\t  ')
 
         assert.strictEqual(isInvalidJsonFile(textDocument), false)
     })
 
     it('returns false for valid JSON with non-ASL language ID', async function () {
         const validJson = '{"test": "value"}'
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'json',
-            content: validJson,
-        })
+        const textDocument = await createTextDocument('json', validJson)
 
         assert.strictEqual(isInvalidJsonFile(textDocument), false)
     })
 
     it('returns false for invalid JSON with non-ASL language ID', async function () {
         const invalidJson = '{"test": invalid}'
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'json',
-            content: invalidJson,
-        })
+        const textDocument = await createTextDocument('json', invalidJson)
 
         assert.strictEqual(isInvalidJsonFile(textDocument), false)
     })
@@ -190,49 +178,34 @@ describe('isInvalidJsonFile', function () {
 describe('isInvalidYamlFile', function () {
     it('returns false for valid YAML with ASL-YAML language ID', async function () {
         const validYaml = 'StartAt: Test\nStates:\n  Test:\n    Type: Pass\n    End: true'
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'asl-yaml',
-            content: validYaml,
-        })
+        const textDocument = await createTextDocument('asl-yaml', validYaml)
 
         assert.strictEqual(isInvalidYamlFile(textDocument), false)
     })
 
     it('returns true for invalid YAML with ASL-YAML language ID', async function () {
         const invalidYaml = 'StartAt: Test\nStates:\n  Test:\n    Type: Pass\n    End: true\n  - invalid list item'
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'asl-yaml',
-            content: invalidYaml,
-        })
+        const textDocument = await createTextDocument('asl-yaml', invalidYaml)
 
         assert.strictEqual(isInvalidYamlFile(textDocument), true)
     })
 
     it('returns false for empty content with ASL-YAML language ID', async function () {
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'asl-yaml',
-            content: '',
-        })
+        const textDocument = await createTextDocument('asl-yaml', '')
 
         assert.strictEqual(isInvalidYamlFile(textDocument), false)
     })
 
     it('returns false for valid YAML with non-ASL-YAML language ID', async function () {
         const validYaml = 'key: value\nlist:\n  - item1\n  - item2'
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'yaml',
-            content: validYaml,
-        })
+        const textDocument = await createTextDocument('yaml', validYaml)
 
         assert.strictEqual(isInvalidYamlFile(textDocument), false)
     })
 
     it('returns false for invalid YAML with non-ASL-YAML language ID', async function () {
         const invalidYaml = 'key: value\n  - invalid'
-        const textDocument = await vscode.workspace.openTextDocument({
-            language: 'yaml',
-            content: invalidYaml,
-        })
+        const textDocument = await createTextDocument('yaml', invalidYaml)
 
         assert.strictEqual(isInvalidYamlFile(textDocument), false)
     })
@@ -273,59 +246,23 @@ describe('isExpressExecution', function () {
 
 describe('parseExecutionArnForStateMachine', function () {
     it('parses express execution ARN correctly', function () {
-        const expressArn = 'arn:aws:states:us-east-1:123456789012:express:stateMachine:MyStateMachine:execution-name'
+        const expressArn =
+            'arn:aws:states:us-east-1:640351538274:express:testexpress:b46b000d-c25d-4bbe-98c7-ee48978cbc51:99df0098-6f92-468c-9429-a7798be2f8a7'
         const result = parseExecutionArnForStateMachine(expressArn)
 
         assert.ok(result)
         assert.strictEqual(result.region, 'us-east-1')
-        assert.strictEqual(result.stateMachineName, 'MyStateMachine')
-        assert.strictEqual(result.stateMachineArn, 'arn:aws:states:us-east-1:123456789012:stateMachine:MyStateMachine')
+        assert.strictEqual(result.stateMachineName, 'testexpress')
+        assert.strictEqual(result.stateMachineArn, 'arn:aws:states:us-east-1:640351538274:stateMachine:testexpress')
     })
 
     it('parses standard execution ARN correctly', function () {
-        const standardArn = 'arn:aws:states:us-west-2:987654321098:stateMachine:TestMachine:execution-id'
+        const standardArn = 'arn:aws:states:us-west-2:640351538274:execution:test:9738b8de-2433-414c-9182-95dd746b7b9e'
         const result = parseExecutionArnForStateMachine(standardArn)
 
         assert.ok(result)
         assert.strictEqual(result.region, 'us-west-2')
-        assert.strictEqual(result.stateMachineName, 'TestMachine')
-        assert.strictEqual(result.stateMachineArn, 'arn:aws:states:us-west-2:987654321098:stateMachine:TestMachine')
-    })
-
-    it('handles different regions correctly', function () {
-        const euArn = 'arn:aws:states:eu-west-1:555666777888:stateMachine:EuroMachine:exec-123'
-        const result = parseExecutionArnForStateMachine(euArn)
-
-        assert.ok(result)
-        assert.strictEqual(result.region, 'eu-west-1')
-        assert.strictEqual(result.stateMachineName, 'EuroMachine')
-        assert.strictEqual(result.stateMachineArn, 'arn:aws:states:eu-west-1:555666777888:stateMachine:EuroMachine')
-    })
-
-    it('handles state machine names with hyphens and special characters', function () {
-        const arnWithSpecialName =
-            'arn:aws:states:ap-southeast-2:111222333444:stateMachine:My-State_Machine.Test:exec-456'
-        const result = parseExecutionArnForStateMachine(arnWithSpecialName)
-
-        assert.ok(result)
-        assert.strictEqual(result.region, 'ap-southeast-2')
-        assert.strictEqual(result.stateMachineName, 'My-State_Machine.Test')
-        assert.strictEqual(
-            result.stateMachineArn,
-            'arn:aws:states:ap-southeast-2:111222333444:stateMachine:My-State_Machine.Test'
-        )
-    })
-
-    it('handles different account IDs correctly', function () {
-        const differentAccountArn = 'arn:aws:states:us-central-1:999888777666:stateMachine:AccountTestMachine:exec-789'
-        const result = parseExecutionArnForStateMachine(differentAccountArn)
-
-        assert.ok(result)
-        assert.strictEqual(result.region, 'us-central-1')
-        assert.strictEqual(result.stateMachineName, 'AccountTestMachine')
-        assert.strictEqual(
-            result.stateMachineArn,
-            'arn:aws:states:us-central-1:999888777666:stateMachine:AccountTestMachine'
-        )
+        assert.strictEqual(result.stateMachineName, 'test')
+        assert.strictEqual(result.stateMachineArn, 'arn:aws:states:us-west-2:640351538274:stateMachine:test')
     })
 })


### PR DESCRIPTION
## Problem
Currently the New Execution and Edit State Machine Buttons in Execution Details don't work

## Solution
New Execution button now opens a new input webview
Edit State Machine launches Workflow Studio 
Added message handling for new execution and edit state machine
Refactoring in utils

## Verification
![test9](https://github.com/user-attachments/assets/6056c3cb-c6cd-4b03-a0fc-d7bbf71210c8)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
