### PR TITLE
fix(amazonq): bring back timeout to local LSP call inline completion

### DIFF
--- a/packages/amazonq/src/util/timeoutUtil.ts
+++ b/packages/amazonq/src/util/timeoutUtil.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function asyncCallWithTimeout<T>(asyncPromise: Promise<T>, message: string, timeLimit: number): Promise<T> {
+    let timeoutHandle: NodeJS.Timeout
+    const timeoutPromise = new Promise((_resolve, reject) => {
+        timeoutHandle = setTimeout(() => reject(new Error(message)), timeLimit)
+    })
+    return Promise.race([asyncPromise, timeoutPromise]).then((result) => {
+        clearTimeout(timeoutHandle)
+        return result as T
+    })
+}


### PR DESCRIPTION
## Problem
During the inline completion migration to Flare, the timeout handling of inline completion API was lost. It was there in earlier versions. The IDE -> Flare call is a local network call that should have a timeout. 

## Solution

Add the inline completion call with timeout back. See https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/util/commonUtil.ts#L21

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
