### PR TITLE
fix(amazonq): update the marketing message for the Amazon Q plugin in VSCode marketplace

### DIFF
--- a/packages/amazonq/README.md
+++ b/packages/amazonq/README.md
@@ -3,39 +3,33 @@
 [![Youtube Channel Views](https://img.shields.io/youtube/channel/views/UCd6MoB9NC6uYN2grvUNT-Zg?style=flat-square&logo=youtube&label=Youtube)](https://www.youtube.com/@amazonwebservices)
 ![Marketplace Installs](https://img.shields.io/vscode-marketplace/i/AmazonWebServices.amazon-q-vscode.svg?label=Installs&style=flat-square)
 
-# Agent capabilities
+# Agentic coding experience
+
+Amazon Q Developer uses information across native and MCP server-based tools to intelligently perform actions beyond code suggestions, such as reading files, generating code diffs, and running commands based on your natural language instruction. Simply type your prompt in your preferred language and Q Developer will provide continuous status updates and iteratively apply changes based on your feedback, helping you accomplish tasks faster.
 
 ### Implement new features
 
-`/dev` to task Amazon Q with generating new code across your entire project and implement features.
+Generate new code across your entire project and implement features.
 
 ### Generate documentation
 
-`/doc` to task Amazon Q with writing API, technical design, and onboarding documentation.
+Write API, technical design, and onboarding documentation.
 
 ### Automate code reviews
 
-`/review` to ask Amazon Q to perform code reviews, flagging suspicious code patterns and assessing deployment risk.
+Perform code reviews, flagging suspicious code patterns and assessing deployment risk.
 
 ### Generate unit tests
 
-`/test` to ask Amazon Q to generate unit tests and add them to your project, helping you improve code quality, fast.
-
-### Transform workloads
-
-`/transform` to upgrade your Java applications in minutes, not weeks.
+Generate unit tests and add them to your project, helping you improve code quality, fast.
 
 <br>
 
 # Core features
 
-### Inline chat
+### MCP support
 
-Seamlessly initiate chat within the inline coding experience. Select a section of code that you need assistance with and initiate chat within the editor to request actions such as "Optimize this code", "Add comments", or "Write tests".
-
-### Chat
-
-Generate code, explain code, and get answers about software development.
+Add Model Context Protocol (MCP) servers to give Amazon Q Developer access to important context.
 
 ### Inline suggestions
 
@@ -43,9 +37,13 @@ Receive real-time code suggestions ranging from snippets to full functions based
 
 [_15+ languages supported including Python, TypeScript, Rust, Terraform, AWS Cloudformation, and more_](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/q-language-ide-support.html)
 
-### Code reference log
+### Inline chat
 
-Attribute code from Amazon Q that is similar to training data. When code suggestions similar to training data are accepted, they will be added to the code reference log.
+Seamlessly chat within the inline coding experience. Select a section of code that you need assistance with and initiate chat within the editor to request actions such as "Optimize this code", "Add comments", or "Write tests".
+
+### Chat
+
+Generate code, explain code, and get answers about software development.
 
 <br>
 
@@ -54,8 +52,6 @@ Attribute code from Amazon Q that is similar to training data. When code suggest
 **Free Tier** - create or log in with an AWS Builder ID (a personal profile from AWS).
 
 **Pro Tier** - if your organization is on the Amazon Q Developer Pro tier, log in with single sign-on.
-
-![Authentication gif](https://raw.githubusercontent.com/aws/aws-toolkit-vscode/HEAD/docs/marketplace/vscode/amazonq/auth-Q.gif)
 
 # Troubleshooting & feedback
 

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -1,7 +1,7 @@
 {
     "name": "amazon-q-vscode",
     "displayName": "Amazon Q",
-    "description": "The most capable generative AI-powered assistant for building, operating, and transforming software, with advanced capabilities for managing data and AI",
+    "description": "The most capable generative AI–powered assistant for software development.",
     "version": "1.86.0-SNAPSHOT",
     "extensionKind": [
         "workspace"


### PR DESCRIPTION
## Problem
Needed to update the marketing message for the plugin

## Solution
Updated it.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
