### PR TITLE
fix(amazonq): correct the isAutoTrigger boolean flag

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -258,6 +258,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         // there is a bug in VS Code, when hitting Enter, the context.triggerKind is Invoke (0)
         // when hitting other keystrokes, the context.triggerKind is Automatic (1)
         // we only mark option + C as manual trigger
+        // this is a workaround since the inlineSuggest.trigger command take no params
         const isAutoTrigger = performance.now() - vsCodeState.lastManualTriggerTime > 50
         if (isAutoTrigger && !CodeSuggestionsState.instance.isSuggestionsEnabled()) {
             // return early when suggestions are disabled with auto trigger

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -255,7 +255,10 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
             return []
         }
 
-        const isAutoTrigger = context.triggerKind === InlineCompletionTriggerKind.Automatic
+        // there is a bug in VS Code, when hitting Enter, the context.triggerKind is Invoke (0)
+        // when hitting other keystrokes, the context.triggerKind is Automatic (1)
+        // we only mark option + C as manual trigger
+        const isAutoTrigger = performance.now() - vsCodeState.lastManualTriggerTime > 50
         if (isAutoTrigger && !CodeSuggestionsState.instance.isSuggestionsEnabled()) {
             // return early when suggestions are disabled with auto trigger
             return []
@@ -348,7 +351,10 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                 this.languageClient,
                 document,
                 position,
-                context,
+                {
+                    triggerKind: isAutoTrigger ? 1 : 0,
+                    selectedCompletionInfo: context.selectedCompletionInfo,
+                },
                 token,
                 isAutoTrigger,
                 getAllRecommendationsOptions,

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -23,6 +23,7 @@ import {
     CodeWhispererSettings,
     getSelectedCustomization,
     TelemetryHelper,
+    vsCodeState,
 } from 'aws-core-vscode/codewhisperer'
 import {
     Settings,
@@ -365,6 +366,7 @@ async function onLanguageServerReady(
             sessionManager.checkInlineSuggestionVisibility()
         }),
         Commands.register({ id: 'aws.amazonq.invokeInlineCompletion', autoconnect: true }, async () => {
+            vsCodeState.lastManualTriggerTime = performance.now()
             await vscode.commands.executeCommand('editor.action.inlineSuggest.trigger')
         }),
         Commands.register('aws.amazonq.refreshAnnotation', async (forceProceed: boolean) => {

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -42,6 +42,8 @@ interface VsCodeState {
     lastUserModificationTime: number
 
     isFreeTierLimitReached: boolean
+
+    lastManualTriggerTime: number
 }
 
 export const vsCodeState: VsCodeState = {
@@ -52,6 +54,7 @@ export const vsCodeState: VsCodeState = {
     isRecommendationsActive: false,
     lastUserModificationTime: 0,
     isFreeTierLimitReached: false,
+    lastManualTriggerTime: 0,
 }
 
 export interface CodeWhispererConfig {


### PR DESCRIPTION
## Problem

There is a bug in VS Code inline completion API, when hitting Enter, the context.triggerKind is Invoke (0)
when hitting other keystrokes, the context.triggerKind is Automatic (1)
we should only mark option + C as manual trigger Invoke(0)

## Solution

Use timestamp to decide what is manual trigger and what is auto trigger.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
