### PR TITLE
fix(amazonq): add startUrl to more metrics

### DIFF
--- a/packages/core/src/shared/lsp/utils/setupStage.ts
+++ b/packages/core/src/shared/lsp/utils/setupStage.ts
@@ -5,6 +5,7 @@
 
 import { LanguageServerSetup, LanguageServerSetupStage, telemetry } from '../../telemetry/telemetry'
 import { tryFunctions } from '../../utilities/tsUtils'
+import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 
 /**
  * Runs the designated stage within a telemetry span and optionally uses the getMetadata extractor to record metadata from the result of the stage.
@@ -20,6 +21,7 @@ export async function lspSetupStage<Result>(
 ) {
     return await telemetry.languageServer_setup.run(async (span) => {
         span.record({ languageServerSetupStage: stageName })
+        span.record({ credentialStartUrl: AuthUtil.instance.startUrl ?? 'Undefined' })
         const result = await runStage()
         if (getMetadata) {
             span.record(getMetadata(result))

--- a/packages/core/src/shared/telemetry/service-2.json
+++ b/packages/core/src/shared/telemetry/service-2.json
@@ -205,7 +205,8 @@
         "AWSProduct",
         "AWSProductVersion",
         "ClientID",
-        "MetricData"
+        "MetricData",
+        "CredentialStartUrl"
       ],
       "members":{
         "AWSProduct":{"shape":"AWSProduct"},
@@ -217,7 +218,8 @@
         "ComputeEnv": {"shape":"ComputeEnv"},
         "ParentProduct":{"shape":"Value"},
         "ParentProductVersion":{"shape":"Value"},
-        "MetricData":{"shape":"MetricData"}
+        "MetricData":{"shape":"MetricData"},
+        "CredentialStartUrl": {"shape":"Value"}
       }
     },
     "Sentiment":{

--- a/packages/core/src/shared/telemetry/telemetryClient.ts
+++ b/packages/core/src/shared/telemetry/telemetryClient.ts
@@ -17,6 +17,7 @@ import globals from '../extensionGlobals'
 import { DevSettings } from '../settings'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 import { getComputeEnvType, getSessionId } from './util'
+import { AuthUtil } from '../../codewhisperer/util/authUtil'
 
 export const accountMetadataKey = 'awsAccount'
 export const regionKey = 'awsRegion'
@@ -112,6 +113,7 @@ export class DefaultTelemetryClient implements TelemetryClient {
                         ParentProduct: vscode.env.appName,
                         ParentProductVersion: vscode.version,
                         MetricData: batch,
+                        CredentialStartUrl: AuthUtil.instance.startUrl ?? 'Undefined',
                     })
                     .promise()
                 this.logger.info(`telemetry: sent batch (size=${batch.length})`)

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1221,6 +1221,42 @@
                     "required": false
                 }
             ]
+        },
+        {
+            "name": "languageServer_setup",
+            "description": "Sets up a language server",
+            "unit": "Milliseconds",
+            "passive": true,
+            "metadata": [
+                {
+                    "type": "id",
+                    "required": true
+                },
+                {
+                    "type": "languageServerSetupStage",
+                    "required": true
+                },
+                {
+                    "type": "languageServerLocation",
+                    "required": false
+                },
+                {
+                    "type": "languageServerVersion",
+                    "required": false
+                },
+                {
+                    "type": "manifestLocation",
+                    "required": false
+                },
+                {
+                    "type": "manifestSchemaVersion",
+                    "required": false
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Problem
Need to differentiate internal vs external customers.

## Solution
add startUrl to more metrics.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
