### PR TITLE
fix(auth): fix UI and error message bug, disable inline chat for IAM, autofill access key id

### DIFF
--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -100,8 +100,8 @@ async function activateAmazonQNode(context: vscode.ExtensionContext) {
 async function getAuthState(): Promise<Omit<AuthUserState, 'source'>> {
     const state = AuthUtil.instance.getAuthState()
 
-    if (AuthUtil.instance.isConnected() && !(AuthUtil.instance.isSsoSession() || isSageMaker())) {
-        getLogger().error('Current Amazon Q connection is not SSO')
+    if (AuthUtil.instance.isConnected() && !(AuthUtil.instance.isSsoSession() || AuthUtil.instance.isIamSession() || isSageMaker())) {
+        getLogger().error('Current Amazon Q connection is not SSO nor IAM')
     }
 
     return {

--- a/packages/amazonq/src/extensionNode.ts
+++ b/packages/amazonq/src/extensionNode.ts
@@ -100,7 +100,10 @@ async function activateAmazonQNode(context: vscode.ExtensionContext) {
 async function getAuthState(): Promise<Omit<AuthUserState, 'source'>> {
     const state = AuthUtil.instance.getAuthState()
 
-    if (AuthUtil.instance.isConnected() && !(AuthUtil.instance.isSsoSession() || AuthUtil.instance.isIamSession() || isSageMaker())) {
+    if (
+        AuthUtil.instance.isConnected() &&
+        !(AuthUtil.instance.isSsoSession() || AuthUtil.instance.isIamSession() || isSageMaker())
+    ) {
         getLogger().error('Current Amazon Q connection is not SSO nor IAM')
     }
 

--- a/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
@@ -483,7 +483,7 @@ describe('AuthUtil', async function () {
                 await auth.getIamCredential()
                 assert.fail('Should have thrown an error')
             } catch (err) {
-                assert.strictEqual((err as Error).message, 'Cannot get token with SSO session')
+                assert.strictEqual((err as Error).message, 'Cannot get credential with SSO session')
             }
         })
 

--- a/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/util/authUtil.test.ts
@@ -483,7 +483,7 @@ describe('AuthUtil', async function () {
                 await auth.getIamCredential()
                 assert.fail('Should have thrown an error')
             } catch (err) {
-                assert.strictEqual((err as Error).message, 'Cannot get credential with SSO session')
+                assert.strictEqual((err as Error).message, 'Cannot get credential without logging in with IAM.')
             }
         })
 
@@ -494,7 +494,7 @@ describe('AuthUtil', async function () {
                 await auth.getIamCredential()
                 assert.fail('Should have thrown an error')
             } catch (err) {
-                assert.strictEqual((err as Error).message, 'Cannot get credential without logging in.')
+                assert.strictEqual((err as Error).message, 'Cannot get credential without logging in with IAM.')
             }
         })
     })

--- a/packages/core/src/auth/auth2.ts
+++ b/packages/core/src/auth/auth2.ts
@@ -344,8 +344,13 @@ export abstract class BaseLogin {
      * Decrypts an encrypted string, removes its quotes, and returns the resulting string
      */
     protected async decrypt(encrypted: string): Promise<string> {
-        const decrypted = await jose.compactDecrypt(encrypted, this.lspAuth.encryptionKey)
-        return decrypted.plaintext.toString().replaceAll('"', '')
+        try {
+            const decrypted = await jose.compactDecrypt(encrypted, this.lspAuth.encryptionKey)
+            return decrypted.plaintext.toString().replaceAll('"', '')
+        } catch (e) {
+            getLogger().error(`Failed to decrypt: ${encrypted}`)
+            return encrypted
+        }
     }
 }
 

--- a/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
+++ b/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
@@ -192,7 +192,7 @@ export function createManageSubscription(): DataQuickPickItem<'manageSubscriptio
 export function createSignout(): DataQuickPickItem<'signout'> {
     const label = localize('AWS.codewhisperer.signoutNode.label', 'Sign Out')
     const icon = getIcon('vscode-export')
-    const connection = AuthUtil.instance.isIamConnection()
+    const connection = AuthUtil.instance.isIamSession()
         ? 'IAM Credentials'
         : AuthUtil.instance.isBuilderIdConnection()
           ? 'AWS Builder ID'

--- a/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
+++ b/packages/core/src/codewhisperer/ui/codeWhispererNodes.ts
@@ -192,7 +192,11 @@ export function createManageSubscription(): DataQuickPickItem<'manageSubscriptio
 export function createSignout(): DataQuickPickItem<'signout'> {
     const label = localize('AWS.codewhisperer.signoutNode.label', 'Sign Out')
     const icon = getIcon('vscode-export')
-    const connection = AuthUtil.instance.isBuilderIdConnection() ? 'AWS Builder ID' : 'IAM Identity Center'
+    const connection = AuthUtil.instance.isIamConnection()
+        ? 'IAM Credentials'
+        : AuthUtil.instance.isBuilderIdConnection()
+          ? 'AWS Builder ID'
+          : 'IAM Identity Center'
 
     return {
         data: 'signout',

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -219,7 +219,7 @@ export class AuthUtil implements IAuthProvider {
         if (this.session) {
             const credential = (await this.session.getCredential()).credential
             if (typeof credential !== 'object') {
-                throw new ToolkitError('Cannot get token with SSO session')
+                throw new ToolkitError('Cannot get credential with SSO session')
             }
             return credential
         } else {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -30,7 +30,16 @@ import { showAmazonQWalkthroughOnce } from '../../amazonq/onboardingPage/walkthr
 import { setContext } from '../../shared/vscode/setContext'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { telemetry } from '../../shared/telemetry/telemetry'
-import { AuthStateEvent, cacheChangedEvent, LanguageClientAuth, Login, SsoLogin, IamLogin } from '../../auth/auth2'
+import {
+    AuthStateEvent,
+    cacheChangedEvent,
+    LanguageClientAuth,
+    Login,
+    SsoLogin,
+    IamLogin,
+    AuthState,
+    LoginTypes,
+} from '../../auth/auth2'
 import { builderIdStartUrl, internalStartUrl } from '../../auth/sso/constants'
 import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
 import { RegionProfileManager } from '../region/regionProfileManager'
@@ -108,11 +117,11 @@ export class AuthUtil implements IAuthProvider {
     }
 
     isSsoSession(): boolean {
-        return this.session instanceof SsoLogin
+        return this.session?.loginType === LoginTypes.SSO
     }
 
     isIamSession(): boolean {
-        return this.session instanceof IamLogin
+        return this.session?.loginType === LoginTypes.IAM
     }
 
     /**
@@ -204,26 +213,20 @@ export class AuthUtil implements IAuthProvider {
     }
 
     async getToken() {
-        if (this.session) {
-            const token = (await this.session.getCredential()).credential
-            if (typeof token !== 'string') {
-                throw new ToolkitError('Cannot get token with IAM session')
-            }
-            return token
+        if (this.isSsoSession()) {
+            const response = await this.session!.getCredential()
+            return response.credential as string
         } else {
-            throw new ToolkitError('Cannot get credential without logging in.')
+            throw new ToolkitError('Cannot get credential without logging in with SSO.')
         }
     }
 
     async getIamCredential() {
-        if (this.session) {
-            const credential = (await this.session.getCredential()).credential
-            if (typeof credential !== 'object') {
-                throw new ToolkitError('Cannot get credential with SSO session')
-            }
-            return credential
+        if (this.isIamSession()) {
+            const response = await this.session!.getCredential()
+            return response.credential as IamCredentials
         } else {
-            throw new ToolkitError('Cannot get credential without logging in.')
+            throw new ToolkitError('Cannot get credential without logging in with IAM.')
         }
     }
 
@@ -231,9 +234,10 @@ export class AuthUtil implements IAuthProvider {
         return this.session?.data
     }
 
-    getAuthState() {
-        if (this.session) {
-            return this.session.getConnectionState()
+    getAuthState(): AuthState {
+        // Check if getConnectionState exists in case of type casts
+        if (typeof this.session?.getConnectionState === 'function') {
+            return this.session!.getConnectionState()
         } else {
             return 'notConnected'
         }
@@ -253,10 +257,6 @@ export class AuthUtil implements IAuthProvider {
 
     isIdcConnection() {
         return Boolean(this.connection?.startUrl && this.connection?.startUrl !== builderIdStartUrl)
-    }
-
-    isIamConnection() {
-        return Boolean(this.connection?.accessKey && this.connection?.secretKey)
     }
 
     isInternalAmazonUser(): boolean {
@@ -360,11 +360,12 @@ export class AuthUtil implements IAuthProvider {
 
     private async stateChangeHandler(e: AuthStateEvent) {
         if (e.state === 'refreshed') {
-            const params = this.session ? (await this.session.getCredential()).updateCredentialsParams : undefined
             if (this.isSsoSession()) {
-                await this.lspAuth.updateBearerToken(params)
+                const params = await this.session!.getCredential()
+                await this.lspAuth.updateBearerToken(params.updateCredentialsParams)
             } else if (this.isIamSession()) {
-                await this.lspAuth.updateIamCredential(params)
+                const params = await this.session!.getCredential()
+                await this.lspAuth.updateIamCredential(params.updateCredentialsParams)
             }
         } else {
             this.logger.info(`codewhisperer: connection changed to ${e.state}`)
@@ -387,11 +388,12 @@ export class AuthUtil implements IAuthProvider {
             this.session = undefined
         }
         if (state === 'connected') {
-            const params = this.session ? (await this.session.getCredential()).updateCredentialsParams : undefined
             if (this.isSsoSession()) {
-                await this.lspAuth.updateBearerToken(params)
+                const params = await this.session!.getCredential()
+                await this.lspAuth.updateBearerToken(params.updateCredentialsParams)
             } else if (this.isIamSession()) {
-                await this.lspAuth.updateIamCredential(params)
+                const params = await this.session!.getCredential()
+                await this.lspAuth.updateIamCredential(params.updateCredentialsParams)
             }
 
             if (this.isIdcConnection()) {

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -255,6 +255,10 @@ export class AuthUtil implements IAuthProvider {
         return Boolean(this.connection?.startUrl && this.connection?.startUrl !== builderIdStartUrl)
     }
 
+    isIamConnection() {
+        return Boolean(this.connection?.accessKey && this.connection?.secretKey)
+    }
+
     isInternalAmazonUser(): boolean {
         return this.isConnected() && this.connection?.startUrl === internalStartUrl
     }

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -33,6 +33,7 @@ import { getLogger } from '../../../shared/logger/logger'
 import { isValidUrl } from '../../../shared/utilities/uriUtils'
 import { RegionProfile } from '../../../codewhisperer/models/model'
 import { ProfileSwitchIntent } from '../../../codewhisperer/region/regionProfileManager'
+import { showMessage } from '../../../shared/utilities/messages'
 
 export abstract class CommonAuthWebview extends VueWebview {
     private readonly className = 'CommonAuthWebview'
@@ -183,7 +184,7 @@ export abstract class CommonAuthWebview extends VueWebview {
     abstract fetchConnections(): Promise<AwsConnection[] | undefined>
 
     async errorNotification(e: AuthError) {
-        void vscode.window.showInformationMessage(`${e.text}`)
+        showMessage('error', e.text)
     }
 
     abstract quitLoginScreen(): Promise<void>
@@ -294,6 +295,15 @@ export abstract class CommonAuthWebview extends VueWebview {
         }
 
         return globals.globalState.tryGet('recentSso', Object, { startUrl: '', region: 'us-east-1' })
+    }
+
+    getDefaultIamKeys(): { accessKey: string } {
+        const devSettings = DevSettings.instance.get('autofillAccessKey', '')
+        if (devSettings) {
+            return { accessKey: devSettings }
+        }
+
+        return globals.globalState.tryGet('recentIamKeys', Object, { accessKey: '' })
     }
 
     cancelAuthFlow() {

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -184,7 +184,7 @@ export abstract class CommonAuthWebview extends VueWebview {
     abstract fetchConnections(): Promise<AwsConnection[] | undefined>
 
     async errorNotification(e: AuthError) {
-        showMessage('error', e.text)
+        await showMessage('error', e.text)
     }
 
     abstract quitLoginScreen(): Promise<void>

--- a/packages/core/src/shared/featureConfig.ts
+++ b/packages/core/src/shared/featureConfig.ts
@@ -118,7 +118,7 @@ export class FeatureConfigProvider {
     }
 
     async fetchFeatureConfigs(): Promise<void> {
-        if (AuthUtil.instance.isConnectionExpired()) {
+        if (AuthUtil.instance.isConnectionExpired() || AuthUtil.instance.isIamSession()) {
             return
         }
 

--- a/packages/core/src/shared/globalState.ts
+++ b/packages/core/src/shared/globalState.ts
@@ -71,6 +71,7 @@ export type globalKey =
     | 'lastOsStartTime'
     | 'recentCredentials'
     | 'recentSso'
+    | 'recentIamKeys'
     // List of regions enabled in AWS Explorer.
     | 'region'
     // TODO: implement this via `PromptSettings` instead of globalState.

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -780,6 +780,7 @@ const devSettings = {
     amazonqWorkspaceLsp: Record(String, String),
     ssoCacheDirectory: String,
     autofillStartUrl: String,
+    autofillAccessKey: String,
     webAuth: Boolean,
     notificationsPollInterval: Number,
 }

--- a/packages/core/src/test/amazonq/utils.ts
+++ b/packages/core/src/test/amazonq/utils.ts
@@ -73,12 +73,12 @@ export async function createSession({
 
     const client = sinon.createStubInstance(FeatureDevClient)
     client.createConversation.resolves(conversationID)
-    const session = new Session(sessionConfig, messenger, tabID, sessionState, client)
+    const sessionNew = new Session(sessionConfig, messenger, tabID, sessionState, client)
 
-    sinon.stub(session, 'conversationId').get(() => conversationID)
-    sinon.stub(session, 'uploadId').get(() => uploadID)
+    sinon.stub(sessionNew, 'conversationId').get(() => conversationID)
+    sinon.stub(sessionNew, 'uploadId').get(() => uploadID)
 
-    return session
+    return sessionNew
 }
 
 export async function sessionRegisterProvider(session: Session, uri: vscode.Uri, fileContents: Uint8Array) {
@@ -86,9 +86,9 @@ export async function sessionRegisterProvider(session: Session, uri: vscode.Uri,
 }
 
 export function generateVirtualMemoryUri(uploadID: string, filePath: string, scheme: string) {
-    const generationFilePath = path.join(uploadID, filePath)
-    const uri = vscode.Uri.from({ scheme, path: generationFilePath })
-    return uri
+    const generationFilePathNew = path.join(uploadID, filePath)
+    const uriNew = vscode.Uri.from({ scheme, path: generationFilePathNew })
+    return uriNew
 }
 
 export async function sessionWriteFile(session: Session, uri: vscode.Uri, encodedContent: Uint8Array) {

--- a/packages/core/src/test/testAuthUtil.ts
+++ b/packages/core/src/test/testAuthUtil.ts
@@ -26,15 +26,22 @@ export async function createTestAuthUtil() {
         },
     }
 
+    const fakeCredential = {
+        credentials: {
+            accessKeyId: 'fake-access-key-id',
+            secretAccessKey: 'fake-secret-access-key',
+            sessionToken: 'fake-session-token',
+        },
+        updateCredentialsParams: {
+            data: 'fake-data',
+        },
+    }
+
     const mockLspAuth: Partial<LanguageClientAuth> = {
         registerSsoTokenChangedHandler: sinon.stub().resolves(),
         updateSsoProfile: sinon.stub().resolves(),
         getSsoToken: sinon.stub().resolves(fakeToken),
-        getIamCredential: sinon.stub().resolves({
-            accessKeyId: 'fake-access-key-id',
-            secretAccessKey: 'fake-secret-access-key',
-            sessionToken: 'fake-session-token',
-        }),
+        getIamCredential: sinon.stub().resolves(fakeCredential),
         getProfile: sinon.stub().resolves({
             sso_registration_scopes: ['codewhisperer'],
         }),


### PR DESCRIPTION
## Problem
UI and error message no longer compatible after adding IAM credentials authflow
IAM Access Key needs manual input every time a client log in

## Solution
This is part of https://github.com/aws/aws-toolkit-vscode/pull/7507 and is built on top of https://github.com/aws/aws-toolkit-vscode/pull/7659.

---

- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
