### PR TITLE
feat(amazonq): enable displayFindings tool

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -732,7 +732,11 @@ async function handlePartialResult<T extends ChatResult>(
     // This is to filter out the message containing findings from CodeReview tool to update CodeIssues panel
     decryptedMessage.additionalMessages = decryptedMessage.additionalMessages?.filter(
         (message) =>
-            !(message.messageId !== undefined && message.messageId.endsWith(CodeWhispererConstants.findingsSuffix))
+            !(
+                message.messageId !== undefined &&
+                (message.messageId.endsWith(CodeWhispererConstants.codeReviewFindingsSuffix) ||
+                    message.messageId.endsWith(CodeWhispererConstants.displayFindingsSuffix))
+            )
     )
 
     if (decryptedMessage.body !== undefined) {
@@ -784,7 +788,11 @@ async function handleSecurityFindings(
     }
     for (let i = decryptedMessage.additionalMessages.length - 1; i >= 0; i--) {
         const message = decryptedMessage.additionalMessages[i]
-        if (message.messageId !== undefined && message.messageId.endsWith(CodeWhispererConstants.findingsSuffix)) {
+        if (
+            message.messageId !== undefined &&
+            (message.messageId.endsWith(CodeWhispererConstants.codeReviewFindingsSuffix) ||
+                message.messageId.endsWith(CodeWhispererConstants.displayFindingsSuffix))
+        ) {
             if (message.body !== undefined) {
                 try {
                     const aggregatedCodeScanIssues: AggregatedCodeScanIssue[] = JSON.parse(message.body)
@@ -803,7 +811,12 @@ async function handleSecurityFindings(
                             issue.visible = !isIssueTitleIgnored && !isSingleIssueIgnored
                         }
                     }
-                    initSecurityScanRender(aggregatedCodeScanIssues, undefined, CodeAnalysisScope.PROJECT)
+                    initSecurityScanRender(
+                        aggregatedCodeScanIssues,
+                        undefined,
+                        CodeAnalysisScope.AGENTIC,
+                        message.messageId.endsWith(CodeWhispererConstants.codeReviewFindingsSuffix)
+                    )
                     SecurityIssueTreeViewProvider.focus()
                 } catch (e) {
                     languageClient.info('Failed to parse findings')

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -182,6 +182,7 @@ export async function startLanguageServer(
                         modelSelection: true,
                         workspaceFilePath: vscode.workspace.workspaceFile?.fsPath,
                         codeReviewInChat: codeReviewInChat,
+                        displayFindings: true,
                     },
                     window: {
                         notifications: true,

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -182,6 +182,7 @@ export async function startLanguageServer(
                         modelSelection: true,
                         workspaceFilePath: vscode.workspace.workspaceFile?.fsPath,
                         codeReviewInChat: codeReviewInChat,
+                        // feature flag for displaying findings found not through CodeReview in the Code Issues Panel
                         displayFindings: true,
                     },
                     window: {

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -108,6 +108,9 @@ export async function startSecurityScan(
     zipUtil: ZipUtil = new ZipUtil(),
     scanUuid?: string
 ) {
+    if (scope === CodeAnalysisScope.AGENTIC) {
+        throw new CreateCodeScanFailedError('Cannot use Agentic scope')
+    }
     const profile = AuthUtil.instance.regionProfileManager.activeRegionProfile
     const logger = getLoggerForScope(scope)
     /**

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -841,6 +841,7 @@ export enum CodeAnalysisScope {
     FILE_AUTO = 'FILE_AUTO',
     FILE_ON_DEMAND = 'FILE_ON_DEMAND',
     PROJECT = 'PROJECT',
+    AGENTIC = 'AGENTIC',
 }
 
 export enum TestGenerationJobStatus {
@@ -907,4 +908,7 @@ export const predictionTrackerDefaultConfig = {
     maxSupplementalContext: 15,
 }
 
-export const findingsSuffix = '_codeReviewFindings'
+export const codeReviewFindingsSuffix = '_codeReviewFindings'
+export const displayFindingsSuffix = '_displayFindings'
+
+export const displayFindingsDetectorName = 'DisplayFindings'

--- a/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/packages/core/src/codewhisperer/service/diagnosticsProvider.ts
@@ -26,8 +26,13 @@ export const securityScanRender: SecurityScanRender = {
 export function initSecurityScanRender(
     securityRecommendationList: AggregatedCodeScanIssue[],
     editor: vscode.TextEditor | undefined,
-    scope: CodeAnalysisScope
+    scope: CodeAnalysisScope,
+    fromQCA: boolean = true
 ) {
+    // fromQCA parameter is used to determine if the findings are coming from QCA or from displayFindings tool.
+    // if the incoming findings are from QCA review, then keep only existing findings from displayFindings
+    // if the incoming findings are not from QCA review, then keep only the existing QCA findings
+    securityScanRender.securityDiagnosticCollection = createSecurityDiagnosticCollection()
     securityScanRender.initialized = false
     if (scope === CodeAnalysisScope.FILE_ON_DEMAND && editor) {
         securityScanRender.securityDiagnosticCollection?.delete(editor.document.uri)
@@ -36,22 +41,20 @@ export function initSecurityScanRender(
     }
     for (const securityRecommendation of securityRecommendationList) {
         updateSecurityDiagnosticCollection(securityRecommendation)
-        updateSecurityIssuesForProviders(securityRecommendation, scope === CodeAnalysisScope.FILE_AUTO)
+        updateSecurityIssuesForProviders(securityRecommendation, scope === CodeAnalysisScope.FILE_AUTO, fromQCA)
     }
     securityScanRender.initialized = true
 }
 
-function updateSecurityIssuesForProviders(securityRecommendation: AggregatedCodeScanIssue, isAutoScope?: boolean) {
+function updateSecurityIssuesForProviders(
+    securityRecommendation: AggregatedCodeScanIssue,
+    isAutoScope?: boolean,
+    fromQCA: boolean = true
+) {
     if (isAutoScope) {
         SecurityIssueProvider.instance.mergeIssues(securityRecommendation)
     } else {
-        const updatedSecurityRecommendationList = [
-            ...SecurityIssueProvider.instance.issues.filter(
-                (group) => group.filePath !== securityRecommendation.filePath
-            ),
-            securityRecommendation,
-        ]
-        SecurityIssueProvider.instance.issues = updatedSecurityRecommendationList
+        SecurityIssueProvider.instance.mergeIssuesDisplayFindings(securityRecommendation, fromQCA)
     }
     SecurityIssueTreeViewProvider.instance.refresh()
 }

--- a/packages/core/src/test/codewhisperer/mergeIssuesDisplayFindings.test.ts
+++ b/packages/core/src/test/codewhisperer/mergeIssuesDisplayFindings.test.ts
@@ -1,0 +1,88 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { SecurityIssueProvider } from '../../codewhisperer/service/securityIssueProvider'
+import { createCodeScanIssue } from './testUtil'
+import { displayFindingsDetectorName } from '../../codewhisperer/models/constants'
+import { AggregatedCodeScanIssue } from '../../codewhisperer/models/model'
+
+describe('mergeIssuesDisplayFindings', () => {
+    let provider: SecurityIssueProvider
+    const testFilePath = '/test/file.py'
+
+    beforeEach(() => {
+        provider = Object.create(SecurityIssueProvider.prototype)
+        provider.issues = []
+    })
+
+    it('should add new issues when no existing group', () => {
+        const newIssues: AggregatedCodeScanIssue = {
+            filePath: testFilePath,
+            issues: [createCodeScanIssue({ findingId: 'new-1' })],
+        }
+
+        provider.mergeIssuesDisplayFindings(newIssues, true)
+
+        assert.strictEqual(provider.issues.length, 1)
+        assert.strictEqual(provider.issues[0].filePath, testFilePath)
+        assert.strictEqual(provider.issues[0].issues.length, 1)
+        assert.strictEqual(provider.issues[0].issues[0].findingId, 'new-1')
+    })
+
+    it('should keep displayFindings when fromQCA is true', () => {
+        provider.issues = [
+            {
+                filePath: testFilePath,
+                issues: [
+                    createCodeScanIssue({ findingId: 'qca-1', detectorName: 'QCA-detector' }),
+                    createCodeScanIssue({ findingId: 'display-1', detectorName: displayFindingsDetectorName }),
+                ],
+            },
+        ]
+
+        const newIssues: AggregatedCodeScanIssue = {
+            filePath: testFilePath,
+            issues: [createCodeScanIssue({ findingId: 'new-qca-1', detectorName: 'QCA-detector' })],
+        }
+
+        provider.mergeIssuesDisplayFindings(newIssues, true)
+
+        assert.strictEqual(provider.issues.length, 1)
+        assert.strictEqual(provider.issues[0].issues.length, 2)
+
+        const findingIds = provider.issues[0].issues.map((issue) => issue.findingId)
+        assert.ok(findingIds.includes('display-1'))
+        assert.ok(findingIds.includes('new-qca-1'))
+        assert.ok(!findingIds.includes('qca-1'))
+    })
+
+    it('should keep QCA findings when fromQCA is false', () => {
+        provider.issues = [
+            {
+                filePath: testFilePath,
+                issues: [
+                    createCodeScanIssue({ findingId: 'qca-1', detectorName: 'QCA-detector' }),
+                    createCodeScanIssue({ findingId: 'display-1', detectorName: displayFindingsDetectorName }),
+                ],
+            },
+        ]
+
+        const newIssues: AggregatedCodeScanIssue = {
+            filePath: testFilePath,
+            issues: [createCodeScanIssue({ findingId: 'new-display-1', detectorName: displayFindingsDetectorName })],
+        }
+
+        provider.mergeIssuesDisplayFindings(newIssues, false)
+
+        assert.strictEqual(provider.issues.length, 1)
+        assert.strictEqual(provider.issues[0].issues.length, 2)
+
+        const findingIds = provider.issues[0].issues.map((issue) => issue.findingId)
+        assert.ok(findingIds.includes('qca-1'))
+        assert.ok(findingIds.includes('new-display-1'))
+        assert.ok(!findingIds.includes('display-1'))
+    })
+})


### PR DESCRIPTION
## Problem
Need to enable and support findings coming in from the displayFindings tool

Also - Agentic scans are supposed to use the CodeAnalysisScope of AGENTIC, which needed to be added

## Solution
Set feature flag for displayFindings to be true

Listen for displayFindings messageId from FLARE similarly to how is being done for CodeReview tool.

Treat displayFindings findings and CodeReview findings separately, so they do not overwrite one another.

<img width="435" height="1363" alt="image" src="https://github.com/user-attachments/assets/17a2e571-65c9-45d5-b89d-bccafda76fe2" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
