### PR TITLE
fix(amazonq): should update session manager state accordingly if Edit…

### DIFF
--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -12,7 +12,6 @@ import { LogInlineCompletionSessionResultsParams } from '@aws/language-server-ru
 import { InlineCompletionItemWithReferences } from '@aws/language-server-runtimes/protocol'
 import path from 'path'
 import { imageVerticalOffset } from './svgGenerator'
-import { AmazonQInlineCompletionItemProvider } from '../completion'
 import { vsCodeState } from 'aws-core-vscode/codewhisperer'
 
 export class EditDecorationManager {
@@ -281,8 +280,7 @@ export async function displaySvgDecoration(
     originalCodeHighlightRanges: Array<{ line: number; start: number; end: number }>,
     session: CodeWhispererSession,
     languageClient: LanguageClient,
-    item: InlineCompletionItemWithReferences,
-    inlineCompletionProvider?: AmazonQInlineCompletionItemProvider
+    item: InlineCompletionItemWithReferences
 ) {
     const originalCode = editor.document.getText()
 
@@ -325,19 +323,6 @@ export async function displaySvgDecoration(
             }
             languageClient.sendNotification('aws/logInlineCompletionSessionResults', params)
             session.triggerOnAcceptance = true
-            // VS Code triggers suggestion on every keystroke, temporarily disable trigger on acceptance
-            // if (inlineCompletionProvider && session.editsStreakPartialResultToken) {
-            //     await inlineCompletionProvider.provideInlineCompletionItems(
-            //         editor.document,
-            //         endPosition,
-            //         {
-            //             triggerKind: vscode.InlineCompletionTriggerKind.Automatic,
-            //             selectedCompletionInfo: undefined,
-            //         },
-            //         new vscode.CancellationTokenSource().token,
-            //         { emitTelemetry: false, showUi: false, editsStreakToken: session.editsStreakPartialResultToken }
-            //     )
-            // }
         },
         async () => {
             // Handle reject

--- a/packages/amazonq/src/app/inline/EditRendering/imageRenderer.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/imageRenderer.ts
@@ -10,17 +10,23 @@ import { getLogger } from 'aws-core-vscode/shared'
 import { LanguageClient } from 'vscode-languageclient'
 import { InlineCompletionItemWithReferences } from '@aws/language-server-runtimes/protocol'
 import { CodeWhispererSession } from '../sessionManager'
-import { AmazonQInlineCompletionItemProvider } from '../completion'
 
+/*
+ * Method to render the edit suggestion as an SVG image
+ * @param item - The edit suggestion
+ * @param editor - The active text editor
+ * @param session - The current session
+ * @param languageClient - The language client
+ * @returns A promise that resolves to true if the image is rendered successfully, false otherwise
+ */
 export async function showEdits(
     item: InlineCompletionItemWithReferences,
     editor: vscode.TextEditor | undefined,
     session: CodeWhispererSession,
-    languageClient: LanguageClient,
-    inlineCompletionProvider?: AmazonQInlineCompletionItemProvider
-) {
+    languageClient: LanguageClient
+): Promise<boolean> {
     if (!editor) {
-        return
+        return false
     }
     try {
         const svgGenerationService = new SvgGenerationService()
@@ -34,7 +40,7 @@ export async function showEdits(
         // TODO: To investigate why it fails and patch [generateDiffSvg]
         if (newCode.length === 0) {
             getLogger('nextEditPrediction').warn('not able to apply provided edit suggestion, skip rendering')
-            return
+            return false
         }
 
         if (svgImage) {
@@ -47,13 +53,15 @@ export async function showEdits(
                 originalCodeHighlightRange,
                 session,
                 languageClient,
-                item,
-                inlineCompletionProvider
+                item
             )
+            return true
         } else {
             getLogger('nextEditPrediction').error('SVG image generation returned an empty result.')
+            return false
         }
     } catch (error) {
         getLogger('nextEditPrediction').error(`Error generating SVG image: ${error}`)
+        return false
     }
 }

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -439,7 +439,11 @@ ${itemLog}
                 if (item.isInlineEdit) {
                     // Check if Next Edit Prediction feature flag is enabled
                     if (Experiments.instance.get('amazonqLSPNEP', true)) {
-                        await showEdits(item, editor, session, this.languageClient, this)
+                        const editShown = await showEdits(item, editor, session, this.languageClient)
+                        // check if the EDITS suggestion is shown and update the session manager state accordingly
+                        if (editShown) {
+                            this.sessionManager.checkInlineSuggestionVisibility()
+                        }
                         logstr += `- duration between trigger to edits suggestion is displayed: ${performance.now() - t0}ms`
                     }
                     return []


### PR DESCRIPTION
…s suggestion was shown

## Problem

If the suggestion is shown to the user and the user continuously types, should treat suggestionState as Reject

## Solution

update session manager state accordingly if Edits suggestion was shown.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
