### PR TITLE
fix(sagemaker): Add code-editor subdomain to refreshUrl

### DIFF
--- a/packages/core/src/awsService/sagemaker/commands.ts
+++ b/packages/core/src/awsService/sagemaker/commands.ts
@@ -85,7 +85,8 @@ export async function deeplinkConnect(
     session: string,
     wsUrl: string,
     token: string,
-    domain: string
+    domain: string,
+    appType: string
 ) {
     getLogger().debug(
         `sm:deeplinkConnect: connectionIdentifier: ${connectionIdentifier} session: ${session} wsUrl: ${wsUrl} token: ${token}`
@@ -104,7 +105,8 @@ export async function deeplinkConnect(
             session,
             wsUrl,
             token,
-            domain
+            domain,
+            appType
         )
 
         await startVscodeRemote(

--- a/packages/core/src/awsService/sagemaker/credentialMapping.ts
+++ b/packages/core/src/awsService/sagemaker/credentialMapping.ts
@@ -79,15 +79,16 @@ export async function persistSSMConnection(
     domain: string,
     session?: string,
     wsUrl?: string,
-    token?: string
+    token?: string,
+    appType?: string
 ): Promise<void> {
     const { region } = parseArn(appArn)
     const endpoint = DevSettings.instance.get('endpoints', {})['sagemaker'] ?? ''
 
-    // TODO: Hardcoded to 'jupyterlab' due to a bug in Studio that only supports refreshing
-    // the token for both CodeEditor and JupyterLab Apps in the jupyterlab subdomain.
-    // This will be fixed shortly after NYSummit launch to support refresh URL in CodeEditor subdomain.
-    const appSubDomain = 'jupyterlab'
+    let appSubDomain = 'jupyterlab'
+    if (appType && appType.toLowerCase() === 'codeeditor') {
+        appSubDomain = 'code-editor'
+    }
 
     let envSubdomain: string
 

--- a/packages/core/src/awsService/sagemaker/model.ts
+++ b/packages/core/src/awsService/sagemaker/model.ts
@@ -50,7 +50,8 @@ export async function prepareDevEnvConnection(
     session?: string,
     wsUrl?: string,
     token?: string,
-    domain?: string
+    domain?: string,
+    appType?: string
 ) {
     const remoteLogger = configureRemoteConnectionLogger()
     const { ssm, vsc, ssh } = (await ensureDependencies()).unwrap()
@@ -72,7 +73,7 @@ export async function prepareDevEnvConnection(
     if (connectionType === 'sm_lc') {
         await persistLocalCredentials(appArn)
     } else if (connectionType === 'sm_dl') {
-        await persistSSMConnection(appArn, domain ?? '', session, wsUrl, token)
+        await persistSSMConnection(appArn, domain ?? '', session, wsUrl, token, appType)
     }
 
     await startLocalServer(ctx)

--- a/packages/core/src/awsService/sagemaker/uriHandlers.ts
+++ b/packages/core/src/awsService/sagemaker/uriHandlers.ts
@@ -18,7 +18,8 @@ export function register(ctx: ExtContext) {
                 params.session,
                 `${params.ws_url}&cell-number=${params['cell-number']}`,
                 params.token,
-                params.domain
+                params.domain,
+                params.app_type
             )
         })
     }
@@ -34,7 +35,8 @@ export function parseConnectParams(query: SearchParams) {
         'session',
         'ws_url',
         'cell-number',
-        'token'
+        'token',
+        'app_type'
     )
     return params
 }


### PR DESCRIPTION
## Problem
-All space reconnection redirect links were hardcoded to route users to the JupyterLab details page, due to a bug in the Studio web application.


## Solution
- With the bug now fixed in SageMaker Studio, we can support redirecting to the Code Editor details page via refreshUrl.
- For backward compatibility, the default remains set to JupyterLab. Once the fix is verified and rolled out across all regions, we can remove the default behavior and instead explicitly check for the appType (e.g., JupyterLab) before setting the redirect.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
