### PR TITLE
feat(amazonq): Add Pin Context Tests and Update to pinContextHelper

### DIFF
--- a/packages/amazonq/test/e2e_new/amazonq/helpers/pinContextHelper.ts
+++ b/packages/amazonq/test/e2e_new/amazonq/helpers/pinContextHelper.ts
@@ -104,3 +104,74 @@ export async function clickPinContextMenuItem(webview: WebviewView, itemName: st
         return false
     }
 }
+/**
+ * Lists all the possible Sub-menu items in the console.
+ * @param webview The WebviewView instance
+ * @returns Promise<boolean> Returns the items as a WebElement List and the labels in a string array
+ */
+export async function getSubMenuItems(webview: WebviewView): Promise<{ items: WebElement[]; labels: string[] }> {
+    try {
+        const menuList = await waitForElement(webview, By.css('.mynah-detailed-list-items-block'))
+        await sleep(3000)
+        const menuListItems = await menuList.findElements(By.css('.mynah-detailed-list-item.mynah-ui-clickable-item'))
+        const labels: string[] = []
+
+        for (const item of menuListItems) {
+            try {
+                const textWrapper = await item.findElement(
+                    By.css('.mynah-detailed-list-item-text.mynah-detailed-list-item-text-direction-row')
+                )
+                const nameElement = await textWrapper.findElement(By.css('.mynah-detailed-list-item-name'))
+                const labelText = await nameElement.getText()
+                labels.push(labelText)
+                console.log('Menu item found:', labelText)
+            } catch (e) {
+                labels.push('')
+                console.log('Could not get text for menu item')
+            }
+        }
+
+        return { items: menuListItems, labels }
+    } catch (e) {
+        console.error('Error getting Pin Context menu items:', e)
+        return { items: [], labels: [] }
+    }
+}
+/**
+ * Clicks a specific item in the Sub-Menu by its label text
+ * @param webview The WebviewView instance
+ * @param itemName The text label of the menu item to click
+ * @returns Promise<boolean> True if the item was found and clicked, false otherwise
+ *
+ * NOTE: To find all possible text labels, you can call getPinContextMenuItems
+ */
+export async function clickSubMenuItem(webview: WebviewView, itemName: string): Promise<boolean> {
+    try {
+        const menuList = await waitForElement(webview, By.css('.mynah-detailed-list-items-block'))
+        await sleep(3000)
+        const menuListItems = await menuList.findElements(By.css('.mynah-detailed-list-item.mynah-ui-clickable-item'))
+        for (const item of menuListItems) {
+            try {
+                const textWrapper = await item.findElement(
+                    By.css('.mynah-detailed-list-item-text.mynah-detailed-list-item-text-direction-row')
+                )
+                const nameElement = await textWrapper.findElement(By.css('.mynah-detailed-list-item-name'))
+                const labelText = await nameElement.getText()
+
+                if (labelText === itemName) {
+                    console.log(`Clicking Pin Context menu item: ${itemName}`)
+                    await item.click()
+                    return true
+                }
+            } catch (e) {
+                continue
+            }
+        }
+
+        console.log(`Pin Context menu item not found: ${itemName}`)
+        return false
+    } catch (e) {
+        console.error(`Error clicking Pin Context menu item ${itemName}:`, e)
+        return false
+    }
+}

--- a/packages/amazonq/test/e2e_new/amazonq/tests/pinContext.test.ts
+++ b/packages/amazonq/test/e2e_new/amazonq/tests/pinContext.test.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import '../utils/setup'
-import { WebviewView } from 'vscode-extension-tester'
+import { WebviewView, By } from 'vscode-extension-tester'
 import { closeAllTabs, dismissOverlayIfPresent } from '../utils/cleanupUtils'
 import { testContext } from '../utils/testContext'
-import { clickPinContextButton, getPinContextMenuItems, clickPinContextMenuItem } from '../helpers/pinContextHelper'
-import { clearChat } from '../utils/generalUtils'
+import { clickPinContextButton, clickPinContextMenuItem, clickSubMenuItem } from '../helpers/pinContextHelper'
+import { waitForElement } from '../utils/generalUtils'
 
 describe('Amazon Q Pin Context Functionality', function () {
     // this timeout is the general timeout for the entire test suite
@@ -18,18 +18,33 @@ describe('Amazon Q Pin Context Functionality', function () {
         webviewView = testContext.webviewView
     })
 
-    after(async function () {
-        await closeAllTabs(webviewView)
-    })
-
     afterEach(async () => {
         await dismissOverlayIfPresent(webviewView)
-        await clearChat(webviewView)
+        await closeAllTabs(webviewView)
     })
-
+    it('File Context Test', async () => {
+        await clickPinContextButton(webviewView)
+        await clickPinContextMenuItem(webviewView, 'Files')
+        await clickPinContextMenuItem(webviewView, 'Active file')
+    })
     it('Pin Context Test', async () => {
         await clickPinContextButton(webviewView)
-        await getPinContextMenuItems(webviewView)
         await clickPinContextMenuItem(webviewView, '@workspace')
+    })
+    it('Prompts Context Test', async () => {
+        await clickPinContextButton(webviewView)
+        await clickPinContextMenuItem(webviewView, 'Prompts')
+        const addPrompt = await waitForElement(webviewView, By.css('.mynah-ui-icon.mynah-ui-icon-list-add'))
+        await addPrompt.click()
+        const chatInput = await waitForElement(webviewView, By.css('[data-testid="chat-item-form-item-text-input"]'))
+        await chatInput.sendKeys('test')
+        const createPrompt = await waitForElement(
+            webviewView,
+            By.css('.mynah-button.fill-state-always.status-primary.mynah-ui-clickable-item')
+        )
+        await createPrompt.click()
+        await clickPinContextButton(webviewView)
+        await clickPinContextMenuItem(webviewView, 'Prompts')
+        await clickSubMenuItem(webviewView, 'test')
     })
 })


### PR DESCRIPTION
## Problem
We have yet to implement the initial P0 Pin Context Tests. The pinContextHelper does not mesh well with sub menu items when clicking through different prompts to use.

## Solution
I have implemented the File Context and Prompt Context Test. The Pin Context test with the @workspace was previously implemented. I have implemented the helpers: getSubMenuItems and clickSubMenuItem in the pinContextHelper. All tests still run together.

Test Suite:
- View Context Options
- Reusable Prompt (New)
- Add File as context (New)
- Add Workspace as Context

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
