### PR TITLE
bug(amazonq): Don't show inline completions when a edit is displayed

### DIFF
--- a/packages/amazonq/.vscode/launch.json
+++ b/packages/amazonq/.vscode/launch.json
@@ -13,10 +13,10 @@
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "env": {
                 "SSMDOCUMENT_LANGUAGESERVER_PORT": "6010",
-                "WEBPACK_DEVELOPER_SERVER": "http://localhost:8080"
+                "WEBPACK_DEVELOPER_SERVER": "http://localhost:8080",
                 // Below allows for overrides used during development
-                // "__AMAZONQLSP_PATH": "${workspaceFolder}/../../../language-servers/app/aws-lsp-codewhisperer-runtimes/out/agent-standalone.js",
-                // "__AMAZONQLSP_UI": "${workspaceFolder}/../../../language-servers/chat-client/build/amazonq-ui.js"
+                "__AMAZONQLSP_PATH": "${workspaceFolder}/../../../language-servers/app/aws-lsp-codewhisperer-runtimes/out/agent-standalone.js",
+                "__AMAZONQLSP_UI": "${workspaceFolder}/../../../language-servers/chat-client/build/amazonq-ui.js"
             },
             "envFile": "${workspaceFolder}/.local.env",
             "outFiles": ["${workspaceFolder}/dist/**/*.js", "${workspaceFolder}/../core/dist/**/*.js"],


### PR DESCRIPTION
FOR DEMONSTRATION OF SOLUTION ONLY, DO NOT MERGE!!!

## Problem

Inline completion suggestions were being shown even when edit suggestions were active, creating a confusing user experience where both types of suggestions could appear simultaneously. 

## Solution

1. Added conflict prevention logic in `provideInlineCompletionItems()` to check for active edit suggestions using the existing `aws.amazonq.editSuggestionActive` context flag 
1. Created `isEditSuggestionActive()` method to encapsulate context checking
1. Implemented DISCARD telemetry for completion suggestions that can't be shown due to active edits
1. Added unit tests covering the new functionality, including edge cases for mixed suggestion types and items without IDs
1. Updated displayImage.ts to properly set/unset the context flag when edit suggestions are displayed/cleared

The solution ensures only one type of suggestion is active at a time while maintaining telemetry compliance and following existing codebase patterns.

Treat all work as PUBLIC. Private feature/x branches will not be squash-merged at release time.
Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
