### PR TITLE
refactor(amazonq): reorganize transformation history code

### DIFF
--- a/packages/core/src/amazonqGumby/chat/controller/controller.ts
+++ b/packages/core/src/amazonqGumby/chat/controller/controller.ts
@@ -58,7 +58,7 @@ import {
 import { getAuthType } from '../../../auth/utils'
 import fs from '../../../shared/fs/fs'
 import { setContext } from '../../../shared/vscode/setContext'
-import { readHistoryFile } from '../../../codewhisperer/service/transformByQ/transformationHubViewProvider'
+import { readHistoryFile } from '../../../codewhisperer/service/transformByQ/transformationHistoryHandler'
 
 // These events can be interactions within the chat,
 // or elsewhere in the IDE

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -941,13 +941,3 @@ export const displayFindingsSuffix = '_displayFindings'
 
 export const displayFindingsDetectorName = 'DisplayFindings'
 export const findingsSuffix = '_codeReviewFindings'
-
-export interface HistoryObject {
-    startTime: string
-    projectName: string
-    status: string
-    duration: string
-    diffPath: string
-    summaryPath: string
-    jobId: string
-}

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -547,7 +547,7 @@ export const noChangesMadeMessage = "I didn't make any changes for this transfor
 
 export const noOngoingJobMessage = 'No ongoing job.'
 
-export const nothingToShowMessage = 'Nothing to show'
+export const noJobHistoryMessage = 'No job history'
 
 export const jobStartedNotification =
     'Amazon Q is transforming your code. It can take 10 to 30 minutes to upgrade your code, depending on the size of your project. To monitor progress, go to the Transformation Hub.'

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationHistoryHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationHistoryHandler.ts
@@ -1,0 +1,288 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import fs from '../../../shared/fs/fs'
+import path from 'path'
+import os from 'os'
+import * as CodeWhispererConstants from '../../models/constants'
+import { JDKVersion, TransformationType, transformByQState } from '../../models/model'
+import { getLogger } from '../../../shared/logger/logger'
+import { codeWhispererClient } from '../../../codewhisperer/client/codewhisperer'
+import { pollTransformationStatusUntilComplete } from '../../commands/startTransformByQ'
+import { downloadAndExtractResultArchive } from './transformApiHandler'
+import { ChatSessionManager } from '../../../amazonqGumby/chat/storages/chatSession'
+import { AuthUtil } from '../../util/authUtil'
+import { setMaven } from './transformFileHandler'
+import { convertToTimeString, isWithin30Days } from '../../../shared/datetime'
+
+export async function readHistoryFile(): Promise<CodeWhispererConstants.HistoryObject[]> {
+    const history: CodeWhispererConstants.HistoryObject[] = []
+    const jobHistoryFilePath = path.join(os.homedir(), '.aws', 'transform', 'transformation_history.tsv')
+
+    if (!(await fs.existsFile(jobHistoryFilePath))) {
+        return history
+    }
+
+    const historyFile = await fs.readFileText(jobHistoryFilePath)
+    const jobs = historyFile.split('\n')
+    jobs.shift() // removes headers
+
+    // Process from end, stop at 10 valid entries
+    for (let i = jobs.length - 1; i >= 0 && history.length < 10; i--) {
+        const job = jobs[i]
+        if (job && isWithin30Days(job.split('\t')[0])) {
+            const jobInfo = job.split('\t')
+            history.push({
+                startTime: jobInfo[0],
+                projectName: jobInfo[1],
+                status: jobInfo[2],
+                duration: jobInfo[3],
+                diffPath: jobInfo[4],
+                summaryPath: jobInfo[5],
+                jobId: jobInfo[6],
+            })
+        }
+    }
+    return history
+}
+
+/* Job refresh-related functions */
+
+export async function refreshJob(jobId: string, currentStatus: string, projectName: string) {
+    // fetch status from server
+    let status = ''
+    let duration = ''
+    if (currentStatus === 'COMPLETED' || currentStatus === 'PARTIALLY_COMPLETED') {
+        // job is already completed, no need to fetch status
+        status = currentStatus
+    } else {
+        try {
+            const response = await codeWhispererClient.codeModernizerGetCodeTransformation({
+                transformationJobId: jobId,
+                profileArn: undefined,
+            })
+            status = response.transformationJob.status ?? currentStatus
+            if (response.transformationJob.endExecutionTime && response.transformationJob.creationTime) {
+                duration = convertToTimeString(
+                    response.transformationJob.endExecutionTime.getTime() -
+                        response.transformationJob.creationTime.getTime()
+                )
+            }
+
+            getLogger().debug(
+                'Code Transformation: Job refresh - Fetched status for job id: %s\n{Status: %s; Duration: %s}',
+                jobId,
+                status,
+                duration
+            )
+        } catch (error) {
+            getLogger().error(
+                'Code Transformation: Error fetching status (job id: %s): %s',
+                jobId,
+                (error as Error).message
+            )
+            return
+        }
+    }
+
+    // retrieve artifacts and updated duration if available
+    let jobHistoryPath: string = ''
+    if (status === 'COMPLETED' || status === 'PARTIALLY_COMPLETED') {
+        // artifacts should be available to download
+        jobHistoryPath = await retrieveArtifacts(jobId, projectName)
+
+        // delete metadata and zipped code files, if they exist
+        await fs.delete(path.join(os.homedir(), '.aws', 'transform', projectName, jobId, 'metadata.txt'), {
+            force: true,
+        })
+        await fs.delete(path.join(os.homedir(), '.aws', 'transform', projectName, jobId, 'zipped-code.zip'), {
+            force: true,
+        })
+    } else if (CodeWhispererConstants.validStatesForBuildSucceeded.includes(status)) {
+        // still in progress on server side
+        if (transformByQState.isRunning()) {
+            getLogger().warn(
+                'Code Transformation: There is a job currently running (id: %s). Cannot resume another job (id: %s)',
+                transformByQState.getJobId(),
+                jobId
+            )
+            return
+        }
+        transformByQState.setRefreshInProgress(true)
+        const messenger = transformByQState.getChatMessenger()
+        const tabID = ChatSessionManager.Instance.getSession().tabID
+        messenger?.sendJobRefreshInProgressMessage(tabID!, jobId)
+        await vscode.commands.executeCommand('aws.amazonq.transformationHub.updateContent', 'job history') // refreshing the table disables all jobs' refresh buttons while this one is resuming
+
+        // resume job and bring to completion
+        try {
+            status = await resumeJob(jobId, projectName, status)
+        } catch (e: any) {
+            getLogger().error('Code Transformation: Error resuming job (id: %s): %s', jobId, (e as Error).message)
+            transformByQState.setJobDefaults()
+            messenger?.sendJobFinishedMessage(tabID!, CodeWhispererConstants.refreshErrorChatMessage)
+            void vscode.window.showErrorMessage(CodeWhispererConstants.refreshErrorNotification(jobId))
+            await vscode.commands.executeCommand('aws.amazonq.transformationHub.updateContent', 'job history')
+            return
+        }
+
+        // download artifacts if available
+        if (
+            CodeWhispererConstants.validStatesForCheckingDownloadUrl.includes(status) &&
+            !CodeWhispererConstants.failureStates.includes(status)
+        ) {
+            duration = convertToTimeString(Date.now() - new Date(transformByQState.getStartTime()).getTime())
+            jobHistoryPath = await retrieveArtifacts(jobId, projectName)
+        }
+
+        // reset state
+        transformByQState.setJobDefaults()
+        messenger?.sendJobFinishedMessage(tabID!, CodeWhispererConstants.refreshCompletedChatMessage)
+    } else {
+        // FAILED or STOPPED job
+        getLogger().info('Code Transformation: No artifacts available to download (job status = %s)', status)
+        if (status === 'FAILED') {
+            // if job failed on backend, mark it to disable the refresh button
+            status = 'FAILED_BE' // this will be truncated to just 'FAILED' in the table
+        }
+        // delete metadata and zipped code files, if they exist
+        await fs.delete(path.join(os.homedir(), '.aws', 'transform', projectName, jobId, 'metadata.txt'), {
+            force: true,
+        })
+        await fs.delete(path.join(os.homedir(), '.aws', 'transform', projectName, jobId, 'zipped-code.zip'), {
+            force: true,
+        })
+    }
+
+    if (status === currentStatus && !jobHistoryPath) {
+        // no changes, no need to update file/table
+        void vscode.window.showInformationMessage(CodeWhispererConstants.refreshNoUpdatesNotification(jobId))
+        return
+    }
+
+    void vscode.window.showInformationMessage(CodeWhispererConstants.refreshCompletedNotification(jobId))
+    // update local file and history table
+
+    await updateHistoryFile(status, duration, jobHistoryPath, jobId)
+}
+
+export async function retrieveArtifacts(jobId: string, projectName: string) {
+    const resultsPath = path.join(os.homedir(), '.aws', 'transform', projectName, 'results') // temporary directory for extraction
+    let jobHistoryPath = path.join(os.homedir(), '.aws', 'transform', projectName, jobId)
+
+    if (await fs.existsFile(path.join(jobHistoryPath, 'diff.patch'))) {
+        getLogger().info('Code Transformation: Diff patch already exists for job id: %s', jobId)
+        jobHistoryPath = ''
+    } else {
+        try {
+            await downloadAndExtractResultArchive(jobId, resultsPath)
+
+            if (!(await fs.existsDir(path.join(jobHistoryPath, 'summary')))) {
+                await fs.mkdir(path.join(jobHistoryPath, 'summary'))
+            }
+            await fs.copy(path.join(resultsPath, 'patch', 'diff.patch'), path.join(jobHistoryPath, 'diff.patch'))
+            await fs.copy(
+                path.join(resultsPath, 'summary', 'summary.md'),
+                path.join(jobHistoryPath, 'summary', 'summary.md')
+            )
+            if (await fs.existsFile(path.join(resultsPath, 'summary', 'buildCommandOutput.log'))) {
+                await fs.copy(
+                    path.join(resultsPath, 'summary', 'buildCommandOutput.log'),
+                    path.join(jobHistoryPath, 'summary', 'buildCommandOutput.log')
+                )
+            }
+        } catch (error) {
+            jobHistoryPath = ''
+        } finally {
+            // delete temporary extraction directory
+            await fs.delete(resultsPath, { recursive: true, force: true })
+        }
+    }
+    return jobHistoryPath
+}
+
+export async function updateHistoryFile(status: string, duration: string, jobHistoryPath: string, jobId: string) {
+    const history: string[][] = []
+    const historyLogFilePath = path.join(os.homedir(), '.aws', 'transform', 'transformation_history.tsv')
+    if (await fs.existsFile(historyLogFilePath)) {
+        const historyFile = await fs.readFileText(historyLogFilePath)
+        const jobs = historyFile.split('\n')
+        jobs.shift() // removes headers
+        if (jobs.length > 0) {
+            for (const job of jobs) {
+                if (job) {
+                    const jobInfo = job.split('\t')
+                    // startTime: jobInfo[0], projectName: jobInfo[1], status: jobInfo[2], duration: jobInfo[3], diffPath: jobInfo[4], summaryPath: jobInfo[5], jobId: jobInfo[6]
+                    if (jobInfo[6] === jobId) {
+                        // update any values if applicable
+                        jobInfo[2] = status
+                        if (duration) {
+                            jobInfo[3] = duration
+                        }
+                        if (jobHistoryPath) {
+                            jobInfo[4] = path.join(jobHistoryPath, 'diff.patch')
+                            jobInfo[5] = path.join(jobHistoryPath, 'summary', 'summary.md')
+                        }
+                    }
+                    history.push(jobInfo)
+                }
+            }
+        }
+    }
+
+    if (history.length === 0) {
+        return
+    }
+
+    // rewrite file
+    await fs.writeFile(historyLogFilePath, 'date\tproject_name\tstatus\tduration\tdiff_patch\tsummary\tjob_id\n')
+    const tsvContent = history.map((row) => row.join('\t')).join('\n') + '\n'
+    await fs.appendFile(historyLogFilePath, tsvContent)
+
+    // update table content
+    await vscode.commands.executeCommand('aws.amazonq.transformationHub.updateContent', 'job history', undefined, true)
+}
+
+async function resumeJob(jobId: string, projectName: string, status: string) {
+    // set state to prepare to resume job
+    await setupTransformationState(jobId, projectName, status)
+    // resume polling the job
+    return await pollAndCompleteTransformation(jobId)
+}
+
+async function setupTransformationState(jobId: string, projectName: string, status: string) {
+    transformByQState.setJobId(jobId)
+    transformByQState.setPolledJobStatus(status)
+    transformByQState.setJobHistoryPath(path.join(os.homedir(), '.aws', 'transform', projectName, jobId))
+    const metadataFile = await fs.readFileText(path.join(transformByQState.getJobHistoryPath(), 'metadata.txt'))
+    const metadata = metadataFile.split('\t')
+    transformByQState.setTransformationType(metadata[1] as TransformationType)
+    transformByQState.setSourceJDKVersion(metadata[2] as JDKVersion)
+    transformByQState.setTargetJDKVersion(metadata[3] as JDKVersion)
+    transformByQState.setCustomDependencyVersionFilePath(metadata[4])
+    transformByQState.setPayloadFilePath(
+        path.join(os.homedir(), '.aws', 'transform', projectName, jobId, 'zipped-code.zip')
+    )
+    setMaven()
+    transformByQState.setCustomBuildCommand(metadata[5])
+    transformByQState.setTargetJavaHome(metadata[6])
+    transformByQState.setProjectPath(metadata[7])
+    transformByQState.setStartTime(metadata[8])
+}
+
+async function pollAndCompleteTransformation(jobId: string) {
+    const status = await pollTransformationStatusUntilComplete(
+        jobId,
+        AuthUtil.instance.regionProfileManager.activeRegionProfile
+    )
+    // delete payload and metadata files
+    await fs.delete(transformByQState.getPayloadFilePath(), { force: true })
+    await fs.delete(path.join(transformByQState.getJobHistoryPath(), 'metadata.txt'), { force: true })
+    // delete temporary build logs file
+    const logFilePath = path.join(os.tmpdir(), 'build-logs.txt')
+    await fs.delete(logFilePath, { force: true })
+    return status
+}

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
@@ -24,14 +24,14 @@ import { startInterval } from '../../commands/startTransformByQ'
 import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/codeTransformTelemetryState'
 import { convertToTimeString } from '../../../shared/datetime'
 import { AuthUtil } from '../../util/authUtil'
-import { refreshJob, readHistoryFile } from './transformationHistoryHandler'
+import { refreshJob, readHistoryFile, HistoryObject } from './transformationHistoryHandler'
 
 export class TransformationHubViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'aws.amazonq.transformationHub'
     private _view?: vscode.WebviewView
     private lastClickedButton: string = ''
     private _extensionUri: vscode.Uri = globals.context.extensionUri
-    private transformationHistory: CodeWhispererConstants.HistoryObject[] = []
+    private transformationHistory: HistoryObject[] = []
     constructor() {}
     static #instance: TransformationHubViewProvider
 
@@ -109,7 +109,7 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
     }
 
     private showJobHistory(): string {
-        const jobsToDisplay: CodeWhispererConstants.HistoryObject[] = [...this.transformationHistory]
+        const jobsToDisplay: HistoryObject[] = [...this.transformationHistory]
         if (transformByQState.isRunning()) {
             const current = sessionJobHistory[transformByQState.getJobId()]
             jobsToDisplay.unshift({
@@ -179,7 +179,7 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
             </html>`
     }
 
-    private getTableMarkup(history: CodeWhispererConstants.HistoryObject[]) {
+    private getTableMarkup(history: HistoryObject[]) {
         return `
             <style>
             .refresh-btn {

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
@@ -187,6 +187,7 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
                 background: none;
                 cursor: pointer;
                 font-size: 16px;
+                color: inherit;
             }
             .refresh-btn:disabled {
                 opacity: 0.3;

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationHubViewProvider.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode'
 import globals from '../../../shared/extensionGlobals'
 import * as CodeWhispererConstants from '../../models/constants'
 import {
-    JDKVersion,
     StepProgress,
     TransformationType,
     jobPlanProgress,
@@ -15,22 +14,17 @@ import {
     transformByQState,
 } from '../../models/model'
 import { getLogger } from '../../../shared/logger/logger'
-import { getTransformationSteps, downloadAndExtractResultArchive } from './transformApiHandler'
+import { getTransformationSteps } from './transformApiHandler'
 import {
     TransformationSteps,
     ProgressUpdates,
     TransformationStatus,
 } from '../../../codewhisperer/client/codewhispereruserclient'
-import { codeWhispererClient } from '../../../codewhisperer/client/codewhisperer'
-import { startInterval, pollTransformationStatusUntilComplete } from '../../commands/startTransformByQ'
+import { startInterval } from '../../commands/startTransformByQ'
 import { CodeTransformTelemetryState } from '../../../amazonqGumby/telemetry/codeTransformTelemetryState'
-import { convertToTimeString, isWithin30Days } from '../../../shared/datetime'
+import { convertToTimeString } from '../../../shared/datetime'
 import { AuthUtil } from '../../util/authUtil'
-import fs from '../../../shared/fs/fs'
-import path from 'path'
-import os from 'os'
-import { ChatSessionManager } from '../../../amazonqGumby/chat/storages/chatSession'
-import { setMaven } from './transformFileHandler'
+import { refreshJob, readHistoryFile } from './transformationHistoryHandler'
 
 export class TransformationHubViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'aws.amazonq.transformationHub'
@@ -84,7 +78,7 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
         this._view.webview.onDidReceiveMessage((message) => {
             switch (message.command) {
                 case 'refreshJob':
-                    void this.refreshJob(message.jobId, message.currentStatus, message.projectName)
+                    void refreshJob(message.jobId, message.currentStatus, message.projectName)
                     break
                 case 'openSummaryPreview':
                     void vscode.commands.executeCommand('markdown.showPreview', vscode.Uri.file(message.filePath))
@@ -143,7 +137,7 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
             <p>${CodeWhispererConstants.transformationHistoryTableDescription}</p>
             ${
                 jobsToDisplay.length === 0
-                    ? `<p><br>${CodeWhispererConstants.nothingToShowMessage}</p>`
+                    ? `<p><br>${CodeWhispererConstants.noJobHistoryMessage}</p>`
                     : this.getTableMarkup(jobsToDisplay)
             }
             <script>
@@ -254,241 +248,6 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
                 </tbody>
             </table>
         `
-    }
-
-    private async refreshJob(jobId: string, currentStatus: string, projectName: string) {
-        // fetch status from server
-        let status = ''
-        let duration = ''
-        if (currentStatus === 'COMPLETED' || currentStatus === 'PARTIALLY_COMPLETED') {
-            // job is already completed, no need to fetch status
-            status = currentStatus
-        } else {
-            try {
-                const response = await codeWhispererClient.codeModernizerGetCodeTransformation({
-                    transformationJobId: jobId,
-                    profileArn: undefined,
-                })
-                status = response.transformationJob.status ?? currentStatus
-                if (response.transformationJob.endExecutionTime && response.transformationJob.creationTime) {
-                    duration = convertToTimeString(
-                        response.transformationJob.endExecutionTime.getTime() -
-                            response.transformationJob.creationTime.getTime()
-                    )
-                }
-
-                getLogger().debug(
-                    'Code Transformation: Job refresh - Fetched status for job id: %s\n{Status: %s; Duration: %s}',
-                    jobId,
-                    status,
-                    duration
-                )
-            } catch (error) {
-                getLogger().error(
-                    'Code Transformation: Error fetching status (job id: %s): %s',
-                    jobId,
-                    (error as Error).message
-                )
-                return
-            }
-        }
-
-        // retrieve artifacts and updated duration if available
-        let jobHistoryPath: string = ''
-        if (status === 'COMPLETED' || status === 'PARTIALLY_COMPLETED') {
-            // artifacts should be available to download
-            jobHistoryPath = await this.retrieveArtifacts(jobId, projectName)
-
-            // delete metadata and zipped code files, if they exist
-            await fs.delete(path.join(os.homedir(), '.aws', 'transform', projectName, jobId, 'metadata.txt'), {
-                force: true,
-            })
-            await fs.delete(path.join(os.homedir(), '.aws', 'transform', projectName, jobId, 'zipped-code.zip'), {
-                force: true,
-            })
-        } else if (CodeWhispererConstants.validStatesForBuildSucceeded.includes(status)) {
-            // still in progress on server side
-            if (transformByQState.isRunning()) {
-                getLogger().warn(
-                    'Code Transformation: There is a job currently running (id: %s). Cannot resume another job (id: %s)',
-                    transformByQState.getJobId(),
-                    jobId
-                )
-                return
-            }
-            transformByQState.setRefreshInProgress(true)
-            const messenger = transformByQState.getChatMessenger()
-            const tabID = ChatSessionManager.Instance.getSession().tabID
-            messenger?.sendJobRefreshInProgressMessage(tabID!, jobId)
-            void this.updateContent('job history') // refreshing the table disables all jobs' refresh buttons while this one is resuming
-
-            // resume job and bring to completion
-            try {
-                status = await this.resumeJob(jobId, projectName, status)
-            } catch (e: any) {
-                getLogger().error('Code Transformation: Error resuming job (id: %s): %s', jobId, (e as Error).message)
-                transformByQState.setJobDefaults()
-                messenger?.sendJobFinishedMessage(tabID!, CodeWhispererConstants.refreshErrorChatMessage)
-                void vscode.window.showErrorMessage(CodeWhispererConstants.refreshErrorNotification(jobId))
-                void this.updateContent('job history')
-                return
-            }
-
-            // download artifacts if available
-            if (
-                CodeWhispererConstants.validStatesForCheckingDownloadUrl.includes(status) &&
-                !CodeWhispererConstants.failureStates.includes(status)
-            ) {
-                duration = convertToTimeString(Date.now() - new Date(transformByQState.getStartTime()).getTime())
-                jobHistoryPath = await this.retrieveArtifacts(jobId, projectName)
-            }
-
-            // reset state
-            transformByQState.setJobDefaults()
-            messenger?.sendJobFinishedMessage(tabID!, CodeWhispererConstants.refreshCompletedChatMessage)
-        } else {
-            // FAILED or STOPPED job
-            getLogger().info('Code Transformation: No artifacts available to download (job status = %s)', status)
-            if (status === 'FAILED') {
-                // if job failed on backend, mark it to disable the refresh button
-                status = 'FAILED_BE' // this will be truncated to just 'FAILED' in the table
-            }
-            // delete metadata and zipped code files, if they exist
-            await fs.delete(path.join(os.homedir(), '.aws', 'transform', projectName, jobId, 'metadata.txt'), {
-                force: true,
-            })
-            await fs.delete(path.join(os.homedir(), '.aws', 'transform', projectName, jobId, 'zipped-code.zip'), {
-                force: true,
-            })
-        }
-
-        if (status === currentStatus && !jobHistoryPath) {
-            // no changes, no need to update file/table
-            void vscode.window.showInformationMessage(CodeWhispererConstants.refreshNoUpdatesNotification(jobId))
-            return
-        }
-
-        void vscode.window.showInformationMessage(CodeWhispererConstants.refreshCompletedNotification(jobId))
-        // update local file and history table
-        await this.updateHistoryFile(status, duration, jobHistoryPath, jobId)
-    }
-
-    private async retrieveArtifacts(jobId: string, projectName: string) {
-        const resultsPath = path.join(os.homedir(), '.aws', 'transform', projectName, 'results') // temporary directory for extraction
-        let jobHistoryPath = path.join(os.homedir(), '.aws', 'transform', projectName, jobId)
-
-        if (await fs.existsFile(path.join(jobHistoryPath, 'diff.patch'))) {
-            getLogger().info('Code Transformation: Diff patch already exists for job id: %s', jobId)
-            jobHistoryPath = ''
-        } else {
-            try {
-                await downloadAndExtractResultArchive(jobId, resultsPath)
-
-                if (!(await fs.existsDir(path.join(jobHistoryPath, 'summary')))) {
-                    await fs.mkdir(path.join(jobHistoryPath, 'summary'))
-                }
-                await fs.copy(path.join(resultsPath, 'patch', 'diff.patch'), path.join(jobHistoryPath, 'diff.patch'))
-                await fs.copy(
-                    path.join(resultsPath, 'summary', 'summary.md'),
-                    path.join(jobHistoryPath, 'summary', 'summary.md')
-                )
-                if (await fs.existsFile(path.join(resultsPath, 'summary', 'buildCommandOutput.log'))) {
-                    await fs.copy(
-                        path.join(resultsPath, 'summary', 'buildCommandOutput.log'),
-                        path.join(jobHistoryPath, 'summary', 'buildCommandOutput.log')
-                    )
-                }
-            } catch (error) {
-                jobHistoryPath = ''
-            } finally {
-                // delete temporary extraction directory
-                await fs.delete(resultsPath, { recursive: true, force: true })
-            }
-        }
-        return jobHistoryPath
-    }
-
-    private async updateHistoryFile(status: string, duration: string, jobHistoryPath: string, jobId: string) {
-        const history: string[][] = []
-        const historyLogFilePath = path.join(os.homedir(), '.aws', 'transform', 'transformation_history.tsv')
-        if (await fs.existsFile(historyLogFilePath)) {
-            const historyFile = await fs.readFileText(historyLogFilePath)
-            const jobs = historyFile.split('\n')
-            jobs.shift() // removes headers
-            if (jobs.length > 0) {
-                for (const job of jobs) {
-                    if (job) {
-                        const jobInfo = job.split('\t')
-                        // startTime: jobInfo[0], projectName: jobInfo[1], status: jobInfo[2], duration: jobInfo[3], diffPath: jobInfo[4], summaryPath: jobInfo[5], jobId: jobInfo[6]
-                        if (jobInfo[6] === jobId) {
-                            // update any values if applicable
-                            jobInfo[2] = status
-                            if (duration) {
-                                jobInfo[3] = duration
-                            }
-                            if (jobHistoryPath) {
-                                jobInfo[4] = path.join(jobHistoryPath, 'diff.patch')
-                                jobInfo[5] = path.join(jobHistoryPath, 'summary', 'summary.md')
-                            }
-                        }
-                        history.push(jobInfo)
-                    }
-                }
-            }
-        }
-
-        if (history.length === 0) {
-            return
-        }
-
-        // rewrite file
-        await fs.writeFile(historyLogFilePath, 'date\tproject_name\tstatus\tduration\tdiff_patch\tsummary\tjob_id\n')
-        const tsvContent = history.map((row) => row.join('\t')).join('\n') + '\n'
-        await fs.appendFile(historyLogFilePath, tsvContent)
-
-        // update table content
-        await this.updateContent('job history', undefined, true)
-    }
-
-    private async resumeJob(jobId: string, projectName: string, status: string) {
-        // set state to prepare to resume job
-        await this.setupTransformationState(jobId, projectName, status)
-        // resume polling the job
-        return await this.pollAndCompleteTransformation(jobId)
-    }
-
-    private async setupTransformationState(jobId: string, projectName: string, status: string) {
-        transformByQState.setJobId(jobId)
-        transformByQState.setPolledJobStatus(status)
-        transformByQState.setJobHistoryPath(path.join(os.homedir(), '.aws', 'transform', projectName, jobId))
-        const metadataFile = await fs.readFileText(path.join(transformByQState.getJobHistoryPath(), 'metadata.txt'))
-        const metadata = metadataFile.split('\t')
-        transformByQState.setTransformationType(metadata[1] as TransformationType)
-        transformByQState.setSourceJDKVersion(metadata[2] as JDKVersion)
-        transformByQState.setTargetJDKVersion(metadata[3] as JDKVersion)
-        transformByQState.setCustomDependencyVersionFilePath(metadata[4])
-        transformByQState.setPayloadFilePath(
-            path.join(os.homedir(), '.aws', 'transform', projectName, jobId, 'zipped-code.zip')
-        )
-        setMaven()
-        transformByQState.setCustomBuildCommand(metadata[5])
-        transformByQState.setTargetJavaHome(metadata[6])
-        transformByQState.setProjectPath(metadata[7])
-        transformByQState.setStartTime(metadata[8])
-    }
-
-    private async pollAndCompleteTransformation(jobId: string) {
-        const status = await pollTransformationStatusUntilComplete(
-            jobId,
-            AuthUtil.instance.regionProfileManager.activeRegionProfile
-        )
-        // delete payload and metadata files
-        await fs.delete(transformByQState.getPayloadFilePath(), { force: true })
-        await fs.delete(path.join(transformByQState.getJobHistoryPath(), 'metadata.txt'), { force: true })
-        // delete temporary build logs file
-        const logFilePath = path.join(os.tmpdir(), 'build-logs.txt')
-        await fs.delete(logFilePath, { force: true })
-        return status
     }
 
     private generateTransformationStepMarkup(
@@ -897,35 +656,4 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
             return `<span class="status-PENDING"> ✓ </span>`
         }
     }
-}
-
-export async function readHistoryFile(): Promise<CodeWhispererConstants.HistoryObject[]> {
-    const history: CodeWhispererConstants.HistoryObject[] = []
-    const jobHistoryFilePath = path.join(os.homedir(), '.aws', 'transform', 'transformation_history.tsv')
-
-    if (!(await fs.existsFile(jobHistoryFilePath))) {
-        return history
-    }
-
-    const historyFile = await fs.readFileText(jobHistoryFilePath)
-    const jobs = historyFile.split('\n')
-    jobs.shift() // removes headers
-
-    // Process from end, stop at 10 valid entries
-    for (let i = jobs.length - 1; i >= 0 && history.length < 10; i--) {
-        const job = jobs[i]
-        if (job && isWithin30Days(job.split('\t')[0])) {
-            const jobInfo = job.split('\t')
-            history.push({
-                startTime: jobInfo[0],
-                projectName: jobInfo[1],
-                status: jobInfo[2],
-                duration: jobInfo[3],
-                diffPath: jobInfo[4],
-                summaryPath: jobInfo[5],
-                jobId: jobInfo[6],
-            })
-        }
-    }
-    return history
 }

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -22,6 +22,7 @@ import { setContext } from '../../../shared/vscode/setContext'
 import * as codeWhisperer from '../../client/codewhisperer'
 import { UserWrittenCodeTracker } from '../../tracker/userWrittenCodeTracker'
 import { AuthUtil } from '../../util/authUtil'
+import { copyArtifacts } from './transformationHistoryHandler'
 
 export abstract class ProposedChangeNode {
     abstract readonly resourcePath: string
@@ -434,7 +435,6 @@ export class ProposedTransformationExplorer {
                 zip.extractAllTo(pathContainingArchive)
                 const files = fs.readdirSync(path.join(pathContainingArchive, ExportResultArchiveStructure.PathToPatch))
                 singlePatchFile = path.join(pathContainingArchive, ExportResultArchiveStructure.PathToPatch, files[0])
-                fs.copyFileSync(singlePatchFile, path.join(transformByQState.getJobHistoryPath(), 'diff.patch')) // store diff patch locally
                 patchFiles.push(singlePatchFile)
                 diffModel.parseDiff(patchFiles[0], transformByQState.getProjectPath())
 
@@ -443,24 +443,8 @@ export class ProposedTransformationExplorer {
                 transformByQState.setSummaryFilePath(
                     path.join(pathContainingArchive, ExportResultArchiveStructure.PathToSummary)
                 )
-                // store summary and build log locally for history
-                if (!fs.existsSync(path.join(transformByQState.getJobHistoryPath(), 'summary'))) {
-                    fs.mkdirSync(path.join(transformByQState.getJobHistoryPath(), 'summary'))
-                }
-                fs.copyFileSync(
-                    transformByQState.getSummaryFilePath(),
-                    path.join(transformByQState.getJobHistoryPath(), 'summary', 'summary.md')
-                )
-                if (
-                    fs.existsSync(
-                        path.join(path.dirname(transformByQState.getSummaryFilePath()), 'buildCommandOutput.log')
-                    )
-                ) {
-                    fs.copyFileSync(
-                        path.join(path.dirname(transformByQState.getSummaryFilePath()), 'buildCommandOutput.log'),
-                        path.join(transformByQState.getJobHistoryPath(), 'summary', 'buildCommandOutput.log')
-                    )
-                }
+
+                await copyArtifacts(pathContainingArchive, transformByQState.getJobHistoryPath())
 
                 transformByQState.setResultArchiveFilePath(pathContainingArchive)
                 await setContext('gumby.isSummaryAvailable', true)

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -22,7 +22,7 @@ import { setContext } from '../../../shared/vscode/setContext'
 import * as codeWhisperer from '../../client/codewhisperer'
 import { UserWrittenCodeTracker } from '../../tracker/userWrittenCodeTracker'
 import { AuthUtil } from '../../util/authUtil'
-import { copyArtifacts } from './transformationHistoryHandler'
+import { copyArtifacts } from './transformFileHandler'
 
 export abstract class ProposedChangeNode {
     abstract readonly resourcePath: string

--- a/packages/core/src/test/amazonqGumby/transformationJobHistory.test.ts
+++ b/packages/core/src/test/amazonqGumby/transformationJobHistory.test.ts
@@ -5,464 +5,328 @@
 
 import assert from 'assert'
 import * as sinon from 'sinon'
-import * as CodeWhispererConstants from '../../codewhisperer/models/constants'
-import { transformByQState, sessionJobHistory } from '../../codewhisperer/models/model'
+import * as vscode from 'vscode'
+import * as os from 'os'
+import * as path from 'path'
+import fs from '../../shared/fs/fs'
+import * as datetime from '../../shared/datetime'
 import { codeWhispererClient } from '../../codewhisperer/client/codewhisperer'
 import {
-    TransformationHubViewProvider,
     readHistoryFile,
-} from '../../codewhisperer/service/transformByQ/transformationHubViewProvider'
-import fs from '../../shared/fs/fs'
-import nodeFs from 'fs' // eslint-disable-line no-restricted-imports
-import { postTransformationJob } from '../../codewhisperer/commands/startTransformByQ'
+    writeToHistoryFile,
+    createMetadataFile,
+    copyArtifacts,
+    cleanupTempJobFiles,
+    refreshJob,
+    JobMetadata,
+} from '../../codewhisperer/service/transformByQ/transformationHistoryHandler'
 import * as transformApiHandler from '../../codewhisperer/service/transformByQ/transformApiHandler'
-import * as vscode from 'vscode'
-import * as datetime from '../../shared/datetime'
+import { ExportResultArchiveStructure } from '../../shared/utilities/download'
+import { JDKVersion, TransformationType } from '../../codewhisperer'
 
-describe('Transformation Job History', function () {
-    let transformationHub: TransformationHubViewProvider
-
-    // Mock job objects
-    const mockJobs = {
-        completed: {
-            startTime: '07/14/25, 09:00 AM',
-            projectName: 'old-project',
-            status: 'COMPLETED',
-            duration: '3 min',
-            diffPath: '/path/to/diff.patch',
-            summaryPath: '/path/to/summary.md',
-            jobId: 'old-job-456',
-        } as CodeWhispererConstants.HistoryObject,
-
-        transforming: {
-            startTime: '07/14/25, 10:00 AM',
-            projectName: 'incomplete-project',
-            status: 'TRANSFORMING',
-            duration: '3 min',
-            diffPath: '',
-            summaryPath: '',
-            jobId: 'inc-100',
-        } as CodeWhispererConstants.HistoryObject,
-
-        failed: {
-            startTime: '07/14/25, 09:00 AM',
-            projectName: 'old-project',
-            status: 'FAILED',
-            duration: '3 min',
-            diffPath: '',
-            summaryPath: '',
-            jobId: 'fail-100',
-        } as CodeWhispererConstants.HistoryObject,
-
-        failedBE: {
-            startTime: '07/10/25, 10:00 AM',
-            projectName: 'failed-project',
-            status: 'FAILED_BE',
-            duration: '3 min',
-            diffPath: '',
-            summaryPath: '',
-            jobId: 'failbe-300',
-        } as CodeWhispererConstants.HistoryObject,
-
-        stopped: {
-            startTime: '07/14/25, 10:00 AM',
-            projectName: 'cancelled-project',
-            status: 'STOPPED',
-            duration: '3 min',
-            diffPath: '',
-            summaryPath: '',
-            jobId: 'stop-200',
-        } as CodeWhispererConstants.HistoryObject,
-    }
-
-    // setup function helpers
-    function setupRunningJob(jobId = 'running-job-123') {
-        sinon.stub(transformByQState, 'isRunning').returns(true)
-        sinon.stub(transformByQState, 'getJobId').returns(jobId)
-        sessionJobHistory[jobId] = {
-            startTime: '07/14/25, 11:00 AM',
-            projectName: 'running-project',
-            status: 'TRANSFORMING',
-            duration: '2 min',
-        }
-        return jobId
-    }
-
-    beforeEach(function () {
-        transformationHub = TransformationHubViewProvider.instance
-    })
-
+describe('Transformation History Handler', function () {
     afterEach(function () {
         sinon.restore()
     })
 
-    describe('Viewing job history in Transformation Hub', function () {
-        it('Nothing to show message when no history', function () {
-            transformationHub['transformationHistory'] = []
-            sinon.stub(transformByQState, 'isRunning').returns(false)
+    describe('Reading history file', function () {
+        it('Returns empty array when history file does not exist', async function () {
+            sinon.stub(fs, 'existsFile').resolves(false)
 
-            const result = transformationHub['showJobHistory']()
+            const result = await readHistoryFile()
 
-            assert(result.includes('Transformation History'))
-            assert(result.includes(CodeWhispererConstants.nothingToShowMessage))
+            assert.strictEqual(result.length, 0)
         })
 
-        it('Can see previously run jobs', function () {
-            transformationHub['transformationHistory'] = [mockJobs.completed, mockJobs.transforming, mockJobs.failedBE]
-            sinon.stub(transformByQState, 'isRunning').returns(false)
+        it('Limits results to 10 most recent jobs', async function () {
+            sinon.stub(fs, 'existsFile').resolves(true)
+            sinon.stub(datetime, 'isWithin30Days').returns(true)
 
-            const result = transformationHub['showJobHistory']()
+            let historyContent = 'date\tproject_name\tstatus\tduration\tdiff_patch\tsummary\tjob_id\n'
+            for (let i = 1; i <= 15; i++) {
+                historyContent += `01/${i}/25, 10:00 AM\tproject-${i}\tCOMPLETED\t5 min\t\t\tjob-${i}\n`
+            }
 
-            assert(result.includes('old-project'))
-            assert(result.includes('COMPLETED'))
-            assert(result.includes('old-job-456'))
-            assert(result.includes('incomplete-project'))
-            assert(result.includes('TRANSFORMING'))
-            assert(result.includes('inc-100'))
-            assert(!result.includes('<td>FAILED_BE</td>'), 'Table should only say FAILED in the status column')
-            assert(result.includes('<table'))
-        })
+            sinon.stub(fs, 'readFileText').resolves(historyContent)
 
-        it('Can see running job at top of table', function () {
-            transformationHub['transformationHistory'] = [mockJobs.completed]
-            const runningJobId = setupRunningJob()
+            const result = await readHistoryFile()
 
-            const result = transformationHub['showJobHistory']()
-
-            const runningIndex = result.indexOf('running-project')
-            const oldIndex = result.indexOf('old-project')
-            assert(runningIndex < oldIndex, 'Running job should appear before completed jobs')
-            assert(result.includes(`row-id="${runningJobId}"`))
-            assert(result.includes('old-job-456'))
+            assert.strictEqual(result.length, 10)
+            assert.strictEqual(result[0].jobId, 'job-15') // most recent first
+            assert.strictEqual(result[9].jobId, 'job-6')
         })
     })
 
-    describe('Job history file operations', function () {
-        let fsExistsStub: sinon.SinonStub
-        let fsReadStub: sinon.SinonStub
-        let nodeFsWriteStub: sinon.SinonStub
+    describe('Writing to history file', function () {
+        let writtenFiles: Map<string, string>
 
         beforeEach(function () {
-            fsExistsStub = sinon.stub(fs, 'existsFile')
-            fsReadStub = sinon.stub(fs, 'readFileText')
+            writtenFiles = new Map()
+
+            // Mock file operations to capture what gets written
+            sinon.stub(fs, 'mkdir').resolves()
+            sinon.stub(fs, 'writeFile').callsFake(async (filePath: any, content: any) => {
+                writtenFiles.set(filePath.toString(), content.toString())
+            })
+            sinon.stub(fs, 'appendFile').callsFake(async (filePath: any, content: any) => {
+                const existing = writtenFiles.get(filePath.toString()) || ''
+                writtenFiles.set(filePath.toString(), existing + content.toString())
+            })
+            sinon.stub(vscode.commands, 'executeCommand').resolves()
         })
 
-        describe('Reading history file', function () {
-            it('Returns empty array when history file does not exist', async function () {
-                fsExistsStub.resolves(false)
+        it('Creates history file with headers when it does not exist', async function () {
+            sinon.stub(fs, 'existsFile').resolves(false)
+            await writeToHistoryFile('01/01/25, 10:00 AM', 'test-project', 'COMPLETED', '5 min', 'job-123', '/job/path')
 
-                const result = (transformationHub['transformationHistory'] = await readHistoryFile())
+            const expectedPath = path.join(os.homedir(), '.aws', 'transform', 'transformation_history.tsv')
+            const fileContent = writtenFiles.get(expectedPath)
 
-                assert.strictEqual(result.length, 0, 'Should return empty array when file does not exist')
-                sinon.assert.calledOnce(fsExistsStub)
-                sinon.assert.notCalled(fsReadStub)
-            })
-
-            it('Only includes jobs within 30 days', async function () {
-                fsExistsStub.resolves(true)
-
-                const recentDate = new Date()
-                const oldDate = new Date(recentDate.getDate() - 40) // 40 days ago
-
-                // Format dates
-                const recentDateStr = recentDate.toLocaleDateString('en-US', {
-                    month: '2-digit',
-                    day: '2-digit',
-                    year: '2-digit',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                })
-                const oldDateStr = oldDate.toLocaleDateString('en-US', {
-                    month: '2-digit',
-                    day: '2-digit',
-                    year: '2-digit',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                })
-
-                const mockHistoryContent =
-                    'date\tproject_name\tstatus\tduration\tdiff_patch\tsummary\tjob_id\n' +
-                    `${recentDateStr}\trecent-project\tCOMPLETED\t3 min\t/path/diff.patch\t/path/summary.md\tjob-123\n` +
-                    `${oldDateStr}\told-project\tCOMPLETED\t5 min\t/path/diff.patch\t/path/summary.md\tjob-456\n`
-
-                fsReadStub.resolves(mockHistoryContent)
-
-                const result = await readHistoryFile()
-                assert.strictEqual(result.length, 1, 'Should only include jobs within 30 days')
-                assert.strictEqual(result[0].projectName, 'recent-project')
-            })
-
-            it('Limits history to 10 most recent jobs', async function () {
-                fsExistsStub.resolves(true)
-                sinon.stub(datetime, 'isWithin30Days').returns(true)
-
-                // Create 15 job entries
-                let mockHistoryContent = 'date\tproject_name\tstatus\tduration\tdiff_patch\tsummary\tjob_id\n'
-                for (let i = 1; i <= 15; i++) {
-                    mockHistoryContent += `07/${i}/25, 09:00 AM\tproject-${i}\tCOMPLETED\t3 min\t/path/diff.patch\t/path/summary.md\tjob-${i}\n`
-                }
-
-                fsReadStub.resolves(mockHistoryContent)
-
-                const result = await readHistoryFile()
-
-                assert.strictEqual(result.length, 10, 'Should limit to 10 jobs')
-                // Should have the most recent jobs (highest numbers)
-                assert.strictEqual(result[0].jobId, 'job-15')
-                assert.strictEqual(result[9].jobId, 'job-6')
-            })
-        })
-
-        describe('Writing to history file', function () {
-            it('Writes job details to history file after job completion', async function () {
-                // Setup job state
-                const jobId = 'completed-job-123'
-                transformByQState.setJobId(jobId)
-                transformByQState.setToSucceeded()
-                transformByQState.setJobHistoryPath('/path/to/job/history')
-                transformByQState.setProjectName('test-project')
-                sessionJobHistory[jobId] = {
-                    startTime: '07/15/25, 10:00 AM',
-                    projectName: 'test-project',
-                    status: 'COMPLETED',
-                    duration: '4 min',
-                }
-
-                nodeFsWriteStub = sinon.stub(nodeFs, 'writeFileSync')
-                sinon.stub(nodeFs, 'existsSync').returns(false) // Assuming history file doesn't exist yet
-                const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves()
-                sinon.stub(transformApiHandler, 'updateJobHistory')
-
-                await postTransformationJob()
-
-                sinon.assert.calledWith(
-                    nodeFsWriteStub.firstCall,
-                    sinon.match(/transformation_history\.tsv$/),
-                    'date\tproject_name\tstatus\tduration\tdiff_patch\tsummary\tjob_id\n'
-                )
-
-                sinon.assert.calledWith(
-                    nodeFsWriteStub.secondCall,
-                    sinon.match(/transformation_history\.tsv$/),
-                    sinon.match(/test-project.*COMPLETED.*4 min.*diff\.patch.*summary\.md.*completed-job-123/),
-                    { flag: 'a' }
-                )
-
-                sinon.assert.calledWith(
-                    executeCommandStub,
-                    'aws.amazonq.transformationHub.updateContent',
-                    'job history',
-                    undefined,
-                    true
-                )
-            })
-        })
-    })
-
-    describe('Refresh button logic', function () {
-        it('Cannot click refresh button when a job is running', function () {
-            transformationHub['transformationHistory'] = [mockJobs.completed, mockJobs.failed]
-            const runningJobId = setupRunningJob()
-
-            const result = transformationHub['showJobHistory']()
-
-            const runningJobButtonRegex = new RegExp(`row-id="${runningJobId}"[^>]*disabled`, 'i')
-            const incompleteJobButtonRegex = new RegExp(`row-id="fail-100"[^>]*disabled`, 'i')
-            const completedJobButtonRegex = new RegExp(`row-id="old-job-456"[^>]*disabled`, 'i')
+            assert(fileContent)
+            assert(fileContent.includes('date\tproject_name\tstatus\tduration\tdiff_patch\tsummary\tjob_id\n'))
             assert(
-                runningJobButtonRegex.test(result) &&
-                    incompleteJobButtonRegex.test(result) &&
-                    completedJobButtonRegex.test(result),
-                "All jobs' refresh buttons should be disabled"
+                fileContent.includes(
+                    '01/01/25, 10:00 AM\ttest-project\tCOMPLETED\t5 min\t/job/path/diff.patch\t/job/path/summary/summary.md\tjob-123\n'
+                )
             )
         })
 
-        it('Cannot click refresh button of STOPPED jobs', function () {
-            transformationHub['transformationHistory'] = [mockJobs.completed, mockJobs.stopped]
+        it('Excludes artifact paths for failed jobs', async function () {
+            sinon.stub(fs, 'existsFile').resolves(false)
+            await writeToHistoryFile('01/01/25, 10:00 AM', 'test-project', 'FAILED', '5 min', 'job-123', '/job/path')
 
-            sinon.stub(transformByQState, 'isRunning').returns(false)
+            const expectedPath = path.join(os.homedir(), '.aws', 'transform', 'transformation_history.tsv')
+            const fileContent = writtenFiles.get(expectedPath)
 
-            const result = transformationHub['showJobHistory']()
+            const lines = fileContent?.split('\n') || []
+            const jobLine = lines.find((line) => line.includes('job-123'))
+            const fields = jobLine?.split('\t') || []
 
-            const runningJobButtonRegex = new RegExp(`row-id="stop-200"[^>]*disabled`, 'i')
-            assert(runningJobButtonRegex.test(result), "STOPPED job's refresh button should be disabled")
+            assert.strictEqual(fields[4], '') // diff path should be empty
+            assert.strictEqual(fields[5], '') // summary path should be empty
         })
 
-        it('Cannot click refresh button of jobs that failed on backend', function () {
-            transformationHub['transformationHistory'] = [mockJobs.failed, mockJobs.failedBE]
+        it('Appends new job to existing history file', async function () {
+            const existingContent =
+                'date\tproject_name\tstatus\tduration\tdiff_patch\tsummary\tjob_id\n' +
+                '12/31/24, 09:00 AM\told-project\tCOMPLETED\t3 min\t/old/diff.patch\t/old/summary.md\told-job-456\n'
 
-            sinon.stub(transformByQState, 'isRunning').returns(false)
+            writtenFiles.set(
+                path.join(os.homedir(), '.aws', 'transform', 'transformation_history.tsv'),
+                existingContent
+            )
 
-            const result = transformationHub['showJobHistory']()
+            sinon.stub(fs, 'existsFile').resolves(true)
 
-            const runningJobButtonRegex = new RegExp(`row-id="failbe-300"[^>]*disabled`, 'i')
-            assert(runningJobButtonRegex.test(result), "FAILED_BE job's refresh button should be disabled")
-            const completedJobButtonRegex = new RegExp(`row-id="fail-100"[^>]*disabled`, 'i')
-            assert(!completedJobButtonRegex.test(result), "Incomplete (FAILED) job's refresh button should be enabled")
+            await writeToHistoryFile('01/01/25, 10:00 AM', 'new-project', 'FAILED', '2 min', 'new-job-789', '/new/path')
+
+            const expectedPath = path.join(os.homedir(), '.aws', 'transform', 'transformation_history.tsv')
+            const fileContent = writtenFiles.get(expectedPath)
+
+            // Verify old data is preserved
+            assert(
+                fileContent?.includes('old-project\tCOMPLETED\t3 min\t/old/diff.patch\t/old/summary.md\told-job-456')
+            )
+
+            // Verify new data is added
+            assert(fileContent?.includes('new-project\tFAILED\t2 min\t\t\tnew-job-789'))
+
+            // Verify both jobs are present and that new job is at bottom of file
+            const lines = fileContent?.split('\n').filter((line) => line.trim()) || []
+            assert.strictEqual(lines.length, 3) // header + 2 job lines
+            assert(lines[1].includes('old-job-456'))
+            assert(lines[2].includes('new-job-789'))
+        })
+    })
+
+    describe('Metadata file operations', function () {
+        let createdFiles: Map<string, string>
+        let createdDirs: Set<string>
+
+        const mockMetadata: JobMetadata = {
+            jobId: 'test-job-123',
+            projectName: 'test-project',
+            transformationType: TransformationType.LANGUAGE_UPGRADE,
+            sourceJDKVersion: JDKVersion.JDK8,
+            targetJDKVersion: JDKVersion.JDK17,
+            customDependencyVersionFilePath: '',
+            customBuildCommand: '',
+            targetJavaHome: '',
+            projectPath: '/path/to/project',
+            startTime: '01/01/24, 10:00 AM',
+        }
+
+        beforeEach(function () {
+            createdFiles = new Map()
+            createdDirs = new Set()
+
+            // Mock file operations to track what gets created
+            sinon.stub(fs, 'mkdir').callsFake(async (dirPath: any) => {
+                createdDirs.add(dirPath.toString())
+            })
+            sinon.stub(fs, 'copy').callsFake(async (src: any, dest: any) => {
+                createdFiles.set(dest.toString(), `copied from ${src.toString()}`)
+            })
+            sinon.stub(fs, 'writeFile').callsFake(async (filePath: any, content: any) => {
+                createdFiles.set(filePath.toString(), content.toString())
+            })
+            sinon.stub(fs, 'delete').callsFake(async (filePath: any) => {
+                createdFiles.delete(filePath.toString())
+            })
+        })
+
+        it('Creates job history directory and metadata files', async function () {
+            const result = await createMetadataFile('/path/to/payload.zip', mockMetadata)
+
+            const expectedPath = path.join(os.homedir(), '.aws', 'transform', 'test-project', 'test-job-123')
+            assert.strictEqual(result, expectedPath)
+
+            // Verify directory was created
+            assert(createdDirs.has(expectedPath))
+
+            // Verify zipped-code.zip was copied
+            const zipPath = path.join(expectedPath, 'zipped-code.zip')
+            assert(createdFiles.has(zipPath))
+            assert.strictEqual(createdFiles.get(zipPath), 'copied from /path/to/payload.zip')
+
+            // Verify metadata.json was created with correct content
+            const metadataPath = path.join(expectedPath, 'metadata.json')
+            assert(createdFiles.has(metadataPath))
+            assert.strictEqual(createdFiles.get(metadataPath), JSON.stringify(mockMetadata))
+        })
+
+        it('Deletes payload, build logs, and metadata files', async function () {
+            // Pre-populate files that would exist
+            createdFiles.set('/payload.zip', 'payload content')
+            createdFiles.set(path.join(os.tmpdir(), 'build-logs.txt'), 'build logs')
+            createdFiles.set('/job/path/metadata.json', 'metadata')
+            createdFiles.set('/job/path/zipped-code.zip', 'zip content')
+
+            await cleanupTempJobFiles('/job/path', 'COMPLETED', '/payload.zip')
+
+            // Verify files were deleted (no longer exist in createdFiles)
+            assert(!createdFiles.has('/payload.zip'))
+            assert(!createdFiles.has(path.join(os.tmpdir(), 'build-logs.txt')))
+            assert(!createdFiles.has('/job/path/metadata.json'))
+            assert(!createdFiles.has('/job/path/zipped-code.zip'))
+        })
+
+        it('Preserves metadata for failed jobs', async function () {
+            // Pre-populate files that would exist
+            createdFiles.set('/job/path/metadata.json', 'metadata')
+            createdFiles.set('/job/path/zipped-code.zip', 'zip content')
+
+            await cleanupTempJobFiles('/job/path', 'FAILED')
+
+            // Verify metadata files still exist (were NOT deleted)
+            assert(createdFiles.has('/job/path/metadata.json'))
+            assert(createdFiles.has('/job/path/zipped-code.zip'))
+        })
+    })
+
+    describe('Copying artifacts', function () {
+        let createdFiles: Map<string, string>
+        let createdDirs: Set<string>
+
+        beforeEach(function () {
+            createdFiles = new Map()
+            createdDirs = new Set()
+
+            // Mock file operations to track what gets created
+            sinon.stub(fs, 'mkdir').callsFake(async (dirPath: any) => {
+                createdDirs.add(dirPath.toString())
+            })
+            sinon.stub(fs, 'copy').callsFake(async (src: any, dest: any) => {
+                createdFiles.set(dest.toString(), `copied from ${src.toString()}`)
+            })
+        })
+
+        it('Copies diff patch and summary files to destination', async function () {
+            await copyArtifacts('/archive/path', '/destination/path')
+
+            // Verify directories were created
+            assert(createdDirs.has('/destination/path'))
+            assert(createdDirs.has('/destination/path/summary'))
+
+            // Verify files were copied to correct locations
+            assert(createdFiles.has('/destination/path/diff.patch'))
+            assert(createdFiles.has('/destination/path/summary/summary.md'))
+
+            // Verify source paths are correct
+            const diffSource = createdFiles.get('/destination/path/diff.patch')
+            const summarySource = createdFiles.get('/destination/path/summary/summary.md')
+            assert(diffSource?.includes(ExportResultArchiveStructure.PathToDiffPatch))
+            assert(summarySource?.includes(ExportResultArchiveStructure.PathToSummary))
         })
     })
 
     describe('Refreshing jobs', function () {
-        describe('Updating status', function () {
-            let codeWhispererClientStub: sinon.SinonStub
+        let createdFiles: Map<string, string>
+        let createdDirs: Set<string>
+        let writtenFiles: Map<string, string>
 
-            beforeEach(function () {
-                codeWhispererClientStub = sinon.stub(codeWhispererClient, 'codeModernizerGetCodeTransformation')
+        beforeEach(function () {
+            createdFiles = new Map()
+            createdDirs = new Set()
+            writtenFiles = new Map()
+
+            // Mock file operations to track what gets created/written
+            sinon.stub(vscode.commands, 'executeCommand').resolves()
+            sinon.stub(fs, 'mkdir').callsFake(async (dirPath: any) => {
+                createdDirs.add(dirPath.toString())
             })
-
-            it('Does not fetch status for already completed jobs', async function () {
-                sinon.stub(transformationHub as any, 'retrieveArtifacts').resolves('') // TODO: refactor TransformationHubViewProvider and extract private methods
-                sinon.stub(transformationHub as any, 'updateHistoryFile').resolves()
-
-                await transformationHub['refreshJob']('job-123', 'COMPLETED', 'test-project')
-                sinon.assert.notCalled(codeWhispererClientStub)
-
-                await transformationHub['refreshJob']('job-456', 'PARTIALLY_COMPLETED', 'test-project2')
-                sinon.assert.notCalled(codeWhispererClientStub)
+            sinon.stub(fs, 'copy').callsFake(async (src: any, dest: any) => {
+                createdFiles.set(dest.toString(), `copied from ${src.toString()}`)
             })
+            sinon.stub(fs, 'delete').resolves()
+            sinon.stub(fs, 'writeFile').callsFake(async (filePath: any, content: any) => {
+                writtenFiles.set(filePath.toString(), content.toString())
+            })
+            sinon.stub(fs, 'appendFile').callsFake(async (filePath: any, content: any) => {
+                const existing = writtenFiles.get(filePath.toString()) || ''
+                writtenFiles.set(filePath.toString(), existing + content.toString())
+            })
+            sinon.stub(transformApiHandler, 'downloadAndExtractResultArchive').resolves()
+        })
 
-            it('Fetches updated status', async function () {
-                const mockResponse = {
-                    transformationJob: {
-                        status: 'COMPLETED',
-                        endExecutionTime: new Date(),
-                        creationTime: new Date(Date.now() - 60000), // 1 minute ago
-                    },
+        it('Updates job status and downloads artifacts', async function () {
+            const mockResponse = {
+                transformationJob: {
+                    status: 'COMPLETED',
+                    endExecutionTime: new Date(),
+                    creationTime: new Date(Date.now() - 300000),
+                },
+            } as any
+            sinon.stub(codeWhispererClient, 'codeModernizerGetCodeTransformation').resolves(mockResponse)
+
+            // Mock existsFile to return false for diff.patch but true for history file
+            sinon.stub(fs, 'existsFile').callsFake(async (filePath: any) => {
+                const pathStr = filePath.toString()
+                if (pathStr.includes('diff.patch')) {
+                    return false // Artifacts don't exist yet, need to download
                 }
-                codeWhispererClientStub.resolves(mockResponse)
-                sinon.stub(transformationHub as any, 'retrieveArtifacts').resolves('')
-                sinon.stub(transformationHub as any, 'updateHistoryFile').resolves()
-
-                await transformationHub['refreshJob']('job-123', 'FAILED', 'test-project')
-                sinon.assert.calledOnce(codeWhispererClientStub)
-            })
-        })
-
-        describe('Downloading artifacts', function () {
-            it('Does not download artifacts when diff patch already exists', async function () {
-                const fsExistsStub = sinon.stub(fs, 'existsFile').resolves(true)
-                const jobHistoryPath = await transformationHub['retrieveArtifacts']('job-123', 'test-project')
-
-                sinon.assert.called(fsExistsStub)
-                assert.strictEqual(jobHistoryPath, '', 'Should return empty string when diff already exists')
+                return true // History file exists
             })
 
-            it('Does not attempt to download artifacts for FAILED/STOPPED jobs', async function () {
-                const mockResponse = {
-                    transformationJob: {
-                        status: 'STOPPED',
-                        endExecutionTime: new Date(),
-                        creationTime: new Date(Date.now() - 60000),
-                    },
-                } as any
-                const codeWhispererClientStub = sinon
-                    .stub(codeWhispererClient, 'codeModernizerGetCodeTransformation')
-                    .resolves(mockResponse)
-                const retrieveArtifactsStub = sinon.stub(transformationHub as any, 'retrieveArtifacts')
-                sinon.stub(transformationHub as any, 'updateHistoryFile').resolves()
-
-                await transformationHub['refreshJob']('job-123', 'FAILED', 'test-project')
-
-                sinon.assert.calledOnce(codeWhispererClientStub)
-                sinon.assert.notCalled(retrieveArtifactsStub)
-            })
-        })
-
-        describe('Updating history file', function () {
-            let fsWriteStub: sinon.SinonStub
-            let fsAppendStub: sinon.SinonStub
-
-            // mocks and setup
-            const mockHistoryContent =
+            // Mock history file content for update
+            const historyContent =
                 'date\tproject_name\tstatus\tduration\tdiff_patch\tsummary\tjob_id\n' +
-                '07/14/25, 09:00 AM\ttest-project\tFAILED\t5 min\t\t\tjob-123\n' +
-                '07/14/25, 10:00 AM\tother-project\tCOMPLETED\t3 min\t/path/diff.patch\t/path/summary.md\tjob-456\n'
+                '01/01/24, 10:00 AM\ttest-project\tFAILED\t\t\t\tjob-123\n'
+            sinon.stub(fs, 'readFileText').resolves(historyContent)
 
-            function createMockTransformationResponse(status: string, timeOffset = 300000) {
-                return {
-                    transformationJob: {
-                        status,
-                        endExecutionTime: new Date(),
-                        creationTime: new Date(Date.now() - timeOffset),
-                    },
-                } as any
-            }
+            await refreshJob('job-123', 'FAILED', 'test-project')
 
-            function setupRefreshJobTest(mockResponse: any) {
-                const codeWhispererClientStub = sinon
-                    .stub(codeWhispererClient, 'codeModernizerGetCodeTransformation')
-                    .resolves(mockResponse)
-                const retrieveArtifactsStub = sinon.stub(transformationHub as any, 'retrieveArtifacts').resolves('')
+            // Verify artifacts were copied to job history path
+            const jobHistoryPath = path.join(os.homedir(), '.aws', 'transform', 'test-project', 'job-123')
+            assert(createdFiles.has(path.join(jobHistoryPath, 'diff.patch')))
+            assert(createdFiles.has(path.join(jobHistoryPath, 'summary', 'summary.md')))
 
-                return { codeWhispererClientStub, retrieveArtifactsStub }
-            }
-
-            beforeEach(function () {
-                fsWriteStub = sinon.stub(fs, 'writeFile').resolves()
-                fsAppendStub = sinon.stub(fs, 'appendFile').resolves()
-                sinon.stub(fs, 'readFileText').resolves(mockHistoryContent)
-                sinon.stub(fs, 'existsFile').resolves(true)
-            })
-
-            it('Updates existing job entry in history file', async function () {
-                const mockResponse = createMockTransformationResponse('STOPPED')
-                const { codeWhispererClientStub, retrieveArtifactsStub } = setupRefreshJobTest(mockResponse)
-
-                await transformationHub['refreshJob']('job-123', 'FAILED', 'test-project')
-
-                sinon.assert.called(fsAppendStub)
-                const writtenContent = fsAppendStub.args[0][1]
-                const updatedJobLine = writtenContent.split('\n').find((line: string) => line.includes('job-123'))
-                assert(updatedJobLine.includes('STOPPED'), 'Status should be updated to STOPPED')
-                assert(updatedJobLine.includes('5 min'), 'Duration should remain 5 min')
-                const unchangedJobLine = writtenContent.split('\n').find((line: string) => line.includes('job-456'))
-                assert(unchangedJobLine)
-                sinon.assert.calledOnce(codeWhispererClientStub)
-                sinon.assert.notCalled(retrieveArtifactsStub)
-            })
-
-            it('Updates history file when job FAILED on backend', async function () {
-                const mockResponse = createMockTransformationResponse('FAILED')
-                const { codeWhispererClientStub, retrieveArtifactsStub } = setupRefreshJobTest(mockResponse)
-
-                await transformationHub['refreshJob']('job-123', 'FAILED', 'test-project')
-
-                sinon.assert.called(fsWriteStub)
-                sinon.assert.called(fsAppendStub)
-                const writtenContent = fsAppendStub.args[0][1]
-                const updatedJobLine = writtenContent.split('\n').find((line: string) => line.includes('job-123'))
-                assert(updatedJobLine.includes('FAILED_BE'), 'Status should be updated to FAILED_BE')
-                assert(updatedJobLine.includes('5 min'), 'Duration should remain 5 min')
-                sinon.assert.calledOnce(codeWhispererClientStub)
-                sinon.assert.notCalled(retrieveArtifactsStub)
-            })
-
-            it('Does not update history file when no changes are needed', async function () {
-                const mockResponse = {
-                    transformationJob: {
-                        status: 'COMPLETED',
-                        endExecutionTime: new Date(),
-                        creationTime: new Date(Date.now() - 60000),
-                    },
-                } as any
-
-                const codeWhispererClientStub = sinon
-                    .stub(codeWhispererClient, 'codeModernizerGetCodeTransformation')
-                    .resolves(mockResponse)
-                sinon.stub(transformationHub as any, 'retrieveArtifacts').resolves('')
-                const updateHistoryFileStub = sinon.stub(transformationHub as any, 'updateHistoryFile').resolves()
-
-                await transformationHub['refreshJob']('job-123', 'COMPLETED', 'test-project')
-
-                sinon.assert.notCalled(codeWhispererClientStub)
-                sinon.assert.notCalled(updateHistoryFileStub)
-            })
-
-            it('Updates content in the UI after updating history file', async function () {
-                const updateContentStub = sinon.stub(transformationHub, 'updateContent').resolves()
-                await transformationHub['updateHistoryFile']('COMPLETED', '5 min', '/new/path', 'job-123')
-                sinon.assert.calledWith(updateContentStub, 'job history', undefined, true)
-            })
+            // Verify history file was updated with new status and artifact paths
+            const historyFilePath = path.join(os.homedir(), '.aws', 'transform', 'transformation_history.tsv')
+            const updatedContent = writtenFiles.get(historyFilePath)
+            assert(updatedContent?.includes('COMPLETED'))
+            assert(updatedContent?.includes('diff.patch'))
+            assert(updatedContent?.includes('summary.md'))
         })
     })
 })


### PR DESCRIPTION
## Problem
Job history-related code is scattered throughout various files, making it difficult to review and understand.

## Solution
Centralize existing history functions in a new file and add helper functions to declutter transformation flow. Update and simplify unit tests accordingly.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
