### PR TITLE
fix(amazonq): discard/reject edit suggestion if it isn't valid

### DIFF
--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -321,7 +321,7 @@ export async function displaySvgDecoration(
 
         const isPatchValid = applyPatch(e.document.getText(), item.insertText as string)
         if (!isPatchValid) {
-            vscode.commands.executeCommand('aws.amazonq.inline.rejectEdit')
+            void vscode.commands.executeCommand('aws.amazonq.inline.rejectEdit')
         }
     })
     await decorationManager.displayEditSuggestion(

--- a/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/displayImage.ts
@@ -306,10 +306,18 @@ export async function displaySvgDecoration(
         return
     }
     const documentChangeListener = vscode.workspace.onDidChangeTextDocument((e) => {
-        if (e.contentChanges.length <= 0) return
-        if (e.document !== editor.document) return
-        if (vsCodeState.isCodeWhispererEditing) return
-        if (getContext('aws.amazonq.editSuggestionActive') === false) return
+        if (e.contentChanges.length <= 0) {
+            return
+        }
+        if (e.document !== editor.document) {
+            return
+        }
+        if (vsCodeState.isCodeWhispererEditing) {
+            return
+        }
+        if (getContext('aws.amazonq.editSuggestionActive') === false) {
+            return
+        }
 
         const isPatchValid = applyPatch(e.document.getText(), item.insertText as string)
         if (!isPatchValid) {


### PR DESCRIPTION
## Problem
discard when it's not yet shown.
reject when user's typing and makes the diff invalid.

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
