### PR TITLE
fix(amazonq): update lsp client name to support Sagemaker AI origin for agentic chat

### DIFF
--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -486,10 +486,15 @@ export function withTelemetryContext(opts: TelemetryContextArgs) {
  * Used to identify the q client info and send the respective origin parameter from LSP to invoke Maestro service at CW API level
  *
  * Returns default value of vscode appName or AmazonQ-For-SMUS-CE in case of a sagemaker unified studio environment
+ * Returns default value of vscode appName
+ * OR AmazonQ-For-SMUS-CE in case of SMUS
+ * OR AmazonQ-For-SMAI-CE in case of SMAI
  */
 export function getClientName(): string {
     if (isSageMaker('SMUS')) {
         return 'AmazonQ-For-SMUS-CE'
+    } else if (isSageMaker('SMAI')) {
+        return 'AmazonQ-For-SMAI-CE'
     }
     return env.appName
 }

--- a/packages/core/src/test/shared/telemetry/util.test.ts
+++ b/packages/core/src/test/shared/telemetry/util.test.ts
@@ -419,15 +419,29 @@ describe('getClientName', function () {
         assert.ok(isSageMakerStub.calledOnceWith('SMUS'))
     })
 
+    it('returns "AmazonQ-For-SMAI-CE" when in SMAI environment', function () {
+        isSageMakerStub.withArgs('SMUS').returns(false)
+        isSageMakerStub.withArgs('SMAI').returns(true)
+        sandbox.stub(vscode.env, 'appName').value('SageMaker Code Editor')
+
+        const result = getClientName()
+
+        assert.strictEqual(result, 'AmazonQ-For-SMAI-CE')
+        assert.ok(isSageMakerStub.calledWith('SMUS'))
+        assert.ok(isSageMakerStub.calledWith('SMAI'))
+    })
+
     it('returns vscode app name when not in SMUS environment', function () {
         const mockAppName = 'Visual Studio Code'
         isSageMakerStub.withArgs('SMUS').returns(false)
+        isSageMakerStub.withArgs('SMAI').returns(false)
         sandbox.stub(vscode.env, 'appName').value(mockAppName)
 
         const result = getClientName()
 
         assert.strictEqual(result, mockAppName)
-        assert.ok(isSageMakerStub.calledOnceWith('SMUS'))
+        assert.ok(isSageMakerStub.calledWith('SMUS'))
+        assert.ok(isSageMakerStub.calledWith('SMAI'))
     })
 
     it('handles undefined app name gracefully', function () {


### PR DESCRIPTION
## Problem
In order to set appropriate Origin Info on LSP side for SMAI CodeEditor, [link](https://github.com/aws/language-servers/blob/68adf18d7ec46a7ecf9c66fd9d52b1b8f7bc236e/server/aws-lsp-codewhisperer/src/shared/utils.ts#L377), clientInfo needs to be distinct
- related [PR to support SMUS](https://github.com/aws/aws-toolkit-vscode/pull/7817)

## Solution
- To check if the environment is SageMaker and a Unified Studio instance and set corresponding clientInfo Name which is ```AmazonQ-For-SMUS-CE```

## Testing
- Built artefact locally using ```npm run compile && npm run package``` and tested on a SMAI CE space
- Ran ```npm run test -w packages/toolkit``` which succeeded
- LSP logs show the respective client Info details
```

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
