### PR TITLE
feat(stepfunctions): Supporting all regions in Execution ARNs

### DIFF
--- a/packages/core/src/stepFunctions/executionDetails/executionDetailProvider.ts
+++ b/packages/core/src/stepFunctions/executionDetails/executionDetailProvider.ts
@@ -12,6 +12,7 @@ import { ComponentType } from '../messageHandlers/types'
 import { isLocalDev, localhost, cdn } from '../constants/webviewResources'
 import { handleMessage } from './handleMessage'
 import { ExecutionDetailsContext } from '../messageHandlers/types'
+import { parseExecutionArnForStateMachine } from '../utils'
 
 /**
  * Provider for Execution Details panels.
@@ -89,7 +90,10 @@ export class ExecutionDetailProvider {
         // Only include start time tag for express executions (when startTime is provided)
         const startTimeTag = startTime ? `<meta name="start-time" content="${startTime}" />` : ''
 
-        return `${htmlFileSplit[0]} <head> ${baseTag} ${localeTag} ${darkModeTag} ${componentTypeTag} ${executionArnTag} ${startTimeTag} ${htmlFileSplit[1]}`
+        const region = parseExecutionArnForStateMachine(executionArn)?.region
+        const regionTag = `<meta name="region" content="${region}" />`
+
+        return `${htmlFileSplit[0]} <head> ${baseTag} ${localeTag} ${darkModeTag} ${componentTypeTag} ${executionArnTag} ${startTimeTag} ${regionTag} ${htmlFileSplit[1]}`
     }
 
     /**

--- a/packages/core/src/stepFunctions/executionDetails/handleMessage.ts
+++ b/packages/core/src/stepFunctions/executionDetails/handleMessage.ts
@@ -33,9 +33,11 @@ export async function handleMessage(message: Message, context: ExecutionDetailsC
             case Command.INIT:
                 void initMessageHandler(context)
                 break
-            case Command.API_CALL:
-                void apiCallMessageHandler(message as ApiCallRequestMessage, context)
+            case Command.API_CALL: {
+                const region = parseExecutionArnForStateMachine(context.executionArn)?.region || 'us-east-1'
+                void apiCallMessageHandler(message as ApiCallRequestMessage, context, region)
                 break
+            }
             case Command.START_EXECUTION:
                 void startExecutionMessageHandler(context)
                 break

--- a/packages/core/src/stepFunctions/messageHandlers/handleMessageHelpers.ts
+++ b/packages/core/src/stepFunctions/messageHandlers/handleMessageHelpers.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Command, Message, MessageType, BaseContext, ApiCallRequestMessage, UnsupportedMessage } from './types'
-import { StepFunctionApiHandler } from './stepFunctionApiHandler'
-import globals from '../../shared/extensionGlobals'
+import { Command, Message, MessageType, BaseContext, UnsupportedMessage, ApiCallRequestMessage } from './types'
 import { getLogger } from '../../shared/logger/logger'
+import { StepFunctionApiHandler } from './stepFunctionApiHandler'
 
 /**
  * Handler for managing webview stage load, which updates load notifications.
@@ -18,17 +17,6 @@ export async function loadStageMessageHandler(context: BaseContext) {
     setTimeout(() => {
         context.loaderNotification?.resolve()
     }, 100)
-}
-
-/**
- * Handler for making API calls from the webview and returning the response.
- * @param request The request message containing the API to call and the parameters
- * @param context The webview context used for returning the API response to the webview
- */
-export function apiCallMessageHandler(request: ApiCallRequestMessage, context: BaseContext) {
-    const logger = getLogger('stepfunctions')
-    const apiHandler = new StepFunctionApiHandler(globals.awsContext.getCredentialDefaultRegion(), context)
-    apiHandler.performApiCall(request).catch((error) => logger.error('%s API call failed: %O', request.apiName, error))
 }
 
 /**
@@ -44,4 +32,16 @@ export async function handleUnsupportedMessage(context: BaseContext, originalMes
         command: Command.UNSUPPORTED_COMMAND,
         originalMessage,
     } as UnsupportedMessage)
+}
+
+/**
+ * Handler for making API calls from the webview and returning the response.
+ * @param request The request message containing the API to call and the parameters
+ * @param context The webview context used for returning the API response to the webview
+ * @param region The AWS region to use for the API calls
+ */
+export function apiCallMessageHandler(request: ApiCallRequestMessage, context: BaseContext, region: string) {
+    const logger = getLogger('stepfunctions')
+    const apiHandler = new StepFunctionApiHandler(region, context)
+    apiHandler.performApiCall(request).catch((error) => logger.error('%s API call failed: %O', request.apiName, error))
 }

--- a/packages/core/src/stepFunctions/workflowStudio/handleMessage.ts
+++ b/packages/core/src/stepFunctions/workflowStudio/handleMessage.ts
@@ -65,9 +65,11 @@ export async function handleMessage(message: Message, context: WebviewContext) {
             case Command.OPEN_FEEDBACK:
                 !isReadonlyMode && void submitFeedback(placeholder, 'Workflow Studio')
                 break
-            case Command.API_CALL:
-                !isReadonlyMode && apiCallMessageHandler(message as ApiCallRequestMessage, context)
+            case Command.API_CALL: {
+                const region = globals.awsContext.getCredentialDefaultRegion()
+                !isReadonlyMode && apiCallMessageHandler(message as ApiCallRequestMessage, context, region)
                 break
+            }
             default:
                 void handleUnsupportedMessage(context, message)
                 break


### PR DESCRIPTION
## Problem
Currently Execution Details only supports `us-east-1` executions

## Solution
Passing region parsed from execution ARN as a meta tag
Separating `apiCallMessageHandler` to Execution Details and Workflow Studio message handlers accordingly

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
