### PR TITLE
ci: create GitHub releases for release candidate branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
                 required: false
                 default: prerelease
     push:
-        branches: [master, feature/*]
+        branches: [master, feature/*, release/*]
         # tags:
         #   - v[0-9]+.[0-9]+.[0-9]+
 
@@ -40,12 +40,16 @@ jobs:
             #   run: echo 'TAG_NAME=prerelease' >> $GITHUB_ENV
             - if: github.event_name == 'workflow_dispatch'
               run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
-            - if: github.ref_name != 'master'
+            - if: startsWith(github.ref_name, 'feature/')
               run: |
-                  TAG_NAME=${{ github.ref_name }}
-                  FEAT_NAME=$(echo $TAG_NAME | sed 's/feature\///')
+                  FEAT_NAME=$(echo ${{ github.ref_name }} | sed 's/feature\///')
                   echo "FEAT_NAME=$FEAT_NAME" >> $GITHUB_ENV
                   echo "TAG_NAME=pre-$FEAT_NAME" >> $GITHUB_ENV
+            - if: startsWith(github.ref_name, 'release/')
+              run: |
+                  RC_NAME=$(echo ${{ github.ref_name }} | sed 's/release\///')
+                  echo "FEAT_NAME=" >> $GITHUB_ENV
+                  echo "TAG_NAME=rc-$RC_NAME" >> $GITHUB_ENV
             - if: github.ref_name == 'master'
               run: |
                   echo "FEAT_NAME=" >> $GITHUB_ENV
@@ -105,10 +109,14 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/download-artifact@v4
             - name: Delete existing prerelease
-              # "prerelease" (main branch) or "pre-<feature>"
-              if: "env.TAG_NAME == 'prerelease' || startsWith(env.TAG_NAME, 'pre-')"
+              # "prerelease" (main branch), "pre-<feature>", or "rc-<date>"
+              if: env.TAG_NAME == 'prerelease' || startsWith(env.TAG_NAME, 'pre-') || startsWith(env.TAG_NAME, 'rc-')
               run: |
-                  echo "SUBJECT=AWS IDE Extensions: ${FEAT_NAME:-${TAG_NAME}}" >> $GITHUB_ENV
+                  if [[ "$TAG_NAME" == rc-* ]]; then
+                    echo "SUBJECT=AWS IDE Extensions Release Candidate: ${TAG_NAME#rc-}" >> $GITHUB_ENV
+                  else
+                    echo "SUBJECT=AWS IDE Extensions: ${FEAT_NAME:-${TAG_NAME}}" >> $GITHUB_ENV
+                  fi
                   gh release delete "$TAG_NAME" --cleanup-tag --yes || true
                   # git push origin :"$TAG_NAME" || true
             - name: Publish Prerelease

--- a/.github/workflows/setup-release-candidate.yml
+++ b/.github/workflows/setup-release-candidate.yml
@@ -1,0 +1,108 @@
+name: Setup Release Candidate
+
+on:
+    workflow_dispatch:
+        inputs:
+            versionIncrement:
+                description: 'Release Version Increment'
+                default: 'Minor'
+                required: true
+                type: choice
+                options:
+                    - Major
+                    - Minor
+                    - Patch
+                    - Custom
+            customVersion:
+                description: "Custom Release Version (only used if release increment is 'Custom') - Format: 3.15.0"
+                default: ''
+                required: false
+                type: string
+            commitId:
+                description: 'Commit ID to create RC from'
+                required: true
+                type: string
+
+jobs:
+    setup-rc:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ inputs.commitId }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  persist-credentials: true
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '18'
+                  cache: 'npm'
+
+            - name: Calculate Release Versions
+              id: release-version
+              run: |
+                  customVersion="${{ inputs.customVersion }}"
+                  versionIncrement="${{ inputs.versionIncrement }}"
+
+                  increment_version() {
+                      local currentVersion=$1
+                      if [[ "$versionIncrement" == "Custom" && -n "$customVersion" ]]; then
+                          echo "$customVersion"
+                      else
+                          IFS='.' read -r major minor patch <<< "$currentVersion"
+                          case "$versionIncrement" in
+                              "Major")
+                                  major=$((major + 1))
+                                  minor=0
+                                  patch=0
+                                  ;;
+                              "Minor")
+                                  minor=$((minor + 1))
+                                  patch=0
+                                  ;;
+                              "Patch")
+                                  patch=$((patch + 1))
+                                  ;;
+                          esac
+                          echo "$major.$minor.$patch"
+                      fi
+                  }
+
+                  # Read and increment toolkit version
+                  toolkitCurrentVersion=$(node -e "console.log(require('./packages/toolkit/package.json').version)" | sed 's/-SNAPSHOT//')
+                  toolkitNewVersion=$(increment_version "$toolkitCurrentVersion")
+
+                  # Read and increment amazonq version
+                  amazonqCurrentVersion=$(node -e "console.log(require('./packages/amazonq/package.json').version)" | sed 's/-SNAPSHOT//')
+                  amazonqNewVersion=$(increment_version "$amazonqCurrentVersion")
+
+                  echo "TOOLKIT_VERSION=$toolkitNewVersion" >> $GITHUB_OUTPUT
+                  echo "AMAZONQ_VERSION=$amazonqNewVersion" >> $GITHUB_OUTPUT
+                  # Use date-based branch naming instead of version-based because we release
+                  # both extensions (toolkit and amazonq) from the same branch, and they may
+                  # have different version numbers. We can change this in the future
+                  echo "BRANCH_NAME=rc-$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+
+            - name: Create RC Branch and Update Versions
+              env:
+                  TOOLKIT_VERSION: ${{ steps.release-version.outputs.TOOLKIT_VERSION }}
+                  AMAZONQ_VERSION: ${{ steps.release-version.outputs.AMAZONQ_VERSION }}
+                  BRANCH_NAME: ${{ steps.release-version.outputs.BRANCH_NAME }}
+              run: |
+                  git config user.name "aws-toolkit-automation"
+                  git config user.email "<>"
+
+                  # Create RC branch using date-based naming
+                  git checkout -b $BRANCH_NAME
+
+                  # Update package versions individually
+                  npm version --no-git-tag-version $TOOLKIT_VERSION -w packages/toolkit
+                  npm version --no-git-tag-version $AMAZONQ_VERSION -w packages/amazonq
+
+                  # Commit version changes
+                  git add packages/toolkit/package.json packages/amazonq/package.json package-lock.json
+                  git commit -m "Bump versions: toolkit=$TOOLKIT_VERSION, amazonq=$AMAZONQ_VERSION"
+
+                  # Push RC branch
+                  git push origin $BRANCH_NAME


### PR DESCRIPTION
## Problem
The AWS Toolkit VSCode project lacked a streamlined release candidate workflow. Creating release candidates would require manual branch creation and version management.

## Solution

Added automated release candidate support:

- Created `.github/workflows/setup-release-candidate.yml `- Workflow to create RC branches with automatic version bumping

- Supports `Major/Minor/Patch/Custom` version increments

- Reads and increments both `toolkit` and `amazonq` package versions independently

- Creates date-based RC branches (`rc-YYYYMMDD`)

- Commits version changes and pushes the RC branch

- Updated `.github/workflows/release.yml` - Added support for `release/* ` branches

- Automatically creates `rc-*` prefixed releases for release candidate branches

- Proper release naming for RC artifacts

This enables a clean RC workflow: trigger the setup workflow with a commit ID and version increment type, then the release pipeline automatically handles the rest.



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
