### PR TITLE
chore: use PAT token in RC workflow

### DIFF
--- a/.github/workflows/setup-release-candidate.yml
+++ b/.github/workflows/setup-release-candidate.yml
@@ -30,7 +30,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   ref: ${{ inputs.commitId }}
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.RELEASE_CANDIDATE_BRANCH_CREATION_PAT }}
                   persist-credentials: true
 
             - name: Setup Node.js
@@ -102,7 +102,7 @@ jobs:
 
                   # Commit version changes
                   git add packages/toolkit/package.json packages/amazonq/package.json package-lock.json
-                  git commit -m "Bump versions: toolkit=$TOOLKIT_VERSION, amazonq=$AMAZONQ_VERSION"
+                  git commit -m "chore: bump versions - toolkit=$TOOLKIT_VERSION, amazonq=$AMAZONQ_VERSION"
 
                   # Push RC branch
                   git push origin $BRANCH_NAME


### PR DESCRIPTION
## Problem
The release candidate workflow was failing with "protected branch update failed" error because the default `GITHUB_TOKEN ` did not exist.

## Solution

Updated the workflow to use `RELEASE_CANDIDATE_BRANCH_CREATION_PAT` instead of `GITHUB_TOKEN` in the checkout step.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
