### PR TITLE
config: update rc branch naming and sanitize input 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
               run: |
                   RC_NAME=$(echo ${{ github.ref_name }} | sed 's/release\///')
                   echo "FEAT_NAME=" >> $GITHUB_ENV
-                  echo "TAG_NAME=rc-$RC_NAME" >> $GITHUB_ENV
+                  echo "TAG_NAME=$RC_NAME" >> $GITHUB_ENV
             - if: github.ref_name == 'master'
               run: |
                   echo "FEAT_NAME=" >> $GITHUB_ENV

--- a/.github/workflows/setup-release-candidate.yml
+++ b/.github/workflows/setup-release-candidate.yml
@@ -43,9 +43,12 @@ jobs:
 
             - name: Calculate Release Versions
               id: release-version
+              env:
+                  CUSTOM_VERSION: ${{ inputs.customVersion }}
+                  VERSION_INCREMENT: ${{ inputs.versionIncrement }}
               run: |
-                  customVersion="${{ inputs.customVersion }}"
-                  versionIncrement="${{ inputs.versionIncrement }}"
+                  customVersion="$CUSTOM_VERSION"
+                  versionIncrement="$VERSION_INCREMENT"
 
                   increment_version() {
                       local currentVersion=$1
@@ -84,7 +87,7 @@ jobs:
                   # Use date-based branch naming instead of version-based because we release
                   # both extensions (toolkit and amazonq) from the same branch, and they may
                   # have different version numbers. We can change this in the future
-                  echo "BRANCH_NAME=rc-$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+                  echo "BRANCH_NAME=release/rc-$(date +%Y%m%d)" >> $GITHUB_OUTPUT
 
             - name: Create RC Branch and Update Versions
               env:


### PR DESCRIPTION
## Problem
The prerelease workflow is configured to run on branches matching release/*. The RC creation workflow previously created branches like `rc-YYYYMMDD` instead of `release/rc-YYMMDD`, which did not match the trigger pattern, meaning the prerelease workflow was never invoked automatically.

As it stands now any team member with write access can perform workflow_dispatch injection.


## Solution

Update the RC creation workflow to create branches in the format `release/rc-YYYYMMDD` instead of `rc-YYYYMMDD`, ensuring they match the prerelease workflow’s `release/*` branch trigger and are picked up for prerelease builds.

 Sanitize the input fields via Github environment variables

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
