### PR TITLE
config: remove need for PAT to create RC branches

### DIFF
--- a/.github/workflows/setup-release-candidate.yml
+++ b/.github/workflows/setup-release-candidate.yml
@@ -26,11 +26,13 @@ on:
 jobs:
     setup-rc:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         steps:
             - uses: actions/checkout@v4
               with:
                   ref: ${{ inputs.commitId }}
-                  token: ${{ secrets.RELEASE_CANDIDATE_BRANCH_CREATION_PAT }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
                   persist-credentials: true
 
             - name: Setup Node.js


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
