### PR TITLE
fix(amazonq): auto save the current file when users trigger auto debug commands

### DIFF
--- a/packages/amazonq/src/lsp/chat/autoDebug/commands.ts
+++ b/packages/amazonq/src/lsp/chat/autoDebug/commands.ts
@@ -97,6 +97,7 @@ export class AutoDebugCommands implements vscode.Disposable {
                 if (!editor) {
                     return
                 }
+                await editor.document.save()
                 await this.controller.fixSpecificProblems(range, diagnostics)
             },
             'Fix with Amazon Q',
@@ -114,6 +115,7 @@ export class AutoDebugCommands implements vscode.Disposable {
                 if (!editor) {
                     return
                 }
+                await editor.document.save()
                 await this.controller.fixAllProblemsInFile(10) // 10 errors per batch
             },
             'Fix All with Amazon Q',


### PR DESCRIPTION
## Problem
Amazon Q couldn't make changes to unsaved files. When users apply fix commands to unsaved files, Amazon Q couldn't fix those problems.

## Solution
Auto save the file when users clicking on the fix commands.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
