### PR TITLE
feat(amazonq): Enable users to edit code files directly on the diff view

### DIFF
--- a/packages/amazonq/src/lsp/chat/autoDebug/commands.ts
+++ b/packages/amazonq/src/lsp/chat/autoDebug/commands.ts
@@ -97,6 +97,7 @@ export class AutoDebugCommands implements vscode.Disposable {
                 if (!editor) {
                     return
                 }
+                await editor.document.save()
                 await this.controller.fixSpecificProblems(range, diagnostics)
             },
             'Fix with Amazon Q',
@@ -114,6 +115,7 @@ export class AutoDebugCommands implements vscode.Disposable {
                 if (!editor) {
                     return
                 }
+                await editor.document.save()
                 await this.controller.fixAllProblemsInFile(10) // 10 errors per batch
             },
             'Fix All with Amazon Q',

--- a/packages/amazonq/src/lsp/chat/autoDebug/commands.ts
+++ b/packages/amazonq/src/lsp/chat/autoDebug/commands.ts
@@ -97,7 +97,6 @@ export class AutoDebugCommands implements vscode.Disposable {
                 if (!editor) {
                     return
                 }
-                await editor.document.save()
                 await this.controller.fixSpecificProblems(range, diagnostics)
             },
             'Fix with Amazon Q',
@@ -115,7 +114,6 @@ export class AutoDebugCommands implements vscode.Disposable {
                 if (!editor) {
                     return
                 }
-                await editor.document.save()
                 await this.controller.fixAllProblemsInFile(10) // 10 errors per batch
             },
             'Fix All with Amazon Q',


### PR DESCRIPTION
## Problem
Currently users couldn't edit code files on the diff view provided by Amazon Q. Users have to open those files in the workspace to edit them. This is very inconvenient.

## Solution
Enable users to edit code files directly on the diff view.

https://github.com/user-attachments/assets/464d9757-cb6f-4f0f-aa6f-de4f3104cdb5



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
