### PR TITLE
fix(amazonq): disable experimental proxy

### DIFF
--- a/packages/core/src/shared/utilities/proxyUtil.ts
+++ b/packages/core/src/shared/utilities/proxyUtil.ts
@@ -68,7 +68,7 @@ export class ProxyUtil {
      */
     private static async setProxyEnvironmentVariables(config: ProxyConfig): Promise<void> {
         // Always enable experimental proxy support for better handling of both explicit and transparent proxies
-        process.env.EXPERIMENTAL_HTTP_PROXY_SUPPORT = 'true'
+        process.env.EXPERIMENTAL_HTTP_PROXY_SUPPORT = 'false'
 
         const proxyUrl = config.proxyUrl
         // Set proxy environment variables


### PR DESCRIPTION
## Problem

There is an issue we suspect is related to the recent support we added for proxy auto-discovery on this GitHub issue: https://github.com/aws/aws-toolkit-vscode/issues/7878

## Solution
Disabling the experimental proxy support

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
