### PR TITLE
feat(amazonq): Add logging into the amazonq E2E UI Test Suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "testE2E": "npm run testE2E -w packages/ --if-present",
         "test:ui:prepare": "./node_modules/.bin/extest get-vscode -s ~/.vscode-test-resources -n && extest get-chromedriver -s ~/.vscode-test-resources -n",
         "test:ui:install": "cd packages/amazonq && npm run package 2>&1 | grep -o 'VSIX Version: [^ ]*' | cut -d' ' -f3 | xargs -I{} bash -c 'cd ../../ && ./node_modules/.bin/extest install-vsix -f amazon-q-vscode-{}.vsix -e packages/amazonq/test/e2e_new/amazonq/resources -s ~/.vscode-test-resources'",
-        "test:ui:run": "npm run testCompile && ./node_modules/.bin/extest run-tests -s ~/.vscode-test-resources -e packages/amazonq/test/e2e_new/amazonq/resources packages/amazonq/dist/test/e2e_new/amazonq/tests/*.test.js",
+        "test:ui:run": "npm run testCompile && ./node_modules/.bin/extest run-tests -s ~/.vscode-test-resources -e packages/amazonq/test/e2e_new/amazonq/resources packages/amazonq/dist/test/e2e_new/amazonq/tests/*.test.js 2>&1 | tee packages/amazonq/test/e2e_new/amazonq/logs/ui_e2e_testlog_$(date +%Y%m%d_%H%M%S).log",
         "test:ui": "npm run test:ui:prepare && npm run test:ui:install && npm run test:ui:run",
         "testInteg": "npm run testInteg -w packages/ --if-present",
         "package": "npm run package -w packages/toolkit -w packages/amazonq",


### PR DESCRIPTION
## Problem
Currently our test suite outputs into the terminal, but this is not stored anywhere. 

## Solution
For a more robust suite, we will begin logging our test runs by the exact date stored in the logs folder within our e2e_new folder.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
