### PR TITLE
fix(amazonq): add flag in settings for controlling experimental proxy support

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -219,6 +219,11 @@
                     "markdownDescription": "%AWS.configuration.description.amazonq.proxy.certificateAuthority%",
                     "default": null,
                     "scope": "application"
+                },
+                "amazonQ.proxy.enableProxyAndCertificateAutoDiscovery": {
+                    "type": "boolean",
+                    "markdownDescription": "%AWS.configuration.description.amazonq.proxy.enableProxyAndCertificateAutoDiscovery%",
+                    "default": true
                 }
             }
         },

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -99,6 +99,7 @@
     "AWS.configuration.description.amazonq.workspaceIndexCacheDirPath": "The path to the directory that contains the cache of the index of your workspace files",
     "AWS.configuration.description.amazonq.ignoredSecurityIssues": "Specifies a list of code issue identifiers that Amazon Q should ignore when reviewing your workspace. Each item in the array should be a unique string identifier for a specific code issue. This allows you to suppress notifications for known issues that you've assessed and determined to be false positives or not applicable to your project. Use this setting with caution, as it may cause you to miss important security alerts.",
     "AWS.configuration.description.amazonq.proxy.certificateAuthority": "Path to a Certificate Authority (PEM file) for SSL/TLS verification when using a proxy.",
+    "AWS.configuration.description.amazonq.proxy.enableProxyAndCertificateAutoDiscovery": "Automatically detect system proxy settings and SSL certificates.",
     "AWS.command.apig.invokeRemoteRestApi": "Invoke remotely",
     "AWS.command.apig.invokeRemoteRestApi.cn": "Invoke on Amazon",
     "AWS.appBuilder.explorerTitle": "Application Builder",

--- a/packages/core/src/shared/settings-amazonq.gen.ts
+++ b/packages/core/src/shared/settings-amazonq.gen.ts
@@ -37,7 +37,8 @@ export const amazonqSettings = {
     "amazonQ.workspaceIndexCacheDirPath": {},
     "amazonQ.workspaceIndexIgnoreFilePatterns": {},
     "amazonQ.ignoredSecurityIssues": {},
-    "amazonQ.proxy.certificateAuthority": {}
+    "amazonQ.proxy.certificateAuthority": {},
+    "amazonQ.proxy.enableProxyAndCertificateAutoDiscovery": {}
 }
 
 export default amazonqSettings

--- a/packages/core/src/shared/utilities/proxyUtil.ts
+++ b/packages/core/src/shared/utilities/proxyUtil.ts
@@ -11,6 +11,7 @@ interface ProxyConfig {
     noProxy: string | undefined
     proxyStrictSSL: boolean | true
     certificateAuthority: string | undefined
+    isProxyAndCertAutoDiscoveryEnabled: boolean
 }
 
 /**
@@ -53,13 +54,15 @@ export class ProxyUtil {
         const amazonQConfig = vscode.workspace.getConfiguration('amazonQ')
         const proxySettings = amazonQConfig.get<{
             certificateAuthority?: string
-        }>('proxy', {})
+            enableProxyAndCertificateAutoDiscovery: boolean
+        }>('proxy', { enableProxyAndCertificateAutoDiscovery: true })
 
         return {
             proxyUrl,
             noProxy,
             proxyStrictSSL,
             certificateAuthority: proxySettings.certificateAuthority,
+            isProxyAndCertAutoDiscoveryEnabled: proxySettings.enableProxyAndCertificateAutoDiscovery,
         }
     }
 
@@ -67,8 +70,8 @@ export class ProxyUtil {
      * Sets environment variables based on proxy configuration
      */
     private static async setProxyEnvironmentVariables(config: ProxyConfig): Promise<void> {
-        // Always enable experimental proxy support for better handling of both explicit and transparent proxies
-        process.env.EXPERIMENTAL_HTTP_PROXY_SUPPORT = 'false'
+        // Set experimental proxy support based on user setting
+        process.env.EXPERIMENTAL_HTTP_PROXY_SUPPORT = config.isProxyAndCertAutoDiscoveryEnabled.toString()
 
         const proxyUrl = config.proxyUrl
         // Set proxy environment variables


### PR DESCRIPTION
## Problem

The proxy and certificate auto-discovery code occasionally causes issues and there is a need to allow control of this by users.


## Solution

Add a checkbox in settings that allow customers to control whether they want Amazon Q's proxy and certificate auto-discovery turned on.



## Testing

Experimental proxy util used once setting enabled:

<img width="438" height="111" alt="Screenshot 2025-08-19 at 10 49 11 AM" src="https://github.com/user-attachments/assets/bafbc879-41db-4ad7-a164-bb8bb2655de0" />


Standard proxy util  used once setting disabled:


<img width="438" height="111" alt="Screenshot 2025-08-19 at 10 50 05 AM" src="https://github.com/user-attachments/assets/d38c4a25-ea9b-41be-8b04-25cbc13f49ec" />



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
