### PR TITLE
fix(amazonq): do not auto trigger if the ongoing typeahead does not match

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -391,6 +391,9 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                 }
                 this.languageClient.sendNotification(this.logSessionResultMessageName, params)
                 this.sessionManager.clear()
+                // Do not make auto trigger if user rejects a suggestion
+                // by typing characters that does not match
+                return []
             }
 
             // tell the tutorial that completions has been triggered


### PR DESCRIPTION
## Problem

Bug: When inline suggestion is active but user types a character that does not match the typeahead, this typing event triggered a inline completion API call that eventually did not manage to display suggestion on screen, which eventually reported as rejected completions.






## Solution


Previously, before Flare migration, we had this design:

https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/amazonq/src/app/inline/activation.ts#L108

Auto trigger will be disabled if at that moment the suggestion is visible. 

Under the previous design, the first character that does not match the typeahead will not make a new auto trigger, it simply rejects the current inline completion. 

This PR is to bring back the old design.

It is not customer facing, hence no change log.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
