### PR TITLE
fix(explorer): Refresh s3 node on profile switch (#7401, #7665)

### DIFF
--- a/packages/amazonq/src/app/inline/EditRendering/svgGenerator.ts
+++ b/packages/amazonq/src/app/inline/EditRendering/svgGenerator.ts
@@ -18,6 +18,8 @@ export const emptyDiffSvg = {
     originalCodeHighlightRange: [],
 }
 
+const defaultLineHighlightLength = 4
+
 export class SvgGenerationService {
     /**
      * Generates an SVG image representing a code diff
@@ -431,8 +433,12 @@ export class SvgGenerationService {
         for (let lineIndex = 0; lineIndex < originalCode.length; lineIndex++) {
             const line = originalCode[lineIndex]
 
+            /**
+             * If [line] is an empty line or only contains whitespace char, [diffWordsWithSpace] will say it's not an "remove", i.e. [part.removed] will be undefined,
+             * therefore the deletion will not be highlighted. Thus fallback this scenario to highlight the entire line
+             */
             // If line exists in modifiedLines as a key, process character diffs
-            if (Array.from(modifiedLines.keys()).includes(line)) {
+            if (Array.from(modifiedLines.keys()).includes(line) && line.trim().length > 0) {
                 const modifiedLine = modifiedLines.get(line)!
                 const changes = diffWordsWithSpace(line, modifiedLine)
 
@@ -455,7 +461,7 @@ export class SvgGenerationService {
                 originalRanges.push({
                     line: lineIndex,
                     start: 0,
-                    end: line.length,
+                    end: line.length ?? defaultLineHighlightLength,
                 })
             }
         }

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -391,6 +391,9 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                 }
                 this.languageClient.sendNotification(this.logSessionResultMessageName, params)
                 this.sessionManager.clear()
+                // Do not make auto trigger if user rejects a suggestion
+                // by typing characters that does not match
+                return []
             }
 
             // tell the tutorial that completions has been triggered

--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode from 'vscode'
+import vscode, { version } from 'vscode'
 import * as nls from 'vscode-nls'
 import { LanguageClient, LanguageClientOptions, RequestType, State } from 'vscode-languageclient'
 import { InlineCompletionManager } from '../app/inline/completion'
@@ -165,7 +165,7 @@ export async function startLanguageServer(
             aws: {
                 clientInfo: {
                     name: getClientName(),
-                    version: extensionVersion,
+                    version: version,
                     extension: {
                         name: 'AmazonQ-For-VSCode',
                         version: extensionVersion,

--- a/packages/core/src/shared/awsClientBuilderV3.ts
+++ b/packages/core/src/shared/awsClientBuilderV3.ts
@@ -120,10 +120,12 @@ export class AWSClientBuilderV3 {
 
     private keyAwsService<C extends AwsClient>(serviceOptions: AwsServiceOptions<C>): string {
         // Serializing certain objects in the args allows us to detect when nested objects change (ex. new retry strategy, endpoints)
+        const profileId = this.context.getCredentialProfileName()
         return [
             String(serviceOptions.serviceClient),
             JSON.stringify(serviceOptions.clientOptions),
             serviceOptions.region,
+            profileId,
             serviceOptions.userAgent ? '1' : '0',
             serviceOptions.settings ? JSON.stringify(serviceOptions.settings.get('endpoints', {})) : '',
         ].join(':')

--- a/packages/toolkit/.changes/next-release/Bug Fix-30febe0c-8b19-445b-a5aa-96594ad30d45.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-30febe0c-8b19-445b-a5aa-96594ad30d45.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Refresh S3 node in explorer on profile change"
+}


### PR DESCRIPTION
## Problem
When a connection is changed, the awsClientBuilderV3 is used to get the service details, and a cache is being used to cache the service. (This new client builder is only used for certain services such as s3). However, in the cache key only region is cached along with other service details, so on profile switch it is still returning the same cached service of previous profile.

## Solution
Retrieved current profile using global aws context, and added it to the cache key, so when profile is switched, cache is updated and service from new profile is retrieved.

This approach resolves the node refresh issue by including the profile in the cache key. I'd appreciate feedback on whether there are any edge cases or alternative approaches I should consider.

I'm also looking for guidance on writing tests for this change. What would be the recommended approach for writing unit/integration tests to verify profile switches?

Thank you.

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
