### PR TITLE
fix(amazonq): XPath Selector for pinContextHelpers and fixing PinContext ability to run in full test suite

### DIFF
--- a/packages/amazonq/test/e2e_new/amazonq/helpers/pinContextHelper.ts
+++ b/packages/amazonq/test/e2e_new/amazonq/helpers/pinContextHelper.ts
@@ -106,6 +106,7 @@ export async function getSubMenuItems(webview: WebviewView): Promise<{ items: We
  * NOTE: To find all possible text labels, you can call getPinContextMenuItems
  */
 export async function clickSubMenuItem(webview: WebviewView, itemName: string): Promise<void> {
+    // We require a sleep function of 0 so that the DOM of the SubMenu can load correctly.
     await sleep(0)
     const item = await waitForElement(
         webview,

--- a/packages/amazonq/test/e2e_new/amazonq/helpers/pinContextHelper.ts
+++ b/packages/amazonq/test/e2e_new/amazonq/helpers/pinContextHelper.ts
@@ -36,7 +36,6 @@ export async function clickPinContextButton(webview: WebviewView): Promise<void>
  * @returns Promise<boolean> Returns the items as a WebElement List and the labels in a string array
  */
 export async function getPinContextMenuItems(webview: WebviewView): Promise<{ items: WebElement[]; labels: string[] }> {
-    await sleep(1000)
     const items = await webview.findElements(
         By.xpath(`//div[contains(@class, 'mynah-detailed-list-item') and contains(@class, 'mynah-ui-clickable-item')]`)
     )
@@ -65,7 +64,6 @@ export async function getPinContextMenuItems(webview: WebviewView): Promise<{ it
  * NOTE: To find all possible text labels, you can call getPinContextMenuItems
  */
 export async function clickPinContextMenuItem(webview: WebviewView, itemName: string): Promise<void> {
-    await sleep(100)
     const item = await waitForElement(
         webview,
         By.xpath(
@@ -81,7 +79,6 @@ export async function clickPinContextMenuItem(webview: WebviewView, itemName: st
  * @returns Promise<boolean> Returns the items as a WebElement List and the labels in a string array
  */
 export async function getSubMenuItems(webview: WebviewView): Promise<{ items: WebElement[]; labels: string[] }> {
-    await sleep(100)
     const items = await webview.findElements(
         By.xpath(`//div[contains(@class, 'mynah-detailed-list-item') and contains(@class, 'mynah-ui-clickable-item')]`)
     )
@@ -109,7 +106,7 @@ export async function getSubMenuItems(webview: WebviewView): Promise<{ items: We
  * NOTE: To find all possible text labels, you can call getPinContextMenuItems
  */
 export async function clickSubMenuItem(webview: WebviewView, itemName: string): Promise<void> {
-    await sleep(100)
+    await sleep(0)
     const item = await waitForElement(
         webview,
         By.xpath(

--- a/packages/amazonq/test/e2e_new/amazonq/helpers/pinContextHelper.ts
+++ b/packages/amazonq/test/e2e_new/amazonq/helpers/pinContextHelper.ts
@@ -36,25 +36,24 @@ export async function clickPinContextButton(webview: WebviewView): Promise<void>
  * @returns Promise<boolean> Returns the items as a WebElement List and the labels in a string array
  */
 export async function getPinContextMenuItems(webview: WebviewView): Promise<{ items: WebElement[]; labels: string[] }> {
-    const menuList = await waitForElement(webview, By.css('.mynah-detailed-list-items-block'))
-    // TODO: Fix the need for a sleep function to be required at all.
-    await sleep(100)
-    const menuListItems = await menuList.findElements(By.css('.mynah-detailed-list-item.mynah-ui-clickable-item'))
+    await sleep(1000)
+    const items = await webview.findElements(
+        By.xpath(`//div[contains(@class, 'mynah-detailed-list-item') and contains(@class, 'mynah-ui-clickable-item')]`)
+    )
 
-    if (menuListItems.length === 0) {
+    if (items.length === 0) {
         throw new Error('No pin context menu items found')
     }
 
     const labels: string[] = []
-    for (const item of menuListItems) {
-        const textWrapper = await item.findElement(By.css('.mynah-detailed-list-item-text'))
-        const nameElement = await textWrapper.findElement(By.css('.mynah-detailed-list-item-name'))
+    for (const item of items) {
+        const nameElement = await item.findElement(By.css('.mynah-detailed-list-item-description'))
         const labelText = await nameElement.getText()
         labels.push(labelText)
         console.log('Menu item found:', labelText)
     }
 
-    return { items: menuListItems, labels }
+    return { items, labels }
 }
 
 /**
@@ -66,22 +65,15 @@ export async function getPinContextMenuItems(webview: WebviewView): Promise<{ it
  * NOTE: To find all possible text labels, you can call getPinContextMenuItems
  */
 export async function clickPinContextMenuItem(webview: WebviewView, itemName: string): Promise<void> {
-    const menuList = await waitForElement(webview, By.css('.mynah-detailed-list-items-block'))
     await sleep(100)
-    const menuListItems = await menuList.findElements(By.css('.mynah-detailed-list-item.mynah-ui-clickable-item'))
-    for (const item of menuListItems) {
-        const textWrapper = await item.findElement(By.css('.mynah-detailed-list-item-text'))
-        const nameElement = await textWrapper.findElement(By.css('.mynah-detailed-list-item-name'))
-        const labelText = await nameElement.getText()
-
-        if (labelText === itemName) {
-            console.log(`Clicking Pin Context menu item: ${itemName}`)
-            await item.click()
-            return
-        }
-    }
-
-    throw new Error(`Pin Context menu item not found: ${itemName}`)
+    const item = await waitForElement(
+        webview,
+        By.xpath(
+            `//div[contains(@class, 'mynah-detailed-list-item') and contains(@class, 'mynah-ui-clickable-item')]//div[contains(@class, 'mynah-detailed-list-item-name') and text()='${itemName}']`
+        )
+    )
+    console.log(`Clicking Pin Context menu item: ${itemName}`)
+    await item.click()
 }
 /**
  * Lists all the possible Sub-menu items in the console.
@@ -89,26 +81,24 @@ export async function clickPinContextMenuItem(webview: WebviewView, itemName: st
  * @returns Promise<boolean> Returns the items as a WebElement List and the labels in a string array
  */
 export async function getSubMenuItems(webview: WebviewView): Promise<{ items: WebElement[]; labels: string[] }> {
-    const menuList = await waitForElement(webview, By.css('.mynah-detailed-list-items-block'))
     await sleep(100)
-    const menuListItems = await menuList.findElements(By.css('.mynah-detailed-list-item.mynah-ui-clickable-item'))
+    const items = await webview.findElements(
+        By.xpath(`//div[contains(@class, 'mynah-detailed-list-item') and contains(@class, 'mynah-ui-clickable-item')]`)
+    )
 
-    if (menuListItems.length === 0) {
+    if (items.length === 0) {
         throw new Error('No sub-menu items found')
     }
 
     const labels: string[] = []
-    for (const item of menuListItems) {
-        const textWrapper = await item.findElement(
-            By.css('.mynah-detailed-list-item-text.mynah-detailed-list-item-text-direction-row')
-        )
-        const nameElement = await textWrapper.findElement(By.css('.mynah-detailed-list-item-name'))
+    for (const item of items) {
+        const nameElement = await item.findElement(By.css('.mynah-detailed-list-item-name'))
         const labelText = await nameElement.getText()
         labels.push(labelText)
         console.log('Menu item found:', labelText)
     }
 
-    return { items: menuListItems, labels }
+    return { items, labels }
 }
 /**
  * Clicks a specific item in the Sub-Menu by its label text
@@ -119,22 +109,13 @@ export async function getSubMenuItems(webview: WebviewView): Promise<{ items: We
  * NOTE: To find all possible text labels, you can call getPinContextMenuItems
  */
 export async function clickSubMenuItem(webview: WebviewView, itemName: string): Promise<void> {
-    const menuList = await waitForElement(webview, By.css('.mynah-detailed-list-items-block'))
     await sleep(100)
-    const menuListItems = await menuList.findElements(By.css('.mynah-detailed-list-item.mynah-ui-clickable-item'))
-    for (const item of menuListItems) {
-        const textWrapper = await item.findElement(
-            By.css('.mynah-detailed-list-item-text.mynah-detailed-list-item-text-direction-row')
+    const item = await waitForElement(
+        webview,
+        By.xpath(
+            `//div[contains(@class, 'mynah-detailed-list-item') and contains(@class, 'mynah-ui-clickable-item')]//div[contains(@class, 'mynah-detailed-list-item-name') and text()='${itemName}']`
         )
-        const nameElement = await textWrapper.findElement(By.css('.mynah-detailed-list-item-name'))
-        const labelText = await nameElement.getText()
-
-        if (labelText === itemName) {
-            console.log(`Clicking Pin Context menu item: ${itemName}`)
-            await item.click()
-            return
-        }
-    }
-
-    throw new Error(`Pin Context menu item not found: ${itemName}`)
+    )
+    console.log(`Clicking Pin Context menu item: ${itemName}`)
+    await item.click()
 }

--- a/packages/amazonq/test/e2e_new/amazonq/tests/pinContext.test.ts
+++ b/packages/amazonq/test/e2e_new/amazonq/tests/pinContext.test.ts
@@ -4,7 +4,7 @@
  */
 import '../utils/setup'
 import { WebviewView, By } from 'vscode-extension-tester'
-import { closeAllTabs, dismissOverlayIfPresent } from '../utils/cleanupUtils'
+import { closeAllTabs } from '../utils/cleanupUtils'
 import { testContext } from '../utils/testContext'
 import { clickPinContextButton, clickPinContextMenuItem, clickSubMenuItem } from '../helpers/pinContextHelper'
 import { waitForElement } from '../utils/generalUtils'
@@ -19,13 +19,13 @@ describe('Amazon Q Pin Context Functionality', function () {
     })
 
     afterEach(async () => {
-        await dismissOverlayIfPresent(webviewView)
+        //await dismissOverlayIfPresent(webviewView)
         await closeAllTabs(webviewView)
     })
     it('Allows User to Add File Context', async () => {
         await clickPinContextButton(webviewView)
         await clickPinContextMenuItem(webviewView, 'Files')
-        await clickPinContextMenuItem(webviewView, 'Active file')
+        await clickSubMenuItem(webviewView, 'Active file')
     })
     it('Allows User to Pin Workspace Context', async () => {
         await clickPinContextButton(webviewView)

--- a/packages/amazonq/test/e2e_new/amazonq/tests/pinContext.test.ts
+++ b/packages/amazonq/test/e2e_new/amazonq/tests/pinContext.test.ts
@@ -19,7 +19,6 @@ describe('Amazon Q Pin Context Functionality', function () {
     })
 
     afterEach(async () => {
-        //await dismissOverlayIfPresent(webviewView)
         await closeAllTabs(webviewView)
     })
     it('Allows User to Add File Context', async () => {


### PR DESCRIPTION
## Problem
We were faced with the problem that when all our tests and helpers were merged together, and then run as a full suite, we saw errors with the pinContext.test.ts file. Namely, it was targeting a background overlay that had identical css components to the pinContext overlay. This is problematic since our entire suite relies on these css components, and even test-ids were not differentiated. Additionally, our pinContextHelpers used sleep functions in the range of 100-3000 ms which is naturally arbitrary values.   

## Solution
We implement the XPath css selectors that are used within Selenium to identify the pinContext Buttons by text, not css classes or ids. This drastically decreases the length and complexity of our helpers while also eliminating the need for sleep functions other than a sleep(0) function for subMenuItems that is needed for the DOM to be loaded. Below is our success of the tests: 

<img width="313" height="77" alt="Screenshot 2025-08-19 at 1 49 34 PM" src="https://github.com/user-attachments/assets/dd378c02-67c1-4f73-a6e7-cd709e028c80" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.

