### PR TITLE
fix(amazonq): Fix Quick Actions Test Suite

### DIFF
--- a/packages/amazonq/test/e2e_new/amazonq/tests/quickActions.test.ts
+++ b/packages/amazonq/test/e2e_new/amazonq/tests/quickActions.test.ts
@@ -4,7 +4,7 @@
  */
 import '../utils/setup'
 import { WebviewView } from 'vscode-extension-tester'
-import { closeAllTabs, dismissOverlayIfPresent } from '../utils/cleanupUtils'
+import { closeAllTabs } from '../utils/cleanupUtils'
 import { testContext } from '../utils/testContext'
 import { clickQuickActionsCommand } from '../helpers/quickActionsHelper'
 import { clearChatInput } from '../utils/generalUtils'
@@ -18,17 +18,19 @@ describe('Amazon Q Chat Quick Actions Functionality', function () {
         webviewView = testContext.webviewView
     })
 
-    after(async function () {
+    afterEach(async () => {
         await closeAllTabs(webviewView)
     })
 
-    afterEach(async () => {
-        // before closing the tabs, make sure that any overlays have been dismissed
-        await dismissOverlayIfPresent(webviewView)
+    it('/help Test', async () => {
+        await clickQuickActionsCommand(webviewView, '/help')
         await clearChatInput(webviewView)
     })
-
-    it('Quick Actions Test', async () => {
-        await clickQuickActionsCommand(webviewView, 'dev')
+    it('/clear Test', async () => {
+        await clickQuickActionsCommand(webviewView, '/clear')
+    })
+    it('/compact Test', async () => {
+        await clickQuickActionsCommand(webviewView, '/compact')
+        await clearChatInput(webviewView)
     })
 })


### PR DESCRIPTION
## Problem
There were some CSS changes to the quick actions menu which caused the old test suite to break. 

## Solution
This change fixes the CSS to match the new quick actions menu, and rewrites the tests to utilize the current Quick Actions commands

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
