### PR TITLE
fix(explorer): Refresh s3 node on profile switch (#7401, #7665)

### DIFF
--- a/packages/core/src/shared/awsClientBuilderV3.ts
+++ b/packages/core/src/shared/awsClientBuilderV3.ts
@@ -120,10 +120,12 @@ export class AWSClientBuilderV3 {
 
     private keyAwsService<C extends AwsClient>(serviceOptions: AwsServiceOptions<C>): string {
         // Serializing certain objects in the args allows us to detect when nested objects change (ex. new retry strategy, endpoints)
+        const profileId = this.context.getCredentialProfileName()
         return [
             String(serviceOptions.serviceClient),
             JSON.stringify(serviceOptions.clientOptions),
             serviceOptions.region,
+            profileId,
             serviceOptions.userAgent ? '1' : '0',
             serviceOptions.settings ? JSON.stringify(serviceOptions.settings.get('endpoints', {})) : '',
         ].join(':')

--- a/packages/toolkit/.changes/next-release/Bug Fix-6318dec2-72a8-4464-ab84-e51913624f8c.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-6318dec2-72a8-4464-ab84-e51913624f8c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "S3 node in explorer is not refreshed on profile change"
+}


### PR DESCRIPTION
## Problem
When a connection is changed, the awsClientBuilderV3 is used to get the service details, and a cache is being used to cache the service. However, in the cache key only region is cached along with other service details, so on profile switch it is still returning the same cached service of previous profile.

## Solution
Retrieved current profile using global aws context, and added it to the cache key, so when profile is switched, cache is updated and service from new profile is retrieved.

This approach resolves the node refresh issue by including the profile in the cache key. I'd appreciate feedback on whether there are any edge cases or alternative approaches I should consider.

I'm also looking for guidance on writing tests for this change. What would be the recommended approach for writing unit/integration tests to verify profile switches?

Thank you.
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
