### PR TITLE
docs(amazonq): update docs for connecting local language-server-runtimes

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -77,25 +77,43 @@ If you want to connect a local version of language-server-runtimes to aws-toolki
     /toolkit
     /core
     /amazonq
+    /language-servers
     /language-server-runtimes
     ```
 
 2. Inside of the language-server-runtimes project run:
+
     ```
     npm install
     npm run compile
     cd runtimes
     npm run prepub
     cd out
-    npm link
-    cd ../../types
-    npm link
+    npm pack
     ```
+
+    You will see a file created like this: `aws-language-server-runtimes-0.*.*.tgz`
+
     If you get an error running `npm run prepub`, you can instead run `npm run prepub:copyFiles` to skip cleaning and testing.
-3. Inside of aws-toolkit-vscode run:
+
+3. Inside of language-servers, find the package where you need the change.
+
+    For example, if you would like the change in `language-servers/app/aws-lsp-codewhisperer-runtimes`, you would run:
+
     ```
-    npm install
-    npm link @aws/language-server-runtimes @aws/language-server-runtimes-types
+    cd language-servers/app/aws-lsp-codewhisperer-runtimes
+
+    npm install ../../../language-server-runtimes/runtimes/out/aws-language-server-runtimes-0.*.*.tgz
+
+    npm run compile
+    ```
+
+4. If you need the change in aws-toolkit-vscode run:
+
+    ```
+    cd aws-toolkit-vscode
+
+    npm install ../language-server-runtimes/runtimes/out/aws-language-server-runtimes-0.2.126.tgz
     ```
 
 ## Amazon Q Inline Activation

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -89,32 +89,48 @@ If you want to connect a local version of language-server-runtimes to aws-toolki
     cd runtimes
     npm run prepub
     cd out
-    npm pack
     ```
-
-    You will see a file created like this: `aws-language-server-runtimes-0.*.*.tgz`
 
     If you get an error running `npm run prepub`, you can instead run `npm run prepub:copyFiles` to skip cleaning and testing.
 
-3. Inside of language-servers, find the package where you need the change.
+3. Choose one of the following approaches:
 
-    For example, if you would like the change in `language-servers/app/aws-lsp-codewhisperer-runtimes`, you would run:
+### Option A: Using npm pack (Recommended)
 
-    ```
+3a. Create a package file:
+
+    npm pack
+
+You will see a file created like this: `aws-language-server-runtimes-0.*.*.tgz`
+
+4a. Inside of language-servers, find the package where you need the change.
+
+For example, if you would like the change in `language-servers/app/aws-lsp-codewhisperer-runtimes`, you would run:
+
     cd language-servers/app/aws-lsp-codewhisperer-runtimes
 
     npm install ../../../language-server-runtimes/runtimes/out/aws-language-server-runtimes-0.*.*.tgz
 
     npm run compile
-    ```
 
-4. If you need the change in aws-toolkit-vscode run:
+5a. If you need the change in aws-toolkit-vscode run:
 
-    ```
     cd aws-toolkit-vscode
 
-    npm install ../language-server-runtimes/runtimes/out/aws-language-server-runtimes-0.2.126.tgz
-    ```
+    npm install ../language-server-runtimes/runtimes/out/aws-language-server-runtimes-0.*.*.tgz
+
+### Option B: Using npm link (Alternative)
+
+3b. Create npm links:
+
+    npm link
+    cd ../../types
+    npm link
+
+4b. Inside of aws-toolkit-vscode run:
+
+    npm install
+    npm link @aws/language-server-runtimes @aws/language-server-runtimes-types
 
 ## Amazon Q Inline Activation
 


### PR DESCRIPTION
## Problem
- `npm link` is not working for some people when connecting local language-server-runtimes

## Solution
- `npm pack` has been working better for people, hence updating documentation to include the `npm pack` approach

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
