### PR TITLE
feat(amazonq): add admin control for MCP servers to block usage

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-5e9de7e7-cf7b-4ed3-824f-062b82b3f4b9.json
+++ b/packages/amazonq/.changes/next-release/Feature-5e9de7e7-cf7b-4ed3-824f-062b82b3f4b9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q supports admin control for MCP servers to block MCP server usage"
+}


### PR DESCRIPTION
## Problem
New feature for mcp admin control needs changelog

## Solution
- Added changelog


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
