### PR TITLE
fix(amazonq): windows keyboard shortcut for fixCode and generateUnitTests

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -925,7 +925,7 @@
             },
             {
                 "command": "aws.amazonq.fixCode",
-                "win": "win+alt+y",
+                "win": "win+alt+h",
                 "mac": "cmd+alt+y",
                 "linux": "meta+alt+y"
             },
@@ -943,7 +943,7 @@
             },
             {
                 "command": "aws.amazonq.generateUnitTests",
-                "key": "win+alt+t",
+                "key": "win+alt+n",
                 "mac": "cmd+alt+t",
                 "linux": "meta+alt+t"
             },


### PR DESCRIPTION
## Problem
Keyboard shortcuts for fixCode and generateUnitTests functions are not working on Windows VSC, although they function correctly on Mac

The current shortcuts conflict with Windows reserved keyboard combinations.

Current Shortcuts (Windows):
- fixCode: Windows + Alt + Y
- generateUnitTests: Windows + Alt + T

New Shortcuts (Windows only):
- fixCode: Windows + Alt + H
- generateUnitTests: Windows + Alt + N

## Solution
This approach results in different letter keys for the same functions across platforms:
- generateUnitTests: 'T' on Mac, 'N' on Windows
- fixCode: 'Y' on Mac, 'H' on Windows




---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
