### PR TITLE
feat(amazonq): Adding feature flag for VSC terminal integration.

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -185,6 +185,8 @@ export async function startLanguageServer(
                         codeReviewInChat: codeReviewInChat,
                         // feature flag for displaying findings found not through CodeReview in the Code Issues Panel
                         displayFindings: true,
+                        // feature flag for vscode terminal integration support
+                        terminalAvailability: true,
                     },
                     window: {
                         notifications: true,


### PR DESCRIPTION
## Notes:
- Adding a feature flag for VSC terminal integration to avoid regressions in other IDE's and in past VSC Amazon Q plugin versions.
- Reference language server pr: https://github.com/aws/language-servers/pull/2186

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
