### PR TITLE
fix(amazonq): bump version to 1.93.0-SNAPSHOT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29868,7 +29868,7 @@
         },
         "packages/amazonq": {
             "name": "amazon-q-vscode",
-            "version": "1.92.0-SNAPSHOT",
+            "version": "1.92.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "aws-core-vscode": "file:../core/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29868,7 +29868,7 @@
         },
         "packages/amazonq": {
             "name": "amazon-q-vscode",
-            "version": "1.92.0",
+            "version": "1.93.0-SNAPSHOT",
             "license": "Apache-2.0",
             "dependencies": {
                 "aws-core-vscode": "file:../core/"

--- a/packages/amazonq/.changes/1.92.0.json
+++ b/packages/amazonq/.changes/1.92.0.json
@@ -1,0 +1,18 @@
+{
+	"date": "2025-08-28",
+	"version": "1.92.0",
+	"entries": [
+		{
+			"type": "Feature",
+			"description": "Amazon Q supports admin control for MCP servers to restrict MCP server usage"
+		},
+		{
+			"type": "Feature",
+			"description": "Enabling dynamic model fetching capabilities in Amazon Q chat"
+		},
+		{
+			"type": "Feature",
+			"description": "Amazon Q: Support for configuring and utilizing remote MCP servers."
+		}
+	]
+}

--- a/packages/amazonq/.changes/next-release/Feature-5e9de7e7-cf7b-4ed3-824f-062b82b3f4b9.json
+++ b/packages/amazonq/.changes/next-release/Feature-5e9de7e7-cf7b-4ed3-824f-062b82b3f4b9.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "Amazon Q supports admin control for MCP servers to restrict MCP server usage"
-}

--- a/packages/amazonq/.changes/next-release/Feature-bac44cae-5e68-4192-bbdc-2aaf4cdc0e7c.json
+++ b/packages/amazonq/.changes/next-release/Feature-bac44cae-5e68-4192-bbdc-2aaf4cdc0e7c.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "Enabling dynamic model fetching capabilities in Amazon Q chat"
-}

--- a/packages/amazonq/.changes/next-release/Feature-dad6607e-513c-4355-9655-e80fd2da9ec2.json
+++ b/packages/amazonq/.changes/next-release/Feature-dad6607e-513c-4355-9655-e80fd2da9ec2.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "Amazon Q: Support for configuring and utilizing remote MCP servers."
-}

--- a/packages/amazonq/CHANGELOG.md
+++ b/packages/amazonq/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.92.0 2025-08-28
+
+- **Feature** Amazon Q supports admin control for MCP servers to restrict MCP server usage
+- **Feature** Enabling dynamic model fetching capabilities in Amazon Q chat
+- **Feature** Amazon Q: Support for configuring and utilizing remote MCP servers.
+
 ## 1.91.0 2025-08-22
 
 - **Bug Fix** Enable inline completion in Jupyter Notebook

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -2,7 +2,7 @@
     "name": "amazon-q-vscode",
     "displayName": "Amazon Q",
     "description": "The most capable generative AI–powered assistant for software development.",
-    "version": "1.92.0-SNAPSHOT",
+    "version": "1.92.0",
     "extensionKind": [
         "workspace"
     ],

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -2,7 +2,7 @@
     "name": "amazon-q-vscode",
     "displayName": "Amazon Q",
     "description": "The most capable generative AI–powered assistant for software development.",
-    "version": "1.92.0",
+    "version": "1.93.0-SNAPSHOT",
     "extensionKind": [
         "workspace"
     ],


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
