### PR TITLE
feat(amazonq): include recommendation text in the explain message

### DIFF
--- a/packages/amazonq/src/lsp/chat/commands.ts
+++ b/packages/amazonq/src/lsp/chat/commands.ts
@@ -30,7 +30,7 @@ export function registerCommands(provider: AmazonQChatViewProvider) {
                 issue,
                 filePath,
                 'Explain',
-                'Provide a small description of the issue. You must not attempt to fix the issue. You should only give a small summary of it to the user.',
+                'Provide a small description of the issue. You must not attempt to fix the issue. You should only give a small summary of it to the user. You must start with the information stored in the recommendation.text field if it is present.',
                 provider,
                 'explainIssue'
             )


### PR DESCRIPTION
## Problem
Customers complained about missing the old deterministic message.

## Solution
As the agent to include this message at the start of its explain response. It was stored in the recommendation.text field.

The agent does some paraphrasing, so the deterministic message

`We detected that this code sets key specifications more than once, key size more than once, or sets both. To make your code more secure, we recommend that you set either KeySpec or NumberOfBytes once. Do not set both.`

Gets turned into

`The CWE-327,328,326,208,1240 - Insecure cryptography issue at line 63 in CsvIterator.java occurs because the code sets both KeySpec and NumberOfBytes parameters on the same GenerateDataKeyRequest object, which are mutually exclusive in AWS KMS.`

There is more information in the explanation after this, but this is the part related to the deterministic recommendation.text

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
