### PR TITLE
fix(amazonq): add back inline completion code files - part 1

### DIFF
--- a/packages/core/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/packages/core/src/codewhisperer/commands/invokeRecommendation.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { vsCodeState, ConfigurationEntry } from '../models/model'
+import { resetIntelliSenseState } from '../util/globalStateUtil'
+import { DefaultCodeWhispererClient } from '../client/codewhisperer'
+import { RecommendationHandler } from '../service/recommendationHandler'
+import { session } from '../util/codeWhispererSession'
+import { RecommendationService } from '../service/recommendationService'
+
+/**
+ * This function is for manual trigger CodeWhisperer
+ */
+
+export async function invokeRecommendation(
+    editor: vscode.TextEditor,
+    client: DefaultCodeWhispererClient,
+    config: ConfigurationEntry
+) {
+    if (!editor || !config.isManualTriggerEnabled) {
+        return
+    }
+
+    /**
+     * Skip when output channel gains focus and invoke
+     */
+    if (editor.document.languageId === 'Log') {
+        return
+    }
+    /**
+     * When using intelliSense, if invocation position changed, reject previous active recommendations
+     */
+    if (vsCodeState.isIntelliSenseActive && editor.selection.active !== session.startPos) {
+        resetIntelliSenseState(
+            config.isManualTriggerEnabled,
+            config.isAutomatedTriggerEnabled,
+            RecommendationHandler.instance.isValidResponse()
+        )
+    }
+
+    await RecommendationService.instance.generateRecommendation(client, editor, 'OnDemand', config, undefined)
+}

--- a/packages/core/src/codewhisperer/commands/onAcceptance.ts
+++ b/packages/core/src/codewhisperer/commands/onAcceptance.ts
@@ -1,0 +1,85 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { vsCodeState, OnRecommendationAcceptanceEntry } from '../models/model'
+import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
+import { CodeWhispererTracker } from '../tracker/codewhispererTracker'
+import { CodeWhispererCodeCoverageTracker } from '../tracker/codewhispererCodeCoverageTracker'
+import { getLogger } from '../../shared/logger/logger'
+import { handleExtraBrackets } from '../util/closingBracketUtil'
+import { RecommendationHandler } from '../service/recommendationHandler'
+import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
+import { ReferenceHoverProvider } from '../service/referenceHoverProvider'
+import path from 'path'
+
+/**
+ * This function is called when user accepts a intelliSense suggestion or an inline suggestion
+ */
+export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEntry) {
+    RecommendationHandler.instance.cancelPaginatedRequest()
+    /**
+     * Format document
+     */
+    if (acceptanceEntry.editor) {
+        const languageContext = runtimeLanguageContext.getLanguageContext(
+            acceptanceEntry.editor.document.languageId,
+            path.extname(acceptanceEntry.editor.document.fileName)
+        )
+        const start = acceptanceEntry.range.start
+        const end = acceptanceEntry.range.end
+
+        // codewhisperer will be doing editing while formatting.
+        // formatting should not trigger consoals auto trigger
+        vsCodeState.isCodeWhispererEditing = true
+        /**
+         * Mitigation to right context handling mainly for auto closing bracket use case
+         */
+        try {
+            await handleExtraBrackets(acceptanceEntry.editor, end, start)
+        } catch (error) {
+            getLogger().error(`${error} in handleAutoClosingBrackets`)
+        }
+        // move cursor to end of suggestion before doing code format
+        // after formatting, the end position will still be editor.selection.active
+        acceptanceEntry.editor.selection = new vscode.Selection(end, end)
+
+        vsCodeState.isCodeWhispererEditing = false
+        CodeWhispererTracker.getTracker().enqueue({
+            time: new Date(),
+            fileUrl: acceptanceEntry.editor.document.uri,
+            originalString: acceptanceEntry.editor.document.getText(new vscode.Range(start, end)),
+            startPosition: start,
+            endPosition: end,
+            requestId: acceptanceEntry.requestId,
+            sessionId: acceptanceEntry.sessionId,
+            index: acceptanceEntry.acceptIndex,
+            triggerType: acceptanceEntry.triggerType,
+            completionType: acceptanceEntry.completionType,
+            language: languageContext.language,
+        })
+        const insertedCoderange = new vscode.Range(start, end)
+        CodeWhispererCodeCoverageTracker.getTracker(languageContext.language)?.countAcceptedTokens(
+            insertedCoderange,
+            acceptanceEntry.editor.document.getText(insertedCoderange),
+            acceptanceEntry.editor.document.fileName
+        )
+        if (acceptanceEntry.references !== undefined) {
+            const referenceLog = ReferenceLogViewProvider.getReferenceLog(
+                acceptanceEntry.recommendation,
+                acceptanceEntry.references,
+                acceptanceEntry.editor
+            )
+            ReferenceLogViewProvider.instance.addReferenceLog(referenceLog)
+            ReferenceHoverProvider.instance.addCodeReferences(
+                acceptanceEntry.recommendation,
+                acceptanceEntry.references
+            )
+        }
+    }
+
+    // at the end of recommendation acceptance, report user decisions and clear recommendations.
+    RecommendationHandler.instance.reportUserDecisions(acceptanceEntry.acceptIndex)
+}

--- a/packages/core/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/packages/core/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -1,0 +1,146 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as CodeWhispererConstants from '../models/constants'
+import { vsCodeState, OnRecommendationAcceptanceEntry } from '../models/model'
+import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
+import { CodeWhispererTracker } from '../tracker/codewhispererTracker'
+import { CodeWhispererCodeCoverageTracker } from '../tracker/codewhispererCodeCoverageTracker'
+import { getLogger } from '../../shared/logger/logger'
+import { RecommendationHandler } from '../service/recommendationHandler'
+import { sleep } from '../../shared/utilities/timeoutUtils'
+import { handleExtraBrackets } from '../util/closingBracketUtil'
+import { Commands } from '../../shared/vscode/commands2'
+import { isInlineCompletionEnabled } from '../util/commonUtil'
+import { ExtContext } from '../../shared/extensions'
+import { onAcceptance } from './onAcceptance'
+import * as codewhispererClient from '../client/codewhisperer'
+import {
+    CodewhispererCompletionType,
+    CodewhispererLanguage,
+    CodewhispererTriggerType,
+} from '../../shared/telemetry/telemetry.gen'
+import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
+import { ReferenceHoverProvider } from '../service/referenceHoverProvider'
+import { ImportAdderProvider } from '../service/importAdderProvider'
+import { session } from '../util/codeWhispererSession'
+import path from 'path'
+import { RecommendationService } from '../service/recommendationService'
+import { Container } from '../service/serviceContainer'
+import { telemetry } from '../../shared/telemetry/telemetry'
+import { TelemetryHelper } from '../util/telemetryHelper'
+import { UserWrittenCodeTracker } from '../tracker/userWrittenCodeTracker'
+
+export const acceptSuggestion = Commands.declare(
+    'aws.amazonq.accept',
+    (context: ExtContext) =>
+        async (
+            range: vscode.Range,
+            effectiveRange: vscode.Range,
+            acceptIndex: number,
+            recommendation: string,
+            requestId: string,
+            sessionId: string,
+            triggerType: CodewhispererTriggerType,
+            completionType: CodewhispererCompletionType,
+            language: CodewhispererLanguage,
+            references: codewhispererClient.References
+        ) => {
+            telemetry.record({
+                traceId: TelemetryHelper.instance.traceId,
+            })
+
+            RecommendationService.instance.incrementAcceptedCount()
+            const editor = vscode.window.activeTextEditor
+            await Container.instance.lineAnnotationController.refresh(editor, 'codewhisperer')
+            const onAcceptanceFunc = isInlineCompletionEnabled() ? onInlineAcceptance : onAcceptance
+            await onAcceptanceFunc({
+                editor,
+                range,
+                effectiveRange,
+                acceptIndex,
+                recommendation,
+                requestId,
+                sessionId,
+                triggerType,
+                completionType,
+                language,
+                references,
+            })
+        }
+)
+/**
+ * This function is called when user accepts a intelliSense suggestion or an inline suggestion
+ */
+export async function onInlineAcceptance(acceptanceEntry: OnRecommendationAcceptanceEntry) {
+    RecommendationHandler.instance.cancelPaginatedRequest()
+    RecommendationHandler.instance.disposeInlineCompletion()
+
+    if (acceptanceEntry.editor) {
+        await sleep(CodeWhispererConstants.vsCodeCursorUpdateDelay)
+        const languageContext = runtimeLanguageContext.getLanguageContext(
+            acceptanceEntry.editor.document.languageId,
+            path.extname(acceptanceEntry.editor.document.fileName)
+        )
+        const start = acceptanceEntry.range.start
+        const end = acceptanceEntry.editor.selection.active
+
+        vsCodeState.isCodeWhispererEditing = true
+        /**
+         * Mitigation to right context handling mainly for auto closing bracket use case
+         */
+        try {
+            // Do not handle extra bracket if there is a right context merge
+            if (acceptanceEntry.recommendation === session.recommendations[acceptanceEntry.acceptIndex].content) {
+                await handleExtraBrackets(acceptanceEntry.editor, end, acceptanceEntry.effectiveRange.start)
+            }
+            await ImportAdderProvider.instance.onAcceptRecommendation(
+                acceptanceEntry.editor,
+                session.recommendations[acceptanceEntry.acceptIndex],
+                start.line
+            )
+        } catch (error) {
+            getLogger().error(`${error} in handling extra brackets or imports`)
+        } finally {
+            vsCodeState.isCodeWhispererEditing = false
+        }
+
+        CodeWhispererTracker.getTracker().enqueue({
+            time: new Date(),
+            fileUrl: acceptanceEntry.editor.document.uri,
+            originalString: acceptanceEntry.editor.document.getText(new vscode.Range(start, end)),
+            startPosition: start,
+            endPosition: end,
+            requestId: acceptanceEntry.requestId,
+            sessionId: acceptanceEntry.sessionId,
+            index: acceptanceEntry.acceptIndex,
+            triggerType: acceptanceEntry.triggerType,
+            completionType: acceptanceEntry.completionType,
+            language: languageContext.language,
+        })
+        const insertedCoderange = new vscode.Range(start, end)
+        CodeWhispererCodeCoverageTracker.getTracker(languageContext.language)?.countAcceptedTokens(
+            insertedCoderange,
+            acceptanceEntry.editor.document.getText(insertedCoderange),
+            acceptanceEntry.editor.document.fileName
+        )
+        UserWrittenCodeTracker.instance.onQFinishesEdits()
+        if (acceptanceEntry.references !== undefined) {
+            const referenceLog = ReferenceLogViewProvider.getReferenceLog(
+                acceptanceEntry.recommendation,
+                acceptanceEntry.references,
+                acceptanceEntry.editor
+            )
+            ReferenceLogViewProvider.instance.addReferenceLog(referenceLog)
+            ReferenceHoverProvider.instance.addCodeReferences(
+                acceptanceEntry.recommendation,
+                acceptanceEntry.references
+            )
+        }
+
+        RecommendationHandler.instance.reportUserDecisions(acceptanceEntry.acceptIndex)
+    }
+}

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -138,10 +138,16 @@ export const runningSecurityScan = 'Reviewing project for code issues...'
 
 export const runningFileScan = 'Reviewing current file for code issues...'
 
+export const noSuggestions = 'No suggestions from Amazon Q'
+
 export const noInlineSuggestionsMsg = 'No suggestions from Amazon Q'
 
 export const licenseFilter = 'Amazon Q suggestions were filtered due to reference settings'
 
+/**
+ * the interval of the background thread invocation, which is triggered by the timer
+ */
+export const defaultCheckPeriodMillis = 1000 * 60 * 5
 /**
  * Key bindings JSON file path
  */

--- a/packages/core/src/codewhisperer/service/classifierTrigger.ts
+++ b/packages/core/src/codewhisperer/service/classifierTrigger.ts
@@ -1,0 +1,609 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import os from 'os'
+import * as vscode from 'vscode'
+import { CodewhispererAutomatedTriggerType } from '../../shared/telemetry/telemetry'
+import { extractContextForCodeWhisperer } from '../util/editorContext'
+import { TelemetryHelper } from '../util/telemetryHelper'
+import { ProgrammingLanguage } from '../client/codewhispereruserclient'
+
+interface normalizedCoefficients {
+    readonly lineNum: number
+    readonly lenLeftCur: number
+    readonly lenLeftPrev: number
+    readonly lenRight: number
+}
+/*
+ uses ML classifier to determine if user input should trigger CWSPR service
+ */
+export class ClassifierTrigger {
+    static #instance: ClassifierTrigger
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    // ML classifier trigger threshold
+    private triggerThreshold = 0.43
+
+    // ML classifier coefficients
+    // os coefficient
+    private osCoefficientMap: Readonly<Record<string, number>> = {
+        'Mac OS X': -0.1552,
+        'Windows 10': -0.0238,
+        Windows: 0.0412,
+        win32: -0.0559,
+    }
+
+    // trigger type coefficient
+    private triggerTypeCoefficientMap: Readonly<Record<string, number>> = {
+        SpecialCharacters: 0.0209,
+        Enter: 0.2853,
+    }
+
+    private languageCoefficientMap: Readonly<Record<string, number>> = {
+        java: -0.4622,
+        javascript: -0.4688,
+        python: -0.3052,
+        typescript: -0.6084,
+        tsx: -0.6084,
+        jsx: -0.4688,
+        shell: -0.4718,
+        ruby: -0.7356,
+        sql: -0.4937,
+        rust: -0.4309,
+        kotlin: -0.4739,
+        php: -0.3917,
+        csharp: -0.3475,
+        go: -0.3504,
+        scala: -0.534,
+        cpp: -0.1734,
+        json: 0,
+        yaml: -0.3,
+        tf: -0.55,
+    }
+
+    // other metadata coefficient
+    private lineNumCoefficient = -0.0416
+    private lengthOfLeftCurrentCoefficient = -1.1747
+    private lengthOfLeftPrevCoefficient = 0.4033
+    private lengthOfRightCoefficient = -0.3321
+    private prevDecisionAcceptCoefficient = 0.5397
+    private prevDecisionRejectCoefficient = -0.1656
+    private prevDecisionOtherCoefficient = 0
+    private ideVscode = -0.1905
+    private lengthLeft0To5 = -0.8756
+    private lengthLeft5To10 = -0.5463
+    private lengthLeft10To20 = -0.4081
+    private lengthLeft20To30 = -0.3272
+    private lengthLeft30To40 = -0.2442
+    private lengthLeft40To50 = -0.1471
+
+    // intercept of logistic regression classifier
+    private intercept = 0.3738713
+
+    private maxx: normalizedCoefficients = {
+        lineNum: 4631.0,
+        lenLeftCur: 157.0,
+        lenLeftPrev: 176.0,
+        lenRight: 10239.0,
+    }
+
+    private minn: normalizedCoefficients = {
+        lineNum: 0.0,
+        lenLeftCur: 0.0,
+        lenLeftPrev: 0.0,
+        lenRight: 0.0,
+    }
+
+    // character and keywords coefficient
+    private charCoefficient: Readonly<Record<string, number>> = {
+        throw: 1.5868,
+        ';': -1.268,
+        any: -1.1565,
+        '7': -1.1347,
+        false: -1.1307,
+        nil: -1.0653,
+        elif: 1.0122,
+        '9': -1.0098,
+        pass: -1.0058,
+        True: -1.0002,
+        False: -0.9434,
+        '6': -0.9222,
+        true: -0.9142,
+        None: -0.9027,
+        '8': -0.9013,
+        break: -0.8475,
+        '}': -0.847,
+        '5': -0.8414,
+        '4': -0.8197,
+        '1': -0.8085,
+        '\\': -0.8019,
+        static: -0.7748,
+        '0': -0.77,
+        end: -0.7617,
+        '(': 0.7239,
+        '/': -0.7104,
+        where: -0.6981,
+        readonly: -0.6741,
+        async: -0.6723,
+        '3': -0.654,
+        continue: -0.6413,
+        struct: -0.64,
+        try: -0.6369,
+        float: -0.6341,
+        using: 0.6079,
+        '@': 0.6016,
+        '|': 0.5993,
+        impl: 0.5808,
+        private: -0.5746,
+        for: 0.5741,
+        '2': -0.5634,
+        let: -0.5187,
+        foreach: 0.5186,
+        select: -0.5148,
+        export: -0.5,
+        mut: -0.4921,
+        ')': -0.463,
+        ']': -0.4611,
+        when: 0.4602,
+        virtual: -0.4583,
+        extern: -0.4465,
+        catch: 0.4446,
+        new: 0.4394,
+        val: -0.4339,
+        map: 0.4284,
+        case: 0.4271,
+        throws: 0.4221,
+        null: -0.4197,
+        protected: -0.4133,
+        q: 0.4125,
+        except: 0.4115,
+        ': ': 0.4072,
+        '^': -0.407,
+        ' ': 0.4066,
+        $: 0.3981,
+        this: 0.3962,
+        switch: 0.3947,
+        '*': -0.3931,
+        module: 0.3912,
+        array: 0.385,
+        '=': 0.3828,
+        p: 0.3728,
+        ON: 0.3708,
+        '`': 0.3693,
+        u: 0.3658,
+        a: 0.3654,
+        require: 0.3646,
+        '>': -0.3644,
+        const: -0.3476,
+        o: 0.3423,
+        sizeof: 0.3416,
+        object: 0.3362,
+        w: 0.3345,
+        print: 0.3344,
+        range: 0.3336,
+        if: 0.3324,
+        abstract: -0.3293,
+        var: -0.3239,
+        i: 0.321,
+        while: 0.3138,
+        J: 0.3137,
+        c: 0.3118,
+        await: -0.3072,
+        from: 0.3057,
+        f: 0.302,
+        echo: 0.2995,
+        '#': 0.2984,
+        e: 0.2962,
+        r: 0.2925,
+        mod: 0.2893,
+        loop: 0.2874,
+        t: 0.2832,
+        '~': 0.282,
+        final: -0.2816,
+        del: 0.2785,
+        override: -0.2746,
+        ref: -0.2737,
+        h: 0.2693,
+        m: 0.2681,
+        '{': 0.2674,
+        implements: 0.2672,
+        inline: -0.2642,
+        match: 0.2613,
+        with: -0.261,
+        x: 0.2597,
+        namespace: -0.2596,
+        operator: 0.2573,
+        double: -0.2563,
+        source: -0.2482,
+        import: -0.2419,
+        NULL: -0.2399,
+        l: 0.239,
+        or: 0.2378,
+        s: 0.2366,
+        then: 0.2354,
+        W: 0.2354,
+        y: 0.2333,
+        local: 0.2288,
+        is: 0.2282,
+        n: 0.2254,
+        '+': -0.2251,
+        G: 0.223,
+        public: -0.2229,
+        WHERE: 0.2224,
+        list: 0.2204,
+        Q: 0.2204,
+        '[': 0.2136,
+        VALUES: 0.2134,
+        H: 0.2105,
+        g: 0.2094,
+        else: -0.208,
+        bool: -0.2066,
+        long: -0.2059,
+        R: 0.2025,
+        S: 0.2021,
+        d: 0.2003,
+        V: 0.1974,
+        K: -0.1961,
+        '<': 0.1958,
+        debugger: -0.1929,
+        NOT: -0.1911,
+        b: 0.1907,
+        boolean: -0.1891,
+        z: -0.1866,
+        LIKE: -0.1793,
+        raise: 0.1782,
+        L: 0.1768,
+        fn: 0.176,
+        delete: 0.1714,
+        unsigned: -0.1675,
+        auto: -0.1648,
+        finally: 0.1616,
+        k: 0.1599,
+        as: 0.156,
+        instanceof: 0.1558,
+        '&': 0.1554,
+        E: 0.1551,
+        M: 0.1542,
+        I: 0.1503,
+        Y: 0.1493,
+        typeof: 0.1475,
+        j: 0.1445,
+        INTO: 0.1442,
+        IF: 0.1437,
+        next: 0.1433,
+        undef: -0.1427,
+        THEN: -0.1416,
+        v: 0.1415,
+        C: 0.1383,
+        P: 0.1353,
+        AND: -0.1345,
+        constructor: 0.1337,
+        void: -0.1336,
+        class: -0.1328,
+        defer: 0.1316,
+        begin: 0.1306,
+        FROM: -0.1304,
+        SET: 0.1291,
+        decimal: -0.1278,
+        friend: 0.1277,
+        SELECT: -0.1265,
+        event: 0.1259,
+        lambda: 0.1253,
+        enum: 0.1215,
+        A: 0.121,
+        lock: 0.1187,
+        ensure: 0.1184,
+        '%': 0.1177,
+        isset: 0.1175,
+        O: 0.1174,
+        '.': 0.1146,
+        UNION: -0.1145,
+        alias: -0.1129,
+        template: -0.1102,
+        WHEN: 0.1093,
+        rescue: 0.1083,
+        DISTINCT: -0.1074,
+        trait: -0.1073,
+        D: 0.1062,
+        in: 0.1045,
+        internal: -0.1029,
+        ',': 0.1027,
+        static_cast: 0.1016,
+        do: -0.1005,
+        OR: 0.1003,
+        AS: -0.1001,
+        interface: 0.0996,
+        super: 0.0989,
+        B: 0.0963,
+        U: 0.0962,
+        T: 0.0943,
+        CALL: -0.0918,
+        BETWEEN: -0.0915,
+        N: 0.0897,
+        yield: 0.0867,
+        done: -0.0857,
+        string: -0.0837,
+        out: -0.0831,
+        volatile: -0.0819,
+        retry: 0.0816,
+        '?': -0.0796,
+        number: -0.0791,
+        short: 0.0787,
+        sealed: -0.0776,
+        package: 0.0765,
+        OPEN: -0.0756,
+        base: 0.0735,
+        and: 0.0729,
+        exit: 0.0726,
+        _: 0.0721,
+        keyof: -0.072,
+        def: 0.0713,
+        crate: -0.0706,
+        '-': -0.07,
+        FUNCTION: 0.0692,
+        declare: -0.0678,
+        include: 0.0671,
+        COUNT: -0.0669,
+        INDEX: -0.0666,
+        CLOSE: -0.0651,
+        fi: -0.0644,
+        uint: 0.0624,
+        params: 0.0575,
+        HAVING: 0.0575,
+        byte: -0.0575,
+        clone: -0.0552,
+        char: -0.054,
+        func: 0.0538,
+        never: -0.053,
+        unset: -0.0524,
+        unless: -0.051,
+        esac: -0.0509,
+        shift: -0.0507,
+        require_once: 0.0486,
+        ELSE: -0.0477,
+        extends: 0.0461,
+        elseif: 0.0452,
+        mutable: -0.0451,
+        asm: 0.0449,
+        '!': 0.0446,
+        LIMIT: 0.0444,
+        ushort: -0.0438,
+        '"': -0.0433,
+        Z: 0.0431,
+        exec: -0.0431,
+        IS: -0.0429,
+        DECLARE: -0.0425,
+        __LINE__: -0.0424,
+        BEGIN: -0.0418,
+        typedef: 0.0414,
+        EXIT: -0.0412,
+        "'": 0.041,
+        function: -0.0393,
+        dyn: -0.039,
+        wchar_t: -0.0388,
+        unique: -0.0383,
+        include_once: 0.0367,
+        stackalloc: 0.0359,
+        RETURN: -0.0356,
+        const_cast: 0.035,
+        MAX: 0.0341,
+        assert: -0.0331,
+        JOIN: -0.0328,
+        use: 0.0318,
+        GET: 0.0317,
+        VIEW: 0.0314,
+        move: 0.0308,
+        typename: 0.0308,
+        die: 0.0305,
+        asserts: -0.0304,
+        reinterpret_cast: -0.0302,
+        USING: -0.0289,
+        elsif: -0.0285,
+        FIRST: -0.028,
+        self: -0.0278,
+        RETURNING: -0.0278,
+        symbol: -0.0273,
+        OFFSET: 0.0263,
+        bigint: 0.0253,
+        register: -0.0237,
+        union: -0.0227,
+        return: -0.0227,
+        until: -0.0224,
+        endfor: -0.0213,
+        implicit: -0.021,
+        LOOP: 0.0195,
+        pub: 0.0182,
+        global: 0.0179,
+        EXCEPTION: 0.0175,
+        delegate: 0.0173,
+        signed: -0.0163,
+        FOR: 0.0156,
+        unsafe: 0.014,
+        NEXT: -0.0133,
+        IN: 0.0129,
+        MIN: -0.0123,
+        go: -0.0112,
+        type: -0.0109,
+        explicit: -0.0107,
+        eval: -0.0104,
+        int: -0.0099,
+        CASE: -0.0096,
+        END: 0.0084,
+        UPDATE: 0.0074,
+        default: 0.0072,
+        chan: 0.0068,
+        fixed: 0.0066,
+        not: -0.0052,
+        X: -0.0047,
+        endforeach: 0.0031,
+        goto: 0.0028,
+        empty: 0.0022,
+        checked: 0.0012,
+        F: -0.001,
+    }
+
+    public getThreshold() {
+        return this.triggerThreshold
+    }
+
+    public recordClassifierResultForManualTrigger(editor: vscode.TextEditor) {
+        this.shouldTriggerFromClassifier(undefined, editor, undefined, true)
+    }
+
+    public recordClassifierResultForAutoTrigger(
+        editor: vscode.TextEditor,
+        triggerType?: CodewhispererAutomatedTriggerType,
+        event?: vscode.TextDocumentChangeEvent
+    ) {
+        if (!triggerType) {
+            return
+        }
+        this.shouldTriggerFromClassifier(event, editor, triggerType, true)
+    }
+
+    public shouldTriggerFromClassifier(
+        event: vscode.TextDocumentChangeEvent | undefined,
+        editor: vscode.TextEditor,
+        autoTriggerType: string | undefined,
+        shouldRecordResult: boolean = false
+    ): boolean {
+        const fileContext = extractContextForCodeWhisperer(editor)
+        const osPlatform = this.normalizeOsName(os.platform(), os.version())
+        const char = event ? event.contentChanges[0].text : ''
+        const lineNum = editor.selection.active.line
+        const classifierResult = this.getClassifierResult(
+            fileContext.leftFileContent,
+            fileContext.rightFileContent,
+            osPlatform,
+            autoTriggerType,
+            char,
+            lineNum,
+            fileContext.programmingLanguage
+        )
+
+        const threshold = this.getThreshold()
+
+        const shouldTrigger = classifierResult > threshold
+        if (shouldRecordResult) {
+            TelemetryHelper.instance.setClassifierResult(classifierResult)
+            TelemetryHelper.instance.setClassifierThreshold(threshold)
+        }
+        return shouldTrigger
+    }
+
+    private getClassifierResult(
+        leftContext: string,
+        rightContext: string,
+        os: string,
+        triggerType: string | undefined,
+        char: string,
+        lineNum: number,
+        language: ProgrammingLanguage
+    ): number {
+        const leftContextLines = leftContext.split(/\r?\n/)
+        const leftContextAtCurrentLine = leftContextLines[leftContextLines.length - 1]
+        const tokens = leftContextAtCurrentLine.trim().split(' ')
+        let keyword = ''
+        const lastToken = tokens[tokens.length - 1]
+        if (lastToken && lastToken.length > 1) {
+            keyword = lastToken
+        }
+        const lengthOfLeftCurrent = leftContextLines[leftContextLines.length - 1].length
+        const lengthOfLeftPrev = leftContextLines[leftContextLines.length - 2]?.length ?? 0
+        const lengthOfRight = rightContext.trim().length
+
+        const triggerTypeCoefficient: number = this.triggerTypeCoefficientMap[triggerType || ''] ?? 0
+        const osCoefficient: number = this.osCoefficientMap[os] ?? 0
+        const charCoefficient: number = this.charCoefficient[char] ?? 0
+        const keyWordCoefficient: number = this.charCoefficient[keyword] ?? 0
+        const ideCoefficient = this.ideVscode
+
+        const previousDecision = TelemetryHelper.instance.getLastTriggerDecisionForClassifier()
+        const languageCoefficients = Object.values(this.languageCoefficientMap)
+        const avrgCoefficient =
+            languageCoefficients.length > 0
+                ? languageCoefficients.reduce((a, b) => a + b) / languageCoefficients.length
+                : 0
+        const languageCoefficient = this.languageCoefficientMap[language.languageName] ?? avrgCoefficient
+
+        let previousDecisionCoefficient = 0
+        if (previousDecision === 'Accept') {
+            previousDecisionCoefficient = this.prevDecisionAcceptCoefficient
+        } else if (previousDecision === 'Reject') {
+            previousDecisionCoefficient = this.prevDecisionRejectCoefficient
+        } else if (previousDecision === 'Discard' || previousDecision === 'Empty') {
+            previousDecisionCoefficient = this.prevDecisionOtherCoefficient
+        }
+
+        let leftContextLengthCoefficient = 0
+        if (leftContext.length >= 0 && leftContext.length < 5) {
+            leftContextLengthCoefficient = this.lengthLeft0To5
+        } else if (leftContext.length >= 5 && leftContext.length < 10) {
+            leftContextLengthCoefficient = this.lengthLeft5To10
+        } else if (leftContext.length >= 10 && leftContext.length < 20) {
+            leftContextLengthCoefficient = this.lengthLeft10To20
+        } else if (leftContext.length >= 20 && leftContext.length < 30) {
+            leftContextLengthCoefficient = this.lengthLeft20To30
+        } else if (leftContext.length >= 30 && leftContext.length < 40) {
+            leftContextLengthCoefficient = this.lengthLeft30To40
+        } else if (leftContext.length >= 40 && leftContext.length < 50) {
+            leftContextLengthCoefficient = this.lengthLeft40To50
+        }
+
+        const result =
+            (this.lengthOfRightCoefficient * (lengthOfRight - this.minn.lenRight)) /
+                (this.maxx.lenRight - this.minn.lenRight) +
+            (this.lengthOfLeftCurrentCoefficient * (lengthOfLeftCurrent - this.minn.lenLeftCur)) /
+                (this.maxx.lenLeftCur - this.minn.lenLeftCur) +
+            (this.lengthOfLeftPrevCoefficient * (lengthOfLeftPrev - this.minn.lenLeftPrev)) /
+                (this.maxx.lenLeftPrev - this.minn.lenLeftPrev) +
+            (this.lineNumCoefficient * (lineNum - this.minn.lineNum)) / (this.maxx.lineNum - this.minn.lineNum) +
+            osCoefficient +
+            triggerTypeCoefficient +
+            charCoefficient +
+            keyWordCoefficient +
+            ideCoefficient +
+            this.intercept +
+            previousDecisionCoefficient +
+            languageCoefficient +
+            leftContextLengthCoefficient
+
+        return sigmoid(result)
+    }
+
+    private normalizeOsName(name: string, version: string | undefined): string {
+        const lowercaseName = name.toLowerCase()
+        if (lowercaseName.includes('windows')) {
+            if (!version) {
+                return 'Windows'
+            } else if (version.includes('Windows NT 10') || version.startsWith('10')) {
+                return 'Windows 10'
+            } else if (version.includes('6.1')) {
+                return 'Windows 7'
+            } else if (version.includes('6.3')) {
+                return 'Windows 8.1'
+            } else {
+                return 'Windows'
+            }
+        } else if (
+            lowercaseName.includes('macos') ||
+            lowercaseName.includes('mac os') ||
+            lowercaseName.includes('darwin')
+        ) {
+            return 'Mac OS X'
+        } else if (lowercaseName.includes('linux')) {
+            return 'Linux'
+        } else {
+            return name
+        }
+    }
+}
+
+const sigmoid = (x: number) => {
+    return 1 / (1 + Math.exp(-x))
+}

--- a/packages/core/src/codewhisperer/service/inlineCompletionItemProvider.ts
+++ b/packages/core/src/codewhisperer/service/inlineCompletionItemProvider.ts
@@ -1,0 +1,194 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import vscode, { Position } from 'vscode'
+import { getPrefixSuffixOverlap } from '../util/commonUtil'
+import { Recommendation } from '../client/codewhisperer'
+import { session } from '../util/codeWhispererSession'
+import { TelemetryHelper } from '../util/telemetryHelper'
+import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
+import { ReferenceInlineProvider } from './referenceInlineProvider'
+import { ImportAdderProvider } from './importAdderProvider'
+import { application } from '../util/codeWhispererApplication'
+import path from 'path'
+import { UserWrittenCodeTracker } from '../tracker/userWrittenCodeTracker'
+
+export class CWInlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
+    private activeItemIndex: number | undefined
+    private nextMove: number
+    private recommendations: Recommendation[]
+    private requestId: string
+    private startPos: Position
+    private nextToken: string
+
+    private _onDidShow: vscode.EventEmitter<void> = new vscode.EventEmitter<void>()
+    public readonly onDidShow: vscode.Event<void> = this._onDidShow.event
+
+    public constructor(
+        itemIndex: number | undefined,
+        firstMove: number,
+        recommendations: Recommendation[],
+        requestId: string,
+        startPos: Position,
+        nextToken: string
+    ) {
+        this.activeItemIndex = itemIndex
+        this.nextMove = firstMove
+        this.recommendations = recommendations
+        this.requestId = requestId
+        this.startPos = startPos
+        this.nextToken = nextToken
+    }
+
+    get getActiveItemIndex() {
+        return this.activeItemIndex
+    }
+
+    public clearActiveItemIndex() {
+        this.activeItemIndex = undefined
+    }
+
+    // iterate suggestions and stop at index 0 or index len - 1
+    private getIteratingIndexes() {
+        const len = this.recommendations.length
+        const startIndex = this.activeItemIndex ? this.activeItemIndex : 0
+        const index = []
+        if (this.nextMove === 0) {
+            for (let i = 0; i < len; i++) {
+                index.push((startIndex + i) % len)
+            }
+        } else if (this.nextMove === -1) {
+            for (let i = startIndex - 1; i >= 0; i--) {
+                index.push(i)
+            }
+            index.push(startIndex)
+        } else {
+            for (let i = startIndex + 1; i < len; i++) {
+                index.push(i)
+            }
+            index.push(startIndex)
+        }
+        return index
+    }
+
+    truncateOverlapWithRightContext(document: vscode.TextDocument, suggestion: string, pos: vscode.Position): string {
+        const trimmedSuggestion = suggestion.trim()
+        // limit of 5000 for right context matching
+        const rightContext = document.getText(new vscode.Range(pos, document.positionAt(document.offsetAt(pos) + 5000)))
+        const overlap = getPrefixSuffixOverlap(trimmedSuggestion, rightContext)
+        const overlapIndex = suggestion.lastIndexOf(overlap)
+        if (overlapIndex >= 0) {
+            const truncated = suggestion.slice(0, overlapIndex)
+            return truncated.trim().length ? truncated : ''
+        } else {
+            return suggestion
+        }
+    }
+
+    getInlineCompletionItem(
+        document: vscode.TextDocument,
+        r: Recommendation,
+        start: vscode.Position,
+        end: vscode.Position,
+        index: number,
+        prefix: string
+    ): vscode.InlineCompletionItem | undefined {
+        if (!r.content.startsWith(prefix)) {
+            return undefined
+        }
+        const effectiveStart = document.positionAt(document.offsetAt(start) + prefix.length)
+        const truncatedSuggestion = this.truncateOverlapWithRightContext(document, r.content, end)
+        if (truncatedSuggestion.length === 0) {
+            if (session.getSuggestionState(index) !== 'Showed') {
+                session.setSuggestionState(index, 'Discard')
+            }
+            return undefined
+        }
+        TelemetryHelper.instance.lastSuggestionInDisplay = truncatedSuggestion
+        return {
+            insertText: truncatedSuggestion,
+            range: new vscode.Range(start, end),
+            command: {
+                command: 'aws.amazonq.accept',
+                title: 'On acceptance',
+                arguments: [
+                    new vscode.Range(start, end),
+                    new vscode.Range(effectiveStart, end),
+                    index,
+                    truncatedSuggestion,
+                    this.requestId,
+                    session.sessionId,
+                    session.triggerType,
+                    session.getCompletionType(index),
+                    runtimeLanguageContext.getLanguageContext(document.languageId, path.extname(document.fileName))
+                        .language,
+                    r.references,
+                ],
+            },
+        }
+    }
+
+    // the returned completion items will always only contain one valid item
+    // this is to trace the current index of visible completion item
+    // so that reference tracker can show
+    // This hack can be removed once inlineCompletionAdditions API becomes public
+    provideInlineCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        _context: vscode.InlineCompletionContext,
+        _token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
+        if (position.line < 0 || position.isBefore(this.startPos)) {
+            application()._clearCodeWhispererUIListener.fire()
+            this.activeItemIndex = undefined
+            return
+        }
+
+        // There's a chance that the startPos is no longer valid in the current document (e.g.
+        // when CodeWhisperer got triggered by 'Enter', the original startPos is with indentation
+        // but then this indentation got removed by VSCode when another new line is inserted,
+        // before the code reaches here). In such case, we need to update the startPos to be a
+        // valid one. Otherwise, inline completion which utilizes this position will function
+        // improperly.
+        const start = document.validatePosition(this.startPos)
+        const end = position
+        const iteratingIndexes = this.getIteratingIndexes()
+        const prefix = document.getText(new vscode.Range(start, end)).replace(/\r\n/g, '\n')
+        const matchedCount = session.recommendations.filter(
+            (r) => r.content.length > 0 && r.content.startsWith(prefix) && r.content !== prefix
+        ).length
+        for (const i of iteratingIndexes) {
+            const r = session.recommendations[i]
+            const item = this.getInlineCompletionItem(document, r, start, end, i, prefix)
+            if (item === undefined) {
+                continue
+            }
+            this.activeItemIndex = i
+            session.setSuggestionState(i, 'Showed')
+            ReferenceInlineProvider.instance.setInlineReference(this.startPos.line, r.content, r.references)
+            ImportAdderProvider.instance.onShowRecommendation(document, this.startPos.line, r)
+            this.nextMove = 0
+            TelemetryHelper.instance.setFirstSuggestionShowTime()
+            session.setPerceivedLatency()
+            UserWrittenCodeTracker.instance.onQStartsMakingEdits()
+            this._onDidShow.fire()
+            if (matchedCount >= 2 || this.nextToken !== '') {
+                const result = [item]
+                for (let j = 0; j < matchedCount - 1; j++) {
+                    result.push({
+                        insertText: `${
+                            typeof item.insertText === 'string' ? item.insertText : item.insertText.value
+                        }${j}`,
+                        range: item.range,
+                    })
+                }
+                return result
+            }
+            return [item]
+        }
+        application()._clearCodeWhispererUIListener.fire()
+        this.activeItemIndex = undefined
+        return []
+    }
+}

--- a/packages/core/src/codewhisperer/service/inlineCompletionService.ts
+++ b/packages/core/src/codewhisperer/service/inlineCompletionService.ts
@@ -1,0 +1,273 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode'
+import { CodeSuggestionsState, ConfigurationEntry, GetRecommendationsResponse, vsCodeState } from '../models/model'
+import * as CodeWhispererConstants from '../models/constants'
+import { DefaultCodeWhispererClient } from '../client/codewhisperer'
+import { RecommendationHandler } from './recommendationHandler'
+import { CodewhispererAutomatedTriggerType, CodewhispererTriggerType } from '../../shared/telemetry/telemetry'
+import { showTimedMessage } from '../../shared/utilities/messages'
+import { getLogger } from '../../shared/logger/logger'
+import { TelemetryHelper } from '../util/telemetryHelper'
+import { AuthUtil } from '../util/authUtil'
+import { shared } from '../../shared/utilities/functionUtils'
+import { ClassifierTrigger } from './classifierTrigger'
+import { getSelectedCustomization } from '../util/customizationUtil'
+import { codicon, getIcon } from '../../shared/icons'
+import { session } from '../util/codeWhispererSession'
+import { noSuggestions } from '../models/constants'
+import { Commands } from '../../shared/vscode/commands2'
+import { listCodeWhispererCommandsId } from '../ui/statusBarMenu'
+
+export class InlineCompletionService {
+    private maxPage = 100
+    private statusBar: CodeWhispererStatusBar
+    private _showRecommendationTimer?: NodeJS.Timer
+
+    constructor(statusBar: CodeWhispererStatusBar = CodeWhispererStatusBar.instance) {
+        this.statusBar = statusBar
+
+        RecommendationHandler.instance.onDidReceiveRecommendation((e) => {
+            this.startShowRecommendationTimer()
+        })
+
+        CodeSuggestionsState.instance.onDidChangeState(() => {
+            return this.refreshStatusBar()
+        })
+    }
+
+    static #instance: InlineCompletionService
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    filePath(): string | undefined {
+        return RecommendationHandler.instance.documentUri?.fsPath
+    }
+
+    private sharedTryShowRecommendation = shared(
+        RecommendationHandler.instance.tryShowRecommendation.bind(RecommendationHandler.instance)
+    )
+
+    private startShowRecommendationTimer() {
+        if (this._showRecommendationTimer) {
+            clearInterval(this._showRecommendationTimer)
+            this._showRecommendationTimer = undefined
+        }
+        this._showRecommendationTimer = setInterval(() => {
+            const delay = performance.now() - vsCodeState.lastUserModificationTime
+            if (delay < CodeWhispererConstants.inlineSuggestionShowDelay) {
+                return
+            }
+            this.sharedTryShowRecommendation()
+                .catch((e) => {
+                    getLogger().error('tryShowRecommendation failed: %s', (e as Error).message)
+                })
+                .finally(() => {
+                    if (this._showRecommendationTimer) {
+                        clearInterval(this._showRecommendationTimer)
+                        this._showRecommendationTimer = undefined
+                    }
+                })
+        }, CodeWhispererConstants.showRecommendationTimerPollPeriod)
+    }
+
+    async getPaginatedRecommendation(
+        client: DefaultCodeWhispererClient,
+        editor: vscode.TextEditor,
+        triggerType: CodewhispererTriggerType,
+        config: ConfigurationEntry,
+        autoTriggerType?: CodewhispererAutomatedTriggerType,
+        event?: vscode.TextDocumentChangeEvent
+    ): Promise<GetRecommendationsResponse> {
+        if (vsCodeState.isCodeWhispererEditing || RecommendationHandler.instance.isSuggestionVisible()) {
+            return {
+                result: 'Failed',
+                errorMessage: 'Amazon Q is already running',
+                recommendationCount: 0,
+            }
+        }
+
+        // Call report user decisions once to report recommendations leftover from last invocation.
+        RecommendationHandler.instance.reportUserDecisions(-1)
+        TelemetryHelper.instance.setInvokeSuggestionStartTime()
+        ClassifierTrigger.instance.recordClassifierResultForAutoTrigger(editor, autoTriggerType, event)
+
+        const triggerChar = event?.contentChanges[0]?.text
+        if (autoTriggerType === 'SpecialCharacters' && triggerChar) {
+            TelemetryHelper.instance.setTriggerCharForUserTriggerDecision(triggerChar)
+        }
+        const isAutoTrigger = triggerType === 'AutoTrigger'
+        if (AuthUtil.instance.isConnectionExpired()) {
+            await AuthUtil.instance.notifyReauthenticate(isAutoTrigger)
+            return {
+                result: 'Failed',
+                errorMessage: 'auth',
+                recommendationCount: 0,
+            }
+        }
+
+        await this.setState('loading')
+
+        RecommendationHandler.instance.checkAndResetCancellationTokens()
+        RecommendationHandler.instance.documentUri = editor.document.uri
+        let response: GetRecommendationsResponse = {
+            result: 'Failed',
+            errorMessage: undefined,
+            recommendationCount: 0,
+        }
+        try {
+            let page = 0
+            while (page < this.maxPage) {
+                response = await RecommendationHandler.instance.getRecommendations(
+                    client,
+                    editor,
+                    triggerType,
+                    config,
+                    autoTriggerType,
+                    true,
+                    page
+                )
+                if (RecommendationHandler.instance.checkAndResetCancellationTokens()) {
+                    RecommendationHandler.instance.reportUserDecisions(-1)
+                    await vscode.commands.executeCommand('aws.amazonq.refreshStatusBar')
+                    if (triggerType === 'OnDemand' && session.recommendations.length === 0) {
+                        void showTimedMessage(response.errorMessage ? response.errorMessage : noSuggestions, 2000)
+                    }
+                    return {
+                        result: 'Failed',
+                        errorMessage: 'cancelled',
+                        recommendationCount: 0,
+                    }
+                }
+                if (!RecommendationHandler.instance.hasNextToken()) {
+                    break
+                }
+                page++
+            }
+        } catch (error) {
+            getLogger().error(`Error ${error} in getPaginatedRecommendation`)
+        }
+        await vscode.commands.executeCommand('aws.amazonq.refreshStatusBar')
+        if (triggerType === 'OnDemand' && session.recommendations.length === 0) {
+            void showTimedMessage(response.errorMessage ? response.errorMessage : noSuggestions, 2000)
+        }
+        TelemetryHelper.instance.tryRecordClientComponentLatency()
+
+        return {
+            result: 'Succeeded',
+            errorMessage: undefined,
+            recommendationCount: session.recommendations.length,
+        }
+    }
+
+    /** Updates the status bar to represent the latest CW state */
+    refreshStatusBar() {
+        if (AuthUtil.instance.isConnectionValid()) {
+            if (AuthUtil.instance.requireProfileSelection()) {
+                return this.setState('needsProfile')
+            }
+            return this.setState('ok')
+        } else if (AuthUtil.instance.isConnectionExpired()) {
+            return this.setState('expired')
+        } else {
+            return this.setState('notConnected')
+        }
+    }
+
+    private async setState(state: keyof typeof states) {
+        switch (state) {
+            case 'loading': {
+                await this.statusBar.setState('loading')
+                break
+            }
+            case 'ok': {
+                await this.statusBar.setState('ok', CodeSuggestionsState.instance.isSuggestionsEnabled())
+                break
+            }
+            case 'expired': {
+                await this.statusBar.setState('expired')
+                break
+            }
+            case 'notConnected': {
+                await this.statusBar.setState('notConnected')
+                break
+            }
+            case 'needsProfile': {
+                await this.statusBar.setState('needsProfile')
+                break
+            }
+        }
+    }
+}
+
+/** The states that the completion service can be in */
+const states = {
+    loading: 'loading',
+    ok: 'ok',
+    expired: 'expired',
+    notConnected: 'notConnected',
+    needsProfile: 'needsProfile',
+} as const
+
+export class CodeWhispererStatusBar {
+    protected statusBar: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1)
+
+    static #instance: CodeWhispererStatusBar
+    static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    protected constructor() {}
+
+    async setState(state: keyof Omit<typeof states, 'ok'>): Promise<void>
+    async setState(status: keyof Pick<typeof states, 'ok'>, isSuggestionsEnabled: boolean): Promise<void>
+    async setState(status: keyof typeof states, isSuggestionsEnabled?: boolean): Promise<void> {
+        const statusBar = this.statusBar
+        statusBar.command = listCodeWhispererCommandsId
+        statusBar.backgroundColor = undefined
+
+        const title = 'Amazon Q'
+        switch (status) {
+            case 'loading': {
+                const selectedCustomization = getSelectedCustomization()
+                statusBar.text = codicon` ${getIcon('vscode-loading~spin')} ${title}${
+                    selectedCustomization.arn === '' ? '' : ` | ${selectedCustomization.name}`
+                }`
+                break
+            }
+            case 'ok': {
+                const selectedCustomization = getSelectedCustomization()
+                const icon = isSuggestionsEnabled ? getIcon('vscode-debug-start') : getIcon('vscode-debug-pause')
+                statusBar.text = codicon`${icon} ${title}${
+                    selectedCustomization.arn === '' ? '' : ` | ${selectedCustomization.name}`
+                }`
+                break
+            }
+
+            case 'expired': {
+                statusBar.text = codicon` ${getIcon('vscode-debug-disconnect')} ${title}`
+                statusBar.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
+                break
+            }
+            case 'needsProfile':
+            case 'notConnected':
+                statusBar.text = codicon` ${getIcon('vscode-chrome-close')} ${title}`
+                statusBar.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
+                break
+        }
+
+        statusBar.show()
+    }
+}
+
+/** In this module due to circulare dependency issues */
+export const refreshStatusBar = Commands.declare(
+    { id: 'aws.amazonq.refreshStatusBar', logging: false },
+    () => async () => {
+        await InlineCompletionService.instance.refreshStatusBar()
+    }
+)

--- a/packages/core/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/packages/core/src/codewhisperer/service/keyStrokeHandler.ts
@@ -1,0 +1,267 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { DefaultCodeWhispererClient } from '../client/codewhisperer'
+import * as CodeWhispererConstants from '../models/constants'
+import { ConfigurationEntry } from '../models/model'
+import { getLogger } from '../../shared/logger/logger'
+import { RecommendationHandler } from './recommendationHandler'
+import { CodewhispererAutomatedTriggerType } from '../../shared/telemetry/telemetry'
+import { getTabSizeSetting } from '../../shared/utilities/editorUtilities'
+import { isInlineCompletionEnabled } from '../util/commonUtil'
+import { ClassifierTrigger } from './classifierTrigger'
+import { extractContextForCodeWhisperer } from '../util/editorContext'
+import { RecommendationService } from './recommendationService'
+
+/**
+ * This class is for CodeWhisperer auto trigger
+ */
+export class KeyStrokeHandler {
+    /**
+     * Special character which automated triggers codewhisperer
+     */
+    public specialChar: string
+    /**
+     * Key stroke count for automated trigger
+     */
+
+    private idleTriggerTimer?: NodeJS.Timer
+
+    public lastInvocationTime?: number
+
+    constructor() {
+        this.specialChar = ''
+    }
+
+    static #instance: KeyStrokeHandler
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    public startIdleTimeTriggerTimer(
+        event: vscode.TextDocumentChangeEvent,
+        editor: vscode.TextEditor,
+        client: DefaultCodeWhispererClient,
+        config: ConfigurationEntry
+    ) {
+        if (this.idleTriggerTimer) {
+            clearInterval(this.idleTriggerTimer)
+            this.idleTriggerTimer = undefined
+        }
+        if (!this.shouldTriggerIdleTime()) {
+            return
+        }
+        this.idleTriggerTimer = setInterval(() => {
+            const duration = (performance.now() - RecommendationHandler.instance.lastInvocationTime) / 1000
+            if (duration < CodeWhispererConstants.invocationTimeIntervalThreshold) {
+                return
+            }
+
+            this.invokeAutomatedTrigger('IdleTime', editor, client, config, event)
+                .catch((e) => {
+                    getLogger().error('invokeAutomatedTrigger failed: %s', (e as Error).message)
+                })
+                .finally(() => {
+                    if (this.idleTriggerTimer) {
+                        clearInterval(this.idleTriggerTimer)
+                        this.idleTriggerTimer = undefined
+                    }
+                })
+        }, CodeWhispererConstants.idleTimerPollPeriod)
+    }
+
+    public shouldTriggerIdleTime(): boolean {
+        if (isInlineCompletionEnabled() && RecommendationService.instance.isRunning) {
+            return false
+        }
+        return true
+    }
+
+    async processKeyStroke(
+        event: vscode.TextDocumentChangeEvent,
+        editor: vscode.TextEditor,
+        client: DefaultCodeWhispererClient,
+        config: ConfigurationEntry
+    ): Promise<void> {
+        try {
+            if (!config.isAutomatedTriggerEnabled) {
+                return
+            }
+
+            // Skip when output channel gains focus and invoke
+            if (editor.document.languageId === 'Log') {
+                return
+            }
+
+            const { rightFileContent } = extractContextForCodeWhisperer(editor)
+            const rightContextLines = rightFileContent.split(/\r?\n/)
+            const rightContextAtCurrentLine = rightContextLines[0]
+            // we do not want to trigger when there is immediate right context on the same line
+            // with "}" being an exception because of IDE auto-complete
+            if (
+                rightContextAtCurrentLine.length &&
+                !rightContextAtCurrentLine.startsWith(' ') &&
+                rightContextAtCurrentLine.trim() !== '}' &&
+                rightContextAtCurrentLine.trim() !== ')'
+            ) {
+                return
+            }
+
+            let triggerType: CodewhispererAutomatedTriggerType | undefined
+            const changedSource = new DefaultDocumentChangedType(event.contentChanges).checkChangeSource()
+
+            switch (changedSource) {
+                case DocumentChangedSource.EnterKey: {
+                    triggerType = 'Enter'
+                    break
+                }
+                case DocumentChangedSource.SpecialCharsKey: {
+                    triggerType = 'SpecialCharacters'
+                    break
+                }
+                case DocumentChangedSource.RegularKey: {
+                    triggerType = ClassifierTrigger.instance.shouldTriggerFromClassifier(event, editor, triggerType)
+                        ? 'Classifier'
+                        : undefined
+                    break
+                }
+                default: {
+                    break
+                }
+            }
+
+            if (triggerType) {
+                await this.invokeAutomatedTrigger(triggerType, editor, client, config, event)
+            }
+        } catch (error) {
+            getLogger().verbose(`Automated Trigger Exception : ${error}`)
+        }
+    }
+
+    async invokeAutomatedTrigger(
+        autoTriggerType: CodewhispererAutomatedTriggerType,
+        editor: vscode.TextEditor,
+        client: DefaultCodeWhispererClient,
+        config: ConfigurationEntry,
+        event: vscode.TextDocumentChangeEvent
+    ): Promise<void> {
+        if (!editor) {
+            return
+        }
+
+        // RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
+        await RecommendationService.instance.generateRecommendation(
+            client,
+            editor,
+            'AutoTrigger',
+            config,
+            autoTriggerType
+        )
+    }
+}
+
+export abstract class DocumentChangedType {
+    constructor(protected readonly contentChanges: ReadonlyArray<vscode.TextDocumentContentChangeEvent>) {
+        this.contentChanges = contentChanges
+    }
+
+    abstract checkChangeSource(): DocumentChangedSource
+
+    // Enter key should always start with ONE '\n' or '\r\n' and potentially following spaces due to IDE reformat
+    protected isEnterKey(str: string): boolean {
+        if (str.length === 0) {
+            return false
+        }
+        return (
+            (str.startsWith('\r\n') && str.substring(2).trim() === '') ||
+            (str[0] === '\n' && str.substring(1).trim() === '')
+        )
+    }
+
+    // Tab should consist of space char only ' ' and the length % tabSize should be 0
+    protected isTabKey(str: string): boolean {
+        const tabSize = getTabSizeSetting()
+        if (str.length % tabSize === 0 && str.trim() === '') {
+            return true
+        }
+        return false
+    }
+
+    protected isUserTypingSpecialChar(str: string): boolean {
+        return ['(', '()', '[', '[]', '{', '{}', ':'].includes(str)
+    }
+
+    protected isSingleLine(str: string): boolean {
+        let newLineCounts = 0
+        for (const ch of str) {
+            if (ch === '\n') {
+                newLineCounts += 1
+            }
+        }
+
+        // since pressing Enter key possibly will generate string like '\n        ' due to indention
+        if (this.isEnterKey(str)) {
+            return true
+        }
+        if (newLineCounts >= 1) {
+            return false
+        }
+        return true
+    }
+}
+
+export class DefaultDocumentChangedType extends DocumentChangedType {
+    constructor(contentChanges: ReadonlyArray<vscode.TextDocumentContentChangeEvent>) {
+        super(contentChanges)
+    }
+
+    checkChangeSource(): DocumentChangedSource {
+        if (this.contentChanges.length === 0) {
+            return DocumentChangedSource.Unknown
+        }
+
+        // event.contentChanges.length will be 2 when user press Enter key multiple times
+        if (this.contentChanges.length > 2) {
+            return DocumentChangedSource.Reformatting
+        }
+
+        // Case when event.contentChanges.length === 1
+        const changedText = this.contentChanges[0].text
+
+        if (this.isSingleLine(changedText)) {
+            if (changedText === '') {
+                return DocumentChangedSource.Deletion
+            } else if (this.isEnterKey(changedText)) {
+                return DocumentChangedSource.EnterKey
+            } else if (this.isTabKey(changedText)) {
+                return DocumentChangedSource.TabKey
+            } else if (this.isUserTypingSpecialChar(changedText)) {
+                return DocumentChangedSource.SpecialCharsKey
+            } else if (changedText.length === 1) {
+                return DocumentChangedSource.RegularKey
+            } else if (new RegExp('^[ ]+$').test(changedText)) {
+                // single line && single place reformat should consist of space chars only
+                return DocumentChangedSource.Reformatting
+            } else {
+                return DocumentChangedSource.Unknown
+            }
+        }
+
+        // Won't trigger cwspr on multi-line changes
+        return DocumentChangedSource.Unknown
+    }
+}
+
+export enum DocumentChangedSource {
+    SpecialCharsKey = 'SpecialCharsKey',
+    RegularKey = 'RegularKey',
+    TabKey = 'TabKey',
+    EnterKey = 'EnterKey',
+    Reformatting = 'Reformatting',
+    Deletion = 'Deletion',
+    Unknown = 'Unknown',
+}

--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -1,0 +1,724 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { extensionVersion } from '../../shared/vscode/env'
+import { RecommendationsList, DefaultCodeWhispererClient, CognitoCredentialsError } from '../client/codewhisperer'
+import * as EditorContext from '../util/editorContext'
+import * as CodeWhispererConstants from '../models/constants'
+import { ConfigurationEntry, GetRecommendationsResponse, vsCodeState } from '../models/model'
+import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
+import { AWSError } from 'aws-sdk'
+import { isAwsError } from '../../shared/errors'
+import { TelemetryHelper } from '../util/telemetryHelper'
+import { getLogger } from '../../shared/logger/logger'
+import { hasVendedIamCredentials } from '../../auth/auth'
+import {
+    asyncCallWithTimeout,
+    isInlineCompletionEnabled,
+    isVscHavingRegressionInlineCompletionApi,
+} from '../util/commonUtil'
+import { showTimedMessage } from '../../shared/utilities/messages'
+import {
+    CodewhispererAutomatedTriggerType,
+    CodewhispererCompletionType,
+    CodewhispererGettingStartedTask,
+    CodewhispererTriggerType,
+    telemetry,
+} from '../../shared/telemetry/telemetry'
+import { CodeWhispererCodeCoverageTracker } from '../tracker/codewhispererCodeCoverageTracker'
+import { invalidCustomizationMessage } from '../models/constants'
+import { getSelectedCustomization, switchToBaseCustomizationAndNotify } from '../util/customizationUtil'
+import { session } from '../util/codeWhispererSession'
+import { Commands } from '../../shared/vscode/commands2'
+import globals from '../../shared/extensionGlobals'
+import { noSuggestions, updateInlineLockKey } from '../models/constants'
+import AsyncLock from 'async-lock'
+import { AuthUtil } from '../util/authUtil'
+import { CWInlineCompletionItemProvider } from './inlineCompletionItemProvider'
+import { application } from '../util/codeWhispererApplication'
+import { openUrl } from '../../shared/utilities/vsCodeUtils'
+import { indent } from '../../shared/utilities/textUtilities'
+import path from 'path'
+import { isIamConnection } from '../../auth/connection'
+import { UserWrittenCodeTracker } from '../tracker/userWrittenCodeTracker'
+
+/**
+ * This class is for getRecommendation/listRecommendation API calls and its states
+ * It does not contain UI/UX related logic
+ */
+
+/**
+ * Commands as a level of indirection so that declare doesn't intercept any registrations for the
+ * language server implementation.
+ *
+ * Otherwise you'll get:
+ *     "Unable to launch amazonq language server: Command "aws.amazonq.rejectCodeSuggestion" has already been declared by the Toolkit"
+ */
+function createCommands() {
+    // below commands override VS Code inline completion commands
+    const prevCommand = Commands.declare('editor.action.inlineSuggest.showPrevious', () => async () => {
+        await RecommendationHandler.instance.showRecommendation(-1)
+    })
+    const nextCommand = Commands.declare('editor.action.inlineSuggest.showNext', () => async () => {
+        await RecommendationHandler.instance.showRecommendation(1)
+    })
+
+    const rejectCommand = Commands.declare('aws.amazonq.rejectCodeSuggestion', () => async () => {
+        telemetry.record({
+            traceId: TelemetryHelper.instance.traceId,
+        })
+
+        await vscode.commands.executeCommand('editor.action.inlineSuggest.hide')
+        RecommendationHandler.instance.reportUserDecisions(-1)
+        await Commands.tryExecute('aws.amazonq.refreshAnnotation')
+    })
+
+    return {
+        prevCommand,
+        nextCommand,
+        rejectCommand,
+    }
+}
+
+const lock = new AsyncLock({ maxPending: 1 })
+
+export class RecommendationHandler {
+    public lastInvocationTime: number
+    // TODO: remove this requestId
+    public requestId: string
+    private nextToken: string
+    private cancellationToken: vscode.CancellationTokenSource
+    private _onDidReceiveRecommendation: vscode.EventEmitter<void> = new vscode.EventEmitter<void>()
+    public readonly onDidReceiveRecommendation: vscode.Event<void> = this._onDidReceiveRecommendation.event
+    private inlineCompletionProvider?: CWInlineCompletionItemProvider
+    private inlineCompletionProviderDisposable?: vscode.Disposable
+    private reject: vscode.Disposable
+    private next: vscode.Disposable
+    private prev: vscode.Disposable
+    private _timer?: NodeJS.Timer
+    documentUri: vscode.Uri | undefined = undefined
+
+    constructor() {
+        this.requestId = ''
+        this.nextToken = ''
+        this.lastInvocationTime = performance.now() - CodeWhispererConstants.invocationTimeIntervalThreshold * 1000
+        this.cancellationToken = new vscode.CancellationTokenSource()
+        this.prev = new vscode.Disposable(() => {})
+        this.next = new vscode.Disposable(() => {})
+        this.reject = new vscode.Disposable(() => {})
+    }
+
+    static #instance: RecommendationHandler
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    isValidResponse(): boolean {
+        return session.recommendations.some((r) => r.content.trim() !== '')
+    }
+
+    async getServerResponse(
+        triggerType: CodewhispererTriggerType,
+        isManualTriggerOn: boolean,
+        promise: Promise<any>
+    ): Promise<any> {
+        const timeoutMessage = hasVendedIamCredentials()
+            ? 'Generate recommendation timeout.'
+            : 'List recommendation timeout'
+        if (isManualTriggerOn && triggerType === 'OnDemand' && hasVendedIamCredentials()) {
+            return vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: CodeWhispererConstants.pendingResponse,
+                    cancellable: false,
+                },
+                async () => {
+                    return await asyncCallWithTimeout(
+                        promise,
+                        timeoutMessage,
+                        CodeWhispererConstants.promiseTimeoutLimit * 1000
+                    )
+                }
+            )
+        }
+        return await asyncCallWithTimeout(promise, timeoutMessage, CodeWhispererConstants.promiseTimeoutLimit * 1000)
+    }
+
+    async getTaskTypeFromEditorFileName(filePath: string): Promise<CodewhispererGettingStartedTask | undefined> {
+        if (filePath.includes('CodeWhisperer_generate_suggestion')) {
+            return 'autoTrigger'
+        } else if (filePath.includes('CodeWhisperer_manual_invoke')) {
+            return 'manualTrigger'
+        } else if (filePath.includes('CodeWhisperer_use_comments')) {
+            return 'commentAsPrompt'
+        } else if (filePath.includes('CodeWhisperer_navigate_suggestions')) {
+            return 'navigation'
+        } else if (filePath.includes('Generate_unit_tests')) {
+            return 'unitTest'
+        } else {
+            return undefined
+        }
+    }
+
+    async getRecommendations(
+        client: DefaultCodeWhispererClient,
+        editor: vscode.TextEditor,
+        triggerType: CodewhispererTriggerType,
+        config: ConfigurationEntry,
+        autoTriggerType?: CodewhispererAutomatedTriggerType,
+        pagination: boolean = true,
+        page: number = 0,
+        generate: boolean = isIamConnection(AuthUtil.instance.conn)
+    ): Promise<GetRecommendationsResponse> {
+        let invocationResult: 'Succeeded' | 'Failed' = 'Failed'
+        let errorMessage: string | undefined = undefined
+        let errorCode: string | undefined = undefined
+
+        if (!editor) {
+            return Promise.resolve<GetRecommendationsResponse>({
+                result: invocationResult,
+                errorMessage: errorMessage,
+                recommendationCount: 0,
+            })
+        }
+        let recommendations: RecommendationsList = []
+        let requestId = ''
+        let sessionId = ''
+        let reason = ''
+        let startTime = 0
+        let latency = 0
+        let nextToken = ''
+        let shouldRecordServiceInvocation = true
+        session.language = runtimeLanguageContext.getLanguageContext(
+            editor.document.languageId,
+            path.extname(editor.document.fileName)
+        ).language
+        session.taskType = await this.getTaskTypeFromEditorFileName(editor.document.fileName)
+
+        if (pagination && !generate) {
+            if (page === 0) {
+                session.requestContext = await EditorContext.buildListRecommendationRequest(
+                    editor as vscode.TextEditor,
+                    this.nextToken,
+                    config.isSuggestionsWithCodeReferencesEnabled
+                )
+            } else {
+                session.requestContext = {
+                    request: {
+                        ...session.requestContext.request,
+                        // Putting nextToken assignment in the end so it overwrites the existing nextToken
+                        nextToken: this.nextToken,
+                    },
+                    supplementalMetadata: session.requestContext.supplementalMetadata,
+                }
+            }
+        } else {
+            session.requestContext = await EditorContext.buildGenerateRecommendationRequest(editor as vscode.TextEditor)
+        }
+        const request = session.requestContext.request
+        // record preprocessing end time
+        TelemetryHelper.instance.setPreprocessEndTime()
+
+        // set start pos for non pagination call or first pagination call
+        if (!pagination || (pagination && page === 0)) {
+            session.startPos = editor.selection.active
+            session.startCursorOffset = editor.document.offsetAt(session.startPos)
+            session.leftContextOfCurrentLine = EditorContext.getLeftContext(editor, session.startPos.line)
+            session.triggerType = triggerType
+            session.autoTriggerType = autoTriggerType
+
+            /**
+             * Validate request
+             */
+            if (!EditorContext.validateRequest(request)) {
+                getLogger().verbose('Invalid Request: %O', request)
+                const languageName = request.fileContext.programmingLanguage.languageName
+                if (!runtimeLanguageContext.isLanguageSupported(languageName)) {
+                    errorMessage = `${languageName} is currently not supported by Amazon Q inline suggestions`
+                }
+                return Promise.resolve<GetRecommendationsResponse>({
+                    result: invocationResult,
+                    errorMessage: errorMessage,
+                    recommendationCount: 0,
+                })
+            }
+        }
+
+        try {
+            startTime = performance.now()
+            this.lastInvocationTime = startTime
+            const mappedReq = runtimeLanguageContext.mapToRuntimeLanguage(request)
+            const codewhispererPromise =
+                pagination && !generate
+                    ? client.listRecommendations(mappedReq)
+                    : client.generateRecommendations(mappedReq)
+            const resp = await this.getServerResponse(triggerType, config.isManualTriggerEnabled, codewhispererPromise)
+            TelemetryHelper.instance.setSdkApiCallEndTime()
+            latency = startTime !== 0 ? performance.now() - startTime : 0
+            if ('recommendations' in resp) {
+                recommendations = (resp && resp.recommendations) || []
+            } else {
+                recommendations = (resp && resp.completions) || []
+            }
+            invocationResult = 'Succeeded'
+            requestId = resp?.$response && resp?.$response?.requestId
+            nextToken = resp?.nextToken ? resp?.nextToken : ''
+            sessionId = resp?.$response?.httpResponse?.headers['x-amzn-sessionid']
+            TelemetryHelper.instance.setFirstResponseRequestId(requestId)
+            if (page === 0) {
+                session.setTimeToFirstRecommendation(performance.now())
+            }
+            if (nextToken === '') {
+                TelemetryHelper.instance.setAllPaginationEndTime()
+            }
+        } catch (error) {
+            if (error instanceof CognitoCredentialsError) {
+                shouldRecordServiceInvocation = false
+            }
+            if (latency === 0) {
+                latency = startTime !== 0 ? performance.now() - startTime : 0
+            }
+            getLogger().error('amazonq inline-suggest: Invocation Exception : %s', (error as Error).message)
+            if (isAwsError(error)) {
+                errorMessage = error.message
+                requestId = error.requestId || ''
+                errorCode = error.code
+                reason = `CodeWhisperer Invocation Exception: ${error?.code ?? error?.name ?? 'unknown'}`
+                await this.onThrottlingException(error, triggerType)
+
+                if (error?.code === 'AccessDeniedException' && errorMessage?.includes('no identity-based policy')) {
+                    getLogger().error('amazonq inline-suggest: AccessDeniedException : %s', (error as Error).message)
+                    void vscode.window
+                        .showErrorMessage(`CodeWhisperer: ${error?.message}`, CodeWhispererConstants.settingsLearnMore)
+                        .then(async (resp) => {
+                            if (resp === CodeWhispererConstants.settingsLearnMore) {
+                                void openUrl(vscode.Uri.parse(CodeWhispererConstants.learnMoreUri))
+                            }
+                        })
+                    await vscode.commands.executeCommand('aws.amazonq.enableCodeSuggestions', false)
+                }
+            } else {
+                errorMessage = error instanceof Error ? error.message : String(error)
+                reason = error ? String(error) : 'unknown'
+            }
+        } finally {
+            const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+            let msg = indent(
+                `codewhisperer: request-id: ${requestId},
+                timestamp(epoch): ${Date.now()},
+                timezone: ${timezone},
+                datetime: ${new Date().toLocaleString([], { timeZone: timezone })},
+                vscode version: '${vscode.version}',
+                extension version: '${extensionVersion}',
+                filename: '${EditorContext.getFileName(editor)}',
+                left context of line:  '${session.leftContextOfCurrentLine}',
+                line number: ${session.startPos.line},
+                character location: ${session.startPos.character},
+                latency: ${latency} ms.
+                Recommendations:`,
+                4,
+                true
+            ).trimStart()
+            for (const [index, item] of recommendations.entries()) {
+                msg += `\n    ${index.toString().padStart(2, '0')}: ${indent(item.content, 8, true).trim()}`
+                session.requestIdList.push(requestId)
+            }
+            getLogger('nextEditPrediction').debug(`codeWhisper request ${requestId}`)
+            if (invocationResult === 'Succeeded') {
+                CodeWhispererCodeCoverageTracker.getTracker(session.language)?.incrementServiceInvocationCount()
+                UserWrittenCodeTracker.instance.onQFeatureInvoked()
+            } else {
+                if (
+                    (errorMessage?.includes(invalidCustomizationMessage) && errorCode === 'AccessDeniedException') ||
+                    errorCode === 'ResourceNotFoundException'
+                ) {
+                    getLogger()
+                        .debug(`The selected customization is no longer available. Retrying with the default model.
+                    Failed request id: ${requestId}`)
+                    await switchToBaseCustomizationAndNotify()
+                    await this.getRecommendations(
+                        client,
+                        editor,
+                        triggerType,
+                        config,
+                        autoTriggerType,
+                        pagination,
+                        page,
+                        true
+                    )
+                }
+            }
+
+            if (shouldRecordServiceInvocation) {
+                TelemetryHelper.instance.recordServiceInvocationTelemetry(
+                    requestId,
+                    sessionId,
+                    session.recommendations.length + recommendations.length - 1,
+                    invocationResult,
+                    latency,
+                    session.language,
+                    session.taskType,
+                    reason,
+                    session.requestContext.supplementalMetadata
+                )
+            }
+        }
+
+        if (this.isCancellationRequested()) {
+            return Promise.resolve<GetRecommendationsResponse>({
+                result: invocationResult,
+                errorMessage: errorMessage,
+                recommendationCount: session.recommendations.length,
+            })
+        }
+
+        const typedPrefix = editor.document
+            .getText(new vscode.Range(session.startPos, editor.selection.active))
+            .replace('\r\n', '\n')
+        if (recommendations.length > 0) {
+            TelemetryHelper.instance.setTypeAheadLength(typedPrefix.length)
+            // mark suggestions that does not match typeahead when arrival as Discard
+            // these suggestions can be marked as Showed if typeahead can be removed with new inline API
+            for (const [i, r] of recommendations.entries()) {
+                const recommendationIndex = i + session.recommendations.length
+                if (
+                    !r.content.startsWith(typedPrefix) &&
+                    session.getSuggestionState(recommendationIndex) === undefined
+                ) {
+                    session.setSuggestionState(recommendationIndex, 'Discard')
+                }
+                session.setCompletionType(recommendationIndex, r)
+            }
+            session.recommendations = pagination ? session.recommendations.concat(recommendations) : recommendations
+            if (isInlineCompletionEnabled() && this.hasAtLeastOneValidSuggestion(typedPrefix)) {
+                this._onDidReceiveRecommendation.fire()
+            }
+        }
+
+        this.requestId = requestId
+        session.sessionId = sessionId
+        this.nextToken = nextToken
+
+        // send Empty userDecision event if user receives no recommendations in this session at all.
+        if (invocationResult === 'Succeeded' && nextToken === '') {
+            // case 1: empty list of suggestion []
+            if (session.recommendations.length === 0) {
+                session.requestIdList.push(requestId)
+                // Received an empty list of recommendations
+                TelemetryHelper.instance.recordUserDecisionTelemetryForEmptyList(
+                    session.requestIdList,
+                    sessionId,
+                    page,
+                    runtimeLanguageContext.getLanguageContext(
+                        editor.document.languageId,
+                        path.extname(editor.document.fileName)
+                    ).language,
+                    session.requestContext.supplementalMetadata
+                )
+            }
+            // case 2: non empty list of suggestion but with (a) empty content or (b) non-matching typeahead
+            else if (!this.hasAtLeastOneValidSuggestion(typedPrefix)) {
+                this.reportUserDecisions(-1)
+            }
+        }
+        return Promise.resolve<GetRecommendationsResponse>({
+            result: invocationResult,
+            errorMessage: errorMessage,
+            recommendationCount: session.recommendations.length,
+        })
+    }
+
+    hasAtLeastOneValidSuggestion(typedPrefix: string): boolean {
+        return session.recommendations.some((r) => r.content.trim() !== '' && r.content.startsWith(typedPrefix))
+    }
+
+    cancelPaginatedRequest() {
+        this.nextToken = ''
+        this.cancellationToken.cancel()
+    }
+
+    isCancellationRequested() {
+        return this.cancellationToken.token.isCancellationRequested
+    }
+
+    checkAndResetCancellationTokens() {
+        if (this.isCancellationRequested()) {
+            this.cancellationToken.dispose()
+            this.cancellationToken = new vscode.CancellationTokenSource()
+            this.nextToken = ''
+            return true
+        }
+        return false
+    }
+    /**
+     * Clear recommendation state
+     */
+    clearRecommendations() {
+        session.requestIdList = []
+        session.recommendations = []
+        session.suggestionStates = new Map<number, string>()
+        session.completionTypes = new Map<number, CodewhispererCompletionType>()
+        this.requestId = ''
+        session.sessionId = ''
+        this.nextToken = ''
+        session.requestContext.supplementalMetadata = undefined
+    }
+
+    async clearInlineCompletionStates() {
+        try {
+            vsCodeState.isCodeWhispererEditing = false
+            application()._clearCodeWhispererUIListener.fire()
+            this.cancelPaginatedRequest()
+            this.clearRecommendations()
+            this.disposeInlineCompletion()
+            await vscode.commands.executeCommand('aws.amazonq.refreshStatusBar')
+            // fix a regression that requires user to hit Esc twice to clear inline ghost text
+            // because disposing a provider does not clear the UX
+            if (isVscHavingRegressionInlineCompletionApi()) {
+                await vscode.commands.executeCommand('editor.action.inlineSuggest.hide')
+            }
+        } finally {
+            this.clearRejectionTimer()
+        }
+    }
+
+    reportDiscardedUserDecisions() {
+        for (const [i, _] of session.recommendations.entries()) {
+            session.setSuggestionState(i, 'Discard')
+        }
+        this.reportUserDecisions(-1)
+    }
+
+    /**
+     * Emits telemetry reflecting user decision for current recommendation.
+     */
+    reportUserDecisions(acceptIndex: number) {
+        if (session.sessionId === '' || this.requestId === '') {
+            return
+        }
+        TelemetryHelper.instance.recordUserDecisionTelemetry(
+            session.requestIdList,
+            session.sessionId,
+            session.recommendations,
+            acceptIndex,
+            session.recommendations.length,
+            session.completionTypes,
+            session.suggestionStates,
+            session.requestContext.supplementalMetadata
+        )
+        if (isInlineCompletionEnabled()) {
+            this.clearInlineCompletionStates().catch((e) => {
+                getLogger().error('clearInlineCompletionStates failed: %s', (e as Error).message)
+            })
+        }
+    }
+
+    hasNextToken(): boolean {
+        return this.nextToken !== ''
+    }
+
+    canShowRecommendationInIntelliSense(
+        editor: vscode.TextEditor,
+        showPrompt: boolean = false,
+        response: GetRecommendationsResponse
+    ): boolean {
+        const reject = () => {
+            this.reportUserDecisions(-1)
+        }
+        if (!this.isValidResponse()) {
+            if (showPrompt) {
+                void showTimedMessage(response.errorMessage ? response.errorMessage : noSuggestions, 3000)
+            }
+            reject()
+            return false
+        }
+        // do not show recommendation if cursor is before invocation position
+        // also mark as Discard
+        if (editor.selection.active.isBefore(session.startPos)) {
+            for (const [i, _] of session.recommendations.entries()) {
+                session.setSuggestionState(i, 'Discard')
+            }
+            reject()
+            return false
+        }
+
+        // do not show recommendation if typeahead does not match
+        // also mark as Discard
+        const typedPrefix = editor.document.getText(
+            new vscode.Range(
+                session.startPos.line,
+                session.startPos.character,
+                editor.selection.active.line,
+                editor.selection.active.character
+            )
+        )
+        if (!session.recommendations[0].content.startsWith(typedPrefix.trimStart())) {
+            for (const [i, _] of session.recommendations.entries()) {
+                session.setSuggestionState(i, 'Discard')
+            }
+            reject()
+            return false
+        }
+        return true
+    }
+
+    async onThrottlingException(awsError: AWSError, triggerType: CodewhispererTriggerType) {
+        if (
+            awsError.code === 'ThrottlingException' &&
+            awsError.message.includes(CodeWhispererConstants.throttlingMessage)
+        ) {
+            if (triggerType === 'OnDemand') {
+                void vscode.window.showErrorMessage(CodeWhispererConstants.freeTierLimitReached)
+            }
+            vsCodeState.isFreeTierLimitReached = true
+        }
+    }
+
+    public disposeInlineCompletion() {
+        this.inlineCompletionProviderDisposable?.dispose()
+        this.inlineCompletionProvider = undefined
+    }
+
+    private disposeCommandOverrides() {
+        this.prev.dispose()
+        this.reject.dispose()
+        this.next.dispose()
+    }
+
+    // These commands override the vs code inline completion commands
+    // They are subscribed when suggestion starts and disposed when suggestion is accepted/rejected
+    // to avoid impacting other plugins or user who uses this API
+    private registerCommandOverrides() {
+        const { prevCommand, nextCommand, rejectCommand } = createCommands()
+        this.prev = prevCommand.register()
+        this.next = nextCommand.register()
+        this.reject = rejectCommand.register()
+    }
+
+    subscribeSuggestionCommands() {
+        this.disposeCommandOverrides()
+        this.registerCommandOverrides()
+        globals.context.subscriptions.push(this.prev)
+        globals.context.subscriptions.push(this.next)
+        globals.context.subscriptions.push(this.reject)
+    }
+
+    async showRecommendation(indexShift: number, noSuggestionVisible: boolean = false) {
+        await lock.acquire(updateInlineLockKey, async () => {
+            if (!vscode.window.state.focused) {
+                this.reportDiscardedUserDecisions()
+                return
+            }
+            const inlineCompletionProvider = new CWInlineCompletionItemProvider(
+                this.inlineCompletionProvider?.getActiveItemIndex,
+                indexShift,
+                session.recommendations,
+                this.requestId,
+                session.startPos,
+                this.nextToken
+            )
+            this.inlineCompletionProviderDisposable?.dispose()
+            // when suggestion is active, registering a new provider will let VS Code invoke inline API automatically
+            this.inlineCompletionProviderDisposable = vscode.languages.registerInlineCompletionItemProvider(
+                Object.assign([], CodeWhispererConstants.platformLanguageIds),
+                inlineCompletionProvider
+            )
+            this.inlineCompletionProvider = inlineCompletionProvider
+
+            if (isVscHavingRegressionInlineCompletionApi() && !noSuggestionVisible) {
+                // fix a regression in new VS Code when disposing and re-registering
+                // a new provider does not auto refresh the inline suggestion widget
+                // by manually refresh it
+                await vscode.commands.executeCommand('editor.action.inlineSuggest.hide')
+                await vscode.commands.executeCommand('editor.action.inlineSuggest.trigger')
+            }
+            if (noSuggestionVisible) {
+                await vscode.commands.executeCommand(`editor.action.inlineSuggest.trigger`)
+                this.sendPerceivedLatencyTelemetry()
+            }
+        })
+    }
+
+    async onEditorChange() {
+        this.reportUserDecisions(-1)
+    }
+
+    async onFocusChange() {
+        this.reportUserDecisions(-1)
+    }
+
+    async onCursorChange(e: vscode.TextEditorSelectionChangeEvent) {
+        // we do not want to reset the states for keyboard events because they can be typeahead
+        if (
+            e.kind !== vscode.TextEditorSelectionChangeKind.Keyboard &&
+            vscode.window.activeTextEditor === e.textEditor
+        ) {
+            application()._clearCodeWhispererUIListener.fire()
+            // when cursor change due to mouse movement we need to reset the active item index for inline
+            if (e.kind === vscode.TextEditorSelectionChangeKind.Mouse) {
+                this.inlineCompletionProvider?.clearActiveItemIndex()
+            }
+        }
+    }
+
+    isSuggestionVisible(): boolean {
+        return this.inlineCompletionProvider?.getActiveItemIndex !== undefined
+    }
+
+    async tryShowRecommendation() {
+        const editor = vscode.window.activeTextEditor
+        if (editor === undefined) {
+            return
+        }
+        if (this.isSuggestionVisible()) {
+            // do not force refresh the tooltip to avoid suggestion "flashing"
+            return
+        }
+        if (
+            editor.selection.active.isBefore(session.startPos) ||
+            editor.document.uri.fsPath !== this.documentUri?.fsPath
+        ) {
+            for (const [i, _] of session.recommendations.entries()) {
+                session.setSuggestionState(i, 'Discard')
+            }
+            this.reportUserDecisions(-1)
+        } else if (session.recommendations.length > 0) {
+            await this.showRecommendation(0, true)
+        }
+    }
+
+    private clearRejectionTimer() {
+        if (this._timer !== undefined) {
+            clearInterval(this._timer)
+            this._timer = undefined
+        }
+    }
+
+    private sendPerceivedLatencyTelemetry() {
+        if (vscode.window.activeTextEditor) {
+            const languageContext = runtimeLanguageContext.getLanguageContext(
+                vscode.window.activeTextEditor.document.languageId,
+                vscode.window.activeTextEditor.document.fileName.substring(
+                    vscode.window.activeTextEditor.document.fileName.lastIndexOf('.') + 1
+                )
+            )
+            telemetry.codewhisperer_perceivedLatency.emit({
+                codewhispererRequestId: this.requestId,
+                codewhispererSessionId: session.sessionId,
+                codewhispererTriggerType: session.triggerType,
+                codewhispererCompletionType: session.getCompletionType(0),
+                codewhispererCustomizationArn: getSelectedCustomization().arn,
+                codewhispererLanguage: languageContext.language,
+                duration: performance.now() - this.lastInvocationTime,
+                passive: true,
+                credentialStartUrl: AuthUtil.instance.startUrl,
+                result: 'Succeeded',
+            })
+        }
+    }
+}

--- a/packages/core/src/codewhisperer/service/recommendationService.ts
+++ b/packages/core/src/codewhisperer/service/recommendationService.ts
@@ -1,0 +1,122 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode'
+import { ConfigurationEntry, GetRecommendationsResponse } from '../models/model'
+import { isInlineCompletionEnabled } from '../util/commonUtil'
+import {
+    CodewhispererAutomatedTriggerType,
+    CodewhispererTriggerType,
+    telemetry,
+} from '../../shared/telemetry/telemetry'
+import { InlineCompletionService } from '../service/inlineCompletionService'
+import { ClassifierTrigger } from './classifierTrigger'
+import { DefaultCodeWhispererClient } from '../client/codewhisperer'
+import { randomUUID } from '../../shared/crypto'
+import { TelemetryHelper } from '../util/telemetryHelper'
+import { AuthUtil } from '../util/authUtil'
+
+export interface SuggestionActionEvent {
+    readonly editor: vscode.TextEditor | undefined
+    readonly isRunning: boolean
+    readonly triggerType: CodewhispererTriggerType
+    readonly response: GetRecommendationsResponse | undefined
+}
+
+export class RecommendationService {
+    static #instance: RecommendationService
+
+    private _isRunning: boolean = false
+    get isRunning() {
+        return this._isRunning
+    }
+
+    private _onSuggestionActionEvent = new vscode.EventEmitter<SuggestionActionEvent>()
+    get suggestionActionEvent(): vscode.Event<SuggestionActionEvent> {
+        return this._onSuggestionActionEvent.event
+    }
+
+    private _acceptedSuggestionCount: number = 0
+    get acceptedSuggestionCount() {
+        return this._acceptedSuggestionCount
+    }
+
+    private _totalValidTriggerCount: number = 0
+    get totalValidTriggerCount() {
+        return this._totalValidTriggerCount
+    }
+
+    public static get instance() {
+        return (this.#instance ??= new RecommendationService())
+    }
+
+    incrementAcceptedCount() {
+        this._acceptedSuggestionCount++
+    }
+
+    incrementValidTriggerCount() {
+        this._totalValidTriggerCount++
+    }
+
+    async generateRecommendation(
+        client: DefaultCodeWhispererClient,
+        editor: vscode.TextEditor,
+        triggerType: CodewhispererTriggerType,
+        config: ConfigurationEntry,
+        autoTriggerType?: CodewhispererAutomatedTriggerType,
+        event?: vscode.TextDocumentChangeEvent
+    ) {
+        // TODO: should move all downstream auth check(inlineCompletionService, recommendationHandler etc) to here(upstream) instead of spreading everywhere
+        if (AuthUtil.instance.isConnected() && AuthUtil.instance.requireProfileSelection()) {
+            return
+        }
+
+        if (this._isRunning) {
+            return
+        }
+
+        /**
+         * Use an existing trace ID if invoked through a command (e.g., manual invocation),
+         * otherwise generate a new trace ID
+         */
+        const traceId = telemetry.attributes?.traceId ?? randomUUID()
+        TelemetryHelper.instance.setTraceId(traceId)
+        await telemetry.withTraceId(async () => {
+            if (isInlineCompletionEnabled()) {
+                if (triggerType === 'OnDemand') {
+                    ClassifierTrigger.instance.recordClassifierResultForManualTrigger(editor)
+                }
+
+                this._isRunning = true
+                let response: GetRecommendationsResponse | undefined = undefined
+
+                try {
+                    this._onSuggestionActionEvent.fire({
+                        editor: editor,
+                        isRunning: true,
+                        triggerType: triggerType,
+                        response: undefined,
+                    })
+
+                    response = await InlineCompletionService.instance.getPaginatedRecommendation(
+                        client,
+                        editor,
+                        triggerType,
+                        config,
+                        autoTriggerType,
+                        event
+                    )
+                } finally {
+                    this._isRunning = false
+                    this._onSuggestionActionEvent.fire({
+                        editor: editor,
+                        isRunning: false,
+                        triggerType: triggerType,
+                        response: response,
+                    })
+                }
+            }
+        }, traceId)
+    }
+}

--- a/packages/core/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/packages/core/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -1,0 +1,319 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { getLogger } from '../../shared/logger/logger'
+import * as CodeWhispererConstants from '../models/constants'
+import globals from '../../shared/extensionGlobals'
+import { vsCodeState } from '../models/model'
+import { CodewhispererLanguage, telemetry } from '../../shared/telemetry/telemetry'
+import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
+import { TelemetryHelper } from '../util/telemetryHelper'
+import { AuthUtil } from '../util/authUtil'
+import { getSelectedCustomization } from '../util/customizationUtil'
+import { codeWhispererClient as client } from '../client/codewhisperer'
+import { isAwsError } from '../../shared/errors'
+import { getUnmodifiedAcceptedTokens } from '../util/commonUtil'
+
+interface CodeWhispererToken {
+    range: vscode.Range
+    text: string
+    accepted: number
+}
+
+const autoClosingKeystrokeInputs = ['[]', '{}', '()', '""', "''"]
+
+/**
+ * This singleton class is mainly used for calculating the code written by codeWhisperer
+ * TODO: Remove this tracker, uses user written code tracker instead.
+ * This is kept in codebase for server side backward compatibility until service fully switch to user written code
+ */
+export class CodeWhispererCodeCoverageTracker {
+    private _acceptedTokens: { [key: string]: CodeWhispererToken[] }
+    private _totalTokens: { [key: string]: number }
+    private _timer?: NodeJS.Timer
+    private _startTime: number
+    private _language: CodewhispererLanguage
+    private _serviceInvocationCount: number
+
+    private constructor(language: CodewhispererLanguage) {
+        this._acceptedTokens = {}
+        this._totalTokens = {}
+        this._startTime = 0
+        this._language = language
+        this._serviceInvocationCount = 0
+    }
+
+    public get serviceInvocationCount(): number {
+        return this._serviceInvocationCount
+    }
+
+    public get acceptedTokens(): { [key: string]: CodeWhispererToken[] } {
+        return this._acceptedTokens
+    }
+
+    public get totalTokens(): { [key: string]: number } {
+        return this._totalTokens
+    }
+
+    public isActive(): boolean {
+        return TelemetryHelper.instance.isTelemetryEnabled() && AuthUtil.instance.isConnected()
+    }
+
+    public incrementServiceInvocationCount() {
+        this._serviceInvocationCount += 1
+    }
+
+    public flush() {
+        if (!this.isActive()) {
+            this._totalTokens = {}
+            this._acceptedTokens = {}
+            this.closeTimer()
+            return
+        }
+        try {
+            this.emitCodeWhispererCodeContribution()
+        } catch (error) {
+            getLogger().error(`Encountered ${error} when emitting code contribution metric`)
+        }
+    }
+
+    // TODO: Improve the range tracking of the accepted recommendation
+    // TODO: use the editor of the filename, not the current editor
+    public updateAcceptedTokensCount(editor: vscode.TextEditor) {
+        const filename = editor.document.fileName
+        if (filename in this._acceptedTokens) {
+            for (let i = 0; i < this._acceptedTokens[filename].length; i++) {
+                const oldText = this._acceptedTokens[filename][i].text
+                const newText = editor.document.getText(this._acceptedTokens[filename][i].range)
+                this._acceptedTokens[filename][i].accepted = getUnmodifiedAcceptedTokens(oldText, newText)
+            }
+        }
+    }
+
+    public emitCodeWhispererCodeContribution() {
+        let totalTokens = 0
+        for (const filename in this._totalTokens) {
+            totalTokens += this._totalTokens[filename]
+        }
+        if (vscode.window.activeTextEditor) {
+            this.updateAcceptedTokensCount(vscode.window.activeTextEditor)
+        }
+        // the accepted characters without counting user modification
+        let acceptedTokens = 0
+        // the accepted characters after calculating user modification
+        let unmodifiedAcceptedTokens = 0
+        for (const filename in this._acceptedTokens) {
+            for (const v of this._acceptedTokens[filename]) {
+                if (filename in this._totalTokens && this._totalTokens[filename] >= v.accepted) {
+                    unmodifiedAcceptedTokens += v.accepted
+                    acceptedTokens += v.text.length
+                }
+            }
+        }
+        const percentCount = ((acceptedTokens / totalTokens) * 100).toFixed(2)
+        const percentage = Math.round(parseInt(percentCount))
+        const selectedCustomization = getSelectedCustomization()
+        if (this._serviceInvocationCount <= 0) {
+            getLogger().debug(`Skip emiting code contribution metric`)
+            return
+        }
+        telemetry.codewhisperer_codePercentage.emit({
+            codewhispererTotalTokens: totalTokens,
+            codewhispererLanguage: this._language,
+            codewhispererAcceptedTokens: unmodifiedAcceptedTokens,
+            codewhispererSuggestedTokens: acceptedTokens,
+            codewhispererPercentage: percentage ? percentage : 0,
+            successCount: this._serviceInvocationCount,
+            codewhispererCustomizationArn: selectedCustomization.arn === '' ? undefined : selectedCustomization.arn,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+
+        client
+            .sendTelemetryEvent({
+                telemetryEvent: {
+                    codeCoverageEvent: {
+                        customizationArn: selectedCustomization.arn === '' ? undefined : selectedCustomization.arn,
+                        programmingLanguage: {
+                            languageName: runtimeLanguageContext.toRuntimeLanguage(this._language),
+                        },
+                        acceptedCharacterCount: acceptedTokens,
+                        unmodifiedAcceptedCharacterCount: unmodifiedAcceptedTokens,
+                        totalCharacterCount: totalTokens,
+                        timestamp: new Date(Date.now()),
+                    },
+                },
+                profileArn: AuthUtil.instance.regionProfileManager.activeRegionProfile?.arn,
+            })
+            .then()
+            .catch((error) => {
+                let requestId: string | undefined
+                if (isAwsError(error)) {
+                    requestId = error.requestId
+                }
+
+                getLogger().debug(
+                    `Failed to sendTelemetryEvent to CodeWhisperer, requestId: ${requestId ?? ''}, message: ${
+                        error.message
+                    }`
+                )
+            })
+    }
+
+    private tryStartTimer() {
+        if (this._timer !== undefined) {
+            return
+        }
+        const currentDate = new globals.clock.Date()
+        this._startTime = currentDate.getTime()
+        this._timer = setTimeout(() => {
+            try {
+                const currentTime = new globals.clock.Date().getTime()
+                const delay: number = CodeWhispererConstants.defaultCheckPeriodMillis
+                const diffTime: number = this._startTime + delay
+                if (diffTime <= currentTime) {
+                    let totalTokens = 0
+                    for (const filename in this._totalTokens) {
+                        totalTokens += this._totalTokens[filename]
+                    }
+                    if (totalTokens > 0) {
+                        this.flush()
+                    } else {
+                        getLogger().debug(
+                            `CodeWhispererCodeCoverageTracker: skipped telemetry due to empty tokens array`
+                        )
+                    }
+                }
+            } catch (e) {
+                getLogger().verbose(`Exception Thrown from CodeWhispererCodeCoverageTracker: ${e}`)
+            } finally {
+                this.resetTracker()
+                this.closeTimer()
+            }
+        }, CodeWhispererConstants.defaultCheckPeriodMillis)
+    }
+
+    private resetTracker() {
+        this._totalTokens = {}
+        this._acceptedTokens = {}
+        this._startTime = 0
+        this._serviceInvocationCount = 0
+    }
+
+    private closeTimer() {
+        if (this._timer !== undefined) {
+            clearTimeout(this._timer)
+            this._timer = undefined
+        }
+    }
+
+    public addAcceptedTokens(filename: string, token: CodeWhispererToken) {
+        if (!(filename in this._acceptedTokens)) {
+            this._acceptedTokens[filename] = []
+        }
+        this._acceptedTokens[filename].push(token)
+    }
+
+    public addTotalTokens(filename: string, count: number) {
+        if (!(filename in this._totalTokens)) {
+            this._totalTokens[filename] = 0
+        }
+        this._totalTokens[filename] += count
+        if (this._totalTokens[filename] < 0) {
+            this._totalTokens[filename] = 0
+        }
+    }
+
+    public countAcceptedTokens(range: vscode.Range, text: string, filename: string) {
+        if (!this.isActive()) {
+            return
+        }
+        // generate accepted recommendation token and stored in collection
+        this.addAcceptedTokens(filename, { range: range, text: text, accepted: text.length })
+        this.addTotalTokens(filename, text.length)
+    }
+
+    // For below 2 edge cases
+    // 1. newline character with indentation
+    // 2. 2 character insertion of closing brackets
+    public getCharacterCountFromComplexEvent(e: vscode.TextDocumentChangeEvent) {
+        function countChanges(cond: boolean, text: string): number {
+            if (!cond) {
+                return 0
+            }
+            if ((text.startsWith('\n') || text.startsWith('\r\n')) && text.trim().length === 0) {
+                return 1
+            }
+            if (autoClosingKeystrokeInputs.includes(text)) {
+                return 2
+            }
+            return 0
+        }
+        if (e.contentChanges.length === 2) {
+            const text1 = e.contentChanges[0].text
+            const text2 = e.contentChanges[1].text
+            const text2Count = countChanges(text1.length === 0, text2)
+            const text1Count = countChanges(text2.length === 0, text1)
+            return text2Count > 0 ? text2Count : text1Count
+        } else if (e.contentChanges.length === 1) {
+            return countChanges(true, e.contentChanges[0].text)
+        }
+        return 0
+    }
+
+    public isFromUserKeystroke(e: vscode.TextDocumentChangeEvent) {
+        return e.contentChanges.length === 1 && e.contentChanges[0].text.length === 1
+    }
+
+    public countTotalTokens(e: vscode.TextDocumentChangeEvent) {
+        // ignore no contentChanges. ignore contentChanges from other plugins (formatters)
+        // only include contentChanges from user keystroke input(one character input).
+        // Also ignore deletion events due to a known issue of tracking deleted CodeWhiperer tokens.
+        if (!runtimeLanguageContext.isLanguageSupported(e.document.languageId) || vsCodeState.isCodeWhispererEditing) {
+            return
+        }
+        // a user keystroke input can be
+        // 1. content change with 1 character insertion
+        // 2. newline character with indentation
+        // 3. 2 character insertion of closing brackets
+        if (this.isFromUserKeystroke(e)) {
+            this.tryStartTimer()
+            this.addTotalTokens(e.document.fileName, 1)
+        } else if (this.getCharacterCountFromComplexEvent(e) !== 0) {
+            this.tryStartTimer()
+            const characterIncrease = this.getCharacterCountFromComplexEvent(e)
+            this.addTotalTokens(e.document.fileName, characterIncrease)
+        }
+        // also include multi character input within 50 characters (not from CWSPR)
+        else if (
+            e.contentChanges.length === 1 &&
+            e.contentChanges[0].text.length > 1 &&
+            TelemetryHelper.instance.lastSuggestionInDisplay !== e.contentChanges[0].text
+        ) {
+            const multiCharInputSize = e.contentChanges[0].text.length
+
+            // select 50 as the cut-off threshold for counting user input.
+            // ignore all white space multi char input, this usually comes from reformat.
+            if (multiCharInputSize < 50 && e.contentChanges[0].text.trim().length > 0) {
+                this.addTotalTokens(e.document.fileName, multiCharInputSize)
+            }
+        }
+    }
+
+    public static readonly instances = new Map<CodewhispererLanguage, CodeWhispererCodeCoverageTracker>()
+
+    public static getTracker(language: string): CodeWhispererCodeCoverageTracker | undefined {
+        if (!runtimeLanguageContext.isLanguageSupported(language)) {
+            return undefined
+        }
+        const cwsprLanguage = runtimeLanguageContext.normalizeLanguage(language)
+        if (!cwsprLanguage) {
+            return undefined
+        }
+        const instance = this.instances.get(cwsprLanguage) ?? new this(cwsprLanguage)
+        this.instances.set(cwsprLanguage, instance)
+        return instance
+    }
+}

--- a/packages/core/src/codewhisperer/util/commonUtil.ts
+++ b/packages/core/src/codewhisperer/util/commonUtil.ts
@@ -3,16 +3,78 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode'
+import * as semver from 'semver'
 import { distance } from 'fastest-levenshtein'
 import { getInlineSuggestEnabled } from '../../shared/utilities/editorUtilities'
+import {
+    AWSTemplateCaseInsensitiveKeyWords,
+    AWSTemplateKeyWords,
+    JsonConfigFileNamingConvention,
+} from '../models/constants'
 
 export function getLocalDatetime() {
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
     return new Date().toLocaleString([], { timeZone: timezone })
 }
 
+export function asyncCallWithTimeout<T>(asyncPromise: Promise<T>, message: string, timeLimit: number): Promise<T> {
+    let timeoutHandle: NodeJS.Timeout
+    const timeoutPromise = new Promise((_resolve, reject) => {
+        timeoutHandle = setTimeout(() => reject(new Error(message)), timeLimit)
+    })
+    return Promise.race([asyncPromise, timeoutPromise]).then((result) => {
+        clearTimeout(timeoutHandle)
+        return result as T
+    })
+}
+
 export function isInlineCompletionEnabled() {
     return getInlineSuggestEnabled()
+}
+
+// This is the VS Code version that started to have regressions in inline completion API
+export function isVscHavingRegressionInlineCompletionApi() {
+    return semver.gte(vscode.version, '1.78.0') && getInlineSuggestEnabled()
+}
+
+export function getFileExt(languageId: string) {
+    switch (languageId) {
+        case 'java':
+            return '.java'
+        case 'python':
+            return '.py'
+        default:
+            break
+    }
+    return undefined
+}
+
+/**
+ * Returns the longest overlap between the Suffix of firstString and Prefix of second string
+ * getPrefixSuffixOverlap("adwg31", "31ggrs") = "31"
+ */
+export function getPrefixSuffixOverlap(firstString: string, secondString: string) {
+    let i = Math.min(firstString.length, secondString.length)
+    while (i > 0) {
+        if (secondString.slice(0, i) === firstString.slice(-i)) {
+            break
+        }
+        i--
+    }
+    return secondString.slice(0, i)
+}
+
+export function checkLeftContextKeywordsForJson(fileName: string, leftFileContent: string, language: string): boolean {
+    if (
+        language === 'json' &&
+        !AWSTemplateKeyWords.some((substring) => leftFileContent.includes(substring)) &&
+        !AWSTemplateCaseInsensitiveKeyWords.some((substring) => leftFileContent.toLowerCase().includes(substring)) &&
+        !JsonConfigFileNamingConvention.has(fileName.toLowerCase())
+    ) {
+        return true
+    }
+    return false
 }
 
 // With edit distance, complicate usermodification can be considered as simple edit(add, delete, replace),

--- a/packages/core/src/codewhisperer/util/editorContext.ts
+++ b/packages/core/src/codewhisperer/util/editorContext.ts
@@ -1,0 +1,425 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as codewhispererClient from '../client/codewhisperer'
+import * as path from 'path'
+import * as CodeWhispererConstants from '../models/constants'
+import { getTabSizeSetting } from '../../shared/utilities/editorUtilities'
+import { truncate } from '../../shared/utilities/textUtilities'
+import { getLogger } from '../../shared/logger/logger'
+import { runtimeLanguageContext } from './runtimeLanguageContext'
+import { fetchSupplementalContext } from './supplementalContext/supplementalContextUtil'
+import { editorStateMaxLength, supplementalContextTimeoutInMs } from '../models/constants'
+import { getSelectedCustomization } from './customizationUtil'
+import { selectFrom } from '../../shared/utilities/tsUtils'
+import { checkLeftContextKeywordsForJson } from './commonUtil'
+import { CodeWhispererSupplementalContext } from '../models/model'
+import { getOptOutPreference } from '../../shared/telemetry/util'
+import { indent } from '../../shared/utilities/textUtilities'
+import { isInDirectory } from '../../shared/filesystemUtilities'
+import { AuthUtil } from './authUtil'
+import { predictionTracker } from '../nextEditPrediction/activation'
+
+let tabSize: number = getTabSizeSetting()
+
+function getEnclosingNotebook(editor: vscode.TextEditor): vscode.NotebookDocument | undefined {
+    // For notebook cells, find the existing notebook with a cell that matches the current editor.
+    return vscode.workspace.notebookDocuments.find(
+        (nb) =>
+            nb.notebookType === 'jupyter-notebook' && nb.getCells().some((cell) => cell.document === editor.document)
+    )
+}
+
+export function getNotebookContext(
+    notebook: vscode.NotebookDocument,
+    editor: vscode.TextEditor,
+    languageName: string,
+    caretLeftFileContext: string,
+    caretRightFileContext: string
+) {
+    // Expand the context for a cell inside of a noteboo with whatever text fits from the preceding and subsequent cells
+    const allCells = notebook.getCells()
+    const cellIndex = allCells.findIndex((cell) => cell.document === editor.document)
+    // Extract text from prior cells if there is enough room in left file context
+    if (caretLeftFileContext.length < CodeWhispererConstants.charactersLimit - 1) {
+        const leftCellsText = getNotebookCellsSliceContext(
+            allCells.slice(0, cellIndex),
+            CodeWhispererConstants.charactersLimit - (caretLeftFileContext.length + 1),
+            languageName,
+            true
+        )
+        if (leftCellsText.length > 0) {
+            caretLeftFileContext = addNewlineIfMissing(leftCellsText) + caretLeftFileContext
+        }
+    }
+    // Extract text from subsequent cells if there is enough room in right file context
+    if (caretRightFileContext.length < CodeWhispererConstants.charactersLimit - 1) {
+        const rightCellsText = getNotebookCellsSliceContext(
+            allCells.slice(cellIndex + 1),
+            CodeWhispererConstants.charactersLimit - (caretRightFileContext.length + 1),
+            languageName,
+            false
+        )
+        if (rightCellsText.length > 0) {
+            caretRightFileContext = addNewlineIfMissing(caretRightFileContext) + rightCellsText
+        }
+    }
+    return { caretLeftFileContext, caretRightFileContext }
+}
+
+export function getNotebookCellContext(cell: vscode.NotebookCell, referenceLanguage?: string): string {
+    // Extract the text verbatim if the cell is code and the cell has the same language.
+    // Otherwise, add the correct comment string for the reference language
+    const cellText = cell.document.getText()
+    if (
+        cell.kind === vscode.NotebookCellKind.Markup ||
+        (runtimeLanguageContext.normalizeLanguage(cell.document.languageId) ?? cell.document.languageId) !==
+            referenceLanguage
+    ) {
+        const commentPrefix = runtimeLanguageContext.getSingleLineCommentPrefix(referenceLanguage)
+        if (commentPrefix === '') {
+            return cellText
+        }
+        return cell.document
+            .getText()
+            .split('\n')
+            .map((line) => `${commentPrefix}${line}`)
+            .join('\n')
+    }
+    return cellText
+}
+
+export function getNotebookCellsSliceContext(
+    cells: vscode.NotebookCell[],
+    maxLength: number,
+    referenceLanguage: string,
+    fromStart: boolean
+): string {
+    // Extract context from array of notebook cells that fits inside `maxLength` characters,
+    // from either the start or the end of the array.
+    let output: string[] = []
+    if (!fromStart) {
+        cells = cells.reverse()
+    }
+    cells.some((cell) => {
+        const cellText = addNewlineIfMissing(getNotebookCellContext(cell, referenceLanguage))
+        if (cellText.length > 0) {
+            if (cellText.length >= maxLength) {
+                if (fromStart) {
+                    output.push(cellText.substring(0, maxLength))
+                } else {
+                    output.push(cellText.substring(cellText.length - maxLength))
+                }
+                return true
+            }
+            output.push(cellText)
+            maxLength -= cellText.length
+        }
+    })
+    if (!fromStart) {
+        output = output.reverse()
+    }
+    return output.join('')
+}
+
+export function addNewlineIfMissing(text: string): string {
+    if (text.length > 0 && !text.endsWith('\n')) {
+        text += '\n'
+    }
+    return text
+}
+
+export function extractContextForCodeWhisperer(editor: vscode.TextEditor): codewhispererClient.FileContext {
+    const document = editor.document
+    const curPos = editor.selection.active
+    const offset = document.offsetAt(curPos)
+
+    let caretLeftFileContext = editor.document.getText(
+        new vscode.Range(
+            document.positionAt(offset - CodeWhispererConstants.charactersLimit),
+            document.positionAt(offset)
+        )
+    )
+    let caretRightFileContext = editor.document.getText(
+        new vscode.Range(
+            document.positionAt(offset),
+            document.positionAt(offset + CodeWhispererConstants.charactersLimit)
+        )
+    )
+    let languageName = 'plaintext'
+    if (!checkLeftContextKeywordsForJson(document.fileName, caretLeftFileContext, editor.document.languageId)) {
+        languageName = runtimeLanguageContext.resolveLang(editor.document)
+    }
+    if (editor.document.uri.scheme === 'vscode-notebook-cell') {
+        const notebook = getEnclosingNotebook(editor)
+        if (notebook) {
+            ;({ caretLeftFileContext, caretRightFileContext } = getNotebookContext(
+                notebook,
+                editor,
+                languageName,
+                caretLeftFileContext,
+                caretRightFileContext
+            ))
+        }
+    }
+
+    return {
+        fileUri: editor.document.uri.toString().substring(0, CodeWhispererConstants.filenameCharsLimit),
+        filename: getFileRelativePath(editor),
+        programmingLanguage: {
+            languageName: languageName,
+        },
+        leftFileContent: caretLeftFileContext,
+        rightFileContent: caretRightFileContext,
+    } as codewhispererClient.FileContext
+}
+
+export function getFileName(editor: vscode.TextEditor): string {
+    const fileName = path.basename(editor.document.fileName)
+    return fileName.substring(0, CodeWhispererConstants.filenameCharsLimit)
+}
+
+export function getFileRelativePath(editor: vscode.TextEditor): string {
+    const fileName = path.basename(editor.document.fileName)
+    let relativePath = ''
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(editor.document.uri)
+    if (!workspaceFolder) {
+        relativePath = fileName
+    } else {
+        const workspacePath = workspaceFolder.uri.fsPath
+        const filePath = editor.document.uri.fsPath
+        relativePath = path.relative(workspacePath, filePath)
+    }
+    // For notebook files, we want to use the programming language for each cell for the code suggestions, so change
+    // the filename sent in the request to reflect that language
+    if (relativePath.endsWith('.ipynb')) {
+        const fileExtension = runtimeLanguageContext.getLanguageExtensionForNotebook(editor.document.languageId)
+        if (fileExtension !== undefined) {
+            const filenameWithNewExtension = relativePath.substring(0, relativePath.length - 5) + fileExtension
+            return filenameWithNewExtension.substring(0, CodeWhispererConstants.filenameCharsLimit)
+        }
+    }
+    return relativePath.substring(0, CodeWhispererConstants.filenameCharsLimit)
+}
+
+async function getWorkspaceId(editor: vscode.TextEditor): Promise<string | undefined> {
+    try {
+        const workspaceIds: { workspaces: { workspaceRoot: string; workspaceId: string }[] } =
+            await vscode.commands.executeCommand('aws.amazonq.getWorkspaceId')
+        for (const item of workspaceIds.workspaces) {
+            const path = vscode.Uri.parse(item.workspaceRoot).fsPath
+            if (isInDirectory(path, editor.document.uri.fsPath)) {
+                return item.workspaceId
+            }
+        }
+    } catch (err) {
+        getLogger().warn(`No workspace id found ${err}`)
+    }
+    return undefined
+}
+
+export async function buildListRecommendationRequest(
+    editor: vscode.TextEditor,
+    nextToken: string,
+    allowCodeWithReference: boolean
+): Promise<{
+    request: codewhispererClient.ListRecommendationsRequest
+    supplementalMetadata: CodeWhispererSupplementalContext | undefined
+}> {
+    const fileContext = extractContextForCodeWhisperer(editor)
+
+    const tokenSource = new vscode.CancellationTokenSource()
+    setTimeout(() => {
+        tokenSource.cancel()
+    }, supplementalContextTimeoutInMs)
+
+    const supplementalContexts = await fetchSupplementalContext(editor, tokenSource.token)
+
+    logSupplementalContext(supplementalContexts)
+
+    // Get predictionSupplementalContext from PredictionTracker
+    let predictionSupplementalContext: codewhispererClient.SupplementalContext[] = []
+    if (predictionTracker) {
+        predictionSupplementalContext = await predictionTracker.generatePredictionSupplementalContext()
+    }
+
+    const selectedCustomization = getSelectedCustomization()
+    const completionSupplementalContext: codewhispererClient.SupplementalContext[] = supplementalContexts
+        ? supplementalContexts.supplementalContextItems.map((v) => {
+              return selectFrom(v, 'content', 'filePath')
+          })
+        : []
+
+    const profile = AuthUtil.instance.regionProfileManager.activeRegionProfile
+
+    const editorState = getEditorState(editor, fileContext)
+
+    // Combine inline and prediction supplemental contexts
+    const finalSupplementalContext = completionSupplementalContext.concat(predictionSupplementalContext)
+    return {
+        request: {
+            fileContext: fileContext,
+            nextToken: nextToken,
+            referenceTrackerConfiguration: {
+                recommendationsWithReferences: allowCodeWithReference ? 'ALLOW' : 'BLOCK',
+            },
+            supplementalContexts: finalSupplementalContext,
+            editorState: editorState,
+            maxResults: CodeWhispererConstants.maxRecommendations,
+            customizationArn: selectedCustomization.arn === '' ? undefined : selectedCustomization.arn,
+            optOutPreference: getOptOutPreference(),
+            workspaceId: await getWorkspaceId(editor),
+            profileArn: profile?.arn,
+        },
+        supplementalMetadata: supplementalContexts,
+    }
+}
+
+export async function buildGenerateRecommendationRequest(editor: vscode.TextEditor): Promise<{
+    request: codewhispererClient.GenerateRecommendationsRequest
+    supplementalMetadata: CodeWhispererSupplementalContext | undefined
+}> {
+    const fileContext = extractContextForCodeWhisperer(editor)
+
+    const tokenSource = new vscode.CancellationTokenSource()
+    // the supplement context fetch mechanisms each has a timeout of supplementalContextTimeoutInMs
+    // adding 10 ms for overall timeout as buffer
+    setTimeout(() => {
+        tokenSource.cancel()
+    }, supplementalContextTimeoutInMs + 10)
+    const supplementalContexts = await fetchSupplementalContext(editor, tokenSource.token)
+
+    logSupplementalContext(supplementalContexts)
+
+    return {
+        request: {
+            fileContext: fileContext,
+            maxResults: CodeWhispererConstants.maxRecommendations,
+            supplementalContexts: supplementalContexts?.supplementalContextItems ?? [],
+        },
+        supplementalMetadata: supplementalContexts,
+    }
+}
+
+export function validateRequest(
+    req: codewhispererClient.ListRecommendationsRequest | codewhispererClient.GenerateRecommendationsRequest
+): boolean {
+    const isLanguageNameValid =
+        req.fileContext.programmingLanguage.languageName !== undefined &&
+        req.fileContext.programmingLanguage.languageName.length >= 1 &&
+        req.fileContext.programmingLanguage.languageName.length <= 128 &&
+        (runtimeLanguageContext.isLanguageSupported(req.fileContext.programmingLanguage.languageName) ||
+            runtimeLanguageContext.isFileFormatSupported(
+                req.fileContext.filename.substring(req.fileContext.filename.lastIndexOf('.') + 1)
+            ))
+    const isFileNameValid = !(req.fileContext.filename === undefined || req.fileContext.filename.length < 1)
+    const isFileContextValid = !(
+        req.fileContext.leftFileContent.length > CodeWhispererConstants.charactersLimit ||
+        req.fileContext.rightFileContent.length > CodeWhispererConstants.charactersLimit
+    )
+    if (isFileNameValid && isLanguageNameValid && isFileContextValid) {
+        return true
+    }
+    return false
+}
+
+export function updateTabSize(val: number): void {
+    tabSize = val
+}
+
+export function getTabSize(): number {
+    return tabSize
+}
+
+export function getEditorState(editor: vscode.TextEditor, fileContext: codewhispererClient.FileContext): any {
+    try {
+        const cursorPosition = editor.selection.active
+        const cursorOffset = editor.document.offsetAt(cursorPosition)
+        const documentText = editor.document.getText()
+
+        // Truncate if document content is too large (defined in constants.ts)
+        let fileText = documentText
+        if (documentText.length > editorStateMaxLength) {
+            const halfLength = Math.floor(editorStateMaxLength / 2)
+
+            // Use truncate function to get the text around the cursor position
+            const leftPart = truncate(documentText.substring(0, cursorOffset), -halfLength, '')
+            const rightPart = truncate(documentText.substring(cursorOffset), halfLength, '')
+
+            fileText = leftPart + rightPart
+        }
+
+        return {
+            document: {
+                programmingLanguage: {
+                    languageName: fileContext.programmingLanguage.languageName,
+                },
+                relativeFilePath: fileContext.filename,
+                text: fileText,
+            },
+            cursorState: {
+                position: {
+                    line: editor.selection.active.line,
+                    character: editor.selection.active.character,
+                },
+            },
+        }
+    } catch (error) {
+        getLogger().error(`Error generating editor state: ${error}`)
+        return undefined
+    }
+}
+
+export function getLeftContext(editor: vscode.TextEditor, line: number): string {
+    let lineText = ''
+    try {
+        if (editor && editor.document.lineAt(line)) {
+            lineText = editor.document.lineAt(line).text
+            if (lineText.length > CodeWhispererConstants.contextPreviewLen) {
+                lineText =
+                    '...' +
+                    lineText.substring(
+                        lineText.length - CodeWhispererConstants.contextPreviewLen - 1,
+                        lineText.length - 1
+                    )
+            }
+        }
+    } catch (error) {
+        getLogger().error(`Error when getting left context ${error}`)
+    }
+
+    return lineText
+}
+
+function logSupplementalContext(supplementalContext: CodeWhispererSupplementalContext | undefined) {
+    if (!supplementalContext) {
+        return
+    }
+
+    let logString = indent(
+        `CodeWhispererSupplementalContext:
+        isUtg: ${supplementalContext.isUtg},
+        isProcessTimeout: ${supplementalContext.isProcessTimeout},
+        contentsLength: ${supplementalContext.contentsLength},
+        latency: ${supplementalContext.latency}
+        strategy: ${supplementalContext.strategy}`,
+        4,
+        true
+    ).trimStart()
+
+    for (const [index, context] of supplementalContext.supplementalContextItems.entries()) {
+        logString += indent(`\nChunk ${index}:\n`, 4, true)
+        logString += indent(
+            `Path: ${context.filePath}
+            Length: ${context.content.length}
+            Score: ${context.score}`,
+            8,
+            true
+        )
+    }
+
+    getLogger().debug(logString)
+}

--- a/packages/core/src/codewhisperer/util/globalStateUtil.ts
+++ b/packages/core/src/codewhisperer/util/globalStateUtil.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vsCodeState } from '../models/model'
+
+export function resetIntelliSenseState(
+    isManualTriggerEnabled: boolean,
+    isAutomatedTriggerEnabled: boolean,
+    hasResponse: boolean
+) {
+    /**
+     * Skip when CodeWhisperer service is turned off
+     */
+    if (!isManualTriggerEnabled && !isAutomatedTriggerEnabled) {
+        return
+    }
+
+    if (vsCodeState.isIntelliSenseActive && hasResponse) {
+        vsCodeState.isIntelliSenseActive = false
+    }
+}

--- a/packages/core/src/codewhisperer/util/supplementalContext/codeParsingUtil.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/codeParsingUtil.ts
@@ -1,0 +1,130 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import path = require('path')
+import { normalize } from '../../../shared/utilities/pathUtils'
+
+// TODO: functionExtractionPattern, classExtractionPattern, imposrtStatementRegex are not scalable and we will deprecate and remove the usage in the near future
+export interface utgLanguageConfig {
+    extension: string
+    testFilenamePattern: RegExp[]
+    functionExtractionPattern?: RegExp
+    classExtractionPattern?: RegExp
+    importStatementRegExp?: RegExp
+}
+
+export const utgLanguageConfigs: Record<string, utgLanguageConfig> = {
+    // Java regexes are not working efficiently for class or function extraction
+    java: {
+        extension: '.java',
+        testFilenamePattern: [/^(.+)Test(\.java)$/, /(.+)Tests(\.java)$/, /Test(.+)(\.java)$/],
+        functionExtractionPattern:
+            /(?:(?:public|private|protected)\s+)(?:static\s+)?(?:[\w<>]+\s+)?(\w+)\s*\([^)]*\)\s*(?:(?:throws\s+\w+)?\s*)[{;]/gm, // TODO: Doesn't work for generice <T> T functions.
+        classExtractionPattern: /(?<=^|\n)\s*public\s+class\s+(\w+)/gm, // TODO: Verify these.
+        importStatementRegExp: /import .*\.([a-zA-Z0-9]+);/,
+    },
+    python: {
+        extension: '.py',
+        testFilenamePattern: [/^test_(.+)(\.py)$/, /^(.+)_test(\.py)$/],
+        functionExtractionPattern: /def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/g, // Worked fine
+        classExtractionPattern: /^class\s+(\w+)\s*:/gm,
+        importStatementRegExp: /from (.*) import.*/,
+    },
+    typescript: {
+        extension: '.ts',
+        testFilenamePattern: [/^(.+)\.test(\.ts|\.tsx)$/, /^(.+)\.spec(\.ts|\.tsx)$/],
+    },
+    javascript: {
+        extension: '.js',
+        testFilenamePattern: [/^(.+)\.test(\.js|\.jsx)$/, /^(.+)\.spec(\.js|\.jsx)$/],
+    },
+    typescriptreact: {
+        extension: '.tsx',
+        testFilenamePattern: [/^(.+)\.test(\.ts|\.tsx)$/, /^(.+)\.spec(\.ts|\.tsx)$/],
+    },
+    javascriptreact: {
+        extension: '.jsx',
+        testFilenamePattern: [/^(.+)\.test(\.js|\.jsx)$/, /^(.+)\.spec(\.js|\.jsx)$/],
+    },
+}
+
+export function extractFunctions(fileContent: string, regex?: RegExp) {
+    if (!regex) {
+        return []
+    }
+    const functionNames: string[] = []
+    let match: RegExpExecArray | null
+
+    while ((match = regex.exec(fileContent)) !== null) {
+        functionNames.push(match[1])
+    }
+    return functionNames
+}
+
+export function extractClasses(fileContent: string, regex?: RegExp) {
+    if (!regex) {
+        return []
+    }
+    const classNames: string[] = []
+    let match: RegExpExecArray | null
+
+    while ((match = regex.exec(fileContent)) !== null) {
+        classNames.push(match[1])
+    }
+    return classNames
+}
+
+export function countSubstringMatches(arr1: string[], arr2: string[]): number {
+    let count = 0
+    for (const str1 of arr1) {
+        for (const str2 of arr2) {
+            if (str2.toLowerCase().includes(str1.toLowerCase())) {
+                count++
+            }
+        }
+    }
+    return count
+}
+
+export async function isTestFile(
+    filePath: string,
+    languageConfig: {
+        languageId: vscode.TextDocument['languageId']
+        fileContent?: string
+    }
+): Promise<boolean> {
+    const normalizedFilePath = normalize(filePath)
+    const pathContainsTest =
+        normalizedFilePath.includes('tests/') ||
+        normalizedFilePath.includes('test/') ||
+        normalizedFilePath.includes('tst/')
+    const fileNameMatchTestPatterns = isTestFileByName(normalizedFilePath, languageConfig.languageId)
+
+    if (pathContainsTest || fileNameMatchTestPatterns) {
+        return true
+    }
+
+    return false
+}
+
+function isTestFileByName(filePath: string, language: vscode.TextDocument['languageId']): boolean {
+    const languageConfig = utgLanguageConfigs[language]
+    if (!languageConfig) {
+        // We have enabled the support only for python and Java for this check
+        // as we depend on Regex for this validation.
+        return false
+    }
+    const testFilenamePattern = languageConfig.testFilenamePattern
+
+    const filename = path.basename(filePath)
+    for (const pattern of testFilenamePattern) {
+        if (pattern.test(filename)) {
+            return true
+        }
+    }
+
+    return false
+}

--- a/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -1,0 +1,389 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import path = require('path')
+import { BM25Document, BM25Okapi } from './rankBm25'
+import {
+    crossFileContextConfig,
+    supplementalContextTimeoutInMs,
+    supplementalContextMaxTotalLength,
+} from '../../models/constants'
+import { isTestFile } from './codeParsingUtil'
+import { getFileDistance } from '../../../shared/filesystemUtilities'
+import { getOpenFilesInWindow } from '../../../shared/utilities/editorUtilities'
+import { getLogger } from '../../../shared/logger/logger'
+import {
+    CodeWhispererSupplementalContext,
+    CodeWhispererSupplementalContextItem,
+    SupplementalContextStrategy,
+} from '../../models/model'
+import { waitUntil } from '../../../shared/utilities/timeoutUtils'
+import { FeatureConfigProvider } from '../../../shared/featureConfig'
+import fs from '../../../shared/fs/fs'
+
+type CrossFileSupportedLanguage =
+    | 'java'
+    | 'python'
+    | 'javascript'
+    | 'typescript'
+    | 'javascriptreact'
+    | 'typescriptreact'
+
+// TODO: ugly, can we make it prettier? like we have to manually type 'java', 'javascriptreact' which is error prone
+// TODO: Move to another config file or constants file
+// Supported language to its corresponding file ext
+const supportedLanguageToDialects: Readonly<Record<CrossFileSupportedLanguage, Set<string>>> = {
+    java: new Set<string>(['.java']),
+    python: new Set<string>(['.py']),
+    javascript: new Set<string>(['.js', '.jsx']),
+    javascriptreact: new Set<string>(['.js', '.jsx']),
+    typescript: new Set<string>(['.ts', '.tsx']),
+    typescriptreact: new Set<string>(['.ts', '.tsx']),
+}
+
+function isCrossFileSupported(languageId: string): languageId is CrossFileSupportedLanguage {
+    return Object.keys(supportedLanguageToDialects).includes(languageId)
+}
+
+interface Chunk {
+    fileName: string
+    content: string
+    nextContent: string
+    score?: number
+}
+
+/**
+ * `none`: supplementalContext is not supported
+ * `opentabs`: opentabs_BM25
+ * `codemap`: repomap + opentabs BM25
+ * `bm25`: global_BM25
+ * `default`: repomap + global_BM25
+ */
+type SupplementalContextConfig = 'none' | 'opentabs' | 'codemap' | 'bm25' | 'default'
+
+export async function fetchSupplementalContextForSrc(
+    editor: vscode.TextEditor,
+    cancellationToken: vscode.CancellationToken
+): Promise<Pick<CodeWhispererSupplementalContext, 'supplementalContextItems' | 'strategy'> | undefined> {
+    const supplementalContextConfig = getSupplementalContextConfig(editor.document.languageId)
+
+    // not supported case
+    if (supplementalContextConfig === 'none') {
+        return undefined
+    }
+
+    // fallback to opentabs if projectContext timeout
+    const opentabsContextPromise = waitUntil(
+        async function () {
+            return await fetchOpentabsContext(editor, cancellationToken)
+        },
+        { timeout: supplementalContextTimeoutInMs, interval: 5, truthy: false }
+    )
+
+    // opentabs context will use bm25 and users' open tabs to fetch supplemental context
+    if (supplementalContextConfig === 'opentabs') {
+        const supContext = (await opentabsContextPromise) ?? []
+        return {
+            supplementalContextItems: supContext,
+            strategy: supContext.length === 0 ? 'empty' : 'opentabs',
+        }
+    }
+
+    // codemap will use opentabs context plus repomap if it's present
+    if (supplementalContextConfig === 'codemap') {
+        let strategy: SupplementalContextStrategy = 'empty'
+        let hasCodemap: boolean = false
+        let hasOpentabs: boolean = false
+        const opentabsContextAndCodemap = await waitUntil(
+            async function () {
+                const result: CodeWhispererSupplementalContextItem[] = []
+                const opentabsContext = await fetchOpentabsContext(editor, cancellationToken)
+                const codemap = await fetchProjectContext(editor, 'codemap')
+
+                function addToResult(items: CodeWhispererSupplementalContextItem[]) {
+                    for (const item of items) {
+                        const curLen = result.reduce((acc, i) => acc + i.content.length, 0)
+                        if (curLen + item.content.length < supplementalContextMaxTotalLength) {
+                            result.push(item)
+                        }
+                    }
+                }
+
+                if (codemap && codemap.length > 0) {
+                    addToResult(codemap)
+                    hasCodemap = true
+                }
+
+                if (opentabsContext && opentabsContext.length > 0) {
+                    addToResult(opentabsContext)
+                    hasOpentabs = true
+                }
+
+                return result
+            },
+            { timeout: supplementalContextTimeoutInMs, interval: 5, truthy: false }
+        )
+
+        if (hasCodemap) {
+            strategy = 'codemap'
+        } else if (hasOpentabs) {
+            strategy = 'opentabs'
+        } else {
+            strategy = 'empty'
+        }
+
+        return {
+            supplementalContextItems: opentabsContextAndCodemap ?? [],
+            strategy: strategy,
+        }
+    }
+
+    // global bm25 without repomap
+    if (supplementalContextConfig === 'bm25') {
+        const projectBM25Promise = waitUntil(
+            async function () {
+                return await fetchProjectContext(editor, 'bm25')
+            },
+            { timeout: supplementalContextTimeoutInMs, interval: 5, truthy: false }
+        )
+
+        const [projectContext, opentabsContext] = await Promise.all([projectBM25Promise, opentabsContextPromise])
+        if (projectContext && projectContext.length > 0) {
+            return {
+                supplementalContextItems: projectContext,
+                strategy: 'bm25',
+            }
+        }
+
+        const supContext = opentabsContext ?? []
+        return {
+            supplementalContextItems: supContext,
+            strategy: supContext.length === 0 ? 'empty' : 'opentabs',
+        }
+    }
+
+    // global bm25 with repomap
+    const projectContextAndCodemapPromise = waitUntil(
+        async function () {
+            return await fetchProjectContext(editor, 'default')
+        },
+        { timeout: supplementalContextTimeoutInMs, interval: 5, truthy: false }
+    )
+
+    const [projectContext, opentabsContext] = await Promise.all([
+        projectContextAndCodemapPromise,
+        opentabsContextPromise,
+    ])
+    if (projectContext && projectContext.length > 0) {
+        return {
+            supplementalContextItems: projectContext,
+            strategy: 'default',
+        }
+    }
+
+    return {
+        supplementalContextItems: opentabsContext ?? [],
+        strategy: 'opentabs',
+    }
+}
+
+export async function fetchProjectContext(
+    editor: vscode.TextEditor,
+    target: 'default' | 'codemap' | 'bm25'
+): Promise<CodeWhispererSupplementalContextItem[]> {
+    //const inputChunkContent = getInputChunk(editor)
+    // TODO:
+    const inlineProjectContext: { content: string; score: number; filePath: string }[] = []
+
+    return inlineProjectContext
+}
+
+export async function fetchOpentabsContext(
+    editor: vscode.TextEditor,
+    cancellationToken: vscode.CancellationToken
+): Promise<CodeWhispererSupplementalContextItem[] | undefined> {
+    const codeChunksCalculated = crossFileContextConfig.numberOfChunkToFetch
+
+    // Step 1: Get relevant cross files to refer
+    const relevantCrossFilePaths = await getCrossFileCandidates(editor)
+
+    // Step 2: Split files to chunks with upper bound on chunkCount
+    // We restrict the total number of chunks to improve on latency.
+    // Chunk linking is required as we want to pass the next chunk value for matched chunk.
+    let chunkList: Chunk[] = []
+    for (const relevantFile of relevantCrossFilePaths) {
+        const chunks: Chunk[] = await splitFileToChunks(relevantFile, crossFileContextConfig.numberOfLinesEachChunk)
+        const linkedChunks = linkChunks(chunks)
+        chunkList.push(...linkedChunks)
+        if (chunkList.length >= codeChunksCalculated) {
+            break
+        }
+    }
+
+    // it's required since chunkList.push(...) is likely giving us a list of size > 60
+    chunkList = chunkList.slice(0, codeChunksCalculated)
+
+    // Step 3: Generate Input chunk (10 lines left of cursor position)
+    // and Find Best K chunks w.r.t input chunk using BM25
+    const inputChunk: Chunk = getInputChunk(editor)
+    const bestChunks: Chunk[] = findBestKChunkMatches(inputChunk, chunkList, crossFileContextConfig.topK)
+
+    // Step 4: Transform best chunks to supplemental contexts
+    const supplementalContexts: CodeWhispererSupplementalContextItem[] = []
+    let totalLength = 0
+    for (const chunk of bestChunks) {
+        totalLength += chunk.nextContent.length
+
+        if (totalLength > crossFileContextConfig.maximumTotalLength) {
+            break
+        }
+
+        supplementalContexts.push({
+            filePath: chunk.fileName,
+            content: chunk.nextContent,
+            score: chunk.score,
+        })
+    }
+
+    // DO NOT send code chunk with empty content
+    getLogger().debug(`CodeWhisperer finished fetching crossfile context out of ${relevantCrossFilePaths.length} files`)
+    return supplementalContexts
+}
+
+function findBestKChunkMatches(chunkInput: Chunk, chunkReferences: Chunk[], k: number): Chunk[] {
+    const chunkContentList = chunkReferences.map((chunk) => chunk.content)
+
+    // performBM25Scoring returns the output in a sorted order (descending of scores)
+    const top3: BM25Document[] = new BM25Okapi(chunkContentList).topN(chunkInput.content, crossFileContextConfig.topK)
+
+    return top3.map((doc) => {
+        // reference to the original metadata since BM25.top3 will sort the result
+        const chunkIndex = doc.index
+        const chunkReference = chunkReferences[chunkIndex]
+        return {
+            content: chunkReference.content,
+            fileName: chunkReference.fileName,
+            nextContent: chunkReference.nextContent,
+            score: doc.score,
+        }
+    })
+}
+
+/* This extract 10 lines to the left of the cursor from trigger file.
+ * This will be the inputquery to bm25 matching against list of cross-file chunks
+ */
+function getInputChunk(editor: vscode.TextEditor) {
+    const chunkSize = crossFileContextConfig.numberOfLinesEachChunk
+    const cursorPosition = editor.selection.active
+    const startLine = Math.max(cursorPosition.line - chunkSize, 0)
+    const endLine = Math.max(cursorPosition.line - 1, 0)
+    const inputChunkContent = editor.document.getText(
+        new vscode.Range(startLine, 0, endLine, editor.document.lineAt(endLine).text.length)
+    )
+    const inputChunk: Chunk = { fileName: editor.document.fileName, content: inputChunkContent, nextContent: '' }
+    return inputChunk
+}
+
+/**
+ * Util to decide if we need to fetch crossfile context since CodeWhisperer CrossFile Context feature is gated by userGroup and language level
+ * @param languageId: VSCode language Identifier
+ * @returns specifically returning undefined if the langueage is not supported,
+ * otherwise true/false depending on if the language is fully supported or not belonging to the user group
+ */
+function getSupplementalContextConfig(languageId: vscode.TextDocument['languageId']): SupplementalContextConfig {
+    if (!isCrossFileSupported(languageId)) {
+        return 'none'
+    }
+
+    const group = FeatureConfigProvider.instance.getProjectContextGroup()
+    switch (group) {
+        default:
+            return 'codemap'
+    }
+}
+
+/**
+ * This linking is required from science experimentations to pass the next contnet chunk
+ * when a given chunk context passes the match in BM25.
+ * Special handling is needed for last(its next points to its own) and first chunk
+ */
+export function linkChunks(chunks: Chunk[]) {
+    const updatedChunks: Chunk[] = []
+
+    // This additional chunk is needed to create a next pointer to chunk 0.
+    const firstChunk = chunks[0]
+    const firstChunkSubContent = firstChunk.content.split('\n').slice(0, 3).join('\n').trimEnd()
+    const newFirstChunk = {
+        fileName: firstChunk.fileName,
+        content: firstChunkSubContent,
+        nextContent: firstChunk.content,
+    }
+    updatedChunks.push(newFirstChunk)
+
+    const n = chunks.length
+    for (let i = 0; i < n; i++) {
+        const chunk = chunks[i]
+        const nextChunk = i < n - 1 ? chunks[i + 1] : chunk
+
+        chunk.nextContent = nextChunk.content
+        updatedChunks.push(chunk)
+    }
+
+    return updatedChunks
+}
+
+export async function splitFileToChunks(filePath: string, chunkSize: number): Promise<Chunk[]> {
+    const chunks: Chunk[] = []
+
+    const fileContent = (await fs.readFileText(filePath)).trimEnd()
+    const lines = fileContent.split('\n')
+
+    for (let i = 0; i < lines.length; i += chunkSize) {
+        const chunkContent = lines.slice(i, Math.min(i + chunkSize, lines.length)).join('\n')
+        const chunk = { fileName: filePath, content: chunkContent.trimEnd(), nextContent: '' }
+        chunks.push(chunk)
+    }
+    return chunks
+}
+
+/**
+ * This function will return relevant cross files sorted by file distance for the given editor file
+ * by referencing open files, imported files and same package files.
+ */
+export async function getCrossFileCandidates(editor: vscode.TextEditor): Promise<string[]> {
+    const targetFile = editor.document.uri.fsPath
+    const language = editor.document.languageId as CrossFileSupportedLanguage
+    const dialects = supportedLanguageToDialects[language]
+
+    /**
+     * Consider a file which
+     * 1. is different from the target
+     * 2. has the same file extension or it's one of the dialect of target file (e.g .js vs. .jsx)
+     * 3. is not a test file
+     */
+    const unsortedCandidates = await getOpenFilesInWindow(async (candidateFile) => {
+        return (
+            targetFile !== candidateFile &&
+            (path.extname(targetFile) === path.extname(candidateFile) ||
+                (dialects && dialects.has(path.extname(candidateFile)))) &&
+            !(await isTestFile(candidateFile, { languageId: language }))
+        )
+    })
+
+    return unsortedCandidates
+        .map((candidate) => {
+            return {
+                file: candidate,
+                fileDistance: getFileDistance(targetFile, candidate),
+            }
+        })
+        .sort((file1, file2) => {
+            return file1.fileDistance - file2.fileDistance
+        })
+        .map((fileToDistance) => {
+            return fileToDistance.file
+        })
+}

--- a/packages/core/src/codewhisperer/util/supplementalContext/rankBm25.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/rankBm25.ts
@@ -1,0 +1,137 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Implementation inspired by https://github.com/dorianbrown/rank_bm25/blob/990470ebbe6b28c18216fd1a8b18fe7446237dd6/rank_bm25.py#L52
+
+export interface BM25Document {
+    content: string
+    /** The score that the document receives. */
+    score: number
+
+    index: number
+}
+
+export abstract class BM25 {
+    protected readonly corpusSize: number
+    protected readonly avgdl: number
+    protected readonly idf: Map<string, number> = new Map()
+    protected readonly docLen: number[] = []
+    protected readonly docFreqs: Map<string, number>[] = []
+    protected readonly nd: Map<string, number> = new Map()
+
+    constructor(
+        protected readonly corpus: string[],
+        protected readonly tokenizer: (str: string) => string[] = defaultTokenizer,
+        protected readonly k1: number,
+        protected readonly b: number,
+        protected readonly epsilon: number
+    ) {
+        this.corpusSize = corpus.length
+
+        let numDoc = 0
+        for (const document of corpus.map((document) => {
+            return tokenizer(document)
+        })) {
+            this.docLen.push(document.length)
+            numDoc += document.length
+
+            const frequencies = new Map<string, number>()
+            for (const word of document) {
+                frequencies.set(word, (frequencies.get(word) || 0) + 1)
+            }
+            this.docFreqs.push(frequencies)
+
+            for (const [word, _] of frequencies.entries()) {
+                this.nd.set(word, (this.nd.get(word) || 0) + 1)
+            }
+        }
+
+        this.avgdl = numDoc / this.corpusSize
+
+        this.calIdf(this.nd)
+    }
+
+    abstract calIdf(nd: Map<string, number>): void
+
+    abstract score(query: string): BM25Document[]
+
+    topN(query: string, n: number): BM25Document[] {
+        const notSorted = this.score(query)
+        const sorted = notSorted.sort((a, b) => b.score - a.score)
+        return sorted.slice(0, Math.min(n, sorted.length))
+    }
+}
+
+export class BM25Okapi extends BM25 {
+    constructor(corpus: string[], tokenizer: (str: string) => string[] = defaultTokenizer) {
+        super(corpus, tokenizer, 1.5, 0.75, 0.25)
+    }
+
+    calIdf(nd: Map<string, number>): void {
+        let idfSum = 0
+
+        const negativeIdfs: string[] = []
+        for (const [word, freq] of nd) {
+            const idf = Math.log(this.corpusSize - freq + 0.5) - Math.log(freq + 0.5)
+            this.idf.set(word, idf)
+            idfSum += idf
+
+            if (idf < 0) {
+                negativeIdfs.push(word)
+            }
+        }
+
+        const averageIdf = idfSum / this.idf.size
+        const eps = this.epsilon * averageIdf
+        for (const word of negativeIdfs) {
+            this.idf.set(word, eps)
+        }
+    }
+
+    score(query: string): BM25Document[] {
+        const queryWords = defaultTokenizer(query)
+        return this.docFreqs.map((docFreq, index) => {
+            let score = 0
+            for (const [_, queryWord] of queryWords.entries()) {
+                const queryWordFreqForDocument = docFreq.get(queryWord) || 0
+                const numerator = (this.idf.get(queryWord) || 0.0) * queryWordFreqForDocument * (this.k1 + 1)
+                const denominator =
+                    queryWordFreqForDocument + this.k1 * (1 - this.b + (this.b * this.docLen[index]) / this.avgdl)
+
+                score += numerator / denominator
+            }
+
+            return {
+                content: this.corpus[index],
+                score: score,
+                index: index,
+            }
+        })
+    }
+}
+
+// TODO: This is a very simple tokenizer, we want to replace this by more sophisticated one.
+function defaultTokenizer(content: string): string[] {
+    const regex = /\w+/g
+    const words = content.split(' ')
+    const result = []
+    for (const word of words) {
+        const wordList = findAll(word, regex)
+        result.push(...wordList)
+    }
+
+    return result
+}
+
+function findAll(str: string, re: RegExp): string[] {
+    let match: RegExpExecArray | null
+    const matches: string[] = []
+
+    while ((match = re.exec(str)) !== null) {
+        matches.push(match[0])
+    }
+
+    return matches
+}

--- a/packages/core/src/codewhisperer/util/supplementalContext/supplementalContextUtil.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/supplementalContextUtil.ts
@@ -1,0 +1,137 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fetchSupplementalContextForTest } from './utgUtils'
+import { fetchSupplementalContextForSrc } from './crossFileContextUtil'
+import { isTestFile } from './codeParsingUtil'
+import * as vscode from 'vscode'
+import { CancellationError } from '../../../shared/utilities/timeoutUtils'
+import { ToolkitError } from '../../../shared/errors'
+import { getLogger } from '../../../shared/logger/logger'
+import { CodeWhispererSupplementalContext } from '../../models/model'
+import * as os from 'os'
+import { crossFileContextConfig } from '../../models/constants'
+
+export async function fetchSupplementalContext(
+    editor: vscode.TextEditor,
+    cancellationToken: vscode.CancellationToken
+): Promise<CodeWhispererSupplementalContext | undefined> {
+    const timesBeforeFetching = performance.now()
+
+    const isUtg = await isTestFile(editor.document.uri.fsPath, {
+        languageId: editor.document.languageId,
+        fileContent: editor.document.getText(),
+    })
+
+    let supplementalContextPromise: Promise<
+        Pick<CodeWhispererSupplementalContext, 'supplementalContextItems' | 'strategy'> | undefined
+    >
+
+    if (isUtg) {
+        supplementalContextPromise = fetchSupplementalContextForTest(editor, cancellationToken)
+    } else {
+        supplementalContextPromise = fetchSupplementalContextForSrc(editor, cancellationToken)
+    }
+
+    return supplementalContextPromise
+        .then((value) => {
+            if (value) {
+                const resBeforeTruncation = {
+                    isUtg: isUtg,
+                    isProcessTimeout: false,
+                    supplementalContextItems: value.supplementalContextItems.filter(
+                        (item) => item.content.trim().length !== 0
+                    ),
+                    contentsLength: value.supplementalContextItems.reduce((acc, curr) => acc + curr.content.length, 0),
+                    latency: performance.now() - timesBeforeFetching,
+                    strategy: value.strategy,
+                }
+
+                return truncateSuppelementalContext(resBeforeTruncation)
+            } else {
+                return undefined
+            }
+        })
+        .catch((err) => {
+            if (err instanceof ToolkitError && err.cause instanceof CancellationError) {
+                return {
+                    isUtg: isUtg,
+                    isProcessTimeout: true,
+                    supplementalContextItems: [],
+                    contentsLength: 0,
+                    latency: performance.now() - timesBeforeFetching,
+                    strategy: 'empty',
+                }
+            } else {
+                getLogger().error(
+                    `Fail to fetch supplemental context for target file ${editor.document.fileName}: ${err}`
+                )
+                return undefined
+            }
+        })
+}
+
+/**
+ * Requirement
+ * - Maximum 5 supplemental context.
+ * - Each chunk can't exceed 10240 characters
+ * - Sum of all chunks can't exceed 20480 characters
+ */
+export function truncateSuppelementalContext(
+    context: CodeWhispererSupplementalContext
+): CodeWhispererSupplementalContext {
+    let c = context.supplementalContextItems.map((item) => {
+        if (item.content.length > crossFileContextConfig.maxLengthEachChunk) {
+            return {
+                ...item,
+                content: truncateLineByLine(item.content, crossFileContextConfig.maxLengthEachChunk),
+            }
+        } else {
+            return item
+        }
+    })
+
+    if (c.length > crossFileContextConfig.maxContextCount) {
+        c = c.slice(0, crossFileContextConfig.maxContextCount)
+    }
+
+    let curTotalLength = c.reduce((acc, cur) => {
+        return acc + cur.content.length
+    }, 0)
+    while (curTotalLength >= 20480 && c.length - 1 >= 0) {
+        const last = c[c.length - 1]
+        c = c.slice(0, -1)
+        curTotalLength -= last.content.length
+    }
+
+    return {
+        ...context,
+        supplementalContextItems: c,
+        contentsLength: curTotalLength,
+    }
+}
+
+export function truncateLineByLine(input: string, l: number): string {
+    const maxLength = l > 0 ? l : -1 * l
+    if (input.length === 0) {
+        return ''
+    }
+
+    const shouldAddNewLineBack = input.endsWith(os.EOL)
+    let lines = input.trim().split(os.EOL)
+    let curLen = input.length
+    while (curLen > maxLength && lines.length - 1 >= 0) {
+        const last = lines[lines.length - 1]
+        lines = lines.slice(0, -1)
+        curLen -= last.length + 1
+    }
+
+    const r = lines.join(os.EOL)
+    if (shouldAddNewLineBack) {
+        return r + os.EOL
+    } else {
+        return r
+    }
+}

--- a/packages/core/src/codewhisperer/util/supplementalContext/utgUtils.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/utgUtils.ts
@@ -1,0 +1,229 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path'
+import { fs } from '../../../shared/fs/fs'
+import * as vscode from 'vscode'
+import {
+    countSubstringMatches,
+    extractClasses,
+    extractFunctions,
+    isTestFile,
+    utgLanguageConfig,
+    utgLanguageConfigs,
+} from './codeParsingUtil'
+import { ToolkitError } from '../../../shared/errors'
+import { supplemetalContextFetchingTimeoutMsg } from '../../models/constants'
+import { CancellationError } from '../../../shared/utilities/timeoutUtils'
+import { utgConfig } from '../../models/constants'
+import { getOpenFilesInWindow } from '../../../shared/utilities/editorUtilities'
+import { getLogger } from '../../../shared/logger/logger'
+import { CodeWhispererSupplementalContext, CodeWhispererSupplementalContextItem, UtgStrategy } from '../../models/model'
+
+const utgSupportedLanguages: vscode.TextDocument['languageId'][] = ['java', 'python']
+
+type UtgSupportedLanguage = (typeof utgSupportedLanguages)[number]
+
+function isUtgSupportedLanguage(languageId: vscode.TextDocument['languageId']): languageId is UtgSupportedLanguage {
+    return utgSupportedLanguages.includes(languageId)
+}
+
+export function shouldFetchUtgContext(languageId: vscode.TextDocument['languageId']): boolean | undefined {
+    if (!isUtgSupportedLanguage(languageId)) {
+        return undefined
+    }
+
+    return languageId === 'java'
+}
+
+/**
+ * This function attempts to find a focal file for the given trigger file.
+ * Attempt 1: If naming patterns followed correctly, source file can be found by name referencing.
+ * Attempt 2: Compare the function and class names of trigger file and all other open files in editor
+ * to find the closest match.
+ * Once found the focal file, we split it into multiple pieces as supplementalContext.
+ * @param editor
+ * @returns
+ */
+export async function fetchSupplementalContextForTest(
+    editor: vscode.TextEditor,
+    cancellationToken: vscode.CancellationToken
+): Promise<Pick<CodeWhispererSupplementalContext, 'supplementalContextItems' | 'strategy'> | undefined> {
+    const shouldProceed = shouldFetchUtgContext(editor.document.languageId)
+
+    if (!shouldProceed) {
+        return shouldProceed === undefined ? undefined : { supplementalContextItems: [], strategy: 'empty' }
+    }
+
+    const languageConfig = utgLanguageConfigs[editor.document.languageId]
+
+    // TODO (Metrics): 1. Total number of calls to fetchSupplementalContextForTest
+    throwIfCancelled(cancellationToken)
+
+    let crossSourceFile = await findSourceFileByName(editor, languageConfig, cancellationToken)
+    if (crossSourceFile) {
+        // TODO (Metrics): 2. Success count for fetchSourceFileByName (find source file by name)
+        getLogger().debug(`CodeWhisperer finished fetching utg context by file name`)
+        return {
+            supplementalContextItems: await generateSupplementalContextFromFocalFile(
+                crossSourceFile,
+                'byName',
+                cancellationToken
+            ),
+            strategy: 'byName',
+        }
+    }
+    throwIfCancelled(cancellationToken)
+
+    crossSourceFile = await findSourceFileByContent(editor, languageConfig, cancellationToken)
+    if (crossSourceFile) {
+        // TODO (Metrics): 3. Success count for fetchSourceFileByContent (find source file by content)
+        getLogger().debug(`CodeWhisperer finished fetching utg context by file content`)
+        return {
+            supplementalContextItems: await generateSupplementalContextFromFocalFile(
+                crossSourceFile,
+                'byContent',
+                cancellationToken
+            ),
+            strategy: 'byContent',
+        }
+    }
+
+    // TODO (Metrics): 4. Failure count - when unable to find focal file (supplemental context empty)
+    getLogger().debug(`CodeWhisperer failed to fetch utg context`)
+    return {
+        supplementalContextItems: [],
+        strategy: 'empty',
+    }
+}
+
+async function generateSupplementalContextFromFocalFile(
+    filePath: string,
+    strategy: UtgStrategy,
+    cancellationToken: vscode.CancellationToken
+): Promise<CodeWhispererSupplementalContextItem[]> {
+    const fileContent = await fs.readFileText(vscode.Uri.parse(filePath!).fsPath)
+
+    // DO NOT send code chunk with empty content
+    if (fileContent.trim().length === 0) {
+        return []
+    }
+
+    return [
+        {
+            filePath: filePath,
+            content: 'UTG\n' + fileContent.slice(0, Math.min(fileContent.length, utgConfig.maxSegmentSize)),
+        },
+    ]
+}
+
+async function findSourceFileByContent(
+    editor: vscode.TextEditor,
+    languageConfig: utgLanguageConfig,
+    cancellationToken: vscode.CancellationToken
+): Promise<string | undefined> {
+    const testFileContent = await fs.readFileText(editor.document.fileName)
+    const testElementList = extractFunctions(testFileContent, languageConfig.functionExtractionPattern)
+
+    throwIfCancelled(cancellationToken)
+
+    testElementList.push(...extractClasses(testFileContent, languageConfig.classExtractionPattern))
+
+    throwIfCancelled(cancellationToken)
+
+    let sourceFilePath: string | undefined = undefined
+    let maxMatchCount = 0
+
+    if (testElementList.length === 0) {
+        // TODO: Add metrics here, as unable to parse test file using Regex.
+        return sourceFilePath
+    }
+
+    const relevantFilePaths = await getRelevantUtgFiles(editor)
+
+    throwIfCancelled(cancellationToken)
+
+    // TODO (Metrics):Add metrics for relevantFilePaths length
+    for (const filePath of relevantFilePaths) {
+        throwIfCancelled(cancellationToken)
+
+        const fileContent = await fs.readFileText(filePath)
+        const elementList = extractFunctions(fileContent, languageConfig.functionExtractionPattern)
+        elementList.push(...extractClasses(fileContent, languageConfig.classExtractionPattern))
+        const matchCount = countSubstringMatches(elementList, testElementList)
+        if (matchCount > maxMatchCount) {
+            maxMatchCount = matchCount
+            sourceFilePath = filePath
+        }
+    }
+    return sourceFilePath
+}
+
+async function getRelevantUtgFiles(editor: vscode.TextEditor): Promise<string[]> {
+    const targetFile = editor.document.uri.fsPath
+    const language = editor.document.languageId
+
+    return await getOpenFilesInWindow(async (candidateFile) => {
+        return (
+            targetFile !== candidateFile &&
+            path.extname(targetFile) === path.extname(candidateFile) &&
+            !(await isTestFile(candidateFile, { languageId: language }))
+        )
+    })
+}
+
+export function guessSrcFileName(
+    testFileName: string,
+    languageId: vscode.TextDocument['languageId']
+): string | undefined {
+    const languageConfig = utgLanguageConfigs[languageId]
+    if (!languageConfig) {
+        return undefined
+    }
+
+    for (const pattern of languageConfig.testFilenamePattern) {
+        try {
+            const match = testFileName.match(pattern)
+            if (match) {
+                return match[1] + match[2]
+            }
+        } catch (err) {
+            if (err instanceof Error) {
+                getLogger().error(
+                    `codewhisperer: error while guessing source file name from file ${testFileName} and pattern ${pattern}: ${err.message}`
+                )
+            }
+        }
+    }
+
+    return undefined
+}
+
+async function findSourceFileByName(
+    editor: vscode.TextEditor,
+    languageConfig: utgLanguageConfig,
+    cancellationToken: vscode.CancellationToken
+): Promise<string | undefined> {
+    const testFileName = path.basename(editor.document.fileName)
+    const assumedSrcFileName = guessSrcFileName(testFileName, editor.document.languageId)
+    if (!assumedSrcFileName) {
+        return undefined
+    }
+
+    const sourceFiles = await vscode.workspace.findFiles(`**/${assumedSrcFileName}`)
+
+    throwIfCancelled(cancellationToken)
+
+    if (sourceFiles.length > 0) {
+        return sourceFiles[0].toString()
+    }
+    return undefined
+}
+
+function throwIfCancelled(token: vscode.CancellationToken): void | never {
+    if (token.isCancellationRequested) {
+        throw new ToolkitError(supplemetalContextFetchingTimeoutMsg, { cause: new CancellationError('timeout') })
+    }
+}

--- a/packages/core/src/codewhisperer/util/telemetryHelper.ts
+++ b/packages/core/src/codewhisperer/util/telemetryHelper.ts
@@ -5,7 +5,7 @@
 import globals from '../../shared/extensionGlobals'
 
 import { runtimeLanguageContext } from './runtimeLanguageContext'
-import { codeWhispererClient as client } from '../client/codewhisperer'
+import { codeWhispererClient as client, Recommendation } from '../client/codewhisperer'
 import { CodewhispererGettingStartedTask, CodewhispererLanguage, telemetry } from '../../shared/telemetry/telemetry'
 import { CodewhispererCompletionType } from '../../shared/telemetry/telemetry'
 import { CodeWhispererSettings } from './codewhispererSettings'
@@ -19,6 +19,46 @@ import { CodeScanRemediationsEventType } from '../client/codewhispereruserclient
 import { CodeAnalysisScope as CodeAnalysisScopeClientSide } from '../models/constants'
 
 export class TelemetryHelper {
+    recordUserDecisionTelemetry(
+        requestIdList: string[],
+        sessionId: string,
+        recommendations: Recommendation[],
+        acceptIndex: number,
+        length: number,
+        completionTypes: Map<number, CodewhispererCompletionType>,
+        suggestionStates: Map<number, string>,
+        supplementalMetadata: CodeWhispererSupplementalContext | undefined
+    ) {
+        throw new Error('Method not implemented.')
+    }
+    recordUserDecisionTelemetryForEmptyList(
+        requestIdList: string[],
+        sessionId: string,
+        page: number,
+        language: string,
+        supplementalMetadata: CodeWhispererSupplementalContext | undefined
+    ) {
+        throw new Error('Method not implemented.')
+    }
+    setTypeAheadLength(length: number) {
+        throw new Error('Method not implemented.')
+    }
+    setTraceId(traceId: string) {
+        throw new Error('Method not implemented.')
+    }
+    setTriggerCharForUserTriggerDecision(triggerChar: string) {
+        throw new Error('Method not implemented.')
+    }
+    // TODO:
+    getLastTriggerDecisionForClassifier() {
+        return ''
+    }
+    setClassifierThreshold(threshold: number) {
+        throw new Error('Method not implemented.')
+    }
+    setClassifierResult(classifierResult: number) {
+        throw new Error('Method not implemented.')
+    }
     // Some variables for client component latency
     private _sdkApiCallEndTime = 0
     get sdkApiCallEndTime(): number {


### PR DESCRIPTION
## Problem

Cherry pick files from https://github.com/aws/aws-toolkit-vscode/pull/7480/files

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
