### PR TITLE
fix(amazonq): removing duplicate refreshStatusBar declare method

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -339,7 +339,7 @@ async function onLanguageServerReady(
     // tutorial for inline chat
     const inlineChatTutorialAnnotation = new InlineChatTutorialAnnotation(inlineTutorialAnnotation)
 
-    const enableInlineRollback = false
+    const enableInlineRollback = true
     if (enableInlineRollback) {
         // use VSC inline
         await activateInline()

--- a/packages/core/src/codewhisperer/service/inlineCompletionService.ts
+++ b/packages/core/src/codewhisperer/service/inlineCompletionService.ts
@@ -18,7 +18,6 @@ import { getSelectedCustomization } from '../util/customizationUtil'
 import { codicon, getIcon } from '../../shared/icons'
 import { session } from '../util/codeWhispererSession'
 import { noSuggestions } from '../models/constants'
-import { Commands } from '../../shared/vscode/commands2'
 import { listCodeWhispererCommandsId } from '../ui/statusBarMenu'
 
 export class InlineCompletionService {
@@ -263,11 +262,3 @@ export class CodeWhispererStatusBar {
         statusBar.show()
     }
 }
-
-/** In this module due to circulare dependency issues */
-export const refreshStatusBar = Commands.declare(
-    { id: 'aws.amazonq.refreshStatusBar', logging: false },
-    () => async () => {
-        await InlineCompletionService.instance.refreshStatusBar()
-    }
-)

--- a/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -194,7 +194,7 @@ export async function fetchProjectContext(
     editor: vscode.TextEditor,
     target: 'default' | 'codemap' | 'bm25'
 ): Promise<CodeWhispererSupplementalContextItem[]> {
-    //const inputChunkContent = getInputChunk(editor)
+    // const inputChunkContent = getInputChunk(editor)
     // TODO:
     const inlineProjectContext: { content: string; score: number; filePath: string }[] = []
 


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
