### PR TITLE
fix(amazonq): read amazonq-ui.js from servers.zip instead of clients.zip

### DIFF
--- a/packages/amazonq/src/lsp/lspInstaller.ts
+++ b/packages/amazonq/src/lsp/lspInstaller.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as nodeFs from 'fs'
 import vscode from 'vscode'
 import { fs, getNodeExecutableName, getRgExecutableName, BaseLspInstaller, ResourcePaths } from 'aws-core-vscode/shared'
 import path from 'path'
@@ -45,11 +46,15 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
 
         const nodePath = path.join(assetDirectory, `servers/${getNodeExecutableName()}`)
         const rgPath = path.join(assetDirectory, `servers/ripgrep/${getRgExecutableName()}`)
+        // Check for amazonq-ui.js in both locations for backwards compatibility
+        const amazonqUiInClientsPath = path.join(assetDirectory, 'clients/amazonq-ui.js')
+        const amazonqUiInServersPath = path.join(assetDirectory, 'servers/amazonq-ui.js')
+        const uiPath = nodeFs.existsSync(amazonqUiInClientsPath) ? amazonqUiInClientsPath : amazonqUiInServersPath
         return {
             lsp: path.join(assetDirectory, 'servers/aws-lsp-codewhisperer.js'),
             node: nodePath,
             ripGrep: rgPath,
-            ui: path.join(assetDirectory, 'clients/amazonq-ui.js'),
+            ui: uiPath,
         }
     }
 
@@ -58,10 +63,14 @@ export class AmazonQLspInstaller extends BaseLspInstaller.BaseLspInstaller<
 
 export function getBundledResourcePaths(ctx: vscode.ExtensionContext): AmazonQResourcePaths {
     const assetDirectory = vscode.Uri.joinPath(ctx.extensionUri, 'resources', 'language-server').fsPath
+    // Check for amazonq-ui.js in both locations for backwards compatibility
+    const amazonqUiInClientsPath = path.join(assetDirectory, 'clients/amazonq-ui.js')
+    const amazonqUiInServersPath = path.join(assetDirectory, 'servers/amazonq-ui.js')
+    const uiPath = nodeFs.existsSync(amazonqUiInClientsPath) ? amazonqUiInClientsPath : amazonqUiInServersPath
     return {
         lsp: path.join(assetDirectory, 'servers', 'aws-lsp-codewhisperer.js'),
         node: process.execPath,
         ripGrep: '',
-        ui: path.join(assetDirectory, 'clients', 'amazonq-ui.js'),
+        ui: uiPath,
     }
 }

--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -76,7 +76,8 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, 
             // resourcePaths = {
             //     lsp = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/aws-lsp-codewhisperer.js'
             //     node = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/node'
-            //     ui = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/clients/amazonq-ui.js'
+            //     ui = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/clients/amazonq-ui.js' or
+            //          '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/amazonq-ui.js'
             // }
             // ```
             resourcePaths: this.resourcePaths(assetDirectory),

--- a/packages/core/src/shared/lsp/types.ts
+++ b/packages/core/src/shared/lsp/types.ts
@@ -23,7 +23,8 @@ export interface LspResult {
  * resourcePaths = {
  *     lsp = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/aws-lsp-codewhisperer.js'
  *     node = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/node'
- *     ui = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/clients/amazonq-ui.js'
+ *     ui = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/clients/amazonq-ui.js' or
+ *          '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/amazonq-ui.js'
  * }
  * ```
  */
@@ -47,7 +48,8 @@ export interface LspResolution<T extends ResourcePaths> extends LspResult {
      * resourcePaths = {
      *     lsp = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/aws-lsp-codewhisperer.js'
      *     node = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/node'
-     *     ui = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/clients/amazonq-ui.js'
+     *     ui = '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/clients/amazonq-ui.js' or
+     *          '<cachedir>/aws/toolkits/language-servers/AmazonQ/3.3.0/servers/amazonq-ui.js'
      * }
      * ```
      */

--- a/scripts/lspArtifact.ts
+++ b/scripts/lspArtifact.ts
@@ -158,7 +158,10 @@ export async function downloadLanguageServer(): Promise<void> {
                         if (!fs.existsSync(path.join(resourcesDir, 'servers', 'aws-lsp-codewhisperer.js'))) {
                             throw new Error(`Extracting aws-lsp-codewhisperer.js failure`)
                         }
-                        if (!fs.existsSync(path.join(resourcesDir, 'clients', 'amazonq-ui.js'))) {
+                        // Check for amazonq-ui.js in both locations for backwards compatibility (moved from clients.zip to servers.zip)
+                        const amazonqUiInClients = fs.existsSync(path.join(resourcesDir, 'clients', 'amazonq-ui.js'))
+                        const amazonqUiInServers = fs.existsSync(path.join(resourcesDir, 'servers', 'amazonq-ui.js'))
+                        if (!amazonqUiInClients && !amazonqUiInServers) {
                             throw new Error(`Extracting amazonq-ui.js failure`)
                         }
                         console.log('Download and extraction completed successfully')


### PR DESCRIPTION
## Problem
Related PR: 
- https://github.com/aws/language-servers/pull/2208

As part of changes made to move `amazonq-ui.js` from `clients.zip` to `servers.zip`, we now need to load the LSP UI from the correct locations.

## Solution

`lspArtifact.ts` - Added backwards compatibility check for `amazonq-ui.js` in both locations

`lspInstaller.ts` - Added backwards compatibility logic to check both clients/ and servers/ directories

`types.ts `- Updated comments to show both possible locations

`baseLspInstaller.ts` - Updated comments to reflect the change

The changes maintain backwards compatibility.


## Testing
Tested using local build on Mac and Windows with the old and new `.zip` setup and plugin works without issue
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
