### PR TITLE
fix(amazonq): show diff.patch first, then parse it

### DIFF
--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -827,11 +827,11 @@ async function processClientInstructions(jobId: string, clientInstructionsPath: 
     getLogger().info(`CodeTransformation: copied project to ${destinationPath}`)
     const diffContents = await fs.readFileText(clientInstructionsPath)
     if (diffContents.trim()) {
-        const diffModel = new DiffModel()
-        diffModel.parseDiff(clientInstructionsPath, path.join(destinationPath, 'sources'), true)
         // show user the diff.patch
         const doc = await vscode.workspace.openTextDocument(clientInstructionsPath)
         await vscode.window.showTextDocument(doc, { viewColumn: vscode.ViewColumn.One })
+        const diffModel = new DiffModel()
+        diffModel.parseDiff(clientInstructionsPath, path.join(destinationPath, 'sources'), true)
     } else {
         // still need to set the project copy so that we can use it below
         transformByQState.setProjectCopyFilePath(path.join(destinationPath, 'sources'))

--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -743,7 +743,7 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
             }
             await sleep(CodeWhispererConstants.transformationJobPollingIntervalSeconds * 1000)
         } catch (e: any) {
-            getLogger().error(`CodeTransformation: GetTransformation error = %O`, e)
+            getLogger().error(`CodeTransformation: error = %O`, e)
             throw e
         }
     }

--- a/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformationResultsViewProvider.ts
@@ -166,6 +166,8 @@ export class DiffModel {
             throw new Error(CodeWhispererConstants.noChangesMadeMessage)
         }
 
+        getLogger().info(`CodeTransformation: parsing patch file at ${pathToDiff}`)
+
         let changedFiles = parsePatch(diffContents)
         // exclude dependency_upgrade.yml from patch application
         changedFiles = changedFiles.filter((file) => !file.oldFileName?.includes('dependency_upgrade'))


### PR DESCRIPTION
## Problem

Better to first open the diff.patch for user to see, then parse it and apply it, so that if it is malformed, it is first visible to user.

## Solution

Open diff.patch first.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
