### PR TITLE
build(amazonq): merge release candidate version rc-20250910

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "prettier": "^3.3.3",
                 "prettier-plugin-sh": "^0.14.0",
                 "pretty-quick": "^4.0.0",
-                "ts-node": "^10.9.1",
+                "ts-node": "^10.9.2",
                 "typescript": "^5.0.4",
                 "webpack": "^5.95.0",
                 "webpack-cli": "^5.1.4",
@@ -34989,7 +34989,7 @@
         },
         "packages/toolkit": {
             "name": "aws-toolkit-vscode",
-            "version": "3.74.0-SNAPSHOT",
+            "version": "3.74.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "aws-core-vscode": "file:../core/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "prettier": "^3.3.3",
                 "prettier-plugin-sh": "^0.14.0",
                 "pretty-quick": "^4.0.0",
-                "ts-node": "^10.9.2",
+                "ts-node": "^10.9.1",
                 "typescript": "^5.0.4",
                 "webpack": "^5.95.0",
                 "webpack-cli": "^5.1.4",
@@ -34989,7 +34989,7 @@
         },
         "packages/toolkit": {
             "name": "aws-toolkit-vscode",
-            "version": "3.74.0",
+            "version": "3.75.0-SNAPSHOT",
             "license": "Apache-2.0",
             "dependencies": {
                 "aws-core-vscode": "file:../core/"

--- a/packages/toolkit/.changes/3.74.0.json
+++ b/packages/toolkit/.changes/3.74.0.json
@@ -1,0 +1,18 @@
+{
+	"date": "2025-09-10",
+	"version": "3.74.0",
+	"entries": [
+		{
+			"type": "Feature",
+			"description": "Feature to support the access of SageMakerUnified Studio resources from the local VSCode IDE"
+		},
+		{
+			"type": "Feature",
+			"description": "AWS Toolkit now correctly uses the endpoint URL specified in the AWS config file for the selected profile"
+		},
+		{
+			"type": "Feature",
+			"description": "Lambda AppBuilder: Now you can install LocalStack VS Code extension from the AppBuilder walkthrough"
+		}
+	]
+}

--- a/packages/toolkit/.changes/next-release/Feature-11b05698-7406-4ccd-afd2-a22d3adbfa67.json
+++ b/packages/toolkit/.changes/next-release/Feature-11b05698-7406-4ccd-afd2-a22d3adbfa67.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "Feature to support the access of SageMakerUnified Studio resources from the local VSCode IDE"
-}

--- a/packages/toolkit/.changes/next-release/Feature-385a8d57-8874-4f90-a7e8-50f058f43c62.json
+++ b/packages/toolkit/.changes/next-release/Feature-385a8d57-8874-4f90-a7e8-50f058f43c62.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "AWS Toolkit now correctly uses the endpoint URL specified in the AWS config file for the selected profile"
-}

--- a/packages/toolkit/.changes/next-release/Feature-b799e933-2707-4cd8-9217-6cdd46ee2b4a.json
+++ b/packages/toolkit/.changes/next-release/Feature-b799e933-2707-4cd8-9217-6cdd46ee2b4a.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "Lambda AppBuilder: Now you can install LocalStack VS Code extension from the AppBuilder walkthrough"
-}

--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.74.0 2025-09-10
+
+- **Feature** Feature to support the access of SageMakerUnified Studio resources from the local VSCode IDE
+- **Feature** AWS Toolkit now correctly uses the endpoint URL specified in the AWS config file for the selected profile
+- **Feature** Lambda AppBuilder: Now you can install LocalStack VS Code extension from the AppBuilder walkthrough
+
 ## 3.73.0 2025-09-05
 
 - Miscellaneous non-user-facing changes

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -2,7 +2,7 @@
     "name": "aws-toolkit-vscode",
     "displayName": "AWS Toolkit",
     "description": "Including CodeCatalyst, Infrastructure Composer, and support for Lambda, S3, CloudWatch Logs, CloudFormation, and many other services.",
-    "version": "3.74.0-SNAPSHOT",
+    "version": "3.74.0",
     "extensionKind": [
         "workspace"
     ],

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -2,7 +2,7 @@
     "name": "aws-toolkit-vscode",
     "displayName": "AWS Toolkit",
     "description": "Including CodeCatalyst, Infrastructure Composer, and support for Lambda, S3, CloudWatch Logs, CloudFormation, and many other services.",
-    "version": "3.74.0",
+    "version": "3.75.0-SNAPSHOT",
     "extensionKind": [
         "workspace"
     ],


### PR DESCRIPTION
## Problem
This merges the released changes for rc-20250910 into main. MCM-134160906

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
