### PR TITLE
Add domain acccount id telemetry

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/explorer/activation.ts
+++ b/packages/core/src/sagemakerunifiedstudio/explorer/activation.ts
@@ -95,7 +95,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
                 if (!validateNode(node)) {
                     return
                 }
-                await telemetry.smus_startSpace.run(async (span) => {
+                await telemetry.smus_openRemoteConnection.run(async (span) => {
                     span.record({
                         smusSpaceKey: node.resource.DomainSpaceKey,
                         smusDomainRegion: node.resource.regionCode,

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -295,6 +295,16 @@
             "name": "smusConnectionType",
             "type": "string",
             "description": "SMUS connection type"
+        },
+        {
+            "name": "smusDomainAccountId",
+            "type": "string",
+            "description": "SMUS domain account id"
+        },
+        {
+            "name": "smusProjectAccountId",
+            "type": "string",
+            "description": "SMUS project account id"
         }
     ],
     "metrics": [
@@ -1359,6 +1369,10 @@
                 {
                     "type": "smusDomainId",
                     "required": false
+                },
+                {
+                    "type": "smusDomainAccountId",
+                    "required": false
                 }
             ]
         },
@@ -1368,6 +1382,10 @@
             "metadata": [
                 {
                     "type": "smusDomainId",
+                    "required": false
+                },
+                {
+                    "type": "smusDomainAccountId",
                     "required": false
                 }
             ]
@@ -1414,7 +1432,7 @@
             "passive": true
         },
         {
-            "name": "smus_startSpace",
+            "name": "smus_openRemoteConnection",
             "description": "Emitted whenever a user starts a SMUS space",
             "metadata": [
                 {


### PR DESCRIPTION
## Problem

- Add domain account id telemetry. This helps to monitor how many unique accounts are using SMUS feature.
- Also renamed `smus_startSpace` to `smus_openRemoteConnection` which more accurately represent what this metric track, opening ssh connection.

## Solution

- in core package run `npm run generateTelemetry`



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
