### PR TITLE
fix(amazonq): fix for path parsing for windows for editable diff view

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -651,7 +651,16 @@ export function registerMessageListeners(
     )
 
     languageClient.onNotification(openFileDiffNotificationType.method, async (params: OpenFileDiffParams) => {
-        const currentFileUri = vscode.Uri.parse(params.originalFileUri)
+        // Handle both file:// URIs and raw file paths, ensuring proper Windows path handling
+        let currentFileUri: vscode.Uri
+        try {
+            // Try parsing as URI first
+            currentFileUri = vscode.Uri.parse(params.originalFileUri, true)
+        } catch {
+            // If parsing fails, treat as file path and create URI
+            currentFileUri = vscode.Uri.file(params.originalFileUri)
+        }
+
         const originalContent = params.originalFileContent ?? ''
         const fileName = path.basename(currentFileUri.fsPath)
 


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/issues/8045
https://github.com/aws/aws-toolkit-vscode/issues/8040

## Solution
fix for path parsing for windows for editable diff view


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
