### PR TITLE
fix(amazonq): fix iam credential update logic to use custom comparator and added buffer time in cred validation

### DIFF
--- a/packages/amazonq/.changes/next-release/Bug Fix-da0e805d-faab-4274-b37a-943c7263e42b.json
+++ b/packages/amazonq/.changes/next-release/Bug Fix-da0e805d-faab-4274-b37a-943c7263e42b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q automatically refreshes expired IAM Credentials in Sagemaker instances"
+}

--- a/packages/amazonq/src/lsp/auth.ts
+++ b/packages/amazonq/src/lsp/auth.ts
@@ -109,8 +109,12 @@ export class AmazonQLspAuth {
     }
 
     private areCredentialsEqual(creds1: any, creds2: any): boolean {
-        if (!creds1 && !creds2) return true
-        if (!creds1 || !creds2) return false
+        if (!creds1 && !creds2) {
+            return true
+        }
+        if (!creds1 || !creds2) {
+            return false
+        }
 
         return (
             creds1.accessKeyId === creds2.accessKeyId &&

--- a/packages/amazonq/src/lsp/auth.ts
+++ b/packages/amazonq/src/lsp/auth.ts
@@ -109,11 +109,8 @@ export class AmazonQLspAuth {
     }
 
     private areCredentialsEqual(creds1: any, creds2: any): boolean {
-        if (!creds1 && !creds2) {
-            return true
-        }
         if (!creds1 || !creds2) {
-            return false
+            return creds1 === creds2
         }
 
         return (

--- a/packages/amazonq/src/lsp/auth.ts
+++ b/packages/amazonq/src/lsp/auth.ts
@@ -19,7 +19,7 @@ import { AuthUtil } from 'aws-core-vscode/codewhisperer'
 import { Writable } from 'stream'
 import { onceChanged, onceChangedWithComparator } from 'aws-core-vscode/utils'
 import { getLogger, oneMinute, isSageMaker } from 'aws-core-vscode/shared'
-import { isSsoConnection, isIamConnection } from 'aws-core-vscode/auth'
+import { isSsoConnection, isIamConnection, areCredentialsEqual } from 'aws-core-vscode/auth'
 
 export const encryptionKey = crypto.randomBytes(32)
 
@@ -108,21 +108,9 @@ export class AmazonQLspAuth {
         this.client.info(`UpdateBearerToken: ${JSON.stringify(request)}`)
     }
 
-    private areCredentialsEqual(creds1: any, creds2: any): boolean {
-        if (!creds1 || !creds2) {
-            return creds1 === creds2
-        }
-
-        return (
-            creds1.accessKeyId === creds2.accessKeyId &&
-            creds1.secretAccessKey === creds2.secretAccessKey &&
-            creds1.sessionToken === creds2.sessionToken
-        )
-    }
-
     public updateIamCredentials = onceChangedWithComparator(
         this._updateIamCredentials.bind(this),
-        ([prevCreds], [currentCreds]) => this.areCredentialsEqual(prevCreds, currentCreds)
+        ([prevCreds], [currentCreds]) => areCredentialsEqual(prevCreds, currentCreds)
     )
     private async _updateIamCredentials(credentials: any) {
         getLogger().info(

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -862,6 +862,7 @@ export class Auth implements AuthService, ConnectionManager {
 
     private async createCachedCredentials(provider: CredentialsProvider) {
         const providerId = provider.getCredentialsId()
+        getLogger().debug(`credentials: create cache credentials for ${provider.getProviderType()}`)
         globals.loginManager.store.invalidateCredentials(providerId)
         const { credentials, endpointUrl } = await globals.loginManager.store.upsertCredentials(providerId, provider)
         await globals.loginManager.validateCredentials(credentials, endpointUrl, provider.getDefaultRegion())
@@ -874,6 +875,7 @@ export class Auth implements AuthService, ConnectionManager {
         if (creds !== undefined && creds.credentialsHashCode === provider.getHashCode()) {
             return creds.credentials
         }
+        return undefined
     }
 
     private readonly getToken = keyedDebounce(this._getToken.bind(this))

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -875,7 +875,6 @@ export class Auth implements AuthService, ConnectionManager {
         if (creds !== undefined && creds.credentialsHashCode === provider.getHashCode()) {
             return creds.credentials
         }
-        return undefined
     }
 
     private readonly getToken = keyedDebounce(this._getToken.bind(this))

--- a/packages/core/src/auth/connection.ts
+++ b/packages/core/src/auth/connection.ts
@@ -71,6 +71,18 @@ export const isBuilderIdConnection = (conn?: Connection): conn is SsoConnection 
 export const isValidCodeCatalystConnection = (conn?: Connection): conn is SsoConnection =>
     isSsoConnection(conn) && hasScopes(conn, scopesCodeCatalyst)
 
+export const areCredentialsEqual = (creds1: any, creds2: any): boolean => {
+    if (!creds1 || !creds2) {
+        return creds1 === creds2
+    }
+
+    return (
+        creds1.accessKeyId === creds2.accessKeyId &&
+        creds1.secretAccessKey === creds2.secretAccessKey &&
+        creds1.sessionToken === creds2.sessionToken
+    )
+}
+
 export function hasScopes(target: SsoConnection | SsoProfile | string[], scopes: string[]): boolean {
     return scopes?.every((s) => (Array.isArray(target) ? target : target.scopes)?.includes(s))
 }

--- a/packages/core/src/auth/credentials/store.ts
+++ b/packages/core/src/auth/credentials/store.ts
@@ -8,7 +8,6 @@ import globals from '../../shared/extensionGlobals'
 import { getLogger } from '../../shared/logger/logger'
 import { asString, CredentialsProvider, CredentialsId } from '../providers/credentials'
 import { CredentialsProviderManager } from '../providers/credentialsProviderManager'
-// import { get } from 'lodash'
 
 export interface CachedCredentials {
     credentials: AWS.Credentials

--- a/packages/core/src/auth/credentials/store.ts
+++ b/packages/core/src/auth/credentials/store.ts
@@ -38,8 +38,7 @@ export class CredentialsStore {
             const expiration = this.credentialsCache[key].credentials.expiration
             const now = new globals.clock.Date()
             const bufferedNow = new globals.clock.Date(now.getTime() + expirationBufferMs)
-            const isValid = expiration !== undefined ? expiration >= bufferedNow : true
-            return isValid
+            return expiration !== undefined ? expiration >= bufferedNow : true
         }
         getLogger().debug(`credentials: no credentials found for ${key}`)
         return false

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -19,6 +19,7 @@ export {
     getTelemetryMetadataForConn,
     isIamConnection,
     isSsoConnection,
+    areCredentialsEqual,
 } from './connection'
 export { Auth } from './auth'
 export { CredentialsStore } from './credentials/store'

--- a/packages/core/src/shared/utilities/functionUtils.ts
+++ b/packages/core/src/shared/utilities/functionUtils.ts
@@ -64,6 +64,32 @@ export function onceChanged<T, U extends any[]>(fn: (...args: U) => T): (...args
 }
 
 /**
+ * Creates a function that runs only if the args changed versus the previous invocation,
+ * using a custom comparator function for argument comparison.
+ *
+ * @param fn The function to wrap
+ * @param comparator Function that returns true if arguments are equal
+ */
+export function onceChangedWithComparator<T, U extends any[]>(
+    fn: (...args: U) => T,
+    comparator: (prev: U, current: U) => boolean
+): (...args: U) => T {
+    let val: T
+    let ran = false
+    let prevArgs: U
+
+    return (...args) => {
+        if (ran && comparator(prevArgs, args)) {
+            return val
+        }
+        val = fn(...args)
+        ran = true
+        prevArgs = args
+        return val
+    }
+}
+
+/**
  * Creates a new function that stores the result of a call.
  *
  * @note This uses an extremely simple mechanism for creating keys from parameters.

--- a/packages/core/src/test/shared/utilities/functionUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/functionUtils.test.ts
@@ -58,8 +58,12 @@ describe('functionUtils', function () {
     it('onceChangedWithComparator()', function () {
         let counter = 0
         const credentialsEqual = ([prev]: [any], [current]: [any]) => {
-            if (!prev && !current) return true
-            if (!prev || !current) return false
+            if (!prev && !current) {
+                return true
+            }
+            if (!prev || !current) {
+                return false
+            }
             return prev.accessKeyId === current.accessKeyId && prev.secretAccessKey === current.secretAccessKey
         }
         const fn = onceChangedWithComparator((creds: any) => void counter++, credentialsEqual)


### PR DESCRIPTION
## Problem
- IAM credentials is not updating in Sagemaker instances due to incorrect comparison logic which prevents credential refresh and hence users cant interact with Q chat after the initial expiration time
- 
<img width="2513" height="1284" alt="image" src="https://github.com/user-attachments/assets/0dc8d158-00ef-4c86-aff8-7e147a101881" />


## Solution
- Add custom comparator logic and method to properly compare credentials by their actual values (accessKeyId,
secretAccessKey, sessionToken) instead of string comparison
- Added 60-second expiration buffer to credential validation. similar to SSO token logic [here](https://github.com/aws/aws-toolkit-vscode/blob/c3685274fc4e09e72c98db4c43b7959634bc63b0/packages/core/src/auth/sso/model.ts#L158) for grace-time
- Tested by building a debug artefact on a SMUS CodeEditor instance and verified q chat is triggering refresh credentials
- ```npm run package && npm run test``` succeeded
- https://drive.corp.amazon.com/documents/parameja@/PR-8070/IAM-Credentials-Refresh-Q-Chat.mov
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
