### PR TITLE
telemetry: add project account id and region

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/auth/providers/smusAuthenticationProvider.ts
+++ b/packages/core/src/sagemakerunifiedstudio/auth/providers/smusAuthenticationProvider.ts
@@ -14,7 +14,7 @@ import * as localizedText from '../../../shared/localizedText'
 import { ToolkitPromptSettings } from '../../../shared/settings'
 import { setContext, getContext } from '../../../shared/vscode/setContext'
 import { getLogger } from '../../../shared/logger/logger'
-import { SmusUtils, SmusErrorCodes, extractAccountIdFromArn } from '../../shared/smusUtils'
+import { SmusUtils, SmusErrorCodes, extractAccountIdFromResourceMetadata } from '../../shared/smusUtils'
 import { createSmusProfile, isValidSmusConnection, SmusConnection } from '../model'
 import { DomainExecRoleCredentialsProvider } from './domainExecRoleCredentialsProvider'
 import { ProjectRoleCredentialsProvider } from './projectRoleCredentialsProvider'
@@ -24,6 +24,7 @@ import { getResourceMetadata } from '../../shared/utils/resourceMetadataUtils'
 import { fromIni } from '@aws-sdk/credential-providers'
 import { randomUUID } from '../../../shared/crypto'
 import { DefaultStsClient } from '../../../shared/clients/stsClient'
+import { DataZoneClient } from '../../shared/client/datazoneClient'
 
 /**
  * Sets the context variable for SageMaker Unified Studio connection state
@@ -55,6 +56,7 @@ export class SmusAuthenticationProvider {
     private projectCredentialProvidersCache = new Map<string, ProjectRoleCredentialsProvider>()
     private connectionCredentialProvidersCache = new Map<string, ConnectionCredentialsProvider>()
     private cachedDomainAccountId: string | undefined
+    private cachedProjectAccountIds = new Map<string, string>()
 
     public constructor(
         public readonly auth = Auth.instance,
@@ -79,6 +81,8 @@ export class SmusAuthenticationProvider {
             this.connectionCredentialProvidersCache.clear()
             // Clear cached domain account ID when connection changes
             this.cachedDomainAccountId = undefined
+            // Clear cached project account IDs when connection changes
+            this.cachedProjectAccountIds.clear()
             // Clear all clients in client store when connection changes
             ConnectionClientStore.getInstance().clearAll()
             await setSmusConnectedContext(this.isConnected())
@@ -445,37 +449,13 @@ export class SmusAuthenticationProvider {
 
         // If in SMUS space environment, extract account ID from resource-metadata file
         if (getContext('aws.smus.inSmusSpaceEnvironment')) {
-            try {
-                logger.debug('SMUS: Extracting domain account ID from ResourceArn in resource-metadata file')
+            const accountId = await extractAccountIdFromResourceMetadata()
 
-                const resourceMetadata = getResourceMetadata()!
-                const resourceArn = resourceMetadata.ResourceArn
+            // Cache the account ID
+            this.cachedDomainAccountId = accountId
+            logger.debug(`Successfully cached domain account ID: ${accountId}`)
 
-                if (!resourceArn) {
-                    throw new ToolkitError('ResourceArn not found in metadata file', {
-                        code: SmusErrorCodes.AccountIdNotFound,
-                    })
-                }
-
-                // Extract account ID from ResourceArn using SmusUtils
-                const accountId = extractAccountIdFromArn(resourceArn)
-
-                // Cache the account ID
-                this.cachedDomainAccountId = accountId
-
-                logger.debug(
-                    `Successfully extracted and cached domain account ID from resource-metadata file: ${accountId}`
-                )
-
-                return accountId
-            } catch (err) {
-                logger.error(`Failed to extract domain account ID from ResourceArn: %s`, err)
-
-                throw new ToolkitError('Failed to extract AWS account ID from ResourceArn in SMUS space environment', {
-                    code: SmusErrorCodes.GetDomainAccountIdFailed,
-                    cause: err instanceof Error ? err : undefined,
-                })
-            }
+            return accountId
         }
 
         if (!this.activeConnection) {
@@ -516,6 +496,81 @@ export class SmusAuthenticationProvider {
             throw new ToolkitError('Failed to retrieve AWS account ID for active domain connection', {
                 code: SmusErrorCodes.GetDomainAccountIdFailed,
                 cause: err instanceof Error ? err : undefined,
+            })
+        }
+    }
+
+    /**
+     * Gets the AWS account ID for a specific project using project credentials
+     * In SMUS space environment, extracts from ResourceArn in metadata (same as domain account)
+     * Otherwise, makes an STS GetCallerIdentity call using project credentials
+     * @param projectId The DataZone project ID
+     * @returns Promise resolving to the project's AWS account ID
+     */
+    public async getProjectAccountId(projectId: string): Promise<string> {
+        const logger = getLogger()
+
+        // Return cached value if available
+        if (this.cachedProjectAccountIds.has(projectId)) {
+            logger.debug(`SMUS: Using cached project account ID for project ${projectId}`)
+            return this.cachedProjectAccountIds.get(projectId)!
+        }
+
+        // If in SMUS space environment, extract account ID from resource-metadata file
+        if (getContext('aws.smus.inSmusSpaceEnvironment')) {
+            const accountId = await extractAccountIdFromResourceMetadata()
+
+            // Cache the account ID
+            this.cachedProjectAccountIds.set(projectId, accountId)
+            logger.debug(`Successfully cached project account ID for project ${projectId}: ${accountId}`)
+
+            return accountId
+        }
+
+        if (!this.activeConnection) {
+            throw new ToolkitError('No active SMUS connection available', { code: SmusErrorCodes.NoActiveConnection })
+        }
+
+        // For non-SMUS space environments, use project credentials with STS
+        try {
+            logger.debug('Fetching project account ID via STS GetCallerIdentity with project credentials')
+
+            // Get project credentials
+            const projectCredProvider = await this.getProjectCredentialProvider(projectId)
+            const projectCreds = await projectCredProvider.getCredentials()
+
+            // Get project region from tooling environment
+            const dzClient = await DataZoneClient.getInstance(this)
+            const toolingEnv = await dzClient.getToolingEnvironment(projectId)
+            const projectRegion = toolingEnv.awsAccountRegion
+
+            if (!projectRegion) {
+                throw new ToolkitError('No AWS account region found in tooling environment', {
+                    code: SmusErrorCodes.RegionNotFound,
+                })
+            }
+
+            // Use STS to get account ID from project credentials
+            const stsClient = new DefaultStsClient(projectRegion, projectCreds)
+            const callerIdentity = await stsClient.getCallerIdentity()
+
+            if (!callerIdentity.Account) {
+                throw new ToolkitError('Account ID not found in STS GetCallerIdentity response', {
+                    code: SmusErrorCodes.AccountIdNotFound,
+                })
+            }
+
+            // Cache the account ID
+            this.cachedProjectAccountIds.set(projectId, callerIdentity.Account)
+            logger.debug(
+                `Successfully retrieved and cached project account ID for project ${projectId}: ${callerIdentity.Account}`
+            )
+
+            return callerIdentity.Account
+        } catch (err) {
+            logger.error('Failed to get project account ID: %s', err as Error)
+            throw new ToolkitError(`Failed to get project account ID: ${(err as Error).message}`, {
+                code: SmusErrorCodes.GetProjectAccountIdFailed,
             })
         }
     }
@@ -617,6 +672,10 @@ export class SmusAuthenticationProvider {
         // Clear cached domain account ID
         this.cachedDomainAccountId = undefined
         logger.debug('SMUS: Cleared cached domain account ID')
+
+        // Clear cached project account IDs
+        this.cachedProjectAccountIds.clear()
+        logger.debug('SMUS: Cleared cached project account IDs')
     }
 
     /**
@@ -664,6 +723,9 @@ export class SmusAuthenticationProvider {
 
         // Clear cached domain account ID
         this.cachedDomainAccountId = undefined
+
+        // Clear cached project account IDs
+        this.cachedProjectAccountIds.clear()
 
         this.logger.debug('SMUS Auth: Successfully disposed authentication provider')
     }

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1462,6 +1462,14 @@
                 {
                     "type": "smusDomainRegion",
                     "required": false
+                },
+                {
+                    "type": "smusProjectRegion",
+                    "required": false
+                },
+                {
+                    "type": "smusProjectAccountId",
+                    "required": false
                 }
             ]
         },
@@ -1488,6 +1496,14 @@
                 {
                     "type": "smusDomainRegion",
                     "required": false
+                },
+                {
+                    "type": "smusProjectRegion",
+                    "required": false
+                },
+                {
+                    "type": "smusProjectAccountId",
+                    "required": false
                 }
             ]
         },
@@ -1513,6 +1529,10 @@
                 },
                 {
                     "type": "smusProjectRegion",
+                    "required": false
+                },
+                {
+                    "type": "smusProjectAccountId",
                     "required": false
                 },
                 {
@@ -1550,6 +1570,10 @@
                     "required": false
                 },
                 {
+                    "type": "smusProjectAccountId",
+                    "required": false
+                },
+                {
                     "type": "smusConnectionId",
                     "required": false
                 },
@@ -1581,6 +1605,10 @@
                 },
                 {
                     "type": "smusProjectRegion",
+                    "required": false
+                },
+                {
+                    "type": "smusProjectAccountId",
                     "required": false
                 },
                 {

--- a/packages/core/src/test/sagemakerunifiedstudio/auth/smusAuthenticationProvider.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/auth/smusAuthenticationProvider.test.ts
@@ -418,7 +418,6 @@ describe('SmusAuthenticationProvider', function () {
     describe('getDomainAccountId', function () {
         let getContextStub: sinon.SinonStub
         let getResourceMetadataStub: sinon.SinonStub
-        let extractAccountIdFromArnStub: sinon.SinonStub
         let getDerCredentialsProviderStub: sinon.SinonStub
         let getDomainRegionStub: sinon.SinonStub
         let mockStsClient: any
@@ -428,7 +427,6 @@ describe('SmusAuthenticationProvider', function () {
             // Mock dependencies
             getContextStub = sinon.stub(vscodeSetContext, 'getContext')
             getResourceMetadataStub = sinon.stub(resourceMetadataUtils, 'getResourceMetadata')
-            extractAccountIdFromArnStub = sinon.stub(smusUtils, 'extractAccountIdFromArn')
 
             // Mock STS client
             mockStsClient = {
@@ -476,41 +474,32 @@ describe('SmusAuthenticationProvider', function () {
         })
 
         describe('in SMUS space environment', function () {
+            let extractAccountIdFromResourceMetadataStub: sinon.SinonStub
+
             beforeEach(function () {
                 getContextStub.withArgs('aws.smus.inSmusSpaceEnvironment').returns(true)
+                extractAccountIdFromResourceMetadataStub = sinon
+                    .stub(smusUtils, 'extractAccountIdFromResourceMetadata')
+                    .resolves('123456789012')
             })
 
-            it('should extract account ID from ResourceArn and cache it', async function () {
+            it('should extract account from resource metadata and cache result', async function () {
                 const testAccountId = '123456789012'
-                const testResourceArn = `arn:aws:sagemaker:us-east-1:${testAccountId}:domain/test-domain`
-
-                getResourceMetadataStub.returns({
-                    ResourceArn: testResourceArn,
-                })
-                extractAccountIdFromArnStub.returns(testAccountId)
 
                 const result = await smusAuthProvider.getDomainAccountId()
 
                 assert.strictEqual(result, testAccountId)
                 assert.strictEqual(smusAuthProvider['cachedDomainAccountId'], testAccountId)
-                assert.ok(getResourceMetadataStub.called)
-                assert.ok(extractAccountIdFromArnStub.calledWith(testResourceArn))
+                assert.ok(extractAccountIdFromResourceMetadataStub.called)
                 assert.ok(mockStsClient.getCallerIdentity.notCalled)
             })
 
-            it('should throw error when ResourceArn is missing from metadata', async function () {
-                getResourceMetadataStub.returns({})
+            it('should throw error when extractAccountIdFromResourceMetadata fails', async function () {
+                extractAccountIdFromResourceMetadataStub.rejects(new ToolkitError('Metadata extraction failed'))
 
                 await assert.rejects(
                     () => smusAuthProvider.getDomainAccountId(),
-                    (err: ToolkitError) => {
-                        return (
-                            err.code === 'GetDomainAccountIdFailed' &&
-                            err.message.includes(
-                                'Failed to extract AWS account ID from ResourceArn in SMUS space environment'
-                            )
-                        )
-                    }
+                    (err: ToolkitError) => err.message.includes('Metadata extraction failed')
                 )
 
                 assert.strictEqual(smusAuthProvider['cachedDomainAccountId'], undefined)
@@ -573,6 +562,198 @@ describe('SmusAuthenticationProvider', function () {
                 )
 
                 assert.strictEqual(smusAuthProvider['cachedDomainAccountId'], undefined)
+            })
+        })
+    })
+
+    describe('getProjectAccountId', function () {
+        let getContextStub: sinon.SinonStub
+        let extractAccountIdFromResourceMetadataStub: sinon.SinonStub
+        let getProjectCredentialProviderStub: sinon.SinonStub
+        let mockProjectCredentialsProvider: any
+        let mockStsClient: any
+        let mockDataZoneClientForProject: any
+
+        const testProjectId = 'test-project-id'
+        const testAccountId = '123456789012'
+        const testRegion = 'us-east-1'
+
+        beforeEach(function () {
+            // Mock dependencies
+            getContextStub = sinon.stub(vscodeSetContext, 'getContext')
+            extractAccountIdFromResourceMetadataStub = sinon
+                .stub(smusUtils, 'extractAccountIdFromResourceMetadata')
+                .resolves(testAccountId)
+
+            // Mock project credentials provider
+            mockProjectCredentialsProvider = {
+                getCredentials: sinon.stub().resolves({
+                    accessKeyId: 'test-key',
+                    secretAccessKey: 'test-secret',
+                    sessionToken: 'test-token',
+                }),
+            }
+            getProjectCredentialProviderStub = sinon
+                .stub(smusAuthProvider, 'getProjectCredentialProvider')
+                .resolves(mockProjectCredentialsProvider)
+
+            // Update the existing mockDataZoneClient to include getToolingEnvironment
+            mockDataZoneClientForProject = {
+                getToolingEnvironment: sinon.stub().resolves({
+                    awsAccountRegion: testRegion,
+                    projectId: testProjectId,
+                    domainId: testDomainId,
+                    createdBy: 'test-user',
+                    name: 'test-environment',
+                    id: 'test-env-id',
+                    status: 'ACTIVE',
+                }),
+            }
+            // Update the existing mockDataZoneClient instead of creating a new stub
+            Object.assign(mockDataZoneClient, mockDataZoneClientForProject)
+
+            // Mock STS client
+            mockStsClient = {
+                getCallerIdentity: sinon.stub().resolves({
+                    Account: testAccountId,
+                    UserId: 'test-user-id',
+                    Arn: 'arn:aws:sts::123456789012:assumed-role/test-role/test-session',
+                }),
+            }
+
+            // Clear cache
+            smusAuthProvider['cachedProjectAccountIds'].clear()
+            mockSecondaryAuthState.activeConnection = mockSmusConnection
+        })
+
+        afterEach(function () {
+            sinon.restore()
+        })
+
+        describe('when cached value exists', function () {
+            it('should return cached project account ID without making any calls', async function () {
+                smusAuthProvider['cachedProjectAccountIds'].set(testProjectId, testAccountId)
+
+                const result = await smusAuthProvider.getProjectAccountId(testProjectId)
+
+                assert.strictEqual(result, testAccountId)
+                assert.ok(getContextStub.notCalled)
+                assert.ok(extractAccountIdFromResourceMetadataStub.notCalled)
+                assert.ok(getProjectCredentialProviderStub.notCalled)
+                assert.ok(mockStsClient.getCallerIdentity.notCalled)
+            })
+        })
+
+        describe('in SMUS space environment', function () {
+            beforeEach(function () {
+                getContextStub.withArgs('aws.smus.inSmusSpaceEnvironment').returns(true)
+            })
+
+            it('should extract account ID from resource metadata and cache it', async function () {
+                const result = await smusAuthProvider.getProjectAccountId(testProjectId)
+
+                assert.strictEqual(result, testAccountId)
+                assert.strictEqual(smusAuthProvider['cachedProjectAccountIds'].get(testProjectId), testAccountId)
+                assert.ok(extractAccountIdFromResourceMetadataStub.called)
+                assert.ok(getProjectCredentialProviderStub.notCalled)
+                assert.ok(mockStsClient.getCallerIdentity.notCalled)
+            })
+
+            it('should throw error when extractAccountIdFromResourceMetadata fails', async function () {
+                extractAccountIdFromResourceMetadataStub.rejects(new ToolkitError('Metadata extraction failed'))
+
+                await assert.rejects(
+                    () => smusAuthProvider.getProjectAccountId(testProjectId),
+                    (err: ToolkitError) => err.message.includes('Metadata extraction failed')
+                )
+
+                assert.ok(!smusAuthProvider['cachedProjectAccountIds'].has(testProjectId))
+            })
+        })
+
+        describe('in non-SMUS space environment', function () {
+            let stsConstructorStub: sinon.SinonStub
+
+            beforeEach(function () {
+                getContextStub.withArgs('aws.smus.inSmusSpaceEnvironment').returns(false)
+                // Stub the DefaultStsClient constructor to return our mock instance
+                const stsClientModule = require('../../../shared/clients/stsClient')
+                stsConstructorStub = sinon.stub(stsClientModule, 'DefaultStsClient').callsFake(() => mockStsClient)
+            })
+
+            afterEach(function () {
+                if (stsConstructorStub) {
+                    stsConstructorStub.restore()
+                }
+            })
+
+            it('should use project credentials with STS to get account ID and cache it', async function () {
+                const result = await smusAuthProvider.getProjectAccountId(testProjectId)
+
+                assert.strictEqual(result, testAccountId)
+                assert.strictEqual(smusAuthProvider['cachedProjectAccountIds'].get(testProjectId), testAccountId)
+                assert.ok(getProjectCredentialProviderStub.calledWith(testProjectId))
+                assert.ok(mockProjectCredentialsProvider.getCredentials.called)
+                assert.ok((DataZoneClient.getInstance as sinon.SinonStub).called)
+                assert.ok(mockDataZoneClientForProject.getToolingEnvironment.calledWith(testProjectId))
+                assert.ok(mockStsClient.getCallerIdentity.called)
+            })
+
+            it('should throw error when no active connection exists', async function () {
+                mockSecondaryAuthState.activeConnection = undefined
+
+                await assert.rejects(
+                    () => smusAuthProvider.getProjectAccountId(testProjectId),
+                    (err: ToolkitError) => {
+                        return (
+                            err.code === 'NoActiveConnection' &&
+                            err.message.includes('No active SMUS connection available')
+                        )
+                    }
+                )
+
+                assert.ok(!smusAuthProvider['cachedProjectAccountIds'].has(testProjectId))
+            })
+
+            it('should throw error when tooling environment has no region', async function () {
+                mockDataZoneClientForProject.getToolingEnvironment.resolves({
+                    id: 'env-123',
+                    awsAccountRegion: undefined,
+                    projectId: undefined,
+                    domainId: undefined,
+                    createdBy: undefined,
+                    name: undefined,
+                    provider: undefined,
+                    $metadata: {},
+                })
+
+                await assert.rejects(
+                    () => smusAuthProvider.getProjectAccountId(testProjectId),
+                    (err: ToolkitError) => {
+                        return (
+                            err.message.includes('Failed to get project account ID') &&
+                            err.message.includes('No AWS account region found in tooling environment')
+                        )
+                    }
+                )
+
+                assert.ok(!smusAuthProvider['cachedProjectAccountIds'].has(testProjectId))
+            })
+
+            it('should throw error when STS GetCallerIdentity fails', async function () {
+                mockStsClient.getCallerIdentity.rejects(new Error('STS call failed'))
+
+                await assert.rejects(
+                    () => smusAuthProvider.getProjectAccountId(testProjectId),
+                    (err: ToolkitError) => {
+                        return (
+                            err.message.includes('Failed to get project account ID') &&
+                            err.message.includes('STS call failed')
+                        )
+                    }
+                )
+
+                assert.ok(!smusAuthProvider['cachedProjectAccountIds'].has(testProjectId))
             })
         })
     })


### PR DESCRIPTION
## Problem
The project account id and region was missing from data connection and space action telemetry.

## Solution
The project account id and region are added to data connection and space action telemetry.

Telemetry for a cross-account example:
```
2025-09-23 15:42:29.674 [debug] telemetry: smus_login {
  Metadata: {
    metricId: 'fdbf85ac-a093-4ab9-ac47-add57a5901cc',
    traceId: '7ee3db34-3f9b-41b7-aa16-824290fa0719',
    parentId: '5c66c1e2-09ba-4308-8e28-a47bfc4acdda',
    smusDomainId: 'dzd_64o7tjjv1cm9gp',
    awsRegion: 'us-east-2',
    smusDomainAccountId: '730335272067',
    duration: '24121',
    result: 'Succeeded',
    awsAccount: 'not-set'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}

2025-09-23 15:42:32.466 [debug] telemetry: smus_accessProject {
  Metadata: {
    metricId: 'cc75867d-cb7c-4392-b7d7-cda1f7ba627c',
    traceId: '7ee3db34-3f9b-41b7-aa16-824290fa0719',
    parentId: 'da7fad30-0aee-4f31-8962-00ef50b408b8',
    smusDomainId: 'dzd_64o7tjjv1cm9gp',
    smusProjectId: 'cxtwtxb6e3ly95',
    smusDomainRegion: 'us-east-2',
    smusDomainAccountId: '730335272067',
    duration: '3994',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}

2025-09-23 15:42:43.475 [debug] telemetry: smus_renderLakehouseNode {
  Metadata: {
    metricId: 'dc09a62e-9f18-45c5-bd8b-c113c6a8c5c9',
    traceId: '58ea5647-a29a-45dc-9e6c-fb4175a34a6d',
    smusToolkitEnv: 'local',
    smusDomainId: 'dzd_64o7tjjv1cm9gp',
    smusDomainAccountId: '730335272067',
    smusProjectId: 'cxtwtxb6e3ly95',
    smusConnectionId: '4r6iscfi0rih0p',
    smusConnectionType: 'LAKEHOUSE',
    smusProjectRegion: 'us-east-1',
    smusProjectAccountId: '976193268201',
    duration: '965',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}


2025-09-23 15:42:46.623 [debug] telemetry: smus_renderS3Node {
  Metadata: {
    metricId: 'be029b31-6111-48f1-8e66-99121dd48484',
    traceId: 'a3698692-e948-4ec4-881a-17a0443e109d',
    smusToolkitEnv: 'local',
    smusDomainId: 'dzd_64o7tjjv1cm9gp',
    smusDomainAccountId: '730335272067',
    smusProjectId: 'cxtwtxb6e3ly95',
    smusConnectionId: '6gy7b7go2jd50p',
    smusConnectionType: 'S3',
    smusProjectRegion: 'us-east-1',
    smusProjectAccountId: '976193268201',
    duration: '1',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}

2025-09-23 15:43:04.774 [debug] telemetry: smus_openRemoteConnection {
  Metadata: {
    metricId: '7f2c4573-b681-4e81-bc34-84509aac1f46',
    traceId: 'fc5d6674-7042-4634-b7aa-1098aee2b540',
    smusSpaceKey: 'd-uyehbqjlnjl0__ce',
    smusDomainRegion: 'us-east-1',
    smusDomainId: 'dzd_64o7tjjv1cm9gp',
    smusDomainAccountId: '730335272067',
    smusProjectId: 'cxtwtxb6e3ly95',
    smusProjectAccountId: '976193268201',
    smusProjectRegion: 'us-east-1',
    duration: '6969',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}
```
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
