### PR TITLE
refactor(iot): migrate to aws-sdk v3 part 2

### DIFF
--- a/packages/core/src/awsService/iot/commands/attachPolicy.ts
+++ b/packages/core/src/awsService/iot/commands/attachPolicy.ts
@@ -12,7 +12,7 @@ import { PromptResult } from '../../../shared/ui/prompter'
 import { IotClient } from '../../../shared/clients/iotClient'
 import { isValidResponse } from '../../../shared/wizards/wizard'
 import { IotCertWithPoliciesNode, IotThingCertNode } from '../explorer/iotCertificateNode'
-import { Iot } from 'aws-sdk'
+import { ListPoliciesResponse, Policy } from '@aws-sdk/client-iot'
 import { IotNode } from '../explorer/iotNodes'
 
 export type PolicyGen = typeof getPolicyList
@@ -69,8 +69,8 @@ function getBaseNode(node: IotThingCertNode | IotCertWithPoliciesNode): IotNode 
 /**
  * Prompts the user to pick a policy to attach.
  */
-async function promptForPolicy(iot: IotClient, policyFetch: PolicyGen): Promise<PromptResult<Iot.Policy>> {
-    const placeHolder: DataQuickPickItem<Iot.Policy> = {
+async function promptForPolicy(iot: IotClient, policyFetch: PolicyGen): Promise<PromptResult<Policy>> {
+    const placeHolder: DataQuickPickItem<Policy> = {
         label: 'No policies found',
         data: undefined,
     }
@@ -87,10 +87,10 @@ async function promptForPolicy(iot: IotClient, policyFetch: PolicyGen): Promise<
  */
 async function* getPolicyList(iot: IotClient) {
     let marker: string | undefined = undefined
-    let filteredPolicies: Iot.Policy[]
+    let filteredPolicies: Policy[]
     do {
         try {
-            const policyResponse: Iot.ListPoliciesResponse = await iot.listPolicies({ marker })
+            const policyResponse: ListPoliciesResponse = await iot.listPolicies({ marker })
             marker = policyResponse.nextMarker
 
             /* The policy name and arn should always be defined when using the

--- a/packages/core/src/awsService/iot/commands/createCert.ts
+++ b/packages/core/src/awsService/iot/commands/createCert.ts
@@ -10,7 +10,7 @@ import { localize } from '../../../shared/utilities/vsCodeUtils'
 import { showViewLogsMessage } from '../../../shared/utilities/messages'
 import { IotCertsFolderNode } from '../explorer/iotCertFolderNode'
 import { fileExists } from '../../../shared/filesystemUtilities'
-import { Iot } from 'aws-sdk'
+import { CreateKeysAndCertificateResponse } from '@aws-sdk/client-iot'
 import { fs } from '../../../shared/fs/fs'
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -34,7 +34,7 @@ export async function createCertificateCommand(
         return
     }
 
-    let certificate: Iot.CreateKeysAndCertificateResponse
+    let certificate: CreateKeysAndCertificateResponse
 
     try {
         certificate = await node.iot.createCertificateAndKeys({

--- a/packages/core/src/awsService/iot/explorer/iotPolicyNode.ts
+++ b/packages/core/src/awsService/iot/explorer/iotPolicyNode.ts
@@ -4,7 +4,6 @@
  */
 
 import * as vscode from 'vscode'
-import { Iot } from 'aws-sdk'
 import { IotClient, IotPolicy } from '../../../shared/clients/iotClient'
 
 import { AWSResourceNode } from '../../../shared/treeview/nodes/awsResourceNode'
@@ -20,6 +19,7 @@ import { localize } from '../../../shared/utilities/vsCodeUtils'
 import { getIcon } from '../../../shared/icons'
 import { Settings } from '../../../shared/settings'
 import { ClassToInterfaceType } from '../../../shared/utilities/tsUtils'
+import { PolicyVersion } from '@aws-sdk/client-iot'
 
 /**
  * Represents an IoT Policy that may have either a Certificate Node or the
@@ -101,7 +101,7 @@ export class IotPolicyWithVersionsNode extends IotPolicyNode {
     }
 
     public async updateChildren(): Promise<void> {
-        const versions: Map<string, Iot.PolicyVersion> = toMap(
+        const versions: Map<string, PolicyVersion> = toMap(
             await toArrayAsync(this.iot.listPolicyVersions({ policyName: this.policy.name })),
             (version) => version.versionId
         )

--- a/packages/core/src/awsService/iot/explorer/iotPolicyVersionNode.ts
+++ b/packages/core/src/awsService/iot/explorer/iotPolicyVersionNode.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Iot } from 'aws-sdk'
+import { PolicyVersion } from '@aws-sdk/client-iot'
 import { IotClient, IotPolicy } from '../../../shared/clients/iotClient'
 import { AWSResourceNode } from '../../../shared/treeview/nodes/awsResourceNode'
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
@@ -19,7 +19,7 @@ import { formatLocalized } from '../../../shared/datetime'
 export class IotPolicyVersionNode extends AWSTreeNodeBase implements AWSResourceNode {
     public constructor(
         public policy: IotPolicy,
-        public version: Iot.PolicyVersion,
+        public version: PolicyVersion,
         public isDefault: boolean,
         public readonly parent: IotPolicyWithVersionsNode,
         public readonly iot: IotClient
@@ -35,7 +35,7 @@ export class IotPolicyVersionNode extends AWSTreeNodeBase implements AWSResource
         this.update(version)
     }
 
-    public update(version: Iot.PolicyVersion): void {
+    public update(version: PolicyVersion): void {
         this.version = version
         this.isDefault = version.isDefaultVersion ?? false
         this.tooltip = localize(

--- a/packages/core/src/test/awsService/iot/commands/createCert.test.ts
+++ b/packages/core/src/test/awsService/iot/commands/createCert.test.ts
@@ -9,7 +9,7 @@ import { createCertificateCommand } from '../../../../awsService/iot/commands/cr
 import { IotNode } from '../../../../awsService/iot/explorer/iotNodes'
 import { IotClient } from '../../../../shared/clients/iotClient'
 import { IotCertsFolderNode } from '../../../../awsService/iot/explorer/iotCertFolderNode'
-import { Iot } from 'aws-sdk'
+import { CreateKeysAndCertificateResponse } from '@aws-sdk/client-iot'
 import { getTestWindow } from '../../../shared/vscode/window'
 import assert from 'assert'
 
@@ -21,7 +21,7 @@ describe('createCertificateCommand', function () {
     const certificateArn = 'arn'
     const certificatePem = 'certPem'
     const keyPair = { PrivateKey: 'private', PublicKey: 'public' }
-    const certificate: Iot.CreateKeysAndCertificateResponse = { certificateId, certificateArn, certificatePem, keyPair }
+    const certificate: CreateKeysAndCertificateResponse = { certificateId, certificateArn, certificatePem, keyPair }
     let iot: IotClient
     let node: IotCertsFolderNode
     let saveLocation: vscode.Uri | undefined = vscode.Uri.file('/certificate.txt')

--- a/packages/core/src/test/awsService/iot/commands/deletePolicy.test.ts
+++ b/packages/core/src/test/awsService/iot/commands/deletePolicy.test.ts
@@ -5,7 +5,7 @@
 
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
-import { Iot } from 'aws-sdk'
+import { PolicyVersion } from '@aws-sdk/client-iot'
 import { deletePolicyCommand } from '../../../../awsService/iot/commands/deletePolicy'
 import { IotPolicyFolderNode } from '../../../../awsService/iot/explorer/iotPolicyFolderNode'
 import { IotPolicyWithVersionsNode } from '../../../../awsService/iot/explorer/iotPolicyNode'
@@ -42,8 +42,8 @@ describe('deletePolicyCommand', function () {
         iot.listPolicyTargets = listPolicyStub
         const policyVersions = ['1']
         const listPolicyVersionsStub = sinon.stub().returns(
-            asyncGenerator<Iot.PolicyVersion>(
-                policyVersions.map<Iot.PolicyVersion>((versionId) => {
+            asyncGenerator<PolicyVersion>(
+                policyVersions.map<PolicyVersion>((versionId) => {
                     return {
                         versionId: versionId,
                     }
@@ -86,8 +86,8 @@ describe('deletePolicyCommand', function () {
         iot.listPolicyTargets = listPolicyStub
         const policyVersions = ['1', '2']
         const listPolicyVersionsStub = sinon.stub().returns(
-            asyncGenerator<Iot.PolicyVersion>(
-                policyVersions.map<Iot.PolicyVersion>((versionId) => {
+            asyncGenerator<PolicyVersion>(
+                policyVersions.map<PolicyVersion>((versionId) => {
                     return {
                         versionId: versionId,
                     }

--- a/packages/core/src/test/awsService/iot/explorer/iotCertFolderNode.test.ts
+++ b/packages/core/src/test/awsService/iot/explorer/iotCertFolderNode.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import { MoreResultsNode } from '../../../../awsexplorer/moreResultsNode'
 import { IotNode } from '../../../../awsService/iot/explorer/iotNodes'
 import { IotCertificate, IotClient } from '../../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { Certificate } from '@aws-sdk/client-iot'
 import { AWSTreeNodeBase } from '../../../../shared/treeview/nodes/awsTreeNodeBase'
 import { IotCertWithPoliciesNode } from '../../../../awsService/iot/explorer/iotCertificateNode'
 import { IotCertsFolderNode } from '../../../../awsService/iot/explorer/iotCertFolderNode'
@@ -21,7 +21,7 @@ describe('IotCertFolderNode', function () {
     let iot: IotClient
     let config: TestSettings
 
-    const cert: Iot.Certificate = {
+    const cert: Certificate = {
         certificateId: 'cert',
         certificateArn: 'arn',
         status: 'ACTIVE',

--- a/packages/core/src/test/awsService/iot/explorer/iotCertificateNode.test.ts
+++ b/packages/core/src/test/awsService/iot/explorer/iotCertificateNode.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import { MoreResultsNode } from '../../../../awsexplorer/moreResultsNode'
 import { IotClient, IotPolicy } from '../../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { Policy } from '@aws-sdk/client-iot'
 import { AWSTreeNodeBase } from '../../../../shared/treeview/nodes/awsTreeNodeBase'
 import { IotPolicyCertNode } from '../../../../awsService/iot/explorer/iotPolicyNode'
 import { IotCertWithPoliciesNode } from '../../../../awsService/iot/explorer/iotCertificateNode'
@@ -22,7 +22,7 @@ describe('IotCertificateNode', function () {
     let config: TestSettings
     const certArn = 'certArn'
     const cert = { id: 'cert', arn: certArn, activeStatus: 'ACTIVE', creationDate: new Date(0) }
-    const policy: Iot.Policy = { policyName: 'policy', policyArn: 'arn' }
+    const policy: Policy = { policyName: 'policy', policyArn: 'arn' }
     const expectedPolicy: IotPolicy = { name: 'policy', arn: 'arn' }
 
     function assertPolicyNode(node: AWSTreeNodeBase, expectedPolicy: IotPolicy): void {

--- a/packages/core/src/test/awsService/iot/explorer/iotPolicyFolderNode.test.ts
+++ b/packages/core/src/test/awsService/iot/explorer/iotPolicyFolderNode.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import { MoreResultsNode } from '../../../../awsexplorer/moreResultsNode'
 import { IotNode } from '../../../../awsService/iot/explorer/iotNodes'
 import { IotClient, IotPolicy } from '../../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { Policy } from '@aws-sdk/client-iot'
 import { AWSTreeNodeBase } from '../../../../shared/treeview/nodes/awsTreeNodeBase'
 import { IotPolicyWithVersionsNode } from '../../../../awsService/iot/explorer/iotPolicyNode'
 import { IotPolicyFolderNode } from '../../../../awsService/iot/explorer/iotPolicyFolderNode'
@@ -20,7 +20,7 @@ describe('IotPolicyFolderNode', function () {
 
     let iot: IotClient
     let config: TestSettings
-    const policy: Iot.Policy = { policyName: 'policy', policyArn: 'arn' }
+    const policy: Policy = { policyName: 'policy', policyArn: 'arn' }
     const expectedPolicy: IotPolicy = { name: 'policy', arn: 'arn' }
 
     function assertPolicyNode(node: AWSTreeNodeBase, expectedPolicy: IotPolicy): void {

--- a/packages/core/src/test/awsService/iot/explorer/iotPolicyNode.test.ts
+++ b/packages/core/src/test/awsService/iot/explorer/iotPolicyNode.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert'
 import { IotClient, IotPolicy } from '../../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { PolicyVersion } from '@aws-sdk/client-iot'
 import { AWSTreeNodeBase } from '../../../../shared/treeview/nodes/awsTreeNodeBase'
 import { asyncGenerator } from '../../../../shared/utilities/collectionUtils'
 import { IotPolicyWithVersionsNode } from '../../../../awsService/iot/explorer/iotPolicyNode'
@@ -19,12 +19,12 @@ describe('IotPolicyNode', function () {
     let config: TestSettings
     const policyName = 'policy'
     const expectedPolicy: IotPolicy = { name: policyName, arn: 'arn' }
-    const policyVersion: Iot.PolicyVersion = { versionId: 'V1', isDefaultVersion: true }
+    const policyVersion: PolicyVersion = { versionId: 'V1', isDefaultVersion: true }
 
     function assertPolicyVersionNode(
         node: AWSTreeNodeBase,
         expectedPolicy: IotPolicy,
-        expectedVersion: Iot.PolicyVersion
+        expectedVersion: PolicyVersion
     ): void {
         assert.ok(node instanceof IotPolicyVersionNode, `Node ${node} should be a Policy Version Node`)
         assert.deepStrictEqual((node as IotPolicyVersionNode).version, expectedVersion)
@@ -39,7 +39,7 @@ describe('IotPolicyNode', function () {
     describe('getChildren', function () {
         it('gets children', async function () {
             const versions = [{ versionId: 'V1', isDefaultVersion: true }]
-            const stub = sinon.stub().returns(asyncGenerator<Iot.PolicyVersion>(versions))
+            const stub = sinon.stub().returns(asyncGenerator<PolicyVersion>(versions))
             iot.listPolicyVersions = stub
             const node = new IotPolicyWithVersionsNode(
                 expectedPolicy,

--- a/packages/core/src/test/awsService/iot/explorer/iotPolicyVersionNode.test.ts
+++ b/packages/core/src/test/awsService/iot/explorer/iotPolicyVersionNode.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert'
 import { IotClient, IotPolicy } from '../../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { PolicyVersion } from '@aws-sdk/client-iot'
 import { IotPolicyWithVersionsNode } from '../../../../awsService/iot/explorer/iotPolicyNode'
 import { IotPolicyVersionNode } from '../../../../awsService/iot/explorer/iotPolicyVersionNode'
 import { stringOrProp } from '../../../../shared/utilities/tsUtils'
@@ -16,8 +16,8 @@ describe('IotPolicyVersionNode', function () {
     const expectedPolicy: IotPolicy = { name: policyName, arn: 'arn' }
     const createDate = new Date(Date.UTC(2021, 1, 1)) // Feb 1 UTC = Jan 31 PDT
     const createDateFormatted = formatLocalized(createDate)
-    const policyVersion: Iot.PolicyVersion = { versionId: 'V1', isDefaultVersion: true, createDate }
-    const nonDefaultVersion: Iot.PolicyVersion = { versionId: 'V2', isDefaultVersion: false, createDate }
+    const policyVersion: PolicyVersion = { versionId: 'V1', isDefaultVersion: true, createDate }
+    const nonDefaultVersion: PolicyVersion = { versionId: 'V2', isDefaultVersion: false, createDate }
 
     it('creates an IoT Policy Version Node for default version', async function () {
         const node = new IotPolicyVersionNode(

--- a/packages/core/src/test/awsService/iot/explorer/iotThingFolderNode.test.ts
+++ b/packages/core/src/test/awsService/iot/explorer/iotThingFolderNode.test.ts
@@ -9,7 +9,7 @@ import { IotNode } from '../../../../awsService/iot/explorer/iotNodes'
 import { IotThingFolderNode } from '../../../../awsService/iot/explorer/iotThingFolderNode'
 import { IotThingNode } from '../../../../awsService/iot/explorer/iotThingNode'
 import { IotClient, IotThing } from '../../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { ThingAttribute } from '@aws-sdk/client-iot'
 import { AWSTreeNodeBase } from '../../../../shared/treeview/nodes/awsTreeNodeBase'
 import { TestSettings } from '../../../utilities/testSettingsConfiguration'
 import sinon from 'sinon'
@@ -20,7 +20,7 @@ describe('IotThingFolderNode', function () {
 
     let iot: IotClient
     let config: TestSettings
-    const thing: Iot.ThingAttribute = { thingName: 'thing', thingArn: 'arn' }
+    const thing: ThingAttribute = { thingName: 'thing', thingArn: 'arn' }
     const expectedThing: IotThing = { name: 'thing', arn: 'arn' }
 
     function assertThingNode(node: AWSTreeNodeBase, expectedThing: IotThing): void {

--- a/packages/core/src/test/awsService/iot/explorer/iotThingNode.test.ts
+++ b/packages/core/src/test/awsService/iot/explorer/iotThingNode.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import { MoreResultsNode } from '../../../../awsexplorer/moreResultsNode'
 import { IotCertificate, IotClient } from '../../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { Certificate } from '@aws-sdk/client-iot'
 import { AWSTreeNodeBase } from '../../../../shared/treeview/nodes/awsTreeNodeBase'
 import { IotThingCertNode } from '../../../../awsService/iot/explorer/iotCertificateNode'
 import { IotThingNode } from '../../../../awsService/iot/explorer/iotThingNode'
@@ -22,7 +22,7 @@ describe('IotThingNode', function () {
     let config: TestSettings
     const thingName = 'thing'
     const thing = { name: thingName, arn: 'thingArn' }
-    const cert: Iot.Certificate = {
+    const cert: Certificate = {
         certificateId: 'cert',
         certificateArn: 'arn',
         status: 'ACTIVE',


### PR DESCRIPTION
## Problem

AWS SDK V2 is EOL.

## Solution

Migrate IoT imports to V3


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
