### PR TITLE
telemetry: flush usertriggerDecision event on keystroke or manual trigger

### DIFF
--- a/packages/core/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/packages/core/src/codewhisperer/commands/invokeRecommendation.ts
@@ -20,6 +20,9 @@ export async function invokeRecommendation(
     client: DefaultCodeWhispererClient,
     config: ConfigurationEntry
 ) {
+    // Call report user decisions once to report recommendations leftover from last invocation.
+    RecommendationHandler.instance.reportUserDecisions(-1)
+
     if (!editor || !config.isManualTriggerEnabled) {
         return
     }

--- a/packages/core/src/codewhisperer/service/inlineCompletionService.ts
+++ b/packages/core/src/codewhisperer/service/inlineCompletionService.ts
@@ -88,8 +88,6 @@ export class InlineCompletionService {
             }
         }
 
-        // Call report user decisions once to report recommendations leftover from last invocation.
-        RecommendationHandler.instance.reportUserDecisions(-1)
         TelemetryHelper.instance.setInvokeSuggestionStartTime()
         ClassifierTrigger.instance.recordClassifierResultForAutoTrigger(editor, autoTriggerType, event)
 

--- a/packages/core/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/packages/core/src/codewhisperer/service/keyStrokeHandler.ts
@@ -87,6 +87,9 @@ export class KeyStrokeHandler {
         client: DefaultCodeWhispererClient,
         config: ConfigurationEntry
     ): Promise<void> {
+        // Call report user decisions once to report recommendations leftover from last invocation.
+        RecommendationHandler.instance.reportUserDecisions(-1)
+
         try {
             if (!config.isAutomatedTriggerEnabled) {
                 return


### PR DESCRIPTION
…

## Problem
previously UTD will be delayed until next service call, which means it doesn't gurantee service team will collect all the datapoints

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
