### PR TITLE
fix(amazonq): send expiration field in update iam call to enable refresh credentials in LSP server

### DIFF
--- a/packages/amazonq/src/lsp/auth.ts
+++ b/packages/amazonq/src/lsp/auth.ts
@@ -118,7 +118,8 @@ export class AmazonQLspAuth {
         )
         if (credentials) {
             getLogger().info(
-                `[SageMaker Debug] IAM credentials structure: accessKeyId=${credentials.accessKeyId ? 'present' : 'missing'}, secretAccessKey=${credentials.secretAccessKey ? 'present' : 'missing'}, sessionToken=${credentials.sessionToken ? 'present' : 'missing'}`
+                `[SageMaker Debug] IAM credentials structure: accessKeyId=${credentials.accessKeyId ? 'present' : 'missing'}, secretAccessKey=${credentials.secretAccessKey ? 'present' : 'missing'}, sessionToken=${credentials.sessionToken ? 'present' : 'missing'},  expiration=${credentials.expiration} ? 'pr
+esent' : 'missing'}`
             )
         }
 
@@ -163,6 +164,7 @@ export class AmazonQLspAuth {
             accessKeyId: credentials.accessKeyId,
             secretAccessKey: credentials.secretAccessKey,
             sessionToken: credentials.sessionToken,
+            expiration: credentials.expiration,
         }
         const payload = new TextEncoder().encode(JSON.stringify({ data: iamCredentials }))
 

--- a/packages/core/src/auth/credentials/store.ts
+++ b/packages/core/src/auth/credentials/store.ts
@@ -95,6 +95,7 @@ export class CredentialsStore {
         credentialsId: CredentialsId,
         credentialsProvider: CredentialsProvider
     ): Promise<CachedCredentials> {
+        getLogger().debug(`store: Fetch new credentials from provider with id: ${asString(credentialsId)}`)
         const credentials = {
             credentials: await credentialsProvider.getCredentials(),
             credentialsHashCode: credentialsProvider.getHashCode(),
@@ -102,7 +103,6 @@ export class CredentialsStore {
         }
 
         this.credentialsCache[asString(credentialsId)] = credentials
-
         return credentials
     }
 }


### PR DESCRIPTION
## Problem
- `Expiration` field is missing in IAM call to language server hence credentials expiration logic is not working properly

## Solution
- Pass `expiration` field in update IAM call
- Update and add log statements related to credential field
- Tested in local using `npm run compile && npm run test`
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
