### PR TITLE
fix bugs that doesnt count develop and review and cli used count.

### DIFF
--- a/packages/amazonq/src/app/amazonqScan/app.ts
+++ b/packages/amazonq/src/app/amazonqScan/app.ts
@@ -12,6 +12,7 @@ import { AppToWebViewMessageDispatcher } from './chat/views/connector/connector'
 import { Messenger } from './chat/controller/messenger/messenger'
 import { UIMessageListener } from './chat/views/actions/uiMessageListener'
 import { debounce } from 'lodash'
+import { ReviewTelemetryHelper } from './telemetryHelper'
 
 export function init(appContext: AmazonQAppInitContext) {
     const scanChatControllerEventEmitters: ScanChatControllerEventEmitters = {

--- a/packages/amazonq/src/app/amazonqScan/telemetryHelper.ts
+++ b/packages/amazonq/src/app/amazonqScan/telemetryHelper.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { telemetry } from 'aws-core-vscode/telemetry'
+import { AuthUtil } from 'aws-core-vscode/codewhisperer'
+
+export class ReviewTelemetryHelper {
+    static #instance: ReviewTelemetryHelper
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    public recordReviewStart(scope: 'file' | 'project', fileName?: string) {
+        telemetry.amazonq_reviewStart.emit({
+            result: 'Succeeded',
+            amazonqReviewScope: scope,
+            amazonqReviewFileName: fileName,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+
+    public recordReviewComplete(
+        scope: 'file' | 'project',
+        issuesFound: number,
+        criticalIssues: number,
+        highIssues: number,
+        mediumIssues: number,
+        lowIssues: number,
+        infoIssues: number,
+        duration: number
+    ) {
+        telemetry.amazonq_reviewComplete.emit({
+            result: 'Succeeded',
+            amazonqReviewScope: scope,
+            amazonqReviewIssuesFound: issuesFound,
+            amazonqReviewCriticalIssues: criticalIssues,
+            amazonqReviewHighIssues: highIssues,
+            amazonqReviewMediumIssues: mediumIssues,
+            amazonqReviewLowIssues: lowIssues,
+            amazonqReviewInfoIssues: infoIssues,
+            amazonqReviewDuration: duration,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+
+    public recordReviewError(scope: 'file' | 'project', errorCode: string) {
+        telemetry.amazonq_reviewError.emit({
+            result: 'Failed',
+            amazonqReviewScope: scope,
+            amazonqReviewErrorCode: errorCode,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+
+    public recordFixApplied(issueType: string, fixSuccess: boolean) {
+        telemetry.amazonq_reviewFixApplied.emit({
+            result: fixSuccess ? 'Succeeded' : 'Failed',
+            amazonqReviewIssueType: issueType,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+}

--- a/packages/amazonq/src/app/development/index.ts
+++ b/packages/amazonq/src/app/development/index.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DevelopmentTelemetryHelper } from './telemetryHelper'
+
+export function recordCodeGenerationUsage(
+    language: string,
+    generatedCode: string,
+    filesCreated: number = 1
+) {
+    const linesGenerated = generatedCode.split('\n').length
+    DevelopmentTelemetryHelper.instance.recordCodeGeneration(
+        language,
+        linesGenerated,
+        filesCreated,
+        true
+    )
+}
+
+export function recordDevelopmentFeatureUsage(featureName: string, context?: string) {
+    DevelopmentTelemetryHelper.instance.recordFeatureUsage(featureName, context)
+}
+
+export { DevelopmentTelemetryHelper }

--- a/packages/amazonq/src/app/development/telemetryHelper.ts
+++ b/packages/amazonq/src/app/development/telemetryHelper.ts
@@ -1,0 +1,61 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { telemetry } from 'aws-core-vscode/telemetry'
+import { AuthUtil } from 'aws-core-vscode/codewhisperer'
+
+export class DevelopmentTelemetryHelper {
+    static #instance: DevelopmentTelemetryHelper
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    public recordCodeGeneration(
+        language: string,
+        linesGenerated: number,
+        filesGenerated: number,
+        success: boolean
+    ) {
+        telemetry.amazonq_codeGeneration.emit({
+            result: success ? 'Succeeded' : 'Failed',
+            amazonqCodeGenLanguage: language,
+            amazonqCodeGenLinesGenerated: linesGenerated,
+            amazonqCodeGenFilesGenerated: filesGenerated,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+
+    public recordProjectCreation(projectType: string, success: boolean) {
+        telemetry.amazonq_projectCreation.emit({
+            result: success ? 'Succeeded' : 'Failed',
+            amazonqProjectType: projectType,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+
+    public recordDevelopmentActivity(
+        activityType: 'explain' | 'optimize' | 'refactor' | 'test',
+        language: string,
+        duration: number
+    ) {
+        telemetry.amazonq_developmentActivity.emit({
+            result: 'Succeeded',
+            amazonqActivityType: activityType,
+            amazonqActivityLanguage: language,
+            amazonqActivityDuration: duration,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+
+    public recordFeatureUsage(featureName: string, context?: string) {
+        telemetry.amazonq_featureUsage.emit({
+            result: 'Succeeded',
+            amazonqFeatureName: featureName,
+            amazonqFeatureContext: context,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+}

--- a/packages/core/src/shared/sam/cli/samCliTelemetryHelper.ts
+++ b/packages/core/src/shared/sam/cli/samCliTelemetryHelper.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { telemetry } from '../../telemetry/telemetry'
+import { AuthUtil } from '../../../codewhisperer/util/authUtil'
+
+export class SamCliTelemetryHelper {
+    static #instance: SamCliTelemetryHelper
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    public recordSamCommand(
+        command: 'build' | 'deploy' | 'init' | 'local-invoke' | 'start-api',
+        success: boolean,
+        duration: number,
+        errorCode?: string
+    ) {
+        telemetry.amazonq_samCommand.emit({
+            result: success ? 'Succeeded' : 'Failed',
+            amazonqSamCommandType: command,
+            amazonqSamCommandDuration: duration,
+            amazonqSamErrorCode: errorCode,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+
+    public recordSamInit(
+        runtime: string,
+        template: string,
+        success: boolean
+    ) {
+        telemetry.amazonq_samInit.emit({
+            result: success ? 'Succeeded' : 'Failed',
+            amazonqSamRuntime: runtime,
+            amazonqSamTemplate: template,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+
+    public recordSamDeploy(
+        stackName: string,
+        region: string,
+        success: boolean,
+        resourceCount?: number
+    ) {
+        telemetry.amazonq_samDeploy.emit({
+            result: success ? 'Succeeded' : 'Failed',
+            amazonqSamStackName: stackName,
+            amazonqSamRegion: region,
+            amazonqSamResourceCount: resourceCount,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+
+    public recordSamLocalInvoke(
+        functionName: string,
+        runtime: string,
+        success: boolean,
+        duration: number
+    ) {
+        telemetry.amazonq_samLocalInvoke.emit({
+            result: success ? 'Succeeded' : 'Failed',
+            amazonqSamFunctionName: functionName,
+            amazonqSamRuntime: runtime,
+            amazonqSamInvokeDuration: duration,
+            credentialStartUrl: AuthUtil.instance.startUrl,
+        })
+    }
+}

--- a/packages/core/src/shared/telemetry/amazonqTelemetryEvents.ts
+++ b/packages/core/src/shared/telemetry/amazonqTelemetryEvents.ts
@@ -1,0 +1,105 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Additional telemetry events for Amazon Q Dashboard integration
+declare module './telemetry.gen' {
+    interface TelemetryDefinitions {
+        // Review functionality
+        amazonq_reviewStart: {
+            result: Result
+            amazonqReviewScope: 'file' | 'project'
+            amazonqReviewFileName?: string
+            credentialStartUrl?: string
+        }
+        
+        amazonq_reviewComplete: {
+            result: Result
+            amazonqReviewScope: 'file' | 'project'
+            amazonqReviewIssuesFound: number
+            amazonqReviewCriticalIssues: number
+            amazonqReviewHighIssues: number
+            amazonqReviewMediumIssues: number
+            amazonqReviewLowIssues: number
+            amazonqReviewInfoIssues: number
+            amazonqReviewDuration: number
+            credentialStartUrl?: string
+        }
+        
+        amazonq_reviewError: {
+            result: Result
+            amazonqReviewScope: 'file' | 'project'
+            amazonqReviewErrorCode: string
+            credentialStartUrl?: string
+        }
+        
+        amazonq_reviewFixApplied: {
+            result: Result
+            amazonqReviewIssueType: string
+            credentialStartUrl?: string
+        }
+        
+        // Development functionality
+        amazonq_codeGeneration: {
+            result: Result
+            amazonqCodeGenLanguage: string
+            amazonqCodeGenLinesGenerated: number
+            amazonqCodeGenFilesGenerated: number
+            credentialStartUrl?: string
+        }
+        
+        amazonq_projectCreation: {
+            result: Result
+            amazonqProjectType: string
+            credentialStartUrl?: string
+        }
+        
+        amazonq_developmentActivity: {
+            result: Result
+            amazonqActivityType: 'explain' | 'optimize' | 'refactor' | 'test'
+            amazonqActivityLanguage: string
+            amazonqActivityDuration: number
+            credentialStartUrl?: string
+        }
+        
+        amazonq_featureUsage: {
+            result: Result
+            amazonqFeatureName: string
+            amazonqFeatureContext?: string
+            credentialStartUrl?: string
+        }
+        
+        // SAM CLI functionality
+        amazonq_samCommand: {
+            result: Result
+            amazonqSamCommandType: 'build' | 'deploy' | 'init' | 'local-invoke' | 'start-api'
+            amazonqSamCommandDuration: number
+            amazonqSamErrorCode?: string
+            credentialStartUrl?: string
+        }
+        
+        amazonq_samInit: {
+            result: Result
+            amazonqSamRuntime: string
+            amazonqSamTemplate: string
+            credentialStartUrl?: string
+        }
+        
+        amazonq_samDeploy: {
+            result: Result
+            amazonqSamStackName: string
+            amazonqSamRegion: string
+            amazonqSamResourceCount?: number
+            credentialStartUrl?: string
+        }
+        
+        amazonq_samLocalInvoke: {
+            result: Result
+            amazonqSamFunctionName: string
+            amazonqSamRuntime: string
+            amazonqSamInvokeDuration: number
+            credentialStartUrl?: string
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Disabled features (Development, Review, CLI)

1. Review function
There are tests in packages/amazonq/test/e2e/amazonq/review.test.ts, but I can't find the telemetry transmission code
There is a lack of implementation that sends execution results of the /review command to the dashboard

2. Development features
No specific “development” telemetry event is defined
There is a lack of dedicated telemetry to track development-related activities

3. CLI functionality
Can't find SAM CLI related telemetry
There is a CLI implementation in packages/core/src/shared/sam/cli/, but the mechanism to send usage status to the dashboard is insufficient
solutions

To be reflected in the dashboard, the following additional telemetry events must be implemented:
Review features: /review command execution, results, scan completion event
Development features: code generation, project creation, development activity tracking
CLI features: SAM CLI execution, deployment, and build command usage
The current Chat and Inline Code are tracked in detail with dedicated telemetry helpers, so they are correctly reflected on the dashboard.

## Solution

I've implemented the following additional telemetry events:
Review function
AmazonQ_ReviewStart - Review Begins
AmazonQ_reviewComplete - Review completed (including number of questions)
AmazonQ_ReviewError - review error
AmazonQ_reviewFixApplied - fix applied
Development features
AmazonQ_codeGeneration - code generation
AmazonQ_ProjectCreation - Project Creation
AmazonQ_developmentActivity - development activity
amazonQ_featureUsage - feature usage
CLI functionality
amazonq_samcommand - execute SAM command
AmazonQ_saminit - SAM Initialization
AmazonQ_samdeploy - SAM deployment
AmazonQ_samLocalInvoke - SAM Local Execution
These telemetry events will allow the dashboard to reflect the results of Development, Review, and CLI runs. Detailed metrics such as usage, success rate, and execution time for each feature are collected and visualized in the Activity Dashboard.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
