### PR TITLE
refactor(schemas): migrate to aws-sdk v3 part 2

### DIFF
--- a/packages/core/src/eventSchemas/explorer/registryItemNode.ts
+++ b/packages/core/src/eventSchemas/explorer/registryItemNode.ts
@@ -6,7 +6,7 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { Schemas } from 'aws-sdk'
+import { RegistrySummary } from '@aws-sdk/client-schemas'
 import * as os from 'os'
 import * as vscode from 'vscode'
 
@@ -25,7 +25,7 @@ export class RegistryItemNode extends AWSTreeNodeBase {
     public override readonly regionCode: string = this.client.regionCode
 
     public constructor(
-        private registryItemOutput: Schemas.RegistrySummary,
+        private registryItemOutput: RegistrySummary,
         private readonly client: SchemaClient
     ) {
         super('', vscode.TreeItemCollapsibleState.Collapsed)
@@ -56,7 +56,7 @@ export class RegistryItemNode extends AWSTreeNodeBase {
         })
     }
 
-    public update(registryItemOutput: Schemas.RegistrySummary): void {
+    public update(registryItemOutput: RegistrySummary): void {
         this.registryItemOutput = registryItemOutput
         this.label = `${this.registryName}`
         let registryArn = ''

--- a/packages/core/src/eventSchemas/explorer/schemaItemNode.ts
+++ b/packages/core/src/eventSchemas/explorer/schemaItemNode.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schemas } from 'aws-sdk'
-
+import { SchemaSummary, SchemaVersionSummary } from '@aws-sdk/client-schemas'
 import * as os from 'os'
 import { SchemaClient } from '../../shared/clients/schemaClient'
 
@@ -15,7 +14,7 @@ import { localize } from '../../shared/utilities/vsCodeUtils'
 
 export class SchemaItemNode extends AWSTreeNodeBase {
     public constructor(
-        private schemaItem: Schemas.SchemaSummary,
+        private schemaItem: SchemaSummary,
         public readonly client: SchemaClient,
         public readonly registryName: string
     ) {
@@ -30,7 +29,7 @@ export class SchemaItemNode extends AWSTreeNodeBase {
         }
     }
 
-    public update(schemaItem: Schemas.SchemaSummary): void {
+    public update(schemaItem: SchemaSummary): void {
         this.schemaItem = schemaItem
         this.label = this.schemaItem.SchemaName || ''
         let schemaArn = ''
@@ -50,7 +49,7 @@ export class SchemaItemNode extends AWSTreeNodeBase {
         return response.Content!
     }
 
-    public async listSchemaVersions(): Promise<Schemas.SchemaVersionSummary[]> {
+    public async listSchemaVersions(): Promise<SchemaVersionSummary[]> {
         const versions = await toArrayAsync(this.client.listSchemaVersions(this.registryName, this.schemaName))
 
         return versions

--- a/packages/core/src/eventSchemas/providers/schemasDataProvider.ts
+++ b/packages/core/src/eventSchemas/providers/schemasDataProvider.ts
@@ -4,10 +4,10 @@
  */
 
 import * as AWS from '@aws-sdk/types'
-import { Schemas } from 'aws-sdk'
 import { SchemaClient } from '../../shared/clients/schemaClient'
 import { getLogger, Logger } from '../../shared/logger/logger'
 import { toArrayAsync } from '../../shared/utilities/collectionUtils'
+import { SchemaSummary } from '@aws-sdk/client-schemas'
 
 export class Cache {
     public constructor(public readonly credentialsRegionDataList: credentialsRegionDataListMap[]) {}
@@ -26,7 +26,7 @@ export interface regionRegistryMap {
 
 export interface registrySchemasMap {
     registryName: string
-    schemaList: Schemas.SchemaSummary[]
+    schemaList: SchemaSummary[]
 }
 
 /**

--- a/packages/core/src/eventSchemas/vue/searchSchemas.ts
+++ b/packages/core/src/eventSchemas/vue/searchSchemas.ts
@@ -5,7 +5,7 @@
 
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
-import { Schemas } from 'aws-sdk'
+import { SchemaSummary, SearchSchemaSummary } from '@aws-sdk/client-schemas'
 import * as vscode from 'vscode'
 import { downloadSchemaItemCode } from '../commands/downloadSchemaItemCode'
 import { RegistryItemNode } from '../explorer/registryItemNode'
@@ -93,7 +93,7 @@ export class SearchSchemasWebview extends VueWebview {
     }
 
     public async downloadCodeBindings(summary: SchemaVersionedSummary) {
-        const schemaItem: Schemas.SchemaSummary = {
+        const schemaItem: SchemaSummary = {
             SchemaName: getSchemaNameFromTitle(summary.Title),
         }
         const schemaItemNode = new SchemaItemNode(schemaItem, this.client, summary.RegistryName)
@@ -230,7 +230,7 @@ export async function getSearchResults(
     return results
 }
 
-export function getSchemaVersionedSummary(searchSummary: Schemas.SearchSchemaSummary[], prefix: string) {
+export function getSchemaVersionedSummary(searchSummary: SearchSchemaSummary[], prefix: string) {
     const results = searchSummary.map((searchSchemaSummary) => ({
         RegistryName: searchSchemaSummary.RegistryName!,
         Title: prefix.concat(searchSchemaSummary.SchemaName!),

--- a/packages/core/src/test/eventSchemas/commands/viewSchemaItem.test.ts
+++ b/packages/core/src/test/eventSchemas/commands/viewSchemaItem.test.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schemas } from 'aws-sdk'
-
+import { DescribeSchemaResponse } from '@aws-sdk/client-schemas'
 import assert from 'assert'
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
@@ -117,7 +116,7 @@ describe('viewSchemaItem', async function () {
     }
 
     function generateSchemaItemNode(): SchemaItemNode {
-        const schemaResponse: Schemas.DescribeSchemaResponse = {
+        const schemaResponse: DescribeSchemaResponse = {
             Content: awsEventSchemaRaw,
         }
         const schemaClient = new DefaultSchemaClient('')

--- a/packages/core/src/test/eventSchemas/explorer/registryItemNode.test.ts
+++ b/packages/core/src/test/eventSchemas/explorer/registryItemNode.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import * as os from 'os'
 import * as sinon from 'sinon'
-import { Schemas } from 'aws-sdk'
+import { RegistrySummary, SchemaSummary } from '@aws-sdk/client-schemas'
 import { RegistryItemNode } from '../../../eventSchemas/explorer/registryItemNode'
 import { SchemaItemNode } from '../../../eventSchemas/explorer/schemaItemNode'
 import { SchemasNode } from '../../../eventSchemas/explorer/schemasNode'
@@ -21,7 +21,7 @@ import { asyncGenerator } from '../../../shared/utilities/collectionUtils'
 import { getIcon } from '../../../shared/icons'
 import { stub } from '../../utilities/stubber'
 
-function createSchemaClient(data?: { schemas?: Schemas.SchemaSummary[]; registries?: Schemas.RegistrySummary[] }) {
+function createSchemaClient(data?: { schemas?: SchemaSummary[]; registries?: RegistrySummary[] }) {
     const client = stub(DefaultSchemaClient, { regionCode: 'code' })
     client.listSchemas.callsFake(() => asyncGenerator(data?.schemas ?? []))
     client.listRegistries.callsFake(() => asyncGenerator(data?.registries ?? []))
@@ -30,7 +30,7 @@ function createSchemaClient(data?: { schemas?: Schemas.SchemaSummary[]; registri
 }
 
 describe('RegistryItemNode', function () {
-    let fakeRegistry: Schemas.RegistrySummary
+    let fakeRegistry: RegistrySummary
 
     before(function () {
         fakeRegistry = {
@@ -58,17 +58,17 @@ describe('RegistryItemNode', function () {
     })
 
     it('returns schemas that belong to Registry', async function () {
-        const schema1Item: Schemas.SchemaSummary = {
+        const schema1Item: SchemaSummary = {
             SchemaArn: 'arn:schema1',
             SchemaName: 'schema1Name',
         }
 
-        const schema2Item: Schemas.SchemaSummary = {
+        const schema2Item: SchemaSummary = {
             SchemaArn: 'arn:schema1',
             SchemaName: 'schema2Name',
         }
 
-        const schema3Item: Schemas.SchemaSummary = {
+        const schema3Item: SchemaSummary = {
             SchemaArn: 'arn:schema1',
             SchemaName: 'schema3Name',
         }


### PR DESCRIPTION
## Problem

AWS SDK V2 is at EOL


## Solution

Migrate Schemas to V3


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
