### PR TITLE
refactor(secretsmanager): migrate to aws sdk v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "prettier": "^3.3.3",
                 "prettier-plugin-sh": "^0.14.0",
                 "pretty-quick": "^4.0.0",
-                "ts-node": "^10.9.2",
+                "ts-node": "^10.9.1",
                 "typescript": "^5.0.4",
                 "webpack": "^5.95.0",
                 "webpack-cli": "^5.1.4",
@@ -37103,7 +37103,7 @@
         },
         "packages/amazonq": {
             "name": "amazon-q-vscode",
-            "version": "1.96.0",
+            "version": "1.97.0-SNAPSHOT",
             "license": "Apache-2.0",
             "dependencies": {
                 "aws-core-vscode": "file:../core/"
@@ -37146,6 +37146,7 @@
                 "@aws-sdk/client-s3-control": "^3.830.0",
                 "@aws-sdk/client-sagemaker": "<3.696.0",
                 "@aws-sdk/client-schemas": "~3.693.0",
+                "@aws-sdk/client-secrets-manager": "~3.693.0",
                 "@aws-sdk/client-sfn": "<3.731.0",
                 "@aws-sdk/client-ssm": "<3.731.0",
                 "@aws-sdk/client-sso": "<3.731.0",
@@ -37671,6 +37672,148 @@
             }
         },
         "packages/core/node_modules/@aws-sdk/client-schemas/node_modules/@smithy/util-retry": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+            "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^3.0.11",
+                "@smithy/types": "^3.7.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "packages/core/node_modules/@aws-sdk/client-secrets-manager": {
+            "version": "3.693.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.693.0.tgz",
+            "integrity": "sha512-PiXkl64LYhwZQ2zPQhxwpnLwGS7Lw8asFCj29SxEaYRnYra3ajE5d+Yvv68qC+diUNkeZh6k6zn7nEOZ4rWEwA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.693.0",
+                "@aws-sdk/client-sts": "3.693.0",
+                "@aws-sdk/core": "3.693.0",
+                "@aws-sdk/credential-provider-node": "3.693.0",
+                "@aws-sdk/middleware-host-header": "3.693.0",
+                "@aws-sdk/middleware-logger": "3.693.0",
+                "@aws-sdk/middleware-recursion-detection": "3.693.0",
+                "@aws-sdk/middleware-user-agent": "3.693.0",
+                "@aws-sdk/region-config-resolver": "3.693.0",
+                "@aws-sdk/types": "3.692.0",
+                "@aws-sdk/util-endpoints": "3.693.0",
+                "@aws-sdk/util-user-agent-browser": "3.693.0",
+                "@aws-sdk/util-user-agent-node": "3.693.0",
+                "@smithy/config-resolver": "^3.0.11",
+                "@smithy/core": "^2.5.2",
+                "@smithy/fetch-http-handler": "^4.1.0",
+                "@smithy/hash-node": "^3.0.9",
+                "@smithy/invalid-dependency": "^3.0.9",
+                "@smithy/middleware-content-length": "^3.0.11",
+                "@smithy/middleware-endpoint": "^3.2.2",
+                "@smithy/middleware-retry": "^3.0.26",
+                "@smithy/middleware-serde": "^3.0.9",
+                "@smithy/middleware-stack": "^3.0.9",
+                "@smithy/node-config-provider": "^3.1.10",
+                "@smithy/node-http-handler": "^3.3.0",
+                "@smithy/protocol-http": "^4.1.6",
+                "@smithy/smithy-client": "^3.4.3",
+                "@smithy/types": "^3.7.0",
+                "@smithy/url-parser": "^3.0.9",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.26",
+                "@smithy/util-defaults-mode-node": "^3.0.26",
+                "@smithy/util-endpoints": "^2.1.5",
+                "@smithy/util-middleware": "^3.0.9",
+                "@smithy/util-retry": "^3.0.9",
+                "@smithy/util-utf8": "^3.0.0",
+                "@types/uuid": "^9.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "packages/core/node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/fetch-http-handler": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.3.tgz",
+            "integrity": "sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.1.8",
+                "@smithy/querystring-builder": "^3.0.11",
+                "@smithy/types": "^3.7.2",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "packages/core/node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/middleware-retry": {
+            "version": "3.0.34",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.34.tgz",
+            "integrity": "sha512-yVRr/AAtPZlUvwEkrq7S3x7Z8/xCd97m2hLDaqdz6ucP2RKHsBjEqaUA2ebNv2SsZoPEi+ZD0dZbOB1u37tGCA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.12",
+                "@smithy/protocol-http": "^4.1.8",
+                "@smithy/service-error-classification": "^3.0.11",
+                "@smithy/smithy-client": "^3.7.0",
+                "@smithy/types": "^3.7.2",
+                "@smithy/util-middleware": "^3.0.11",
+                "@smithy/util-retry": "^3.0.11",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "packages/core/node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/node-http-handler": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.3.tgz",
+            "integrity": "sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^3.1.9",
+                "@smithy/protocol-http": "^4.1.8",
+                "@smithy/querystring-builder": "^3.0.11",
+                "@smithy/types": "^3.7.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "packages/core/node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/protocol-http": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+            "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.7.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "packages/core/node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/service-error-classification": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+            "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.7.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "packages/core/node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/util-retry": {
             "version": "3.0.11",
             "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
             "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -591,6 +591,7 @@
         "@aws-sdk/client-s3-control": "^3.830.0",
         "@aws-sdk/client-sagemaker": "<3.696.0",
         "@aws-sdk/client-schemas": "~3.693.0",
+        "@aws-sdk/client-secrets-manager": "~3.693.0",
         "@aws-sdk/client-sfn": "<3.731.0",
         "@aws-sdk/client-ssm": "<3.731.0",
         "@aws-sdk/client-sso": "<3.731.0",

--- a/packages/core/src/awsService/redshift/wizards/connectionWizard.ts
+++ b/packages/core/src/awsService/redshift/wizards/connectionWizard.ts
@@ -16,7 +16,7 @@ import { RegionProvider } from '../../../shared/regions/regionProvider'
 import { createRegionPrompter } from '../../../shared/ui/common/region'
 import { ClustersMessage } from 'aws-sdk/clients/redshift'
 import { Prompter } from '../../../shared/ui/prompter'
-import { ListSecretsResponse } from 'aws-sdk/clients/secretsmanager'
+import { ListSecretsResponse } from '@aws-sdk/client-secrets-manager'
 import { SecretsManagerClient } from '../../../shared/clients/secretsManagerClient'
 import { redshiftHelpUrl } from '../../../shared/constants'
 


### PR DESCRIPTION
## Problem

AWS SDK V2 is at EOL.


## Solution

Migrate SecretsManager client to V3


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
