### PR TITLE
fix(amazonq): fix to remove notification pop-up for data sharing toggle

### DIFF
--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -157,21 +157,6 @@ export async function activate(context: ExtContext): Promise<void> {
                 }
             }
 
-            if (configurationChangeEvent.affectsConfiguration('amazonQ.shareContentWithAWS')) {
-                if (auth.isEnterpriseSsoInUse()) {
-                    await vscode.window
-                        .showInformationMessage(
-                            CodeWhispererConstants.ssoConfigAlertMessageShareData,
-                            CodeWhispererConstants.settingsLearnMore
-                        )
-                        .then(async (resp) => {
-                            if (resp === CodeWhispererConstants.settingsLearnMore) {
-                                void openUrl(vscode.Uri.parse(CodeWhispererConstants.learnMoreUri))
-                            }
-                        })
-                }
-            }
-
             if (configurationChangeEvent.affectsConfiguration('editor.inlineSuggest.enabled')) {
                 await vscode.window
                     .showInformationMessage(


### PR DESCRIPTION
## Problem

We need to remove the notifcation pop-up for data sharing toggle in Amazon Q settings


## Solution

- removed the toggle


https://github.com/user-attachments/assets/6a56de02-26a0-4d28-8190-88d238740e22



---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
