### PR TITLE
refactor(amazonq): fix sagemaker credential log typo

### DIFF
--- a/packages/amazonq/src/lsp/auth.ts
+++ b/packages/amazonq/src/lsp/auth.ts
@@ -118,8 +118,7 @@ export class AmazonQLspAuth {
         )
         if (credentials) {
             getLogger().info(
-                `[SageMaker Debug] IAM credentials structure: accessKeyId=${credentials.accessKeyId ? 'present' : 'missing'}, secretAccessKey=${credentials.secretAccessKey ? 'present' : 'missing'}, sessionToken=${credentials.sessionToken ? 'present' : 'missing'},  expiration=${credentials.expiration} ? 'pr
-esent' : 'missing'}`
+                `[SageMaker Debug] IAM credentials structure: accessKeyId=${credentials.accessKeyId ? 'present' : 'missing'}, secretAccessKey=${credentials.secretAccessKey ? 'present' : 'missing'}, sessionToken=${credentials.sessionToken ? 'present' : 'missing'},  expiration=${credentials.expiration ? 'present' : 'missing'}`
             )
         }
 


### PR DESCRIPTION
## Problem
Typo in log statement for Sagemaker Update IAM Credential logic currently prints expiration time

## Solution
- Fix typo to show availability of field in credentials
- `npm run compile && npm run test` succeeded

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
