### PR TITLE
fix(amazonq): remove the security scan command

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -594,12 +594,6 @@
                 "enablement": "aws.codewhisperer.connected"
             },
             {
-                "command": "aws.amazonq.security.scan-statusbar",
-                "title": "%AWS.command.amazonq.security.scan%",
-                "category": "%AWS.amazonq.title%",
-                "enablement": "aws.codewhisperer.connected && !aws.isSageMaker"
-            },
-            {
                 "command": "aws.amazonq.refactorCode",
                 "title": "%AWS.command.amazonq.refactorCode%",
                 "category": "%AWS.amazonq.title%",


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
