### PR TITLE
test(amazonq): proxy

### DIFF
--- a/packages/core/src/shared/request.ts
+++ b/packages/core/src/shared/request.ts
@@ -4,6 +4,7 @@
  */
 
 import crossFetch from 'cross-fetch'
+const { HttpsProxyAgent } = require('https-proxy-agent')
 
 const request = {
     /**
@@ -23,7 +24,21 @@ const request = {
         params?: RequestParamsArg,
         wrappedFetch = crossFetch
     ): FetchRequest {
-        return new FetchRequest(url, { ...params, method }, wrappedFetch)
+        const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY
+
+        const updateParams: any = { ...params }
+
+        if (proxy) {
+            const proxyAgent = new HttpsProxyAgent(proxy)
+
+            updateParams.agent = proxyAgent
+
+            updateParams.headers = {
+                ...(params?.headers || {}),
+            }
+        }
+
+        return new FetchRequest(url, { ...updateParams, method }, wrappedFetch)
     },
 }
 export default request

--- a/packages/core/src/shared/request.ts
+++ b/packages/core/src/shared/request.ts
@@ -25,9 +25,7 @@ const request = {
         wrappedFetch = crossFetch
     ): FetchRequest {
         const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY
-
         const updateParams: any = { ...params }
-
         if (proxy) {
             const proxyAgent = new HttpsProxyAgent(proxy)
 

--- a/packages/core/src/shared/request.ts
+++ b/packages/core/src/shared/request.ts
@@ -4,7 +4,6 @@
  */
 
 import crossFetch from 'cross-fetch'
-import { getLogger } from './logger'
 const { HttpsProxyAgent } = require('https-proxy-agent')
 
 const request = {
@@ -26,9 +25,6 @@ const request = {
         wrappedFetch = crossFetch
     ): FetchRequest {
         const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY
-        if (proxy) {
-            getLogger().info(`detectied proxy being used via env variable and is attaching ${proxy} to userAgent`)
-        }
         const updateParams: any = { ...params }
         if (proxy) {
             const proxyAgent = new HttpsProxyAgent(proxy)

--- a/packages/core/src/shared/request.ts
+++ b/packages/core/src/shared/request.ts
@@ -4,6 +4,7 @@
  */
 
 import crossFetch from 'cross-fetch'
+import { getLogger } from './logger'
 const { HttpsProxyAgent } = require('https-proxy-agent')
 
 const request = {
@@ -25,14 +26,15 @@ const request = {
         wrappedFetch = crossFetch
     ): FetchRequest {
         const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY
+        if (proxy) {
+            getLogger().info(`detectied proxy being used via env variable and is attaching ${proxy} to userAgent`)
+        }
         const updateParams: any = { ...params }
         if (proxy) {
             const proxyAgent = new HttpsProxyAgent(proxy)
-
             updateParams.agent = proxyAgent
-
             updateParams.headers = {
-                ...(params?.headers || {}),
+                ...(params?.headers || {}), // ???? do we need this?
             }
         }
 


### PR DESCRIPTION
## Problem

```
amazonqLsp: Failed to start downloaded LSP, falling back to bundled LSP: Unable to download dependencies from https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json. Check your network connectivity or firewall configuration and then try again.\
-09-29 14:07:00.075 [info] [2025-09-29T06:07:00.017Z] lserver: Chat configuration updated customizationArn to undefined\
2025-09-29 14:07:00.075 [info] [2025-09-29T06:07:00.017Z] lserver: Chat configuration telemetry preference to OPTIN\
2025-09-29 14:07:00.076 [info] [Info  - 2:07:00 PM] [2025-09-29T06:07:00.017Z] lserver: LSP on initialize for QCodeAnalysisServer\
2025-09-29 14:07:00.076 [info] [2025-09-29T06:07:00.018Z] lserver: Passing client for class Service to sdkInitializator (v2) for additional setup (e.g. proxy)\
2025-09-29 14:07:00.076 [info] [Warn  - 2:07:00 PM] Failed to read system certificates: <ref *1> Error: spawnSync c:\\Users\\??????????\\.vscode\\extensions\\amazonwebservices.amazon-q-vscode-1.88.0\\resources\\language-server\\servers\\roots.exe ENOENT\
    at Object.spawnSync (node:internal/child_process:1120:20)\
    at spawnSync (node:child_process:934:24)\
    at Object.execFileSync (node:child_process:977:15)\
    at Object.func [as execFileSync] (node:electron/js2c/node_init:2:2617)\
    at Object.i [as run] (c:\\Users\\I???????????????????????\\.vscode\\extensions\\amazonwebservices.amazon-q-vscode-1.88.0\\resources\\language-server\\servers\\aws-lsp-codewhisperer.js:2:9963605)\
    at n (c:\\Users\\?????????????????\\.vscode\\extensions\\amazonwebservices.amazon-q-vscode-1.88.0\\resources\\language-server\\servers\\aws-lsp-codewhisperer.js:2:3248719)\
    at t.readWindowsCertificates (c:\\Users\\????????????????\\.vscode\\extensions\\amazonwebservices.amazon-q-vscode-1.88.0\\resources\\language-server\\servers\\aws-lsp-codewhisperer.js:2:8634102)\
    at b.readSystemCertificates (c:\\Users\\???????????\\.vscode\\extensions\\amazonwebservices.amazon-q-vscode-1.88.0\\resources\\language-server\\servers\\aws-lsp-codewhisperer.js:2:9232551)\
    at b.getCertificates (c:\\Users\\???????????????\\.vscode\\extensions\\amazonwebservices.amazon-q-vscode-1.88.0\\resources\\language-server\\servers\\aws-lsp-codewhisperer.js:2:9232694)\
    at b.createSecureAgent (c:\\Users\\???????????????\\.vscode\\extensions\\amazonwebservices.amazon-q-vscode-1.88.0\\resources\\language-server\\servers\\aws-lsp-codewhisperer.js:2:9233463) \{\
  errno: -4058,\
  code: 'ENOENT',\
  syscall: 'spawnSync c:\\\\Users\\\???????????????????\\\\.vscode\\\\extensions\\\\amazonwebservices.amazon-q-vscode-1.88.0\\\\resources\\\\language-server\\\\servers\\\\roots.exe',\
  path: 'c:\\\\Users\\\\?????????????????\\\.vscode\\\\extensions\\\\amazonwebservices.amazon-q-vscode-1.88.0\\\\resources\\\\language-server\\\\servers\\\\roots.exe',\
  spawnargs: [ 'root', 'ca' ],\
  error: [Circular *1],\
  status: null,\
  signal: null,\
  output: null,\
  pid: 0,\
  stdout: undefined,\
  stderr: undefined\
\}\
2025-09-29 14:07:00.076 [info] Total certificates read: 150\
2025-09-29 14:07:00.077 [info] Removed expired certificates: 1\
2025-09-29 14:07:00.077 [info] Using certificates: 149\
2025-09-29 14:07:00.077 [info] [Warn  - 2:07:00 PM] os\uc0\u8209 proxy\u8209 config shim failed: The "path" argument must be of type string. Received type number (82779)\
```

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
