### PR TITLE
feat(stepfunctions): Auto fill existing ExecutionInput when click StartExecution from ExecutionDetails tab.

### DIFF
--- a/packages/core/src/stepFunctions/executionDetails/handleMessage.ts
+++ b/packages/core/src/stepFunctions/executionDetails/handleMessage.ts
@@ -11,6 +11,7 @@ import {
     ExecutionDetailsContext,
     ApiCallRequestMessage,
     InitResponseMessage,
+    StartExecutionMessage,
 } from '../messageHandlers/types'
 import {
     loadStageMessageHandler,
@@ -39,7 +40,7 @@ export async function handleMessage(message: Message, context: ExecutionDetailsC
                 break
             }
             case Command.START_EXECUTION:
-                void startExecutionMessageHandler(context)
+                void startExecutionMessageHandler(message as StartExecutionMessage, context)
                 break
             case Command.EDIT_STATE_MACHINE:
                 void editStateMachineMessageHandler(context)
@@ -85,7 +86,7 @@ async function initMessageHandler(context: ExecutionDetailsContext) {
     }
 }
 
-async function startExecutionMessageHandler(context: ExecutionDetailsContext) {
+async function startExecutionMessageHandler(message: StartExecutionMessage, context: ExecutionDetailsContext) {
     const logger = getLogger('stepfunctions')
     try {
         // Parsing execution ARN to get state machine info
@@ -100,6 +101,7 @@ async function startExecutionMessageHandler(context: ExecutionDetailsContext) {
             arn: stateMachineArn,
             name: stateMachineName,
             region: region,
+            executionInput: message.executionInput,
         })
     } catch (error) {
         logger.error('Start execution failed: %O', error)

--- a/packages/core/src/stepFunctions/messageHandlers/types.ts
+++ b/packages/core/src/stepFunctions/messageHandlers/types.ts
@@ -105,6 +105,10 @@ export interface SyncFileRequestMessage extends SaveFileRequestMessage {
     fileContents: string
 }
 
+export interface StartExecutionMessage extends Message {
+    executionInput?: string
+}
+
 export enum ApiAction {
     IAMListRoles = 'iam:ListRoles',
     SFNTestState = 'sfn:TestState',

--- a/packages/core/src/stepFunctions/utils.ts
+++ b/packages/core/src/stepFunctions/utils.ts
@@ -177,19 +177,21 @@ export const openWorkflowStudioWithDefinition = async (
  * Shows the Execute State Machine webview with the provided state machine data
  * @param extensionContext The extension context
  * @param outputChannel The output channel for logging
- * @param stateMachineData Object containing arn, name, and region of the state machine
+ * @param stateMachineData Object containing arn, name, region, and optional executionInput of the state machine
  * @returns The webview instance
  */
 export const showExecuteStateMachineWebview = async (stateMachineData: {
     arn: string
     name: string
     region: string
+    executionInput?: string
 }) => {
     const Panel = VueWebview.compilePanel(ExecuteStateMachineWebview)
     const wv = new Panel(globals.context, globals.outputChannel, {
         arn: stateMachineData.arn,
         name: stateMachineData.name,
         region: stateMachineData.region,
+        executionInput: stateMachineData.executionInput,
     })
 
     await wv.show({

--- a/packages/core/src/stepFunctions/vue/executeStateMachine/executeStateMachine.ts
+++ b/packages/core/src/stepFunctions/vue/executeStateMachine/executeStateMachine.ts
@@ -22,6 +22,7 @@ interface StateMachine {
     arn: string
     name: string
     region: string
+    executionInput?: string
 }
 
 export class ExecuteStateMachineWebview extends VueWebview {
@@ -89,11 +90,16 @@ export class ExecuteStateMachineWebview extends VueWebview {
     }
 }
 
-export async function executeStateMachine(context: ExtContext, node: StateMachineNode): Promise<void> {
+export async function executeStateMachine(
+    context: ExtContext,
+    node: StateMachineNode,
+    executionInput?: string
+): Promise<void> {
     await showExecuteStateMachineWebview({
         arn: node.details.stateMachineArn || '',
         name: node.details.name || '',
         region: node.regionCode,
+        executionInput,
     })
     telemetry.stepfunctions_executeStateMachineView.emit()
 }

--- a/packages/core/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
+++ b/packages/core/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
@@ -55,11 +55,15 @@ const defaultInitialData = {
     name: '',
     region: '',
     arn: '',
+    executionInput: '',
 }
 
 export default defineComponent({
     async created() {
         this.initialData = (await client.init()) ?? this.initialData
+        if (this.initialData.executionInput) {
+            this.executionInput = this.initialData.executionInput
+        }
     },
     data: () => ({
         initialData: defaultInitialData,
@@ -89,7 +93,9 @@ export default defineComponent({
                     break
                 case 'textarea':
                     this.placeholderJson = defaultJsonPlaceholder
-                    this.executionInput = ''
+                    if (!this.initialData.executionInput) {
+                        this.executionInput = ''
+                    }
                     this.fileInputVisible = false
                     break
             }

--- a/packages/core/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
+++ b/packages/core/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
@@ -62,7 +62,7 @@ export default defineComponent({
     async created() {
         this.initialData = (await client.init()) ?? this.initialData
         if (this.initialData.executionInput) {
-            this.executionInput = this.initialData.executionInput
+            this.executionInput = this.formatJson(this.initialData.executionInput)
         }
     },
     data: () => ({
@@ -110,7 +110,7 @@ export default defineComponent({
                 reader.onload = (event) => {
                     if (event.target) {
                         const result = event.target.result
-                        this.executionInput = result as string
+                        this.executionInput = this.formatJson(result as string)
                     }
                 } // desired file content
                 reader.onerror = (error) => {
@@ -119,6 +119,15 @@ export default defineComponent({
                 reader.readAsText(inputFile.files[0])
                 this.selectedFile = inputFile.files[0].name
                 this.textAreaVisible = true
+            }
+        },
+        formatJson: function (jsonString: string): string {
+            try {
+                const parsed = JSON.parse(jsonString)
+                return JSON.stringify(parsed, null, 2)
+            } catch (error) {
+                console.warn('Failed to format JSON:', error)
+                return jsonString
             }
         },
         sendInput: function () {

--- a/packages/toolkit/.changes/next-release/Feature-f6abbaf7-7d02-4056-b4dd-2e13cc56776d.json
+++ b/packages/toolkit/.changes/next-release/Feature-f6abbaf7-7d02-4056-b4dd-2e13cc56776d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "[Step Functions] Start Execution from Execution Details tab now fills the existing Execution Input in the Start Execution tab."
+}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -4576,109 +4576,137 @@
                     "fontCharacter": "\\f1d0"
                 }
             },
-            "aws-lambda-function": {
+            "aws-lambda-create-stack": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d1"
                 }
             },
-            "aws-mynah-MynahIconBlack": {
+            "aws-lambda-create-stack-light": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d2"
                 }
             },
-            "aws-mynah-MynahIconWhite": {
+            "aws-lambda-function": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d3"
                 }
             },
-            "aws-mynah-logo": {
+            "aws-mynah-MynahIconBlack": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d4"
                 }
             },
-            "aws-redshift-cluster": {
+            "aws-mynah-MynahIconWhite": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d5"
                 }
             },
-            "aws-redshift-cluster-connected": {
+            "aws-mynah-logo": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d6"
                 }
             },
-            "aws-redshift-database": {
+            "aws-redshift-cluster": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d7"
                 }
             },
-            "aws-redshift-redshift-cluster-connected": {
+            "aws-redshift-cluster-connected": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d8"
                 }
             },
-            "aws-redshift-schema": {
+            "aws-redshift-database": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d9"
                 }
             },
-            "aws-redshift-table": {
+            "aws-redshift-redshift-cluster-connected": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1da"
                 }
             },
-            "aws-s3-bucket": {
+            "aws-redshift-schema": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1db"
                 }
             },
-            "aws-s3-create-bucket": {
+            "aws-redshift-table": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1dc"
                 }
             },
-            "aws-schemas-registry": {
+            "aws-s3-bucket": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1dd"
                 }
             },
-            "aws-schemas-schema": {
+            "aws-s3-create-bucket": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1de"
                 }
             },
-            "aws-stepfunctions-preview": {
+            "aws-sagemaker-code-editor": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1df"
+                }
+            },
+            "aws-sagemaker-jupyter-lab": {
+                "description": "AWS Contributed Icon",
+                "default": {
+                    "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
+                    "fontCharacter": "\\f1e0"
+                }
+            },
+            "aws-schemas-registry": {
+                "description": "AWS Contributed Icon",
+                "default": {
+                    "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
+                    "fontCharacter": "\\f1e1"
+                }
+            },
+            "aws-schemas-schema": {
+                "description": "AWS Contributed Icon",
+                "default": {
+                    "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
+                    "fontCharacter": "\\f1e2"
+                }
+            },
+            "aws-stepfunctions-preview": {
+                "description": "AWS Contributed Icon",
+                "default": {
+                    "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
+                    "fontCharacter": "\\f1e3"
                 }
             }
         },


### PR DESCRIPTION
## Problem
When starting a new StateMachine execution from the ExecutionDetails tab, currently we do not fill the StartExecution tab with the existing ExecutionInput.
## Solution
Auto fill existing ExecutionInput when click StartExecution from ExecutionDetails tab.
## Demo
![StartExecution](https://github.com/user-attachments/assets/1aa6a7d4-efab-4292-9f2f-a2512e66e4ba)
---
- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.