### PR TITLE
fix(studio): ssh config causing remote connection errors to SageMaker Studio compute

### DIFF
--- a/packages/core/src/shared/sshConfig.ts
+++ b/packages/core/src/shared/sshConfig.ts
@@ -208,7 +208,7 @@ Host ${this.configHostName}
 
     protected createSSHConfigSection(proxyCommand: string): string {
         if (this.scriptPrefix === 'sagemaker_connect') {
-            return `${this.getSageMakerSSHConfig(proxyCommand)}User '%r'\n`
+            return `${this.getSageMakerSSHConfig(proxyCommand)}`
         } else if (this.keyPath) {
             return `${this.getBaseSSHConfig(proxyCommand)}IdentityFile '${this.keyPath}'\n    User '%r'\n`
         }


### PR DESCRIPTION
fix(studio): ssh config causing remote connection errors to SageMaker Studio compute