### PR TITLE
fix(studio): ssh config causing remote connection errors to SageMaker Studio compute

### DIFF
--- a/packages/core/src/shared/sshConfig.ts
+++ b/packages/core/src/shared/sshConfig.ts
@@ -208,7 +208,7 @@ Host ${this.configHostName}
 
     protected createSSHConfigSection(proxyCommand: string): string {
         if (this.scriptPrefix === 'sagemaker_connect') {
-            return `${this.getSageMakerSSHConfig(proxyCommand)}User '%r'\n`
+            return `${this.getSageMakerSSHConfig(proxyCommand)}`
         } else if (this.keyPath) {
             return `${this.getBaseSSHConfig(proxyCommand)}IdentityFile '${this.keyPath}'\n    User '%r'\n`
         }


### PR DESCRIPTION
Fixes SSH configuration issue that leads to remote connection errors when connecting to SageMaker Studio compute instances.

**Problem**: Missing or incorrect SSH configuration causing connection failures
**Solution**: Updated SSH config to properly handle remote connections to Studio compute

This change ensures reliable remote connections to SageMaker Studio compute environments.