### PR TITLE
fix(amazonq): add quotes around jar path

### DIFF
--- a/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformMavenHandler.ts
@@ -17,7 +17,7 @@ import globals from '../../../shared/extensionGlobals'
 function collectDependenciesAndMetadata(dependenciesFolderPath: string, workingDirPath: string) {
     getLogger().info('CodeTransformation: running mvn clean test-compile with maven JAR')
 
-    const baseCommand = transformByQState.getMavenName() // will always be 'mvn'
+    const baseCommand = transformByQState.getMavenName() // always 'mvn'
     const jarPath = globals.context.asAbsolutePath(path.join('resources', 'amazonQCT', 'QCT-Maven-1-0-156-0.jar'))
 
     getLogger().info('CodeTransformation: running Maven extension with JAR')


### PR DESCRIPTION
## Problem

Absolute paths sometimes contain spaces, preventing Maven from running.


## Solution

Handle spaces by surrounding the full path with double quotes.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
