### PR TITLE
fix(amazonq): exclude .github dir from upload ZIP

### DIFF
--- a/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQ/transformApiHandler.ts
@@ -275,7 +275,8 @@ function isExcludedSourceFile(path: string): boolean {
     return sourceExcludedExtensions.some((extension) => path.endsWith(extension))
 }
 
-// zip all dependency files and all source files excluding "target" (contains large JARs) plus ".git" and ".idea" (may appear in diff.patch)
+// zip all dependency files and all source files
+// excludes "target" (contains large JARs) plus ".git", ".idea", and ".github" (may appear in diff.patch)
 export function getFilesRecursively(dir: string, isDependenciesFolder: boolean): string[] {
     const entries = nodefs.readdirSync(dir, { withFileTypes: true })
     const files = entries.flatMap((entry) => {
@@ -284,7 +285,12 @@ export function getFilesRecursively(dir: string, isDependenciesFolder: boolean):
             if (isDependenciesFolder) {
                 // include all dependency files
                 return getFilesRecursively(res, isDependenciesFolder)
-            } else if (entry.name !== 'target' && entry.name !== '.git' && entry.name !== '.idea') {
+            } else if (
+                entry.name !== 'target' &&
+                entry.name !== '.git' &&
+                entry.name !== '.idea' &&
+                entry.name !== '.github'
+            ) {
                 // exclude the above directories when zipping source code
                 return getFilesRecursively(res, isDependenciesFolder)
             } else {

--- a/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/transformByQ.test.ts
@@ -503,6 +503,10 @@ dependencyManagement:
         await fs.mkdir(gitFolder)
         await fs.writeFile(path.join(gitFolder, 'config'), 'sample content for the test file')
 
+        const githubFolder = path.join(tempDir, '.github')
+        await fs.mkdir(githubFolder)
+        await fs.writeFile(path.join(githubFolder, 'config'), 'more sample content for the test file')
+
         const zippedFiles = getFilesRecursively(tempDir, false)
         assert.strictEqual(zippedFiles.length, 1)
     })


### PR DESCRIPTION
## Problem

`.github` directory should not be uploaded to QCT backend, since it contains unrelated files, which can show up in the diff, and can cause the parsing of the patch file to fail.

## Solution

Exclude it when zipping.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
