### PR TITLE
build(amazonq): upgrade to node 24 for setting up release candidate

### DIFF
--- a/.github/workflows/setup-release-candidate.yml
+++ b/.github/workflows/setup-release-candidate.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: '18'
+                  node-version: '24'
                   cache: 'npm'
 
             - name: Generate Branch Name


### PR DESCRIPTION
## Problem

Build runs forever when creating release candidate as there is a node version mismatch. 

See: https://github.com/aws/aws-toolkit-vscode/actions/runs/18413496294/job/52471582408


## Solution
bump from node 18 to 24


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
