### PR TITLE
fix(smus): update space before creating new app if space setting is changed

### DIFF
--- a/packages/core/src/test/shared/clients/sagemakerClient.test.ts
+++ b/packages/core/src/test/shared/clients/sagemakerClient.test.ts
@@ -360,6 +360,7 @@ describe('SagemakerClient.startSpace', function () {
         getTestWindow().getFirstMessage().selectItem('Yes')
 
         await promise
+        sinon.assert.calledOnce(updateSpaceStub)
         sinon.assert.calledOnce(createAppStub)
     })
 

--- a/packages/toolkit/.changes/next-release/Bug Fix-f521ea3f-0ac5-4fc0-b939-9776b7a7fd88.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-f521ea3f-0ac5-4fc0-b939-9776b7a7fd88.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "The space is updated upon creation of a new app with the requested settings"
+}


### PR DESCRIPTION
## Problem
Upgrading Space from Toolkit from ml.t3.medium to ml.t3.large does not update the Space properties. It only creates a new app with the updated instance type.


## Solution
Make sure to update Space before creating App when it is needed


## Testing
Verified that the it does not overwrite the the missing props. Diff link https://diff.corp.amazon.com/compare/54b0ofvc
- before updating space 
```
sagemaker-user@default:~$ aws sagemaker describe-space --domain-id d-rxs4hhmzrnho  --space-name ce 
{
    "DomainId": "d-rxs4hhmzrnho",
    "SpaceArn": "arn:aws:sagemaker:us-east-2:050752642559:space/d-rxs4hhmzrnho/ce",
    "SpaceName": "ce",
    "Status": "InService",
    "LastModifiedTime": "2025-10-13T21:21:00.933000+00:00",
    "CreationTime": "2025-09-08T20:58:08.976000+00:00",
    "SpaceSettings": {
        "CodeEditorAppSettings": {
            "DefaultResourceSpec": {
                "SageMakerImageArn": "arn:aws:sagemaker:us-east-2:137914896644:image/sagemaker-distribution-cpu",
                "SageMakerImageVersionAlias": "2.8",
                "InstanceType": "ml.t3.medium"
            },
            "AppLifecycleManagement": {
                "IdleSettings": {
                    "IdleTimeoutInMinutes": 60
                }
            }
        },
        "AppType": "CodeEditor",
        "SpaceStorageSettings": {
            "EbsStorageSettings": {
                "EbsVolumeSizeInGb": 16
            }
        },
        "CustomFileSystems": [
            {
                "S3FileSystem": {
                    "S3Uri": "s3://amazon-sagemaker-050752642559-us-east-2-63f9df3f396b/dzd_bh80g0fbj1h7xl/c1wqm5rlzb150p/shared"
                }
            }
        ],
        "RemoteAccess": "DISABLED"
    },
    "OwnershipSettings": {
        "OwnerUserProfileName": "915b9590-a081-704d-8914-0e482edfb1ef"
    },
    "SpaceSharingSettings": {
        "SharingType": "Private"
    },
    "Url": "https://y89msnjovs0fqgr.studio.us-east-2.sagemaker.aws/codeeditor/default"
}
```

After updating space:
```
sagemaker-user@default:~$ aws sagemaker describe-space --domain-id d-rxs4hhmzrnho  --space-name ce 
{
    "DomainId": "d-rxs4hhmzrnho",
    "SpaceArn": "arn:aws:sagemaker:us-east-2:050752642559:space/d-rxs4hhmzrnho/ce",
    "SpaceName": "ce",
    "Status": "InService",
    "LastModifiedTime": "2025-10-13T21:28:28.870000+00:00",
    "CreationTime": "2025-09-08T20:58:08.976000+00:00",
    "SpaceSettings": {
        "CodeEditorAppSettings": {
            "DefaultResourceSpec": {
                "SageMakerImageArn": "arn:aws:sagemaker:us-east-2:137914896644:image/sagemaker-distribution-cpu",
                "SageMakerImageVersionAlias": "2.8",
                "InstanceType": "ml.t3.large"
            },
            "AppLifecycleManagement": {
                "IdleSettings": {
                    "IdleTimeoutInMinutes": 60
                }
            }
        },
        "AppType": "CodeEditor",
        "SpaceStorageSettings": {
            "EbsStorageSettings": {
                "EbsVolumeSizeInGb": 16
            }
        },
        "CustomFileSystems": [
            {
                "S3FileSystem": {
                    "S3Uri": "s3://amazon-sagemaker-050752642559-us-east-2-63f9df3f396b/dzd_bh80g0fbj1h7xl/c1wqm5rlzb150p/shared"
                }
            }
        ],
        "RemoteAccess": "ENABLED"
    },
    "OwnershipSettings": {
        "OwnerUserProfileName": "915b9590-a081-704d-8914-0e482edfb1ef"
    },
    "SpaceSharingSettings": {
        "SharingType": "Private"
    },
    "Url": "https://y89msnjovs0fqgr.studio.us-east-2.sagemaker.aws/codeeditor/default"
}
```

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
