### PR TITLE
test(core): unskip flaky test

### DIFF
--- a/packages/core/src/test/awsService/appBuilder/walkthrough.test.ts
+++ b/packages/core/src/test/awsService/appBuilder/walkthrough.test.ts
@@ -83,7 +83,7 @@ const scenarios: TestScenario[] = [
     },
 ]
 
-describe.skip('AppBuilder Walkthrough', function () {
+describe('AppBuilder Walkthrough', function () {
     before(async function () {
         // ensure auto scan is disabled before testrun
         await CodeScansState.instance.setScansEnabled(false)


### PR DESCRIPTION
## Problem
The `AppBuilder Walkthrough` test was previously skipped because it is flaky and would some friction when merging in PRs to the `feature/v2-to-v3-migration` branch

## Solution
Unskip the `AppBuilder Walkthrough` test as we prepare to merge the `feature/v2-to-v3-migration` branch into `main`


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
