### PR TITLE
ci: fix attribution step in release candidate action

### DIFF
--- a/.github/workflows/setup-release-candidate.yml
+++ b/.github/workflows/setup-release-candidate.yml
@@ -49,7 +49,8 @@ jobs:
 
                   # Add generated license files
                   git add LICENSE-THIRD-PARTY
-                  git commit -m "Update third-party license attribution for $BRANCH_NAME"
+                  # If there are no changes, then we don't need a new attribution commit
+                  git commit -m "Update third-party license attribution for $BRANCH_NAME" || true
 
                   # Push RC branch
                   git push origin $BRANCH_NAME


### PR DESCRIPTION
There may not always be a change to the license file

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
