### PR TITLE
fix(smus): fix refresh interval for tracking pending space nodes

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode.ts
+++ b/packages/core/src/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode.ts
@@ -18,6 +18,7 @@ import { PollingSet } from '../../../shared/utilities/pollingSet'
 import { SmusAuthenticationProvider } from '../../auth/providers/smusAuthenticationProvider'
 import { SmusUtils } from '../../shared/smusUtils'
 import { getIcon } from '../../../shared/icons'
+import { PENDING_NODE_POLLING_INTERVAL_MS } from './utils'
 
 export class SageMakerUnifiedStudioSpacesParentNode implements TreeNode {
     public readonly id = 'smusSpacesParentNode'
@@ -29,7 +30,10 @@ export class SageMakerUnifiedStudioSpacesParentNode implements TreeNode {
     private readonly onDidChangeEmitter = new vscode.EventEmitter<void>()
     public readonly onDidChangeTreeItem = this.onDidChangeEmitter.event
     public readonly onDidChangeChildren = this.onDidChangeEmitter.event
-    public readonly pollingSet: PollingSet<string> = new PollingSet(5, this.updatePendingNodes.bind(this))
+    public readonly pollingSet: PollingSet<string> = new PollingSet(
+        PENDING_NODE_POLLING_INTERVAL_MS,
+        this.updatePendingNodes.bind(this)
+    )
     private spaceAwsAccountRegion: string | undefined
 
     public constructor(

--- a/packages/core/src/sagemakerunifiedstudio/explorer/nodes/utils.ts
+++ b/packages/core/src/sagemakerunifiedstudio/explorer/nodes/utils.ts
@@ -21,6 +21,12 @@ import {
 import { DataZoneConnection } from '../../shared/client/datazoneClient'
 
 /**
+ * Polling interval in milliseconds for checking space status updates
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const PENDING_NODE_POLLING_INTERVAL_MS = 5000
+
+/**
  * Gets the label for a node based on its data
  */
 export function getLabel(data: {


### PR DESCRIPTION
## Problem
- On transitioning from "Stopped" to/from "Running", the space node calls trackPendingNode() which adds it to the PollingSet. The PollingSet starts polling every 5 milliseconds which calls describeSpace + describeApp
## Solution
- Update the polling interval to 5sec

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
