### PR TITLE
feat(ai-league): Hide all services except Lambda and S3. Call parent frame after updating Lambda

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "version": "0.0.1",
     "private": true,
     "license": "Apache-2.0",
+    "enabledApiProposals": [
+        "embedded"
+    ],
     "prettier": {
         "printWidth": 120,
         "trailingComma": "es5",

--- a/packages/core/src/awsexplorer/regionNode.ts
+++ b/packages/core/src/awsexplorer/regionNode.ts
@@ -52,43 +52,53 @@ const serviceCandidates: ServiceNode[] = [
     {
         serviceId: 'apigateway',
         createFn: (regionCode: string, partitionId: string) => new ApiGatewayNode(partitionId, regionCode),
+        when: () => false,
     },
     {
         serviceId: 'apprunner',
         createFn: (regionCode: string) => new AppRunnerNode(regionCode, new AppRunnerClient(regionCode)),
+        when: () => false,
     },
     {
         serviceId: 'cloudformation',
         createFn: (regionCode: string) => new CloudFormationNode(regionCode),
+        when: () => false,
     },
     {
         serviceId: 'docdb',
         createFn: (regionCode: string) => new DocumentDBNode(DefaultDocumentDBClient.create(regionCode)),
+        when: () => false,
     },
     {
         serviceId: 'logs',
         createFn: (regionCode: string) => new CloudWatchLogsNode(regionCode),
+        when: () => false,
     },
     {
         serviceId: 'ec2',
         createFn: (regionCode: string, partitionId: string) =>
             new Ec2ParentNode(regionCode, partitionId, new Ec2Client(regionCode)),
+        when: () => false,
     },
     {
         serviceId: 'ecr',
         createFn: (regionCode: string) => new EcrNode(new DefaultEcrClient(regionCode)),
+        when: () => false,
     },
     {
         serviceId: 'redshift',
         createFn: (regionCode: string) => new RedshiftNode(new DefaultRedshiftClient(regionCode)),
+        when: () => false,
     },
     {
         serviceId: 'ecs',
         createFn: (regionCode: string) => new TreeShim(getEcsRootNode(regionCode)),
+        when: () => false,
     },
     {
         serviceId: 'iot',
         createFn: (regionCode: string) => new IotNode(new DefaultIotClient(regionCode)),
+        when: () => false,
     },
     {
         serviceId: 'lambda',
@@ -101,23 +111,28 @@ const serviceCandidates: ServiceNode[] = [
     {
         serviceId: 'api.sagemaker',
         createFn: (regionCode: string) => new SagemakerParentNode(regionCode, new SagemakerClient(regionCode)),
+        when: () => false,
     },
     {
         serviceId: 'schemas',
         createFn: (regionCode: string) => new SchemasNode(new DefaultSchemaClient(regionCode)),
+        when: () => false,
     },
     {
         serviceId: 'states',
         createFn: (regionCode: string) => new StepFunctionsNode(regionCode),
+        when: () => false,
     },
     {
         serviceId: 'ssm',
         createFn: (regionCode: string) => new SsmDocumentNode(regionCode),
+        when: () => false,
     },
     {
         allRegions: true,
         serviceId: 'cloudcontrol',
         createFn: (regionCode: string) => new ResourcesNode(regionCode),
+        when: () => false,
     },
 ]
 

--- a/packages/core/src/lambda/explorer/lambdaNodes.ts
+++ b/packages/core/src/lambda/explorer/lambdaNodes.ts
@@ -38,6 +38,7 @@ export class LambdaNode extends AWSTreeNodeBase {
         super('Lambda', vscode.TreeItemCollapsibleState.Collapsed)
         this.functionNodes = new Map<string, LambdaFunctionNode>()
         this.contextValue = 'awsLambdaNode'
+        this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded
     }
 
     public override async getChildren(): Promise<AWSTreeNodeBase[]> {

--- a/packages/core/src/shared/clients/lambdaClient.ts
+++ b/packages/core/src/shared/clients/lambdaClient.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode'
 import { Lambda } from 'aws-sdk'
 import { _Blob } from 'aws-sdk/clients/lambda'
 import { ToolkitError } from '../errors'
@@ -156,6 +157,17 @@ export class DefaultLambdaClient {
                 .promise()
             getLogger().debug('updateFunctionCode returned response: %O', response)
             await client.waitFor('functionUpdated', { FunctionName: name }).promise()
+
+            vscode.window.sendMessage!({
+                channel: 'vscode.awstoolkit.lambdaUpdateFunctionCode:request',
+                type: 'application/x-ai-league-code-editor+json',
+                value: [
+                    '*',
+                    {
+                        FunctionName: name,
+                    },
+                ],
+            })
 
             return response
         } catch (e) {

--- a/packages/core/types/vscode.web.d.ts
+++ b/packages/core/types/vscode.web.d.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Custom extensions to vscode extensions API for AWS Console integration. Only
+ * works with custom fork of VSCode supporting postMessage through VSCode
+ * Proposed API wrapper.
+ */
+declare module 'vscode' {
+    namespace window {
+        export const receiveMessage: Event<any> | undefined
+        export const sendMessage: ((message: any) => void) | undefined
+    }
+}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -80,6 +80,9 @@
         "generateIcons": "ts-node ../../scripts/generateIcons.ts",
         "generateSettings": "ts-node ../../scripts/generateSettings.ts"
     },
+    "enabledApiProposals": [
+        "embedded"
+    ],
     "contributes": {
         "configuration": {
             "type": "object",
@@ -767,22 +770,22 @@
                 {
                     "id": "aws.cdk",
                     "name": "%AWS.cdk.explorerTitle%",
-                    "when": "!aws.explorer.showAuthView"
+                    "when": "false"
                 },
                 {
                     "id": "aws.appBuilder",
                     "name": "%AWS.appBuilder.explorerTitle%",
-                    "when": "(isCloud9 || !aws.isWebExtHost) && !aws.explorer.showAuthView"
+                    "when": "false"
                 },
                 {
                     "id": "aws.codecatalyst",
                     "name": "%AWS.codecatalyst.explorerTitle%",
-                    "when": "(!isCloud9 && !aws.isSageMaker || isCloud9CodeCatalyst) && !aws.explorer.showAuthView"
+                    "when": "false"
                 },
                 {
                     "id": "aws.smus.rootView",
                     "name": "%AWS.sagemakerunifiedstudio.explorerTitle%",
-                    "when": "!aws.explorer.showAuthView"
+                    "when": "false"
                 },
                 {
                     "type": "webview",


### PR DESCRIPTION
For AI League re:Invent launch, we need a custom built version of AWS Toolkit extension:
- Hide irrelevant services in each region's node in Explorer.
- Hide other views for Code Catalyst, SMUS, etc.
- Notify AI League parent app when user has deployed Lambda from within Code Editor.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
