### PR TITLE
fix(core): remove project scan unit tests

### DIFF
--- a/packages/core/src/test/codewhisperer/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/startSecurityScan.test.ts
@@ -17,14 +17,7 @@ import { assertTelemetry, closeAllEditors, getFetchStubWithResponse } from '../t
 import { AWSError } from 'aws-sdk'
 import { getTestWindow } from '../shared/vscode/window'
 import { SeverityLevel } from '../shared/vscode/message'
-import { cancel } from '../../shared/localizedText'
-import {
-    showScannedFilesMessage,
-    stopScanMessage,
-    CodeAnalysisScope,
-    monthlyLimitReachedNotification,
-    scansLimitReachedErrorMessage,
-} from '../../codewhisperer/models/constants'
+import { showScannedFilesMessage, CodeAnalysisScope } from '../../codewhisperer/models/constants'
 import * as model from '../../codewhisperer/models/model'
 import * as errors from '../../shared/errors'
 import * as timeoutUtils from '../../shared/utilities/timeoutUtils'


### PR DESCRIPTION
## Problem
Some of the unit tests were flakey

## Solution
Remove flakey test. We are okay to do this because the project scan flow is no longer in use

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
