### PR TITLE
test: flaky walkthrough test

### DIFF
--- a/packages/core/src/test/awsService/appBuilder/walkthrough.test.ts
+++ b/packages/core/src/test/awsService/appBuilder/walkthrough.test.ts
@@ -224,13 +224,14 @@ describe('AppBuilder Walkthrough', function () {
                 })
 
                 it('download serverlessland proj', async function () {
+                    const config = vscode.workspace.getConfiguration('aws.samcli')
+                    await config.update('enableCodeLenses', false, vscode.ConfigurationTarget.Global)
                     // When
-                    const genPromise = genWalkthroughProject('API', workspaceUri, 'python')
-                    await getTestWindow().waitForMessage(/template.yaml already exist/)
-                    await genPromise
+                    await genWalkthroughProject('API', workspaceUri, 'python')
                     // Then template should be overwritten
                     assert.equal(await fs.exists(vscode.Uri.joinPath(workspaceUri, 'template.yaml')), true)
                     assert.notEqual(await fs.readFileText(vscode.Uri.joinPath(workspaceUri, 'template.yaml')), prevInfo)
+                    await config.update('enableCodeLenses', true, vscode.ConfigurationTarget.Global)
                 })
             })
 


### PR DESCRIPTION
## Problem
The test is checking for a popup to confirm overwrite of the SAM template. It is most likely getting blocked due to the "Scanning cloudformation template" warning popup that shows up before.

## Solution
https://github.com/aws/aws-toolkit-vscode/issues/3510 says disabling AWS SAM Codelens removes the aforementioned popup so I added a statement to disable the statement beforehand, and enabled it after this test runs so as not to impact other tests.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
