### PR TITLE
feat(smus): UX improvements for connecting running spaces from toolkit

### DIFF
--- a/packages/core/src/awsService/sagemaker/commands.ts
+++ b/packages/core/src/awsService/sagemaker/commands.ts
@@ -16,10 +16,19 @@ import _ from 'lodash'
 import { prepareDevEnvConnection, tryRemoteConnection } from './model'
 import { ExtContext } from '../../shared/extensions'
 import { SagemakerClient } from '../../shared/clients/sagemaker'
+import { AccessDeniedException } from '@amzn/sagemaker-client'
 import { ToolkitError } from '../../shared/errors'
 import { showConfirmationMessage } from '../../shared/utilities/messages'
 import { RemoteSessionError } from '../../shared/remoteSession'
-import { ConnectFromRemoteWorkspaceMessage, InstanceTypeError } from './constants'
+import {
+    ConnectFromRemoteWorkspaceMessage,
+    InstanceTypeError,
+    InstanceTypeInsufficientMemory,
+    InstanceTypeInsufficientMemoryMessage,
+    RemoteAccess,
+    RemoteAccessRequiredMessage,
+    SpaceStatus,
+} from './constants'
 import { SagemakerUnifiedStudioSpaceNode } from '../../sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpaceNode'
 
 const localize = nls.loadMessageBundle()
@@ -136,10 +145,10 @@ export async function stopSpace(
     sageMakerClient?: SagemakerClient
 ) {
     await tryRefreshNode(node)
-    if (node.getStatus() === 'Stopped' || node.getStatus() === 'Stopping') {
+    if (node.getStatus() === SpaceStatus.STOPPED || node.getStatus() === SpaceStatus.STOPPING) {
         void vscode.window.showWarningMessage(`Space ${node.spaceApp.SpaceName} is already in Stopped/Stopping state.`)
         return
-    } else if (node.getStatus() === 'Starting') {
+    } else if (node.getStatus() === SpaceStatus.STARTING) {
         void vscode.window.showWarningMessage(
             `Space ${node.spaceApp.SpaceName} is in Starting state. Wait until it is Running to attempt stop again.`
         )
@@ -167,7 +176,7 @@ export async function stopSpace(
         })
     } catch (err) {
         const error = err as Error
-        if (error.name === 'AccessDeniedException') {
+        if (error instanceof AccessDeniedException) {
             throw new ToolkitError('You do not have permission to stop spaces. Please contact your administrator', {
                 cause: error,
                 code: error.name,
@@ -195,47 +204,163 @@ export async function openRemoteConnect(
     const spaceName = node.spaceApp.SpaceName!
     await tryRefreshNode(node)
 
-    // for Stopped SM spaces - check instance type before showing progress
-    if (node.getStatus() === 'Stopped') {
-        //  In case of SMUS, we pass in a SM Client and for SM AI, it creates a new SM Client.
-        const client = sageMakerClient ? sageMakerClient : new SagemakerClient(node.regionCode)
+    const remoteAccess = node.spaceApp.SpaceSettingsSummary?.RemoteAccess
+    const nodeStatus = node.getStatus()
 
-        try {
-            await client.startSpace(spaceName, node.spaceApp.DomainId!)
-            await tryRefreshNode(node)
-            const appType = node.spaceApp.SpaceSettingsSummary?.AppType
-            if (!appType) {
-                throw new ToolkitError('AppType is undefined for the selected space. Cannot start remote connection.', {
-                    code: 'undefinedAppType',
-                })
-            }
+    // Route to appropriate handler based on space state
+    if (nodeStatus === SpaceStatus.RUNNING && remoteAccess !== RemoteAccess.ENABLED) {
+        return handleRunningSpaceWithDisabledAccess(node, ctx, spaceName, sageMakerClient)
+    } else if (nodeStatus === SpaceStatus.STOPPED) {
+        return handleStoppedSpace(node, ctx, spaceName, sageMakerClient)
+    } else if (nodeStatus === SpaceStatus.RUNNING) {
+        return handleRunningSpaceWithEnabledAccess(node, ctx, spaceName)
+    }
+}
 
-            // Only start showing progress after instance type validation
-            return await vscode.window.withProgress(
-                {
-                    location: vscode.ProgressLocation.Notification,
-                    cancellable: false,
-                    title: `Connecting to ${spaceName}`,
-                },
-                async (progress) => {
-                    progress.report({ message: 'Starting the space.' })
-                    await client.waitForAppInService(node.spaceApp.DomainId!, spaceName, appType)
-                    await tryRemoteConnection(node, ctx, progress)
-                }
-            )
-        } catch (err: any) {
-            // Ignore InstanceTypeError since it means the user decided not to use an instanceType with more memory
-            // just return without showing progress
-            if (err.code === InstanceTypeError) {
-                return
+/**
+ * Checks if an instance type upgrade will be needed for remote access
+ */
+export async function checkInstanceTypeUpgradeNeeded(
+    node: SagemakerSpaceNode | SagemakerUnifiedStudioSpaceNode,
+    sageMakerClient?: SagemakerClient
+): Promise<{ upgradeNeeded: boolean; currentType?: string; recommendedType?: string }> {
+    const client = sageMakerClient || new SagemakerClient(node.regionCode)
+
+    try {
+        const spaceDetails = await client.describeSpace({
+            DomainId: node.spaceApp.DomainId!,
+            SpaceName: node.spaceApp.SpaceName!,
+        })
+
+        const appType = spaceDetails.SpaceSettings!.AppType!
+
+        // Get current instance type
+        const currentResourceSpec =
+            appType === 'JupyterLab'
+                ? spaceDetails.SpaceSettings!.JupyterLabAppSettings?.DefaultResourceSpec
+                : spaceDetails.SpaceSettings!.CodeEditorAppSettings?.DefaultResourceSpec
+
+        const currentInstanceType = currentResourceSpec?.InstanceType
+
+        // Check if upgrade is needed
+        if (currentInstanceType && currentInstanceType in InstanceTypeInsufficientMemory) {
+            // Current type has insufficient memory
+            return {
+                upgradeNeeded: true,
+                currentType: currentInstanceType,
+                recommendedType: InstanceTypeInsufficientMemory[currentInstanceType],
             }
-            throw new ToolkitError(`Remote connection failed: ${(err as Error).message}`, {
-                cause: err as Error,
-                code: err.code,
+        }
+
+        return { upgradeNeeded: false, currentType: currentInstanceType }
+    } catch (err) {
+        const error = err as Error
+        if (error instanceof AccessDeniedException) {
+            throw new ToolkitError('You do not have permission to describe spaces. Please contact your administrator', {
+                cause: error,
+                code: error.name,
             })
         }
-    } else if (node.getStatus() === 'Running') {
-        // For running spaces, show progress
+        throw err
+    }
+}
+
+/**
+ * Handles connecting to a running space with disabled remote access
+ * Requires stopping the space, enabling remote access, and restarting
+ */
+async function handleRunningSpaceWithDisabledAccess(
+    node: SagemakerSpaceNode | SagemakerUnifiedStudioSpaceNode,
+    ctx: vscode.ExtensionContext,
+    spaceName: string,
+    sageMakerClient?: SagemakerClient
+) {
+    // Check if instance type upgrade will be needed
+    const instanceTypeInfo = await checkInstanceTypeUpgradeNeeded(node, sageMakerClient)
+
+    let prompt: string
+    if (instanceTypeInfo.upgradeNeeded) {
+        prompt = InstanceTypeInsufficientMemoryMessage(
+            spaceName,
+            instanceTypeInfo.currentType!,
+            instanceTypeInfo.recommendedType!
+        )
+    } else {
+        // Only remote access needs to be enabled
+        prompt = RemoteAccessRequiredMessage
+    }
+
+    const confirmed = await showConfirmationMessage({
+        prompt,
+        confirm: 'Restart and Connect',
+        cancel: 'Cancel',
+        type: 'warning',
+    })
+
+    if (!confirmed) {
+        return
+    }
+
+    // Enable remote access and connect
+    const client = sageMakerClient || new SagemakerClient(node.regionCode)
+
+    return await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            cancellable: false,
+            title: `Connecting to ${spaceName}`,
+        },
+        async (progress) => {
+            try {
+                // Show initial progress message
+                progress.report({ message: 'Stopping the space' })
+
+                // Stop the running space
+                await client.deleteApp({
+                    DomainId: node.spaceApp.DomainId!,
+                    SpaceName: spaceName,
+                    AppType: node.spaceApp.App!.AppType!,
+                    AppName: node.spaceApp.App?.AppName,
+                })
+
+                // Update progress message
+                progress.report({ message: 'Starting the space' })
+
+                // Start the space with remote access enabled (skip prompts since user already consented)
+                await client.startSpace(spaceName, node.spaceApp.DomainId!, true)
+                await tryRefreshNode(node)
+                await client.waitForAppInService(node.spaceApp.DomainId!, spaceName, node.spaceApp.App!.AppType!)
+                await tryRemoteConnection(node, ctx, progress)
+            } catch (err: any) {
+                // Handle user declining instance type upgrade
+                if (err.code === InstanceTypeError) {
+                    return
+                }
+                throw new ToolkitError(`Remote connection failed: ${err.message}`, {
+                    cause: err,
+                    code: err.code,
+                })
+            }
+        }
+    )
+}
+
+/**
+ * Handles connecting to a stopped space
+ * Starts the space and connects (remote access enabled automatically if needed)
+ */
+async function handleStoppedSpace(
+    node: SagemakerSpaceNode | SagemakerUnifiedStudioSpaceNode,
+    ctx: vscode.ExtensionContext,
+    spaceName: string,
+    sageMakerClient?: SagemakerClient
+) {
+    const client = sageMakerClient || new SagemakerClient(node.regionCode)
+
+    try {
+        await client.startSpace(spaceName, node.spaceApp.DomainId!)
+        await tryRefreshNode(node)
+
         return await vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
@@ -243,8 +368,41 @@ export async function openRemoteConnect(
                 title: `Connecting to ${spaceName}`,
             },
             async (progress) => {
+                progress.report({ message: 'Starting the space' })
+                await client.waitForAppInService(node.spaceApp.DomainId!, spaceName, node.spaceApp.App!.AppType!)
                 await tryRemoteConnection(node, ctx, progress)
             }
         )
+    } catch (err: any) {
+        // Handle user declining instance type upgrade
+        if (err.code === InstanceTypeError) {
+            return
+        }
+        throw new ToolkitError(`Remote connection failed: ${(err as Error).message}`, {
+            cause: err as Error,
+            code: err.code,
+        })
     }
+}
+
+/**
+ * Handles connecting to a running space with enabled remote access
+ * Direct connection without any space modifications
+ */
+async function handleRunningSpaceWithEnabledAccess(
+    node: SagemakerSpaceNode | SagemakerUnifiedStudioSpaceNode,
+    ctx: vscode.ExtensionContext,
+    spaceName: string,
+    sageMakerClient?: SagemakerClient
+) {
+    return await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            cancellable: false,
+            title: `Connecting to ${spaceName}`,
+        },
+        async (progress) => {
+            await tryRemoteConnection(node, ctx, progress)
+        }
+    )
 }

--- a/packages/core/src/awsService/sagemaker/constants.ts
+++ b/packages/core/src/awsService/sagemaker/constants.ts
@@ -18,6 +18,19 @@ export const InstanceTypeInsufficientMemory: Record<string, string> = {
     'ml.c5.large': 'ml.c5.xlarge',
 }
 
+// Remote access constants
+export const RemoteAccess = {
+    ENABLED: 'ENABLED',
+    DISABLED: 'DISABLED',
+} as const
+
+export const SpaceStatus = {
+    RUNNING: 'Running',
+    STOPPED: 'Stopped',
+    STARTING: 'Starting',
+    STOPPING: 'Stopping',
+} as const
+
 export const InstanceTypeInsufficientMemoryMessage = (
     spaceName: string,
     chosenInstanceType: string,
@@ -29,3 +42,6 @@ export const InstanceTypeInsufficientMemoryMessage = (
 export const InstanceTypeNotSelectedMessage = (spaceName: string) => {
     return `No instanceType specified for [${spaceName}]. ${InstanceTypeMinimum} is the default instance type, which meets minimum 8 GiB memory requirements for remote access. Continuing will start your space with instanceType [${InstanceTypeMinimum}] and remotely connect.`
 }
+
+export const RemoteAccessRequiredMessage =
+    'This space requires remote access to be enabled.\nWould you like to restart the space and connect?\nAny unsaved work will be lost.'

--- a/packages/core/src/shared/clients/sagemaker.ts
+++ b/packages/core/src/shared/clients/sagemaker.ts
@@ -44,11 +44,13 @@ import {
     InstanceTypeInsufficientMemory,
     InstanceTypeInsufficientMemoryMessage,
     InstanceTypeNotSelectedMessage,
+    RemoteAccess,
 } from '../../awsService/sagemaker/constants'
 import { getDomainSpaceKey } from '../../awsService/sagemaker/utils'
 import { getLogger } from '../logger/logger'
 import { ToolkitError } from '../errors'
-import { yes, no, continueText, cancel } from '../localizedText'
+import { continueText, cancel } from '../localizedText'
+import { showConfirmationMessage } from '../utilities/messages'
 import { AwsCredentialIdentity } from '@aws-sdk/types'
 import globals from '../extensionGlobals'
 
@@ -126,7 +128,7 @@ export class SagemakerClient extends ClientWrapper<SageMakerClient> {
         return this.makeRequest(DeleteAppCommand, request)
     }
 
-    public async startSpace(spaceName: string, domainId: string) {
+    public async startSpace(spaceName: string, domainId: string, skipInstanceTypePrompts: boolean = false) {
         let spaceDetails: DescribeSpaceCommandOutput
 
         // Get existing space details
@@ -155,40 +157,53 @@ export class SagemakerClient extends ClientWrapper<SageMakerClient> {
 
         // Is InstanceType defined and has enough memory?
         if (instanceType && instanceType in InstanceTypeInsufficientMemory) {
-            // Prompt user to select one with sufficient memory (1 level up from their chosen one)
-            const response = await vscode.window.showErrorMessage(
-                InstanceTypeInsufficientMemoryMessage(
-                    spaceDetails.SpaceName || '',
-                    instanceType,
-                    InstanceTypeInsufficientMemory[instanceType]
-                ),
-                yes,
-                no
-            )
+            if (skipInstanceTypePrompts) {
+                // User already consented, upgrade automatically
+                instanceType = InstanceTypeInsufficientMemory[instanceType]
+            } else {
+                // Prompt user to select one with sufficient memory (1 level up from their chosen one)
+                const confirmed = await showConfirmationMessage({
+                    prompt: InstanceTypeInsufficientMemoryMessage(
+                        spaceDetails.SpaceName || '',
+                        instanceType,
+                        InstanceTypeInsufficientMemory[instanceType]
+                    ),
+                    confirm: 'Restart and Connect',
+                    cancel: 'Cancel',
+                    type: 'warning',
+                })
 
-            if (response === no) {
-                throw new ToolkitError('InstanceType has insufficient memory.', { code: InstanceTypeError })
+                if (!confirmed) {
+                    throw new ToolkitError('InstanceType has insufficient memory.', { code: InstanceTypeError })
+                }
+
+                instanceType = InstanceTypeInsufficientMemory[instanceType]
             }
-
-            instanceType = InstanceTypeInsufficientMemory[instanceType]
         } else if (!instanceType) {
-            // Prompt user to select the minimum supported instance type
-            const response = await vscode.window.showErrorMessage(
-                InstanceTypeNotSelectedMessage(spaceDetails.SpaceName || ''),
-                continueText,
-                cancel
-            )
+            if (skipInstanceTypePrompts) {
+                // User already consented, use minimum
+                instanceType = InstanceTypeMinimum
+            } else {
+                // Prompt user to select the minimum supported instance type
+                const confirmed = await showConfirmationMessage({
+                    prompt: InstanceTypeNotSelectedMessage(spaceDetails.SpaceName || ''),
+                    confirm: continueText,
+                    cancel: cancel,
+                    type: 'warning',
+                })
 
-            if (response === cancel) {
-                throw new ToolkitError('InstanceType not defined.', { code: InstanceTypeError })
+                if (!confirmed) {
+                    throw new ToolkitError('InstanceType not defined.', { code: InstanceTypeError })
+                }
+
+                instanceType = InstanceTypeMinimum
             }
-
-            instanceType = InstanceTypeMinimum
         }
 
         // First, update the space if needed
         const needsRemoteAccess =
-            !spaceDetails.SpaceSettings?.RemoteAccess || spaceDetails.SpaceSettings?.RemoteAccess === 'DISABLED'
+            !spaceDetails.SpaceSettings?.RemoteAccess ||
+            spaceDetails.SpaceSettings?.RemoteAccess === RemoteAccess.DISABLED
         const instanceTypeChanged = requestedResourceSpec?.InstanceType !== instanceType
 
         if (needsRemoteAccess || instanceTypeChanged) {
@@ -196,7 +211,7 @@ export class SagemakerClient extends ClientWrapper<SageMakerClient> {
                 DomainId: domainId,
                 SpaceName: spaceName,
                 SpaceSettings: {
-                    ...(needsRemoteAccess && { RemoteAccess: 'ENABLED' }),
+                    ...(needsRemoteAccess && { RemoteAccess: RemoteAccess.ENABLED }),
                     ...(instanceTypeChanged && {
                         [appTypeSettingsMap[appType]]: {
                             DefaultResourceSpec: {

--- a/packages/core/src/test/awsService/sagemaker/commands.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/commands.test.ts
@@ -1,0 +1,402 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as sinon from 'sinon'
+import assert from 'assert'
+import { SagemakerClient } from '../../../shared/clients/sagemaker'
+import { getTestWindow } from '../../shared/vscode/window'
+import {
+    RemoteAccessRequiredMessage,
+    InstanceTypeInsufficientMemoryMessage,
+} from '../../../awsService/sagemaker/constants'
+
+// Import types only, actual functions will be dynamically imported
+import type { openRemoteConnect as openRemoteConnectStatic } from '../../../awsService/sagemaker/commands'
+
+describe('SageMaker Commands', () => {
+    let sandbox: sinon.SinonSandbox
+    let mockClient: any
+    let mockNode: any
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+        mockClient = sandbox.createStubInstance(SagemakerClient)
+        mockNode = {
+            regionCode: 'us-east-1',
+            spaceApp: {
+                DomainId: 'domain-123',
+                SpaceName: 'test-space',
+            },
+        }
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+        getTestWindow().dispose()
+
+        for (const key of Object.keys(require.cache)) {
+            if (key.includes('awsService/sagemaker/commands')) {
+                delete require.cache[key]
+            }
+        }
+    })
+
+    describe('openRemoteConnect handler integration tests', () => {
+        let mockTryRefreshNode: sinon.SinonStub
+        let mockTryRemoteConnection: sinon.SinonStub
+        let mockIsRemoteWorkspace: sinon.SinonStub
+        let openRemoteConnect: typeof openRemoteConnectStatic
+
+        beforeEach(() => {
+            mockNode = {
+                regionCode: 'us-east-1',
+                spaceApp: {
+                    DomainId: 'domain-123',
+                    SpaceName: 'test-space',
+                    App: {
+                        AppType: 'JupyterLab',
+                        AppName: 'default',
+                    },
+                    SpaceSettingsSummary: {
+                        RemoteAccess: 'DISABLED',
+                    },
+                },
+                getStatus: sandbox.stub().returns('Running'),
+            }
+
+            // Mock helper functions
+            mockTryRefreshNode = sandbox.stub().resolves()
+            mockTryRemoteConnection = sandbox.stub().resolves()
+            mockIsRemoteWorkspace = sandbox.stub().returns(false)
+
+            sandbox.replace(
+                require('../../../awsService/sagemaker/explorer/sagemakerSpaceNode'),
+                'tryRefreshNode',
+                mockTryRefreshNode
+            )
+            sandbox.replace(
+                require('../../../awsService/sagemaker/model'),
+                'tryRemoteConnection',
+                mockTryRemoteConnection
+            )
+            sandbox.replace(require('../../../shared/vscode/env'), 'isRemoteWorkspace', mockIsRemoteWorkspace)
+
+            const freshModule = require('../../../awsService/sagemaker/commands')
+            openRemoteConnect = freshModule.openRemoteConnect
+        })
+
+        describe('handleRunningSpaceWithDisabledAccess', () => {
+            beforeEach(() => {
+                mockNode.getStatus.returns('Running')
+                mockNode.spaceApp.SpaceSettingsSummary.RemoteAccess = 'DISABLED'
+            })
+
+            /**
+             * Test 1: Shows confirmation dialog mentioning "remote access" when instance type is sufficient
+             *
+             * Scenario: User tries to connect to a running space that doesn't have remote access enabled,
+             * but the instance type (ml.t3.large) has sufficient memory for remote access.
+             *
+             * Expected behavior:
+             * - System checks instance type via describeSpace
+             * - Shows confirmation dialog mentioning only "remote access" (no instance upgrade needed)
+             * - User confirms, then space is restarted with remote access enabled
+             * - Connection is established
+             */
+            it('shows confirmation dialog with remote access message when no upgrade needed', async () => {
+                mockClient.describeSpace.resolves({
+                    $metadata: {},
+                    SpaceSettings: {
+                        AppType: 'JupyterLab',
+                        JupyterLabAppSettings: {
+                            DefaultResourceSpec: {
+                                InstanceType: 'ml.t3.large', // Sufficient memory
+                            },
+                        },
+                    },
+                })
+                mockClient.deleteApp.resolves()
+                mockClient.startSpace.resolves()
+                mockClient.waitForAppInService.resolves()
+
+                // Setup test window to handle confirmation dialog
+                getTestWindow().onDidShowMessage((message) => {
+                    if (message.message.includes(RemoteAccessRequiredMessage)) {
+                        message.selectItem('Restart and Connect')
+                    }
+                })
+
+                await openRemoteConnect(mockNode, {} as any, mockClient)
+
+                // Verify describeSpace was called to check instance type
+                assert(mockClient.describeSpace.calledOnce)
+                assert(
+                    mockClient.describeSpace.calledWith({
+                        DomainId: 'domain-123',
+                        SpaceName: 'test-space',
+                    })
+                )
+
+                // Verify confirmation dialog was shown
+                const messages = getTestWindow().shownMessages
+                assert(messages.length > 0)
+                const confirmMessage = messages.find((m) => m.message.includes('remote access'))
+                assert(confirmMessage, 'Should show remote access message')
+                assert(!confirmMessage.message.includes('ml.t3'), 'Should not mention instance type upgrade')
+            })
+
+            /**
+             * Test 2: Shows confirmation dialog mentioning instance upgrade when needed
+             *
+             * Scenario: User tries to connect to a running space with an instance type (ml.t3.medium)
+             * that has insufficient memory for remote access.
+             *
+             * Expected behavior:
+             * - System checks instance type via describeSpace
+             * - Detects ml.t3.medium is insufficient (needs upgrade to ml.t3.large)
+             * - Dialog includes current type (ml.t3.medium) and target type (ml.t3.large)
+             * - User confirms, then space is restarted with upgraded instance and remote access
+             */
+            it('shows confirmation dialog with instance upgrade message when upgrade needed', async () => {
+                mockClient.describeSpace.resolves({
+                    $metadata: {},
+                    SpaceSettings: {
+                        AppType: 'JupyterLab',
+                        JupyterLabAppSettings: {
+                            DefaultResourceSpec: {
+                                InstanceType: 'ml.t3.medium', // Insufficient memory
+                            },
+                        },
+                    },
+                })
+                mockClient.deleteApp.resolves()
+                mockClient.startSpace.resolves()
+                mockClient.waitForAppInService.resolves()
+
+                // Setup test window to handle confirmation dialog
+                getTestWindow().onDidShowMessage((message) => {
+                    if (
+                        message.message.includes(
+                            InstanceTypeInsufficientMemoryMessage('test-space', 'ml.t3.medium', 'ml.t3.large')
+                        )
+                    ) {
+                        message.selectItem('Restart and Connect')
+                    }
+                })
+
+                await openRemoteConnect(mockNode, {} as any, mockClient)
+
+                // Verify describeSpace was called to check instance type
+                assert(mockClient.describeSpace.calledOnce)
+
+                // Verify confirmation dialog includes instance type upgrade info
+                const messages = getTestWindow().shownMessages
+                const expectedMessage = InstanceTypeInsufficientMemoryMessage(
+                    'test-space',
+                    'ml.t3.medium',
+                    'ml.t3.large'
+                )
+                const confirmMessage = messages.find((m) => m.message.includes(expectedMessage))
+                assert(confirmMessage, 'Should show instance upgrade message')
+            })
+
+            /**
+             * Test 3: Verifies the full workflow when user confirms
+             *
+             * Scenario: User confirms the restart dialog for a running space with disabled remote access.
+             *
+             * Expected behavior (in order):
+             * 1. tryRefreshNode() - Refresh node state before starting
+             * 2. describeSpace() - Check instance type requirements
+             * 3. Show confirmation dialog
+             * 4. User confirms
+             * 5. deleteApp() - Stop the running space
+             * 6. startSpace() - Restart with remote access enabled (3rd param = true)
+             * 7. tryRefreshNode() - Refresh node state after restart
+             * 8. waitForAppInService() - Wait for space to be ready
+             * 9. tryRemoteConnection() - Establish the remote connection
+             */
+            it('performs space restart and connection when user confirms', async () => {
+                mockClient.describeSpace.resolves({
+                    $metadata: {},
+                    SpaceSettings: {
+                        AppType: 'JupyterLab',
+                        JupyterLabAppSettings: {
+                            DefaultResourceSpec: {
+                                InstanceType: 'ml.t3.large',
+                            },
+                        },
+                    },
+                })
+                mockClient.deleteApp.resolves()
+                mockClient.startSpace.resolves()
+                mockClient.waitForAppInService.resolves()
+
+                // Setup test window to confirm
+                getTestWindow().onDidShowMessage((message) => {
+                    if (message.items.some((item) => item.title === 'Restart and Connect')) {
+                        message.selectItem('Restart and Connect')
+                    }
+                })
+
+                await openRemoteConnect(mockNode, {} as any, mockClient)
+
+                // Verify tryRefreshNode was called at the start of openRemoteConnect
+                assert(mockTryRefreshNode.calledBefore(mockClient.deleteApp))
+
+                // Verify space operations were performed in correct order
+                assert(mockClient.deleteApp.calledOnce)
+                assert(
+                    mockClient.deleteApp.calledWith({
+                        DomainId: 'domain-123',
+                        SpaceName: 'test-space',
+                        AppType: 'JupyterLab',
+                        AppName: 'default',
+                    })
+                )
+                assert(mockClient.startSpace.calledOnce)
+                assert(mockClient.startSpace.calledWith('test-space', 'domain-123', true)) // Remote access enabled
+
+                // Verify tryRefreshNode was called after startSpace
+                assert(mockTryRefreshNode.calledAfter(mockClient.startSpace))
+
+                assert(mockClient.waitForAppInService.calledOnce)
+                assert(mockClient.waitForAppInService.calledWith('domain-123', 'test-space', 'JupyterLab'))
+                assert(mockTryRemoteConnection.calledOnce)
+            })
+
+            /**
+             * Test 4: Verifies nothing happens when user cancels
+             *
+             * Scenario: User is shown the confirmation dialog but clicks "Cancel" instead of confirming.
+             *
+             * Expected behavior:
+             * - tryRefreshNode() is called (happens before showing dialog)
+             * - describeSpace() is called (to check instance type)
+             * - Confirmation dialog is shown
+             * - User cancels
+             * - NO space operations are performed (no deleteApp, startSpace, or connection attempts)
+             */
+            it('does not perform operations when user cancels', async () => {
+                mockClient.describeSpace.resolves({
+                    $metadata: {},
+                    SpaceSettings: {
+                        AppType: 'JupyterLab',
+                        JupyterLabAppSettings: {
+                            DefaultResourceSpec: {
+                                InstanceType: 'ml.t3.large',
+                            },
+                        },
+                    },
+                })
+
+                // Setup test window to cancel
+                getTestWindow().onDidShowMessage((message) => {
+                    message.selectItem('Cancel')
+                })
+
+                await openRemoteConnect(mockNode, {} as any, mockClient)
+
+                // Verify tryRefreshNode was called (happens before confirmation)
+                assert(mockTryRefreshNode.calledOnce)
+                // Verify no space operations were performed after cancellation
+                assert(mockClient.deleteApp.notCalled)
+                assert(mockClient.startSpace.notCalled)
+                assert(mockTryRemoteConnection.notCalled)
+            })
+        })
+
+        describe('handleStoppedSpace', () => {
+            beforeEach(() => {
+                mockNode.getStatus.returns('Stopped')
+            })
+
+            /**
+             * Test: Starts space and connects without showing confirmation dialog
+             *
+             * Scenario: User tries to connect to a stopped space.
+             *
+             * Expected behavior:
+             * - NO confirmation dialog is shown
+             * - tryRefreshNode() is called at the start
+             * - startSpace() is called WITHOUT remote access flag (2 params only)
+             * - tryRefreshNode() is called again after starting
+             * - waitForAppInService() waits for space to be ready
+             * - tryRemoteConnection() establishes the connection
+             *
+             * Key difference from running space: No confirmation needed because starting
+             * a stopped space is non-destructive
+             */
+            it('starts space and connects without confirmation', async () => {
+                mockClient.startSpace.resolves()
+                mockClient.waitForAppInService.resolves()
+
+                await openRemoteConnect(mockNode, {} as any, mockClient)
+
+                // Verify no confirmation dialog shown for stopped space
+                const confirmMessages = getTestWindow().shownMessages.filter((m) =>
+                    m.message.includes('Restart and Connect')
+                )
+                assert.strictEqual(confirmMessages.length, 0, 'Should not show confirmation for stopped space')
+
+                // Verify tryRefreshNode was called at start of openRemoteConnect
+                assert(mockTryRefreshNode.calledBefore(mockClient.startSpace))
+
+                // Verify space operations - startSpace is called before withProgress
+                assert(mockClient.startSpace.calledOnce)
+                assert(mockClient.startSpace.calledWith('test-space', 'domain-123')) // No remote access flag
+
+                // Verify tryRefreshNode was called after startSpace (before progress)
+                assert(mockTryRefreshNode.calledAfter(mockClient.startSpace))
+                assert.strictEqual(mockTryRefreshNode.callCount, 2) // Once at start, once after startSpace
+
+                // Verify operations inside progress callback
+                assert(mockClient.waitForAppInService.calledOnce)
+                assert(mockClient.waitForAppInService.calledWith('domain-123', 'test-space', 'JupyterLab'))
+                assert(mockTryRemoteConnection.calledOnce)
+            })
+        })
+
+        describe('handleRunningSpaceWithEnabledAccess', () => {
+            beforeEach(() => {
+                mockNode.getStatus.returns('Running')
+                mockNode.spaceApp.SpaceSettingsSummary.RemoteAccess = 'ENABLED'
+            })
+
+            /**
+             * Test: Connects directly without any space operations
+             *
+             * Scenario: User tries to connect to a running space that already has remote access enabled.
+             *
+             * Expected behavior:
+             * - tryRefreshNode() is called once at the start
+             * - NO confirmation dialog is shown (space is already configured correctly)
+             * - NO space operations are performed:
+             *   - No deleteApp() (no need to stop)
+             *   - No startSpace() (already running)
+             *   - No waitForAppInService() (already ready)
+             * - ONLY tryRemoteConnection() is called to establish the connection
+             *
+             * This is the "happy path" - space is ready, just connect directly.
+             */
+            it('connects directly without any space operations', async () => {
+                await openRemoteConnect(mockNode, {} as any, mockClient)
+
+                // Verify tryRefreshNode was called at start
+                assert(mockTryRefreshNode.calledOnce)
+                // Verify no confirmation needed
+                const confirmMessages = getTestWindow().shownMessages.filter((m) =>
+                    m.message.includes('Restart and Connect')
+                )
+                assert.strictEqual(confirmMessages.length, 0)
+                // Verify no space operations performed
+                assert(mockClient.deleteApp.notCalled)
+                assert(mockClient.startSpace.notCalled)
+                assert(mockClient.waitForAppInService.notCalled)
+                // Only remote connection should be attempted
+                assert(mockTryRemoteConnection.calledOnce)
+            })
+        })
+    })
+})

--- a/packages/core/src/test/shared/clients/sagemakerClient.test.ts
+++ b/packages/core/src/test/shared/clients/sagemakerClient.test.ts
@@ -355,9 +355,9 @@ describe('SagemakerClient.startSpace', function () {
 
         const promise = client.startSpace('my-space', 'my-domain')
 
-        // Wait for the error message to appear and select "Yes"
+        // Wait for the error message to appear and select "Restart and Connect"
         await getTestWindow().waitForMessage(/not supported for remote access/)
-        getTestWindow().getFirstMessage().selectItem('Yes')
+        getTestWindow().getFirstMessage().selectItem('Restart and Connect')
 
         await promise
         sinon.assert.calledOnce(updateSpaceStub)
@@ -380,9 +380,9 @@ describe('SagemakerClient.startSpace', function () {
 
         const promise = client.startSpace('my-space', 'my-domain')
 
-        // Wait for the error message to appear and select "No"
+        // Wait for the error message to appear and select "Cancel"
         await getTestWindow().waitForMessage(/not supported for remote access/)
-        getTestWindow().getFirstMessage().selectItem('No')
+        getTestWindow().getFirstMessage().selectItem('Cancel')
 
         await assert.rejects(promise, (err: ToolkitError) => err.message === 'InstanceType has insufficient memory.')
     })

--- a/packages/toolkit/.changes/next-release/Feature-4c794a68-e807-405c-8d31-2c91e3efd574.json
+++ b/packages/toolkit/.changes/next-release/Feature-4c794a68-e807-405c-8d31-2c91e3efd574.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SageMaker: Improved UX for connecting to running spaces with better progress indicators and streamlined remote access handling"
+}

--- a/packages/toolkit/.changes/next-release/feature-smus-ux-improvements.json
+++ b/packages/toolkit/.changes/next-release/feature-smus-ux-improvements.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SageMaker: Improved UX for connecting to running spaces with better progress indicators and streamlined remote access handling"
+}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1504,22 +1504,22 @@
                 {
                     "command": "aws.sagemaker.stopSpace",
                     "group": "inline@0",
-                    "when": "view != aws.smus.rootView  && viewItem =~ /^(awsSagemakerSpaceRunningRemoteEnabledNode|awsSagemakerSpaceRunningRemoteDisabledNode)$/"
+                    "when": "view != aws.smus.rootView && viewItem == awsSagemakerSpaceRunningNode"
                 },
                 {
                     "command": "aws.smus.stopSpace",
                     "group": "inline@0",
-                    "when": "view == aws.smus.rootView && viewItem =~ /^(awsSagemakerSpaceRunningRemoteEnabledNode|awsSagemakerSpaceRunningRemoteDisabledNode|awsSagemakerSpaceRunningNode)$/"
+                    "when": "view == aws.smus.rootView && viewItem == awsSagemakerSpaceRunningNode"
                 },
                 {
                     "command": "aws.sagemaker.openRemoteConnection",
                     "group": "inline@1",
-                    "when": "view != aws.smus.rootView && viewItem =~ /^(awsSagemakerSpaceRunningRemoteEnabledNode|awsSagemakerSpaceStoppedRemoteEnabledNode|awsSagemakerSpaceStoppedRemoteDisabledNode)$/"
+                    "when": "view != aws.smus.rootView && viewItem =~ /^(awsSagemakerSpaceRunningNode|awsSagemakerSpaceNode)$/"
                 },
                 {
                     "command": "aws.smus.openRemoteConnection",
                     "group": "inline@1",
-                    "when": "view == aws.smus.rootView && viewItem =~ /^(awsSagemakerSpaceRunningRemoteEnabledNode|awsSagemakerSpaceStoppedRemoteEnabledNode|awsSagemakerSpaceStoppedRemoteDisabledNode)$/"
+                    "when": "view == aws.smus.rootView && viewItem =~ /^(awsSagemakerSpaceRunningNode|smusSpaceNode)$/"
                 },
                 {
                     "command": "_aws.toolkit.notifications.dismiss",


### PR DESCRIPTION
## Problem
- Connect button only appeared for spaces with remote access enabled. When users landed on the toolkit and saw running spaces without remote access, there was no connect button visible. This created confusion because:
-- Users expected to be able to connect to any running space
-- No visual indication that connection was possible
-- Users didn't understand why some spaces were "connectable" and others weren't

## Solution
- Always show connect button for all spaces (running and stopped, regardless of remote access status). When users click connect on a space without remote access, show clear dialog explaining what needs to happen and get their consent upfront.
- There is no breaking change.
- Tested for all use-cases SM-AI and SMUS

## Current User Exp
---
https://github.com/user-attachments/assets/9c5c8634-42df-4cd1-988b-12cc8008d69e


- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
