### PR TITLE
fix(lambda): Avoid deleting lambda function if publish debug version failed in Remote Debugging

### DIFF
--- a/packages/core/src/lambda/remoteDebugging/ldkClient.ts
+++ b/packages/core/src/lambda/remoteDebugging/ldkClient.ts
@@ -401,7 +401,7 @@ export class LdkClient {
     }
 
     async deleteDebugVersion(functionArn: string, qualifier: string) {
-        if (!qualifier || qualifier === '$LATEST'){
+        if (!qualifier || qualifier === '$LATEST') {
             // avoid deleting function directly
             return true
         }

--- a/packages/core/src/test/lambda/remoteDebugging/ldkClient.test.ts
+++ b/packages/core/src/test/lambda/remoteDebugging/ldkClient.test.ts
@@ -348,6 +348,24 @@ describe('LdkClient', () => {
             assert(mockLambdaClient.deleteFunction.calledOnce, 'Should call deleteFunction')
         })
 
+        it('should skip deletion when qualifier is empty or latest', async () => {
+            const result = await ldkClient.deleteDebugVersion(
+                'arn:aws:lambda:us-east-1:123456789012:function:testFunction',
+                ''
+            )
+
+            const result2 = await ldkClient.deleteDebugVersion(
+                'arn:aws:lambda:us-east-1:123456789012:function:testFunction',
+                '$LATEST'
+            )
+            assert.strictEqual(result, true, 'Should return true without attempting deletion when empty')
+            assert.strictEqual(result2, true, 'Should return true without attempting deletion when latest')
+            assert(
+                mockLambdaClient.deleteFunction.notCalled,
+                'Should not call deleteFunction when qualifier is empty or latest'
+            )
+        })
+
         it('should handle version deletion errors', async () => {
             mockLambdaClient.deleteFunction.rejects(new Error('Delete failed'))
 

--- a/packages/toolkit/.changes/next-release/Bug Fix-275be675-3247-4d5a-a82d-0ce864bb1274.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-275be675-3247-4d5a-a82d-0ce864bb1274.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Remote debugging will not delete lambda function by accident if publish version failed"
+}


### PR DESCRIPTION
## Problem
deleteDebugVersion should only delete the published version, but if in some rare case the version publish failed but workflow still go down to the clean up part, the lambda function itself might be deleted

## Solution
Directly Return if qualifier is undefined/latest

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
