### PR TITLE
fix(amazonq): include reason for inline notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "plugins/*"
             ],
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.128",
+                "@aws/language-server-runtimes": "^0.3.5",
                 "@types/node": "^22.7.5",
                 "jaro-winkler": "^0.2.8",
                 "vscode-nls": "^5.2.0",
@@ -2309,6 +2309,7 @@
         "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -2360,6 +2361,7 @@
         "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -2787,6 +2789,7 @@
         "node_modules/@aws-sdk/client-apprunner/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -2838,6 +2841,7 @@
         "node_modules/@aws-sdk/client-apprunner/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -3268,6 +3272,7 @@
         "node_modules/@aws-sdk/client-cloudcontrol/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -3319,6 +3324,7 @@
         "node_modules/@aws-sdk/client-cloudcontrol/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -3749,6 +3755,7 @@
         "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.682.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -3800,6 +3807,7 @@
         "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sts": {
             "version": "3.682.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4283,6 +4291,7 @@
         "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.682.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4334,6 +4343,7 @@
         "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/client-sts": {
             "version": "3.682.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4765,7 +4775,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4813,7 +4822,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4862,7 +4870,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -4883,7 +4890,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -4897,7 +4903,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -4910,7 +4915,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -4924,7 +4928,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -4941,7 +4944,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/node-config-provider": "^4.0.1",
@@ -4957,7 +4959,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -4969,7 +4970,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
             "version": "3.743.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -4983,7 +4983,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -4994,7 +4993,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -5017,7 +5015,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/config-resolver": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5032,7 +5029,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5050,7 +5046,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -5065,7 +5060,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/hash-node": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-buffer-from": "^4.0.0",
@@ -5079,7 +5073,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/invalid-dependency": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5091,7 +5084,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-content-length": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5104,7 +5096,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -5122,7 +5113,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-retry": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5141,7 +5131,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5153,7 +5142,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5165,7 +5153,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -5179,7 +5166,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5194,7 +5180,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5206,7 +5191,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5218,7 +5202,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5230,7 +5213,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5248,7 +5230,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -5265,7 +5246,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5276,7 +5256,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5289,7 +5268,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -5302,7 +5280,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5313,7 +5290,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-node": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5324,7 +5300,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-config-provider": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5335,7 +5310,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-browser": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/smithy-client": "^4.1.6",
@@ -5350,7 +5324,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-node": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/config-resolver": "^4.0.1",
                 "@smithy/credential-provider-imds": "^4.0.1",
@@ -5367,7 +5340,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-endpoints": {
             "version": "3.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5380,7 +5352,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5392,7 +5363,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-retry": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/service-error-classification": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5405,7 +5375,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -5417,7 +5386,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -5438,7 +5406,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5452,7 +5419,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-logger": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -5465,7 +5431,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5479,7 +5444,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -5496,7 +5460,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/node-config-provider": "^4.0.1",
@@ -5512,7 +5475,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5524,7 +5486,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
             "version": "3.743.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -5538,7 +5499,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -5549,7 +5509,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -5572,7 +5531,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/config-resolver": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5587,7 +5545,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5605,7 +5562,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -5620,7 +5576,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/hash-node": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-buffer-from": "^4.0.0",
@@ -5634,7 +5589,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/invalid-dependency": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5646,7 +5600,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-content-length": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5659,7 +5612,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -5677,7 +5629,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-retry": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5696,7 +5647,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5708,7 +5658,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5720,7 +5669,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -5734,7 +5682,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5749,7 +5696,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5761,7 +5707,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5773,7 +5718,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5785,7 +5729,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5803,7 +5746,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -5820,7 +5762,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5831,7 +5772,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5844,7 +5784,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -5857,7 +5796,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5868,7 +5806,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-node": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5879,7 +5816,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-config-provider": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5890,7 +5826,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-browser": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/smithy-client": "^4.1.6",
@@ -5905,7 +5840,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-node": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/config-resolver": "^4.0.1",
                 "@smithy/credential-provider-imds": "^4.0.1",
@@ -5922,7 +5856,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-endpoints": {
             "version": "3.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5935,7 +5868,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5947,7 +5879,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-retry": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/service-error-classification": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5960,7 +5891,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -5992,7 +5922,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -6007,7 +5936,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -6028,7 +5956,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6040,7 +5967,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6058,7 +5984,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -6076,7 +6001,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6088,7 +6012,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6100,7 +6023,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -6114,7 +6036,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6126,7 +6047,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6138,7 +6058,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6150,7 +6069,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6168,7 +6086,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -6185,7 +6102,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6196,7 +6112,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -6209,7 +6124,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6220,7 +6134,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6232,7 +6145,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -6244,7 +6156,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -6264,7 +6175,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -6285,7 +6195,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6297,7 +6206,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6315,7 +6223,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -6330,7 +6237,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -6348,7 +6254,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6360,7 +6265,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6372,7 +6276,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -6386,7 +6289,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6401,7 +6303,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6413,7 +6314,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6425,7 +6325,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6437,7 +6336,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6455,7 +6353,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -6472,7 +6369,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6483,7 +6379,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -6496,7 +6391,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -6509,7 +6403,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6520,7 +6413,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6532,7 +6424,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -6544,7 +6435,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.758.0",
                 "@aws-sdk/credential-provider-http": "3.758.0",
@@ -6566,7 +6456,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6578,7 +6467,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6590,7 +6478,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6602,7 +6489,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6613,7 +6499,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -6629,7 +6514,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -6650,7 +6534,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6662,7 +6545,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6680,7 +6562,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -6698,7 +6579,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6710,7 +6590,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6722,7 +6601,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -6736,7 +6614,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6748,7 +6625,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6760,7 +6636,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6772,7 +6647,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6790,7 +6664,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -6807,7 +6680,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6818,7 +6690,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -6831,7 +6702,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6842,7 +6712,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6854,7 +6723,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -6866,7 +6734,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/client-sso": "3.758.0",
                 "@aws-sdk/core": "3.758.0",
@@ -6884,7 +6751,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -6905,7 +6771,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/nested-clients": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -6921,7 +6786,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6933,7 +6797,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6951,7 +6814,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -6969,7 +6831,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6981,7 +6842,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6993,7 +6853,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -7007,7 +6866,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7019,7 +6877,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7031,7 +6888,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7043,7 +6899,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -7061,7 +6916,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -7078,7 +6932,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7089,7 +6942,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -7102,7 +6954,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7113,7 +6964,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7125,7 +6975,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -7268,7 +7117,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/abort-controller": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7280,7 +7128,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7291,7 +7138,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/property-provider": "^4.0.1",
@@ -7306,7 +7152,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -7320,7 +7165,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7332,7 +7176,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7344,7 +7187,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7355,7 +7197,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -7368,7 +7209,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/is-array-buffer": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7379,7 +7219,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-builder": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-uri-escape": "^4.0.0",
@@ -7392,7 +7231,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7403,7 +7241,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7415,7 +7252,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7426,7 +7262,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/service-error-classification": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0"
             },
@@ -7437,7 +7272,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/service-error-classification/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7448,7 +7282,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-buffer-from": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -7460,7 +7293,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-hex-encoding": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7471,7 +7303,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream": {
             "version": "4.1.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/node-http-handler": "^4.0.3",
@@ -7489,7 +7320,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -7504,7 +7334,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -7519,7 +7348,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7531,7 +7359,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7542,7 +7369,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -7555,7 +7381,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -7567,7 +7392,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-uri-escape": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -9708,6 +9532,7 @@
         "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -9759,6 +9584,7 @@
         "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -10190,6 +10016,7 @@
             "version": "3.693.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -10242,6 +10069,7 @@
             "version": "3.693.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -11708,6 +11536,7 @@
         "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -11759,6 +11588,7 @@
         "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -12194,6 +12024,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -12247,6 +12078,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -12716,6 +12548,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -12769,6 +12602,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -13402,6 +13236,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -13455,6 +13290,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -13924,6 +13760,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -13977,6 +13814,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -14394,6 +14232,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -14447,6 +14286,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -16047,6 +15887,7 @@
         "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -16098,6 +15939,7 @@
         "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -16534,6 +16376,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -16587,6 +16430,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -17058,6 +16902,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -17111,6 +16956,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -17577,6 +17423,7 @@
         "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -17628,6 +17475,7 @@
         "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -18005,6 +17853,7 @@
         "node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.637.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -18164,6 +18013,7 @@
         "node_modules/@aws-sdk/client-sts": {
             "version": "3.637.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -18410,7 +18260,6 @@
         "node_modules/@aws-sdk/credential-provider-ini": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/credential-provider-env": "3.758.0",
@@ -18433,7 +18282,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/client-sso": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -18481,7 +18329,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -18502,7 +18349,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -18517,7 +18363,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-http": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -18537,7 +18382,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-process": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -18553,7 +18397,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-sso": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/client-sso": "3.758.0",
                 "@aws-sdk/core": "3.758.0",
@@ -18571,7 +18414,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -18585,7 +18427,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-logger": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -18598,7 +18439,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -18612,7 +18452,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -18629,7 +18468,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/node-config-provider": "^4.0.1",
@@ -18645,7 +18483,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/token-providers": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/nested-clients": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -18661,7 +18498,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -18673,7 +18509,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/util-endpoints": {
             "version": "3.743.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -18687,7 +18522,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -18698,7 +18532,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -18721,7 +18554,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/abort-controller": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -18733,7 +18565,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/config-resolver": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -18748,7 +18579,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -18766,7 +18596,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/credential-provider-imds": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/property-provider": "^4.0.1",
@@ -18781,7 +18610,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -18796,7 +18624,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/hash-node": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-buffer-from": "^4.0.0",
@@ -18810,7 +18637,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/invalid-dependency": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -18822,7 +18648,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/is-array-buffer": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -18833,7 +18658,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-content-length": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/types": "^4.1.0",
@@ -18846,7 +18670,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -18864,7 +18687,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-retry": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -18883,7 +18705,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -18895,7 +18716,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -18907,7 +18727,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -18921,7 +18740,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -18936,7 +18754,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -18948,7 +18765,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -18960,7 +18776,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/querystring-builder": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-uri-escape": "^4.0.0",
@@ -18973,7 +18788,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/querystring-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -18985,7 +18799,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/service-error-classification": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0"
             },
@@ -18996,7 +18809,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19008,7 +18820,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -19026,7 +18837,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -19043,7 +18853,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19054,7 +18863,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -19067,7 +18875,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -19080,7 +18887,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19091,7 +18897,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-body-length-node": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19102,7 +18907,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-buffer-from": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -19114,7 +18918,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-config-provider": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19125,7 +18928,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-defaults-mode-browser": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/smithy-client": "^4.1.6",
@@ -19140,7 +18942,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-defaults-mode-node": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/config-resolver": "^4.0.1",
                 "@smithy/credential-provider-imds": "^4.0.1",
@@ -19157,7 +18958,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-endpoints": {
             "version": "3.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -19170,7 +18970,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-hex-encoding": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19181,7 +18980,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19193,7 +18991,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-retry": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/service-error-classification": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -19206,7 +19003,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-stream": {
             "version": "4.1.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/node-http-handler": "^4.0.3",
@@ -19224,7 +19020,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-uri-escape": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19235,7 +19030,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -19407,7 +19201,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/nested-clients": "3.758.0",
@@ -19423,7 +19216,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -19444,7 +19236,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19456,7 +19247,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/abort-controller": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19468,7 +19258,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -19486,7 +19275,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -19501,7 +19289,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/is-array-buffer": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19512,7 +19299,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -19530,7 +19316,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19542,7 +19327,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19554,7 +19338,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -19568,7 +19351,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -19583,7 +19365,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19595,7 +19376,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19607,7 +19387,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/querystring-builder": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-uri-escape": "^4.0.0",
@@ -19620,7 +19399,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/querystring-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19632,7 +19410,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19644,7 +19421,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -19662,7 +19438,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -19679,7 +19454,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19690,7 +19464,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -19703,7 +19476,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -19716,7 +19488,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19727,7 +19498,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-buffer-from": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -19739,7 +19509,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-hex-encoding": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19750,7 +19519,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19762,7 +19530,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-stream": {
             "version": "4.1.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/node-http-handler": "^4.0.3",
@@ -19780,7 +19547,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-uri-escape": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19791,7 +19557,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -21535,7 +21300,6 @@
         "node_modules/@aws-sdk/nested-clients": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -21583,7 +21347,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -21604,7 +21367,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -21618,7 +21380,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -21631,7 +21392,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -21645,7 +21405,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -21662,7 +21421,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/node-config-provider": "^4.0.1",
@@ -21678,7 +21436,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21690,7 +21447,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
             "version": "3.743.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -21704,7 +21460,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -21715,7 +21470,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -21738,7 +21492,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21750,7 +21503,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/config-resolver": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -21765,7 +21517,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -21783,7 +21534,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/credential-provider-imds": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/property-provider": "^4.0.1",
@@ -21798,7 +21548,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -21813,7 +21562,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/hash-node": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-buffer-from": "^4.0.0",
@@ -21827,7 +21575,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/invalid-dependency": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21839,7 +21586,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -21850,7 +21596,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-content-length": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/types": "^4.1.0",
@@ -21863,7 +21608,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -21881,7 +21625,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-retry": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -21900,7 +21643,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21912,7 +21654,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21924,7 +21665,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -21938,7 +21678,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -21953,7 +21692,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21965,7 +21703,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21977,7 +21714,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-builder": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-uri-escape": "^4.0.0",
@@ -21990,7 +21726,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -22002,7 +21737,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/service-error-classification": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0"
             },
@@ -22013,7 +21747,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -22025,7 +21758,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -22043,7 +21775,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -22060,7 +21791,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22071,7 +21801,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -22084,7 +21813,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -22097,7 +21825,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22108,7 +21835,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-node": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22119,7 +21845,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -22131,7 +21856,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-config-provider": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22142,7 +21866,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-browser": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/smithy-client": "^4.1.6",
@@ -22157,7 +21880,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-node": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/config-resolver": "^4.0.1",
                 "@smithy/credential-provider-imds": "^4.0.1",
@@ -22174,7 +21896,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-endpoints": {
             "version": "3.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -22187,7 +21908,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-hex-encoding": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22198,7 +21918,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -22210,7 +21929,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-retry": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/service-error-classification": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -22223,7 +21941,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-stream": {
             "version": "4.1.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/node-http-handler": "^4.0.3",
@@ -22241,7 +21958,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-uri-escape": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22252,7 +21968,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -22605,12 +22320,12 @@
             }
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.128",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.128.tgz",
-            "integrity": "sha512-C666VAvY2PQ8CQkDzjL/+N9rfcFzY6vuGe733drMwwRVHt8On0B0PQPjy31ZjxHUUcjVp78Nb9vmSUEVBfxGTQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.3.5.tgz",
+            "integrity": "sha512-42Ed8O3NMUgZnOZugWCR3uNu2K4cQ7LO3DHMZPQlxpiR7BiyoUo572UMTX9HZyFNErunqdtb0SBPmrdQSLCljQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.56",
+                "@aws/language-server-runtimes-types": "^0.1.61",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/api-logs": "^0.200.0",
                 "@opentelemetry/core": "^2.0.0",
@@ -22621,7 +22336,6 @@
                 "@opentelemetry/sdk-metrics": "^2.0.1",
                 "@smithy/node-http-handler": "^4.0.4",
                 "ajv": "^8.17.1",
-                "aws-sdk": "^2.1692.0",
                 "hpagent": "^1.2.0",
                 "jose": "^5.9.6",
                 "mac-ca": "^3.1.1",
@@ -22633,13 +22347,13 @@
                 "win-ca": "^3.5.1"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=24.0.0"
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.56",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.56.tgz",
-            "integrity": "sha512-Md/L750JShCHUsCQUJva51Ofkn/GDBEX8PpZnWUIVqkpddDR00SLQS2smNf4UHtKNJ2fefsfks/Kqfuatjkjvg==",
+            "version": "0.1.61",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.61.tgz",
+            "integrity": "sha512-kRBcbNDZrJtw3UFqcJ60tYfxM/DzDCHQEz38HINvyecfDCHRTpAAebOMoRQ7PagmsPJ4tasEwzEyRSg2vxq6aQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -23379,6 +23093,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -25134,6 +24849,7 @@
         "node_modules/@types/node": {
             "version": "22.8.4",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.8"
             }
@@ -25357,6 +25073,7 @@
             "version": "7.14.1",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.14.1",
                 "@typescript-eslint/types": "7.14.1",
@@ -26199,6 +25916,7 @@
             "version": "8.14.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -26252,6 +25970,7 @@
             "version": "6.12.6",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -27172,6 +26891,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001629",
                 "electron-to-chromium": "^1.4.796",
@@ -28893,6 +28613,7 @@
             "version": "8.56.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -28947,6 +28668,7 @@
             "version": "9.1.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -31448,6 +31170,7 @@
             "version": "7.2.3",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -32325,6 +32048,7 @@
             "version": "10.1.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
@@ -33438,6 +33162,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -33573,6 +33298,7 @@
             "version": "3.3.3",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -34587,6 +34313,7 @@
             "version": "1.69.5",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -36035,6 +35762,7 @@
             "version": "5.2.2",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -36513,6 +36241,7 @@
         "node_modules/vue": {
             "version": "3.3.4",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.3.4",
                 "@vue/compiler-sfc": "3.3.4",
@@ -36689,6 +36418,7 @@
             "version": "5.95.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.5",
                 "@webassemblyjs/ast": "^1.12.1",
@@ -36734,6 +36464,7 @@
             "version": "5.1.4",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -36808,6 +36539,7 @@
             "version": "8.11.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -36915,6 +36647,7 @@
             "version": "8.8.2",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -38726,6 +38459,7 @@
         "packages/core/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -39248,6 +38982,99 @@
                 }
             }
         },
+        "packages/core/node_modules/@aws/language-server-runtimes": {
+            "version": "0.2.129",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.129.tgz",
+            "integrity": "sha512-ZTObivXrC04FIZHlRgL/E3Dx+hq4wFMOXCGTMHlVUiRs8FaXLXvENZbi0+5/I3Ex/CNwazQWgVaBHJ+dMw42nw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws/language-server-runtimes-types": "^0.1.56",
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/api-logs": "^0.200.0",
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/exporter-logs-otlp-http": "^0.200.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "^0.200.0",
+                "@opentelemetry/resources": "^2.0.1",
+                "@opentelemetry/sdk-logs": "^0.200.0",
+                "@opentelemetry/sdk-metrics": "^2.0.1",
+                "@smithy/node-http-handler": "^4.0.4",
+                "ajv": "^8.17.1",
+                "aws-sdk": "^2.1692.0",
+                "hpagent": "^1.2.0",
+                "jose": "^5.9.6",
+                "mac-ca": "^3.1.1",
+                "registry-js": "^1.16.1",
+                "rxjs": "^7.8.2",
+                "vscode-languageserver": "^9.0.1",
+                "vscode-languageserver-protocol": "^3.17.5",
+                "vscode-uri": "^3.1.0",
+                "win-ca": "^3.5.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/core/node_modules/@aws/language-server-runtimes/node_modules/jose": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+            "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "packages/core/node_modules/@opentelemetry/core": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "packages/core/node_modules/@opentelemetry/resources": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "packages/core/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+            "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/resources": "2.2.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
         "packages/core/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.2",
             "license": "Apache-2.0",
@@ -39752,6 +39579,37 @@
         },
         "packages/core/node_modules/@types/node": {
             "version": "16.18.95",
+            "dev": true,
+            "license": "MIT"
+        },
+        "packages/core/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "packages/core/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "packages/core/node_modules/vscode-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+            "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "webpack-merge": "^5.10.0"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.128",
+        "@aws/language-server-runtimes": "^0.3.5",
         "@types/node": "^22.7.5",
         "jaro-winkler": "^0.2.8",
         "vscode-nls": "^5.2.0",

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -1289,158 +1289,172 @@
                     "fontCharacter": "\\f1d2"
                 }
             },
-            "aws-lambda-function": {
+            "aws-lambda-deployed-function": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d3"
                 }
             },
-            "aws-mynah-MynahIconBlack": {
+            "aws-lambda-function": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d4"
                 }
             },
-            "aws-mynah-MynahIconWhite": {
+            "aws-lambda-invoke-remotely": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d5"
                 }
             },
-            "aws-mynah-logo": {
+            "aws-mynah-MynahIconBlack": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d6"
                 }
             },
-            "aws-redshift-cluster": {
+            "aws-mynah-MynahIconWhite": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d7"
                 }
             },
-            "aws-redshift-cluster-connected": {
+            "aws-mynah-logo": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d8"
                 }
             },
-            "aws-redshift-database": {
+            "aws-redshift-cluster": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1d9"
                 }
             },
-            "aws-redshift-redshift-cluster-connected": {
+            "aws-redshift-cluster-connected": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1da"
                 }
             },
-            "aws-redshift-schema": {
+            "aws-redshift-database": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1db"
                 }
             },
-            "aws-redshift-table": {
+            "aws-redshift-redshift-cluster-connected": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1dc"
                 }
             },
-            "aws-s3-bucket": {
+            "aws-redshift-schema": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1dd"
                 }
             },
-            "aws-s3-create-bucket": {
+            "aws-redshift-table": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1de"
                 }
             },
-            "aws-sagemaker-code-editor": {
+            "aws-s3-bucket": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1df"
                 }
             },
-            "aws-sagemaker-jupyter-lab": {
+            "aws-s3-create-bucket": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e0"
                 }
             },
-            "aws-sagemakerunifiedstudio-catalog": {
+            "aws-sagemaker-code-editor": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e1"
                 }
             },
-            "aws-sagemakerunifiedstudio-spaces": {
+            "aws-sagemaker-jupyter-lab": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e2"
                 }
             },
-            "aws-sagemakerunifiedstudio-spaces-dark": {
+            "aws-sagemakerunifiedstudio-catalog": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e3"
                 }
             },
-            "aws-sagemakerunifiedstudio-symbol-int": {
+            "aws-sagemakerunifiedstudio-spaces": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e4"
                 }
             },
-            "aws-sagemakerunifiedstudio-table": {
+            "aws-sagemakerunifiedstudio-spaces-dark": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e5"
                 }
             },
-            "aws-schemas-registry": {
+            "aws-sagemakerunifiedstudio-symbol-int": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e6"
                 }
             },
-            "aws-schemas-schema": {
+            "aws-sagemakerunifiedstudio-table": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e7"
                 }
             },
-            "aws-stepfunctions-preview": {
+            "aws-schemas-registry": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
                     "fontCharacter": "\\f1e8"
+                }
+            },
+            "aws-schemas-schema": {
+                "description": "AWS Contributed Icon",
+                "default": {
+                    "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
+                    "fontCharacter": "\\f1e9"
+                }
+            },
+            "aws-stepfunctions-preview": {
+                "description": "AWS Contributed Icon",
+                "default": {
+                    "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
+                    "fontCharacter": "\\f1ea"
                 }
             }
         },

--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -37,6 +37,7 @@ import {
     getDiagnosticsOfCurrentFile,
     toIdeDiagnostics,
     handleExtraBrackets,
+    InlineCompletionLoggingReason,
 } from 'aws-core-vscode/codewhisperer'
 import { LineTracker } from './stateTracker/lineTracker'
 import { InlineTutorialAnnotation } from './tutorials/inlineTutorialAnnotation'
@@ -424,6 +425,7 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
                             discarded: !prevSession.displayed,
                         },
                     },
+                    reason: InlineCompletionLoggingReason.IMPLICIT_REJECT,
                     firstCompletionDisplayLatency: prevSession.firstCompletionDisplayLatency,
                     totalSessionDisplayTime: Date.now() - prevSession.requestStartTime,
                 }

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -942,6 +942,10 @@ export const predictionTrackerDefaultConfig = {
     maxSupplementalContext: 15,
 }
 
+export enum InlineCompletionLoggingReason {
+    IMPLICIT_REJECT = 'IMPLICIT_REJECT',
+}
+
 export const codeReviewFindingsSuffix = '_codeReviewFindings'
 export const displayFindingsSuffix = '_displayFindings'
 


### PR DESCRIPTION
## Problem
We need additional reason parameter for inline completion metrics 

## Solution
include reason for inline notification

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
