### PR TITLE
fix(smus): Improve error handling when the Space takes too long to start

### DIFF
--- a/packages/core/src/awsService/sagemaker/commands.ts
+++ b/packages/core/src/awsService/sagemaker/commands.ts
@@ -332,7 +332,8 @@ async function handleRunningSpaceWithDisabledAccess(
                 await client.waitForAppInService(
                     node.spaceApp.DomainId!,
                     spaceName,
-                    node.spaceApp.SpaceSettingsSummary!.AppType!
+                    node.spaceApp.SpaceSettingsSummary!.AppType!,
+                    progress
                 )
                 await tryRemoteConnection(node, ctx, progress)
             } catch (err: any) {
@@ -376,7 +377,8 @@ async function handleStoppedSpace(
                 await client.waitForAppInService(
                     node.spaceApp.DomainId!,
                     spaceName,
-                    node.spaceApp.SpaceSettingsSummary!.AppType!
+                    node.spaceApp.SpaceSettingsSummary!.AppType!,
+                    progress
                 )
                 await tryRemoteConnection(node, ctx, progress)
             }

--- a/packages/core/src/shared/clients/sagemaker.ts
+++ b/packages/core/src/shared/clients/sagemaker.ts
@@ -1,5 +1,4 @@
-/*!
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+/*! * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -58,6 +57,12 @@ const appTypeSettingsMap: Record<string, string> = {
     [AppType.JupyterLab as string]: 'JupyterLabAppSettings',
     [AppType.CodeEditor as string]: 'CodeEditorAppSettings',
 } as const
+
+export const waitForAppConfig = {
+    softTimeoutRetries: 12,
+    hardTimeoutRetries: 120,
+    intervalMs: 5000,
+}
 
 export interface SagemakerSpaceApp extends SpaceDetails {
     App?: AppDetails
@@ -364,10 +369,9 @@ export class SagemakerClient extends ClientWrapper<SageMakerClient> {
         domainId: string,
         spaceName: string,
         appType: string,
-        maxRetries = 30,
-        intervalMs = 5000
+        progress?: vscode.Progress<{ message?: string; increment?: number }>
     ): Promise<void> {
-        for (let attempt = 0; attempt < maxRetries; attempt++) {
+        for (let attempt = 0; attempt < waitForAppConfig.hardTimeoutRetries; attempt++) {
             const { Status } = await this.describeApp({
                 DomainId: domainId,
                 SpaceName: spaceName,
@@ -383,7 +387,13 @@ export class SagemakerClient extends ClientWrapper<SageMakerClient> {
                 throw new ToolkitError(`App failed to start. Status: ${Status}`)
             }
 
-            await sleep(intervalMs)
+            if (attempt === waitForAppConfig.softTimeoutRetries) {
+                progress?.report({
+                    message: `Starting the space is taking longer than usual. The space will connect when ready`,
+                })
+            }
+
+            await sleep(waitForAppConfig.intervalMs)
         }
 
         throw new ToolkitError(`Timed out waiting for app "${spaceName}" to reach "InService" status.`)

--- a/packages/core/src/test/shared/clients/sagemakerClient.test.ts
+++ b/packages/core/src/test/shared/clients/sagemakerClient.test.ts
@@ -251,10 +251,18 @@ describe('SagemakerClient.waitForAppInService', function () {
     it('times out after max retries', async function () {
         describeAppStub.resolves({ Status: 'Pending' })
 
-        await assert.rejects(
-            client.waitForAppInService('domain1', 'space1', 'CodeEditor', 2, 10),
-            /Timed out waiting for app/
-        )
+        const sagemakerModule = await import('../../../shared/clients/sagemaker.js')
+        const originalValue = sagemakerModule.waitForAppConfig.hardTimeoutRetries
+        sagemakerModule.waitForAppConfig.hardTimeoutRetries = 3
+
+        try {
+            await assert.rejects(
+                client.waitForAppInService('domain1', 'space1', 'CodeEditor'),
+                /Timed out waiting for app/
+            )
+        } finally {
+            sagemakerModule.waitForAppConfig.hardTimeoutRetries = originalValue
+        }
     })
 })
 


### PR DESCRIPTION
## Problem

Occasionally, then a user clicks the Connect button for a Space that is in the Stopped status, the corresponding App that gets created eventually takes too long to become Running, so the user is shown the following error message.
```
Remote connection failed: Timed out waiting for app "default-b97e54b8-e0e1-70b7-a216-856fcbb3cc61" to reach "InService" status. | Timed out waiting for app "default-b97e54b8-e0e1-70b7-a216-856fcbb3cc61" to reach "InService" status.
```
We can't prevent this from happening as it depends on the SageMaker platform, but we can improve the user experience around this.


## Solution

* Add more time to hard timeout
* update the process messages when App takes longer than usual to connect 

## Appearance 
### currently:

<img width="474" height="67" alt="Screenshot 2025-11-12 at 12 13 53 PM (3)" src="https://github.com/user-attachments/assets/2b543afa-621f-4ac0-8838-3b1d0ca74276" />
(2 min 30 sec)

-> 

<img width="469" height="161" alt="Screenshot 2025-11-12 at 12 05 16 PM" src="https://github.com/user-attachments/assets/ce4d7f3f-7d52-48ed-937d-b07a7e09175d" />



### this change:
<img width="474" height="67" alt="Screenshot 2025-11-12 at 12 13 53 PM (3)" src="https://github.com/user-attachments/assets/2b543afa-621f-4ac0-8838-3b1d0ca74276" />
(1 min)

-> 

**Note: Based on @dylanraws' and ricokyle@'s suggestions, the exact wording is changed to "Connecting to testX: Starting the Space is taking longer than usual. The space will connect when ready"**
<img width="478" height="127" alt="Screenshot 2025-11-11 at 10 02 37 AM" src="https://github.com/user-attachments/assets/b9d0c4b2-e25b-4c05-8ea5-ecb65c9b3fa5" />
(9 min)

->

<img width="469" height="161" alt="Screenshot 2025-11-12 at 12 05 16 PM" src="https://github.com/user-attachments/assets/ce4d7f3f-7d52-48ed-937d-b07a7e09175d" />




---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
