### PR TITLE
fix(amazonq): add reject reason to nep telemetry

### DIFF
--- a/packages/amazonq/test/unit/app/inline/EditRendering/displayImage.test.ts
+++ b/packages/amazonq/test/unit/app/inline/EditRendering/displayImage.test.ts
@@ -8,6 +8,7 @@ import * as sinon from 'sinon'
 import assert from 'assert'
 import { EditDecorationManager, displaySvgDecoration } from '../../../../../src/app/inline/EditRendering/displayImage'
 import { EditSuggestionState } from '../../../../../src/app/inline/editSuggestionState'
+import { InlineCompletionLoggingReason } from 'aws-core-vscode/codewhisperer'
 
 // Shared helper function to create common stubs
 function createCommonStubs(sandbox: sinon.SinonSandbox) {
@@ -371,7 +372,12 @@ describe('displaySvgDecoration cursor distance auto-reject', function () {
 
         selectionChangeListener(createSelectionChangeEvent(startLine + 26))
 
-        sinon.assert.calledOnceWithExactly(commandsStub, 'aws.amazonq.inline.rejectEdit')
+        sinon.assert.calledOnceWithExactly(
+            commandsStub,
+            'aws.amazonq.inline.rejectEdit',
+            false,
+            InlineCompletionLoggingReason.IMPLICIT_REJECT
+        )
     })
 
     it('should reject when cursor moves more than 25 lines before the edit', async function () {
@@ -384,7 +390,12 @@ describe('displaySvgDecoration cursor distance auto-reject', function () {
 
         selectionChangeListener(createSelectionChangeEvent(startLine - 26))
 
-        sinon.assert.calledOnceWithExactly(commandsStub, 'aws.amazonq.inline.rejectEdit')
+        sinon.assert.calledOnceWithExactly(
+            commandsStub,
+            'aws.amazonq.inline.rejectEdit',
+            false,
+            InlineCompletionLoggingReason.IMPLICIT_REJECT
+        )
     })
 
     it('should not reject when edit is near beginning of file and cursor cannot move far enough', async function () {


### PR DESCRIPTION
## Problem
we need to differentiate implicit/explicit reject for NEP

## Solution
add reject reason to nep telemetry

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
