### PR TITLE
fix(sam): fixing flaky integration tests.

### DIFF
--- a/packages/core/scripts/test/launchTestUtilities.ts
+++ b/packages/core/scripts/test/launchTestUtilities.ts
@@ -121,6 +121,7 @@ async function getVSCodeCliArgs(params: {
             ['DEVELOPMENT_PATH']: projectRootDir,
             ['AWS_TOOLKIT_AUTOMATION']: params.suite,
             ['TEST_DIR']: process.env.TEST_DIR,
+            ['JAVA_HOME']: process.env.JAVA_HOME,
             ...params.env,
         },
     }


### PR DESCRIPTION


## Problem

- https://d1ihu6zq92vp9p.cloudfront.net/45451b0f-383e-4f4a-adc0-ce623f5765be/report.html
```
Error: Activating extension 'redhat.java' failed: Java 21 or more recent is required to run the Java extension. Please download and install a recent JDK. You can still compile your projects with older JDKs by configuring ['java.configuration.runtimes'](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes).
    at v.n (/tmp/.vscode-test/vscode-linux-x64-1.83.0/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:125:6274)
    at async v.m (/tmp/.vscode-test/vscode-linux-x64-1.83.0/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:125:6168)
    at async v.l (/tmp/.vscode-test/vscode-linux-x64-1.83.0/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:125:5625)
```


## Solution
- Fixed test

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
