### PR TITLE
fix(lambda): robust checking on remote debugging

### DIFF
--- a/packages/core/src/lambda/vue/remoteInvoke/remoteInvoke.vue
+++ b/packages/core/src/lambda/vue/remoteInvoke/remoteInvoke.vue
@@ -54,11 +54,21 @@
                         id="attachDebugger"
                         v-model="debugState.remoteDebuggingEnabled"
                         @change="debugPreCheck"
-                        :disabled="!initialData.runtimeSupportsRemoteDebug || !initialData.remoteDebugLayer"
+                        :disabled="
+                            !initialData.runtimeSupportsRemoteDebug ||
+                            !initialData.remoteDebugLayer ||
+                            !initialData.LambdaFunctionNode?.configuration.SnapStart
+                        "
                         class="remote-debug-checkbox"
                     />
                     <div class="setting-description">
-                        <info-wrap v-if="initialData.runtimeSupportsRemoteDebug && initialData.remoteDebugLayer">
+                        <info-wrap
+                            v-if="
+                                initialData.runtimeSupportsRemoteDebug &&
+                                initialData.remoteDebugLayer &&
+                                initialData.LambdaFunctionNode?.configuration.SnapStart
+                            "
+                        >
                             Remote debugging is not recommended for production environments. The AWS Toolkit modifies
                             your function by deploying it with an additional layer to enable remote debugging. Your
                             local code breakpoints are then used to step through the remote function invocation.
@@ -82,6 +92,12 @@
                         </info>
                         <info v-else-if="!initialData.remoteDebugLayer" style="color: var(--vscode-errorForeground)">
                             Region {{ initialData.FunctionRegion }} doesn't support remote debugging yet
+                        </info>
+                        <info
+                            v-else-if="!initialData.LambdaFunctionNode?.configuration.SnapStart"
+                            style="color: var(--vscode-errorForeground)"
+                        >
+                            Doesn't support remote debugging yet
                         </info>
                     </div>
                 </div>


### PR DESCRIPTION
## Problem
Remote debugging doesn't work well on custom function types which doesn't support SnapStart

## Solution
disable until it's supported

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
