### PR TITLE
fix(sagemaker): rearrange order for double unescape

### DIFF
--- a/packages/core/src/awsService/sagemaker/model.ts
+++ b/packages/core/src/awsService/sagemaker/model.ts
@@ -174,14 +174,14 @@ export async function prepareDevEnvConnection(
                   const logFileLocation = path.join(ctx.globalStorageUri.fsPath, 'hyperpod-connection.log')
                   const decodedWsUrl =
                       wsUrl
-                          ?.replace(/&amp;/g, '&')
-                          .replace(/&#39;/g, "'")
-                          .replace(/&quot;/g, '"') || ''
+                          ?.replace(/&#39;/g, "'")
+                          .replace(/&quot;/g, '"')
+                          .replace(/&amp;/g, '&') || ''
                   const decodedToken =
                       token
-                          ?.replace(/&amp;/g, '&')
-                          .replace(/&#39;/g, "'")
-                          .replace(/&quot;/g, '"') || ''
+                          ?.replace(/&#39;/g, "'")
+                          .replace(/&quot;/g, '"')
+                          .replace(/&amp;/g, '&') || ''
                   const region = decodedWsUrl ? extractRegionFromStreamUrl(decodedWsUrl) : ''
 
                   const hyperPodEnv: NodeJS.ProcessEnv = {


### PR DESCRIPTION
## Problem
- replacement may produce '&' characters that are double-unescaped

## Solution
- change the order of the .replace() calls in the decoding of both wsUrl and token such that &amp; is decoded after all other HTML entities have been decoded

- Addressing bot suggestion in https://github.com/aws/aws-toolkit-vscode/pull/8341

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
