### PR TITLE
feat(auth): Add initial support for console session credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2309,6 +2309,7 @@
         "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -2360,6 +2361,7 @@
         "node_modules/@aws-sdk/client-api-gateway/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -2787,6 +2789,7 @@
         "node_modules/@aws-sdk/client-apprunner/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -2838,6 +2841,7 @@
         "node_modules/@aws-sdk/client-apprunner/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -3268,6 +3272,7 @@
         "node_modules/@aws-sdk/client-cloudcontrol/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -3319,6 +3324,7 @@
         "node_modules/@aws-sdk/client-cloudcontrol/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -3749,6 +3755,7 @@
         "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.682.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -3800,6 +3807,7 @@
         "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sts": {
             "version": "3.682.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4283,6 +4291,7 @@
         "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.682.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4334,6 +4343,7 @@
         "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/client-sts": {
             "version": "3.682.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4765,7 +4775,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4813,7 +4822,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4862,7 +4870,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -4883,7 +4890,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -4897,7 +4903,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -4910,7 +4915,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -4924,7 +4928,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -4941,7 +4944,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/node-config-provider": "^4.0.1",
@@ -4957,7 +4959,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -4969,7 +4970,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
             "version": "3.743.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -4983,7 +4983,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -4994,7 +4993,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -5017,7 +5015,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/config-resolver": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5032,7 +5029,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5050,7 +5046,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -5065,7 +5060,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/hash-node": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-buffer-from": "^4.0.0",
@@ -5079,7 +5073,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/invalid-dependency": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5091,7 +5084,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-content-length": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5104,7 +5096,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -5122,7 +5113,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-retry": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5141,7 +5131,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5153,7 +5142,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5165,7 +5153,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -5179,7 +5166,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5194,7 +5180,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5206,7 +5191,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5218,7 +5202,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5230,7 +5213,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5248,7 +5230,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -5265,7 +5246,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5276,7 +5256,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5289,7 +5268,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -5302,7 +5280,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5313,7 +5290,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-node": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5324,7 +5300,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-config-provider": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5335,7 +5310,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-browser": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/smithy-client": "^4.1.6",
@@ -5350,7 +5324,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-node": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/config-resolver": "^4.0.1",
                 "@smithy/credential-provider-imds": "^4.0.1",
@@ -5367,7 +5340,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-endpoints": {
             "version": "3.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5380,7 +5352,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5392,7 +5363,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-retry": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/service-error-classification": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5405,7 +5375,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -5417,7 +5386,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -5438,7 +5406,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5452,7 +5419,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-logger": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -5465,7 +5431,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5479,7 +5444,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -5496,7 +5460,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/node-config-provider": "^4.0.1",
@@ -5512,7 +5475,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5524,7 +5486,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
             "version": "3.743.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -5538,7 +5499,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -5549,7 +5509,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -5572,7 +5531,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/config-resolver": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5587,7 +5545,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5605,7 +5562,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -5620,7 +5576,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/hash-node": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-buffer-from": "^4.0.0",
@@ -5634,7 +5589,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/invalid-dependency": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5646,7 +5600,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-content-length": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5659,7 +5612,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -5677,7 +5629,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-retry": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5696,7 +5647,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5708,7 +5658,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5720,7 +5669,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -5734,7 +5682,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5749,7 +5696,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5761,7 +5707,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5773,7 +5718,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5785,7 +5729,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -5803,7 +5746,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -5820,7 +5762,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5831,7 +5772,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5844,7 +5784,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -5857,7 +5796,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5868,7 +5806,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-node": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5879,7 +5816,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-config-provider": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -5890,7 +5826,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-browser": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/smithy-client": "^4.1.6",
@@ -5905,7 +5840,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-node": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/config-resolver": "^4.0.1",
                 "@smithy/credential-provider-imds": "^4.0.1",
@@ -5922,7 +5856,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-endpoints": {
             "version": "3.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5935,7 +5868,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -5947,7 +5879,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-retry": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/service-error-classification": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -5960,7 +5891,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -5992,7 +5922,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -6007,7 +5936,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -6028,7 +5956,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6040,7 +5967,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6058,7 +5984,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -6076,7 +6001,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6088,7 +6012,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6100,7 +6023,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -6114,7 +6036,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6126,7 +6047,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6138,7 +6058,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6150,7 +6069,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6168,7 +6086,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -6185,7 +6102,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6196,7 +6112,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -6209,7 +6124,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6220,7 +6134,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6232,7 +6145,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -6244,7 +6156,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -6264,7 +6175,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -6285,7 +6195,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6297,7 +6206,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6315,7 +6223,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -6330,7 +6237,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -6348,7 +6254,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6360,7 +6265,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6372,7 +6276,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -6386,7 +6289,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6401,7 +6303,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6413,7 +6314,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6425,7 +6325,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6437,7 +6336,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6455,7 +6353,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -6472,7 +6369,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6483,7 +6379,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -6496,7 +6391,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -6509,7 +6403,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6520,7 +6413,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6532,7 +6424,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -6544,7 +6435,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.758.0",
                 "@aws-sdk/credential-provider-http": "3.758.0",
@@ -6566,7 +6456,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6578,7 +6467,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6590,7 +6478,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6602,7 +6489,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6613,7 +6499,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -6629,7 +6514,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -6650,7 +6534,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6662,7 +6545,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6680,7 +6562,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -6698,7 +6579,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6710,7 +6590,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6722,7 +6601,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -6736,7 +6614,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6748,7 +6625,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6760,7 +6636,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6772,7 +6647,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6790,7 +6664,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -6807,7 +6680,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6818,7 +6690,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -6831,7 +6702,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -6842,7 +6712,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6854,7 +6723,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -6866,7 +6734,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/client-sso": "3.758.0",
                 "@aws-sdk/core": "3.758.0",
@@ -6884,7 +6751,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -6905,7 +6771,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/nested-clients": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -6921,7 +6786,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6933,7 +6797,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -6951,7 +6814,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -6969,7 +6831,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6981,7 +6842,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -6993,7 +6853,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -7007,7 +6866,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7019,7 +6877,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7031,7 +6888,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7043,7 +6899,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -7061,7 +6916,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -7078,7 +6932,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7089,7 +6942,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -7102,7 +6954,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7113,7 +6964,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7125,7 +6975,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -7268,7 +7117,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/abort-controller": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7280,7 +7128,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7291,7 +7138,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/property-provider": "^4.0.1",
@@ -7306,7 +7152,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -7320,7 +7165,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7332,7 +7176,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7344,7 +7187,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7355,7 +7197,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/credential-provider-imds/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -7368,7 +7209,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/is-array-buffer": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7379,7 +7219,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-builder": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-uri-escape": "^4.0.0",
@@ -7392,7 +7231,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7403,7 +7241,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7415,7 +7252,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7426,7 +7262,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/service-error-classification": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0"
             },
@@ -7437,7 +7272,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/service-error-classification/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7448,7 +7282,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-buffer-from": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -7460,7 +7293,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-hex-encoding": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7471,7 +7303,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream": {
             "version": "4.1.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/node-http-handler": "^4.0.3",
@@ -7489,7 +7320,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -7504,7 +7334,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -7519,7 +7348,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -7531,7 +7359,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -7542,7 +7369,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -7555,7 +7381,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -7567,7 +7392,6 @@
         "node_modules/@aws-sdk/client-codecatalyst/node_modules/@smithy/util-uri-escape": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -9708,6 +9532,7 @@
         "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -9759,6 +9584,7 @@
         "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -10190,6 +10016,7 @@
             "version": "3.693.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -10242,6 +10069,7 @@
             "version": "3.693.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -12817,6 +12645,7 @@
         "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -12868,6 +12697,7 @@
         "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -13303,6 +13133,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -13356,6 +13187,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -13825,6 +13657,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -13878,6 +13711,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -14511,6 +14345,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -14564,6 +14399,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -15033,6 +14869,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -15086,6 +14923,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -15503,6 +15341,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -15556,6 +15395,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -17156,6 +16996,7 @@
         "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -17207,6 +17048,7 @@
         "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -17643,6 +17485,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -17696,6 +17539,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -18167,6 +18011,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
             "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -18220,6 +18065,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
             "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -18686,6 +18532,7 @@
         "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -18737,6 +18584,7 @@
         "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -19114,6 +18962,7 @@
         "node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.637.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -19273,6 +19122,7 @@
         "node_modules/@aws-sdk/client-sts": {
             "version": "3.637.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -19393,14 +19243,423 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.730.0.tgz",
-            "integrity": "sha512-Ynp67VkpaaFubqPrqGxLbg5XuS+QTjR7JVhZvjNO6Su4tQVKBFSfQpDIXTyggD9UVixXy4NB9cqg30uvebDeiw==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.936.0.tgz",
+            "integrity": "sha512-+aSC59yiD4M5RcYp9Gx3iwX/n4hO3ZWA2Mxmkzmt9gYFBbJ9umx2LpBdrV64y57AtOvfGeo0h7PAXniIufagxw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-cognito-identity": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/client-cognito-identity": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/client-cognito-identity": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.936.0.tgz",
+            "integrity": "sha512-AkJZ426y0G8Lsyi9p7mWudacMKeo8XLZOfxUmeThMkDa3GxGQ1y6BTrOj6ZcvqQ1Hz7Abb3QWPC+EMqhu1Lncw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/credential-provider-node": "3.936.0",
+                "@aws-sdk/middleware-host-header": "3.936.0",
+                "@aws-sdk/middleware-logger": "3.936.0",
+                "@aws-sdk/middleware-recursion-detection": "3.936.0",
+                "@aws-sdk/middleware-user-agent": "3.936.0",
+                "@aws-sdk/region-config-resolver": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/util-endpoints": "3.936.0",
+                "@aws-sdk/util-user-agent-browser": "3.936.0",
+                "@aws-sdk/util-user-agent-node": "3.936.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.5",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.12",
+                "@smithy/middleware-retry": "^4.4.12",
+                "@smithy/middleware-serde": "^4.2.6",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.11",
+                "@smithy/util-defaults-mode-node": "^4.2.14",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/client-sso": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.936.0.tgz",
+            "integrity": "sha512-0G73S2cDqYwJVvqL08eakj79MZG2QRaB56Ul8/Ps9oQxllr7DMI1IQ/N3j3xjxgpq/U36pkoFZ8aK1n7Sbr3IQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/middleware-host-header": "3.936.0",
+                "@aws-sdk/middleware-logger": "3.936.0",
+                "@aws-sdk/middleware-recursion-detection": "3.936.0",
+                "@aws-sdk/middleware-user-agent": "3.936.0",
+                "@aws-sdk/region-config-resolver": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/util-endpoints": "3.936.0",
+                "@aws-sdk/util-user-agent-browser": "3.936.0",
+                "@aws-sdk/util-user-agent-node": "3.936.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.5",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.12",
+                "@smithy/middleware-retry": "^4.4.12",
+                "@smithy/middleware-serde": "^4.2.6",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.11",
+                "@smithy/util-defaults-mode-node": "^4.2.14",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/core": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.936.0.tgz",
+            "integrity": "sha512-eGJ2ySUMvgtOziHhDRDLCrj473RJoL4J1vPjVM3NrKC/fF3/LoHjkut8AAnKmrW6a2uTzNKubigw8dEnpmpERw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.936.0.tgz",
+            "integrity": "sha512-dKajFuaugEA5i9gCKzOaVy9uTeZcApE+7Z5wdcZ6j40523fY1a56khDAUYkCfwqa7sHci4ccmxBkAo+fW1RChA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.936.0.tgz",
+            "integrity": "sha512-5FguODLXG1tWx/x8fBxH+GVrk7Hey2LbXV5h9SFzYCx/2h50URBm0+9hndg0Rd23+xzYe14F6SI9HA9c1sPnjg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-stream": "^4.5.6",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.936.0.tgz",
+            "integrity": "sha512-TbUv56ERQQujoHcLMcfL0Q6bVZfYF83gu/TjHkVkdSlHPOIKaG/mhE2XZSQzXv1cud6LlgeBbfzVAxJ+HPpffg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/credential-provider-env": "3.936.0",
+                "@aws-sdk/credential-provider-http": "3.936.0",
+                "@aws-sdk/credential-provider-login": "3.936.0",
+                "@aws-sdk/credential-provider-process": "3.936.0",
+                "@aws-sdk/credential-provider-sso": "3.936.0",
+                "@aws-sdk/credential-provider-web-identity": "3.936.0",
+                "@aws-sdk/nested-clients": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.936.0.tgz",
+            "integrity": "sha512-rk/2PCtxX9xDsQW8p5Yjoca3StqmQcSfkmD7nQ61AqAHL1YgpSQWqHE+HjfGGiHDYKG7PvE33Ku2GyA7lEIJAw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.936.0",
+                "@aws-sdk/credential-provider-http": "3.936.0",
+                "@aws-sdk/credential-provider-ini": "3.936.0",
+                "@aws-sdk/credential-provider-process": "3.936.0",
+                "@aws-sdk/credential-provider-sso": "3.936.0",
+                "@aws-sdk/credential-provider-web-identity": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.936.0.tgz",
+            "integrity": "sha512-GpA4AcHb96KQK2PSPUyvChvrsEKiLhQ5NWjeef2IZ3Jc8JoosiedYqp6yhZR+S8cTysuvx56WyJIJc8y8OTrLA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.936.0.tgz",
+            "integrity": "sha512-wHlEAJJvtnSyxTfNhN98JcU4taA1ED2JvuI2eePgawqBwS/Tzi0mhED1lvNIaWOkjfLd+nHALwszGrtJwEq4yQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.936.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/token-providers": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.936.0.tgz",
+            "integrity": "sha512-v3qHAuoODkoRXsAF4RG+ZVO6q2P9yYBT4GMpMEfU9wXVNn7AIfwZgTwzSUfnjNiGva5BKleWVpRpJ9DeuLFbUg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/nested-clients": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+            "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+            "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
+            "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.936.0",
+                "@aws/lambda-invoke-store": "^0.2.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.936.0.tgz",
+            "integrity": "sha512-YB40IPa7K3iaYX0lSnV9easDOLPLh+fJyUDF3BH8doX4i1AOSsYn86L4lVldmOaSX+DwiaqKHpvk4wPBdcIPWw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/util-endpoints": "3.936.0",
+                "@smithy/core": "^3.18.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/nested-clients": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.936.0.tgz",
+            "integrity": "sha512-eyj2tz1XmDSLSZQ5xnB7cLTVKkSJnYAEoNDSUNhzWPxrBDYeJzIbatecOKceKCU8NBf8gWWZCK/CSY0mDxMO0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/middleware-host-header": "3.936.0",
+                "@aws-sdk/middleware-logger": "3.936.0",
+                "@aws-sdk/middleware-recursion-detection": "3.936.0",
+                "@aws-sdk/middleware-user-agent": "3.936.0",
+                "@aws-sdk/region-config-resolver": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/util-endpoints": "3.936.0",
+                "@aws-sdk/util-user-agent-browser": "3.936.0",
+                "@aws-sdk/util-user-agent-node": "3.936.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.5",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.12",
+                "@smithy/middleware-retry": "^4.4.12",
+                "@smithy/middleware-serde": "^4.2.6",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.11",
+                "@smithy/util-defaults-mode-node": "^4.2.14",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+            "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/token-providers": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.936.0.tgz",
+            "integrity": "sha512-vvw8+VXk0I+IsoxZw0mX9TMJawUJvEsg3EF7zcCSetwhNPAU8Xmlhv7E/sN/FgSmm7b7DsqKoW6rVtQiCs1PWQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/nested-clients": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -19408,11 +19667,321 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-            "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+            "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.0.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+            "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-endpoints": "^3.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+            "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/types": "^4.9.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.936.0.tgz",
+            "integrity": "sha512-XOEc7PF9Op00pWV2AYCGDSu5iHgYjIO53Py2VUQTIvP7SRCaCsXmA33mjBvC2Ms6FhSyWNa4aK4naUGIz0hQcw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+            "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "fast-xml-parser": "5.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.1.tgz",
+            "integrity": "sha512-sIyFcoPZkTtNu9xFeEoynMef3bPJIAbOfUh+ueYcfhVl6xm2VRtMcMclSxmZCMnHHd4hlYKJeq/aggmBEWynww==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/abort-controller": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
+            "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/config-resolver": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
+            "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-config-provider": "^4.2.0",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/core": {
+            "version": "3.18.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.5.tgz",
+            "integrity": "sha512-6gnIz3h+PEPQGDj8MnRSjDvKBah042jEoPgjFGJ4iJLBE78L4lY/n98x14XyPF4u3lN179Ub/ZKFY5za9GeLQw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.2.6",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-stream": "^4.5.6",
+                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/uuid": "^1.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/credential-provider-imds": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
+            "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
+            "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/querystring-builder": "^4.2.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/hash-node": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
+            "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/invalid-dependency": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
+            "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/is-array-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+            "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/middleware-content-length": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
+            "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.3.12",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.12.tgz",
+            "integrity": "sha512-9pAX/H+VQPzNbouhDhkW723igBMLgrI8OtX+++M7iKJgg/zY/Ig3i1e6seCcx22FWhE6Q/S61BRdi2wXBORT+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.18.5",
+                "@smithy/middleware-serde": "^4.2.6",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/middleware-retry": {
+            "version": "4.4.12",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.12.tgz",
+            "integrity": "sha512-S4kWNKFowYd0lID7/DBqWHOQxmxlsf0jBaos9chQZUWTVOjSW1Ogyh8/ib5tM+agFDJ/TCxuCTvrnlc+9cIBcQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/service-error-classification": "^4.2.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/uuid": "^1.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/middleware-serde": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
+            "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/middleware-stack": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
+            "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/node-config-provider": {
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
+            "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/node-http-handler": {
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
+            "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/querystring-builder": "^4.2.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -19420,11 +19989,114 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/property-provider": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
-            "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
+            "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/protocol-http": {
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
+            "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/querystring-builder": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
+            "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-uri-escape": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/querystring-parser": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
+            "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/service-error-classification": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
+            "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
+            "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/signature-v4": {
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
+            "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.2.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-hex-encoding": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-uri-escape": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/smithy-client": {
+            "version": "4.9.8",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.8.tgz",
+            "integrity": "sha512-8xgq3LgKDEFoIrLWBho/oYKyWByw9/corz7vuh1upv7ZBm0ZMjGYBhbn6v643WoIqA9UTcx5A5htEp/YatUwMA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.18.5",
+                "@smithy/middleware-endpoint": "^4.3.12",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-stream": "^4.5.6",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -19432,15 +20104,253 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
-            "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
+            "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/url-parser": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
+            "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.2.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-base64": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+            "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+            "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-body-length-node": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+            "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-buffer-from": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+            "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-config-provider": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+            "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.3.11",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.11.tgz",
+            "integrity": "sha512-yHv+r6wSQXEXTPVCIQTNmXVWs7ekBTpMVErjqZoWkYN75HIFN5y9+/+sYOejfAuvxWGvgzgxbTHa/oz61YTbKw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.14.tgz",
+            "integrity": "sha512-ljZN3iRvaJUgulfvobIuG97q1iUuCMrvXAlkZ4msY+ZuVHQHDIqn7FKZCEj+bx8omz6kF5yQXms/xhzjIO5XiA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-endpoints": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
+            "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+            "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-middleware": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
+            "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-retry": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
+            "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.2.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-stream": {
+            "version": "4.5.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
+            "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-hex-encoding": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-uri-escape": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+            "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-utf8": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+            "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/fast-xml-parser": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/strnum": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+            "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.693.0",
@@ -19519,7 +20429,6 @@
         "node_modules/@aws-sdk/credential-provider-ini": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/credential-provider-env": "3.758.0",
@@ -19542,7 +20451,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/client-sso": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -19590,7 +20498,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -19611,7 +20518,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -19626,7 +20532,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-http": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -19646,7 +20551,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-process": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -19662,7 +20566,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/credential-provider-sso": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/client-sso": "3.758.0",
                 "@aws-sdk/core": "3.758.0",
@@ -19680,7 +20583,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -19694,7 +20596,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-logger": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -19707,7 +20608,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -19721,7 +20621,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -19738,7 +20637,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/node-config-provider": "^4.0.1",
@@ -19754,7 +20652,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/token-providers": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/nested-clients": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -19770,7 +20667,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19782,7 +20678,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/util-endpoints": {
             "version": "3.743.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -19796,7 +20691,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -19807,7 +20701,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -19830,7 +20723,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/abort-controller": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19842,7 +20734,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/config-resolver": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -19857,7 +20748,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -19875,7 +20765,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/credential-provider-imds": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/property-provider": "^4.0.1",
@@ -19890,7 +20779,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -19905,7 +20793,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/hash-node": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-buffer-from": "^4.0.0",
@@ -19919,7 +20806,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/invalid-dependency": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -19931,7 +20817,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/is-array-buffer": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -19942,7 +20827,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-content-length": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/types": "^4.1.0",
@@ -19955,7 +20839,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -19973,7 +20856,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-retry": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -19992,7 +20874,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -20004,7 +20885,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -20016,7 +20896,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -20030,7 +20909,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -20045,7 +20923,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -20057,7 +20934,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -20069,7 +20945,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/querystring-builder": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-uri-escape": "^4.0.0",
@@ -20082,7 +20957,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/querystring-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -20094,7 +20968,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/service-error-classification": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0"
             },
@@ -20105,7 +20978,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -20117,7 +20989,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -20135,7 +21006,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -20152,7 +21022,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -20163,7 +21032,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -20176,7 +21044,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -20189,7 +21056,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -20200,7 +21066,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-body-length-node": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -20211,7 +21076,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-buffer-from": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -20223,7 +21087,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-config-provider": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -20234,7 +21097,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-defaults-mode-browser": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/smithy-client": "^4.1.6",
@@ -20249,7 +21111,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-defaults-mode-node": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/config-resolver": "^4.0.1",
                 "@smithy/credential-provider-imds": "^4.0.1",
@@ -20266,7 +21127,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-endpoints": {
             "version": "3.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -20279,7 +21139,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-hex-encoding": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -20290,7 +21149,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -20302,7 +21160,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-retry": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/service-error-classification": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -20315,7 +21172,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-stream": {
             "version": "4.1.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/node-http-handler": "^4.0.3",
@@ -20333,7 +21189,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-uri-escape": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -20344,7 +21199,6 @@
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -21373,7 +22227,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/nested-clients": "3.758.0",
@@ -21389,7 +22242,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -21410,7 +22262,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21422,7 +22273,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/abort-controller": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21434,7 +22284,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -21452,7 +22301,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -21467,7 +22315,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/is-array-buffer": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -21478,7 +22325,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -21496,7 +22342,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21508,7 +22353,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21520,7 +22364,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -21534,7 +22377,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -21549,7 +22391,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21561,7 +22402,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21573,7 +22413,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/querystring-builder": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-uri-escape": "^4.0.0",
@@ -21586,7 +22425,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/querystring-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21598,7 +22436,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21610,7 +22447,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -21628,7 +22464,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -21645,7 +22480,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -21656,7 +22490,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -21669,7 +22502,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -21682,7 +22514,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -21693,7 +22524,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-buffer-from": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -21705,7 +22535,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-hex-encoding": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -21716,7 +22545,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -21728,7 +22556,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-stream": {
             "version": "4.1.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/node-http-handler": "^4.0.3",
@@ -21746,7 +22573,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-uri-escape": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -21757,7 +22583,6 @@
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -21767,25 +22592,80 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.730.0.tgz",
-            "integrity": "sha512-Z25yfmHOehgIDVyY8h7GmAEbodHD2iLgNmrBBkkJXCE6d4GwDet3Qeyw4bQPPyuycBtYOUiz5Oco03+YGOEhYA==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.936.0.tgz",
+            "integrity": "sha512-RWiX6wuReeEU7/P7apGwWMNO7nrai/CXmMMaho3+pJW7i6ImosgsjSe5tetdv1r4djOtM1b4J4WAbHPKJUahUg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-cognito-identity": "3.730.0",
-                "@aws-sdk/core": "3.730.0",
-                "@aws-sdk/credential-provider-cognito-identity": "3.730.0",
-                "@aws-sdk/credential-provider-env": "3.730.0",
-                "@aws-sdk/credential-provider-http": "3.730.0",
-                "@aws-sdk/credential-provider-ini": "3.730.0",
-                "@aws-sdk/credential-provider-node": "3.730.0",
-                "@aws-sdk/credential-provider-process": "3.730.0",
-                "@aws-sdk/credential-provider-sso": "3.730.0",
-                "@aws-sdk/credential-provider-web-identity": "3.730.0",
-                "@aws-sdk/nested-clients": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/credential-provider-imds": "^4.0.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/client-cognito-identity": "3.936.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/credential-provider-cognito-identity": "3.936.0",
+                "@aws-sdk/credential-provider-env": "3.936.0",
+                "@aws-sdk/credential-provider-http": "3.936.0",
+                "@aws-sdk/credential-provider-ini": "3.936.0",
+                "@aws-sdk/credential-provider-login": "3.936.0",
+                "@aws-sdk/credential-provider-node": "3.936.0",
+                "@aws-sdk/credential-provider-process": "3.936.0",
+                "@aws-sdk/credential-provider-sso": "3.936.0",
+                "@aws-sdk/credential-provider-web-identity": "3.936.0",
+                "@aws-sdk/nested-clients": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.5",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-cognito-identity": {
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.936.0.tgz",
+            "integrity": "sha512-AkJZ426y0G8Lsyi9p7mWudacMKeo8XLZOfxUmeThMkDa3GxGQ1y6BTrOj6ZcvqQ1Hz7Abb3QWPC+EMqhu1Lncw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/credential-provider-node": "3.936.0",
+                "@aws-sdk/middleware-host-header": "3.936.0",
+                "@aws-sdk/middleware-logger": "3.936.0",
+                "@aws-sdk/middleware-recursion-detection": "3.936.0",
+                "@aws-sdk/middleware-user-agent": "3.936.0",
+                "@aws-sdk/region-config-resolver": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/util-endpoints": "3.936.0",
+                "@aws-sdk/util-user-agent-browser": "3.936.0",
+                "@aws-sdk/util-user-agent-node": "3.936.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.5",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.12",
+                "@smithy/middleware-retry": "^4.4.12",
+                "@smithy/middleware-serde": "^4.2.6",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.11",
+                "@smithy/util-defaults-mode-node": "^4.2.14",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -21793,47 +22673,48 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.730.0.tgz",
-            "integrity": "sha512-mI8kqkSuVlZklewEmN7jcbBMyVODBld3MsTjCKSl5ztduuPX69JD7nXLnWWPkw1PX4aGTO24AEoRMGNxntoXUg==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.936.0.tgz",
+            "integrity": "sha512-0G73S2cDqYwJVvqL08eakj79MZG2QRaB56Ul8/Ps9oQxllr7DMI1IQ/N3j3xjxgpq/U36pkoFZ8aK1n7Sbr3IQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.730.0",
-                "@aws-sdk/middleware-host-header": "3.723.0",
-                "@aws-sdk/middleware-logger": "3.723.0",
-                "@aws-sdk/middleware-recursion-detection": "3.723.0",
-                "@aws-sdk/middleware-user-agent": "3.730.0",
-                "@aws-sdk/region-config-resolver": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
-                "@aws-sdk/util-endpoints": "3.730.0",
-                "@aws-sdk/util-user-agent-browser": "3.723.0",
-                "@aws-sdk/util-user-agent-node": "3.730.0",
-                "@smithy/config-resolver": "^4.0.0",
-                "@smithy/core": "^3.0.0",
-                "@smithy/fetch-http-handler": "^5.0.0",
-                "@smithy/hash-node": "^4.0.0",
-                "@smithy/invalid-dependency": "^4.0.0",
-                "@smithy/middleware-content-length": "^4.0.0",
-                "@smithy/middleware-endpoint": "^4.0.0",
-                "@smithy/middleware-retry": "^4.0.0",
-                "@smithy/middleware-serde": "^4.0.0",
-                "@smithy/middleware-stack": "^4.0.0",
-                "@smithy/node-config-provider": "^4.0.0",
-                "@smithy/node-http-handler": "^4.0.0",
-                "@smithy/protocol-http": "^5.0.0",
-                "@smithy/smithy-client": "^4.0.0",
-                "@smithy/types": "^4.0.0",
-                "@smithy/url-parser": "^4.0.0",
-                "@smithy/util-base64": "^4.0.0",
-                "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.0",
-                "@smithy/util-defaults-mode-node": "^4.0.0",
-                "@smithy/util-endpoints": "^3.0.0",
-                "@smithy/util-middleware": "^4.0.0",
-                "@smithy/util-retry": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/middleware-host-header": "3.936.0",
+                "@aws-sdk/middleware-logger": "3.936.0",
+                "@aws-sdk/middleware-recursion-detection": "3.936.0",
+                "@aws-sdk/middleware-user-agent": "3.936.0",
+                "@aws-sdk/region-config-resolver": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/util-endpoints": "3.936.0",
+                "@aws-sdk/util-user-agent-browser": "3.936.0",
+                "@aws-sdk/util-user-agent-node": "3.936.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.5",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.12",
+                "@smithy/middleware-retry": "^4.4.12",
+                "@smithy/middleware-serde": "^4.2.6",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.11",
+                "@smithy/util-defaults-mode-node": "^4.2.14",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -21841,20 +22722,23 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.730.0.tgz",
-            "integrity": "sha512-jonKyR+2GcqbZj2WDICZS0c633keLc9qwXnePu83DfAoFXMMIMyoR/7FOGf8F3OrIdGh8KzE9VvST+nZCK9EJA==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.936.0.tgz",
+            "integrity": "sha512-eGJ2ySUMvgtOziHhDRDLCrj473RJoL4J1vPjVM3NrKC/fF3/LoHjkut8AAnKmrW6a2uTzNKubigw8dEnpmpERw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/core": "^3.0.0",
-                "@smithy/node-config-provider": "^4.0.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/protocol-http": "^5.0.0",
-                "@smithy/signature-v4": "^5.0.0",
-                "@smithy/smithy-client": "^4.0.0",
-                "@smithy/types": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.0",
-                "fast-xml-parser": "4.4.1",
+                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -21862,14 +22746,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.730.0.tgz",
-            "integrity": "sha512-fFXgo3jBXLWqu8I07Hd96mS7RjrtpDgm3bZShm0F3lKtqDQF+hObFWq9A013SOE+RjMLVfbABhToXAYct3FcBw==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.936.0.tgz",
+            "integrity": "sha512-dKajFuaugEA5i9gCKzOaVy9uTeZcApE+7Z5wdcZ6j40523fY1a56khDAUYkCfwqa7sHci4ccmxBkAo+fW1RChA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -21877,19 +22762,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.730.0.tgz",
-            "integrity": "sha512-1aF3elbCzpVhWLAuV63iFElfLOqLGGTp4fkf2VAFIDO3hjshpXUQssTgIWiBwwtJYJdOSxaFrCU7u8frjr/5aQ==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.936.0.tgz",
+            "integrity": "sha512-5FguODLXG1tWx/x8fBxH+GVrk7Hey2LbXV5h9SFzYCx/2h50URBm0+9hndg0Rd23+xzYe14F6SI9HA9c1sPnjg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/fetch-http-handler": "^5.0.0",
-                "@smithy/node-http-handler": "^4.0.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/protocol-http": "^5.0.0",
-                "@smithy/smithy-client": "^4.0.0",
-                "@smithy/types": "^4.0.0",
-                "@smithy/util-stream": "^4.0.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-stream": "^4.5.6",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -21897,22 +22783,24 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.730.0.tgz",
-            "integrity": "sha512-zwsxkBuQuPp06o45ATAnznHzj3+ibop/EaTytNzSv0O87Q59K/jnS/bdtv1n6bhe99XCieRNTihvtS7YklzK7A==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.936.0.tgz",
+            "integrity": "sha512-TbUv56ERQQujoHcLMcfL0Q6bVZfYF83gu/TjHkVkdSlHPOIKaG/mhE2XZSQzXv1cud6LlgeBbfzVAxJ+HPpffg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.730.0",
-                "@aws-sdk/credential-provider-env": "3.730.0",
-                "@aws-sdk/credential-provider-http": "3.730.0",
-                "@aws-sdk/credential-provider-process": "3.730.0",
-                "@aws-sdk/credential-provider-sso": "3.730.0",
-                "@aws-sdk/credential-provider-web-identity": "3.730.0",
-                "@aws-sdk/nested-clients": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/credential-provider-imds": "^4.0.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/shared-ini-file-loader": "^4.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/credential-provider-env": "3.936.0",
+                "@aws-sdk/credential-provider-http": "3.936.0",
+                "@aws-sdk/credential-provider-login": "3.936.0",
+                "@aws-sdk/credential-provider-process": "3.936.0",
+                "@aws-sdk/credential-provider-sso": "3.936.0",
+                "@aws-sdk/credential-provider-web-identity": "3.936.0",
+                "@aws-sdk/nested-clients": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -21920,21 +22808,22 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.730.0.tgz",
-            "integrity": "sha512-ztRjh1edY7ut2wwrj1XqHtqPY/NXEYIk5fYf04KKsp8zBi81ScVqP7C+Cst6PFKixjgLSG6RsqMx9GSAalVv0Q==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.936.0.tgz",
+            "integrity": "sha512-rk/2PCtxX9xDsQW8p5Yjoca3StqmQcSfkmD7nQ61AqAHL1YgpSQWqHE+HjfGGiHDYKG7PvE33Ku2GyA7lEIJAw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.730.0",
-                "@aws-sdk/credential-provider-http": "3.730.0",
-                "@aws-sdk/credential-provider-ini": "3.730.0",
-                "@aws-sdk/credential-provider-process": "3.730.0",
-                "@aws-sdk/credential-provider-sso": "3.730.0",
-                "@aws-sdk/credential-provider-web-identity": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/credential-provider-imds": "^4.0.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/shared-ini-file-loader": "^4.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/credential-provider-env": "3.936.0",
+                "@aws-sdk/credential-provider-http": "3.936.0",
+                "@aws-sdk/credential-provider-ini": "3.936.0",
+                "@aws-sdk/credential-provider-process": "3.936.0",
+                "@aws-sdk/credential-provider-sso": "3.936.0",
+                "@aws-sdk/credential-provider-web-identity": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -21942,15 +22831,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.730.0.tgz",
-            "integrity": "sha512-cNKUQ81eptfZN8MlSqwUq3+5ln8u/PcY57UmLZ+npxUHanqO1akpgcpNsLpmsIkoXGbtSQrLuDUgH86lS/SWOw==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.936.0.tgz",
+            "integrity": "sha512-GpA4AcHb96KQK2PSPUyvChvrsEKiLhQ5NWjeef2IZ3Jc8JoosiedYqp6yhZR+S8cTysuvx56WyJIJc8y8OTrLA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/shared-ini-file-loader": "^4.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -21958,17 +22848,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.730.0.tgz",
-            "integrity": "sha512-SdI2xrTbquJLMxUh5LpSwB8zfiKq3/jso53xWRgrVfeDlrSzZuyV6QghaMs3KEEjcNzwEnTfSIjGQyRXG9VrEw==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.936.0.tgz",
+            "integrity": "sha512-wHlEAJJvtnSyxTfNhN98JcU4taA1ED2JvuI2eePgawqBwS/Tzi0mhED1lvNIaWOkjfLd+nHALwszGrtJwEq4yQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.730.0",
-                "@aws-sdk/core": "3.730.0",
-                "@aws-sdk/token-providers": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/shared-ini-file-loader": "^4.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/client-sso": "3.936.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/token-providers": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -21976,15 +22867,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.730.0.tgz",
-            "integrity": "sha512-l5vdPmvF/d890pbvv5g1GZrdjaSQkyPH/Bc8dO/ZqkWxkIP8JNgl48S2zgf4DkP3ik9K2axWO828L5RsMDQzdA==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.936.0.tgz",
+            "integrity": "sha512-v3qHAuoODkoRXsAF4RG+ZVO6q2P9yYBT4GMpMEfU9wXVNn7AIfwZgTwzSUfnjNiGva5BKleWVpRpJ9DeuLFbUg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.730.0",
-                "@aws-sdk/nested-clients": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/nested-clients": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -21992,13 +22885,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.723.0.tgz",
-            "integrity": "sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+            "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/protocol-http": "^5.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22006,12 +22900,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.723.0.tgz",
-            "integrity": "sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+            "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22019,13 +22914,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.723.0.tgz",
-            "integrity": "sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
+            "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/protocol-http": "^5.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/types": "3.936.0",
+                "@aws/lambda-invoke-store": "^0.2.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22033,16 +22930,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.730.0.tgz",
-            "integrity": "sha512-aPMZvNmf2a42B41au3bA3ODU4HfHka2nYT/SAIhhVXH1ENYfAmZo7FraFPxetKepFMCtL7j4QE6/LDucK6liIw==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.936.0.tgz",
+            "integrity": "sha512-YB40IPa7K3iaYX0lSnV9easDOLPLh+fJyUDF3BH8doX4i1AOSsYn86L4lVldmOaSX+DwiaqKHpvk4wPBdcIPWw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@aws-sdk/util-endpoints": "3.730.0",
-                "@smithy/core": "^3.0.0",
-                "@smithy/protocol-http": "^5.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/util-endpoints": "3.936.0",
+                "@smithy/core": "^3.18.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22050,47 +22948,48 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/nested-clients": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.730.0.tgz",
-            "integrity": "sha512-vilIgf1/7kre8DdE5zAQkDOwHFb/TahMn/6j2RZwFLlK7cDk91r19deSiVYnKQkupDMtOfNceNqnorM4I3PDzw==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.936.0.tgz",
+            "integrity": "sha512-eyj2tz1XmDSLSZQ5xnB7cLTVKkSJnYAEoNDSUNhzWPxrBDYeJzIbatecOKceKCU8NBf8gWWZCK/CSY0mDxMO0A==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.730.0",
-                "@aws-sdk/middleware-host-header": "3.723.0",
-                "@aws-sdk/middleware-logger": "3.723.0",
-                "@aws-sdk/middleware-recursion-detection": "3.723.0",
-                "@aws-sdk/middleware-user-agent": "3.730.0",
-                "@aws-sdk/region-config-resolver": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
-                "@aws-sdk/util-endpoints": "3.730.0",
-                "@aws-sdk/util-user-agent-browser": "3.723.0",
-                "@aws-sdk/util-user-agent-node": "3.730.0",
-                "@smithy/config-resolver": "^4.0.0",
-                "@smithy/core": "^3.0.0",
-                "@smithy/fetch-http-handler": "^5.0.0",
-                "@smithy/hash-node": "^4.0.0",
-                "@smithy/invalid-dependency": "^4.0.0",
-                "@smithy/middleware-content-length": "^4.0.0",
-                "@smithy/middleware-endpoint": "^4.0.0",
-                "@smithy/middleware-retry": "^4.0.0",
-                "@smithy/middleware-serde": "^4.0.0",
-                "@smithy/middleware-stack": "^4.0.0",
-                "@smithy/node-config-provider": "^4.0.0",
-                "@smithy/node-http-handler": "^4.0.0",
-                "@smithy/protocol-http": "^5.0.0",
-                "@smithy/smithy-client": "^4.0.0",
-                "@smithy/types": "^4.0.0",
-                "@smithy/url-parser": "^4.0.0",
-                "@smithy/util-base64": "^4.0.0",
-                "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.0",
-                "@smithy/util-defaults-mode-node": "^4.0.0",
-                "@smithy/util-endpoints": "^3.0.0",
-                "@smithy/util-middleware": "^4.0.0",
-                "@smithy/util-retry": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/middleware-host-header": "3.936.0",
+                "@aws-sdk/middleware-logger": "3.936.0",
+                "@aws-sdk/middleware-recursion-detection": "3.936.0",
+                "@aws-sdk/middleware-user-agent": "3.936.0",
+                "@aws-sdk/region-config-resolver": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/util-endpoints": "3.936.0",
+                "@aws-sdk/util-user-agent-browser": "3.936.0",
+                "@aws-sdk/util-user-agent-node": "3.936.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.5",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.12",
+                "@smithy/middleware-retry": "^4.4.12",
+                "@smithy/middleware-serde": "^4.2.6",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.11",
+                "@smithy/util-defaults-mode-node": "^4.2.14",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22098,15 +22997,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.723.0.tgz",
-            "integrity": "sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+            "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/node-config-provider": "^4.0.0",
-                "@smithy/types": "^4.0.0",
-                "@smithy/util-config-provider": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22114,15 +23013,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.730.0.tgz",
-            "integrity": "sha512-BSPssGj54B/AABWXARIPOT/1ybFahM1ldlfmXy9gRmZi/afe9geWJGlFYCCt3PmqR+1Ny5XIjSfue+kMd//drQ==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.936.0.tgz",
+            "integrity": "sha512-vvw8+VXk0I+IsoxZw0mX9TMJawUJvEsg3EF7zcCSetwhNPAU8Xmlhv7E/sN/FgSmm7b7DsqKoW6rVtQiCs1PWQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/nested-clients": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/property-provider": "^4.0.0",
-                "@smithy/shared-ini-file-loader": "^4.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/core": "3.936.0",
+                "@aws-sdk/nested-clients": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22130,11 +23031,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-            "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+            "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.0.0",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22142,13 +23044,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.730.0.tgz",
-            "integrity": "sha512-1KTFuVnk+YtLgWr6TwDiggcDqtPpOY2Cszt3r2lkXfaEAX6kHyOZi1vdvxXjPU5LsOBJem8HZ7KlkmrEi+xowg==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+            "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/types": "^4.0.0",
-                "@smithy/util-endpoints": "^3.0.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-endpoints": "^3.2.5",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22156,25 +23060,27 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.723.0.tgz",
-            "integrity": "sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+            "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/types": "^4.9.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.730.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.730.0.tgz",
-            "integrity": "sha512-yBvkOAjqsDEl1va4eHNOhnFBk0iCY/DBFNyhvtTMqPF4NO+MITWpFs3J9JtZKzJlQ6x0Yb9TLQ8NhDjEISz5Ug==",
+            "version": "3.936.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.936.0.tgz",
+            "integrity": "sha512-XOEc7PF9Op00pWV2AYCGDSu5iHgYjIO53Py2VUQTIvP7SRCaCsXmA33mjBvC2Ms6FhSyWNa4aK4naUGIz0hQcw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.730.0",
-                "@aws-sdk/types": "3.723.0",
-                "@smithy/node-config-provider": "^4.0.0",
-                "@smithy/types": "^4.0.0",
+                "@aws-sdk/middleware-user-agent": "3.936.0",
+                "@aws-sdk/types": "3.936.0",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22189,12 +23095,36 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/abort-controller": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
-            "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+            "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
+                "@smithy/types": "^4.9.0",
+                "fast-xml-parser": "5.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.1.tgz",
+            "integrity": "sha512-sIyFcoPZkTtNu9xFeEoynMef3bPJIAbOfUh+ueYcfhVl6xm2VRtMcMclSxmZCMnHHd4hlYKJeq/aggmBEWynww==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/abort-controller": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
+            "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22202,14 +23132,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/config-resolver": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
-            "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
+            "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.1.3",
-                "@smithy/types": "^4.3.1",
-                "@smithy/util-config-provider": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.4",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-config-provider": "^4.2.0",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22217,18 +23149,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/core": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.5.3.tgz",
-            "integrity": "sha512-xa5byV9fEguZNofCclv6v9ra0FYh5FATQW/da7FQUVTic94DfrN/NvmKZjrMyzbpqfot9ZjBaO8U1UeTbmSLuA==",
+            "version": "3.18.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.5.tgz",
+            "integrity": "sha512-6gnIz3h+PEPQGDj8MnRSjDvKBah042jEoPgjFGJ4iJLBE78L4lY/n98x14XyPF4u3lN179Ub/ZKFY5za9GeLQw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.0.8",
-                "@smithy/protocol-http": "^5.1.2",
-                "@smithy/types": "^4.3.1",
-                "@smithy/util-base64": "^4.0.0",
-                "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.4",
-                "@smithy/util-stream": "^4.2.2",
-                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/middleware-serde": "^4.2.6",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-stream": "^4.5.6",
+                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/uuid": "^1.1.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22236,14 +23170,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/credential-provider-imds": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
-            "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
+            "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.1.3",
-                "@smithy/property-provider": "^4.0.4",
-                "@smithy/types": "^4.3.1",
-                "@smithy/url-parser": "^4.0.4",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22251,14 +23186,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/fetch-http-handler": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
-            "integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
+            "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.1.2",
-                "@smithy/querystring-builder": "^4.0.4",
-                "@smithy/types": "^4.3.1",
-                "@smithy/util-base64": "^4.0.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/querystring-builder": "^4.2.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22266,13 +23202,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/hash-node": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
-            "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
+            "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
-                "@smithy/util-buffer-from": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22280,11 +23217,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/invalid-dependency": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
-            "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
+            "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22292,9 +23230,10 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/is-array-buffer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+            "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22303,12 +23242,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-content-length": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
-            "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
+            "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.1.2",
-                "@smithy/types": "^4.3.1",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22316,17 +23256,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-endpoint": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.11.tgz",
-            "integrity": "sha512-zDogwtRLzKl58lVS8wPcARevFZNBOOqnmzWWxVe9XiaXU2CADFjvJ9XfNibgkOWs08sxLuSr81NrpY4mgp9OwQ==",
+            "version": "4.3.12",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.12.tgz",
+            "integrity": "sha512-9pAX/H+VQPzNbouhDhkW723igBMLgrI8OtX+++M7iKJgg/zY/Ig3i1e6seCcx22FWhE6Q/S61BRdi2wXBORT+A==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.5.3",
-                "@smithy/middleware-serde": "^4.0.8",
-                "@smithy/node-config-provider": "^4.1.3",
-                "@smithy/shared-ini-file-loader": "^4.0.4",
-                "@smithy/types": "^4.3.1",
-                "@smithy/url-parser": "^4.0.4",
-                "@smithy/util-middleware": "^4.0.4",
+                "@smithy/core": "^3.18.5",
+                "@smithy/middleware-serde": "^4.2.6",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-middleware": "^4.2.5",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22334,31 +23275,33 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-retry": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.12.tgz",
-            "integrity": "sha512-wvIH70c4e91NtRxdaLZF+mbLZ/HcC6yg7ySKUiufL6ESp6zJUSnJucZ309AvG9nqCFHSRB5I6T3Ez1Q9wCh0Ww==",
+            "version": "4.4.12",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.12.tgz",
+            "integrity": "sha512-S4kWNKFowYd0lID7/DBqWHOQxmxlsf0jBaos9chQZUWTVOjSW1Ogyh8/ib5tM+agFDJ/TCxuCTvrnlc+9cIBcQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.1.3",
-                "@smithy/protocol-http": "^5.1.2",
-                "@smithy/service-error-classification": "^4.0.5",
-                "@smithy/smithy-client": "^4.4.3",
-                "@smithy/types": "^4.3.1",
-                "@smithy/util-middleware": "^4.0.4",
-                "@smithy/util-retry": "^4.0.5",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/service-error-classification": "^4.2.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/uuid": "^1.1.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-serde": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
-            "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
+            "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.1.2",
-                "@smithy/types": "^4.3.1",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22366,11 +23309,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-stack": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
-            "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
+            "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22378,13 +23322,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-config-provider": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
-            "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
+            "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.0.4",
-                "@smithy/shared-ini-file-loader": "^4.0.4",
-                "@smithy/types": "^4.3.1",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22392,14 +23337,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-http-handler": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
-            "integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
+            "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.0.4",
-                "@smithy/protocol-http": "^5.1.2",
-                "@smithy/querystring-builder": "^4.0.4",
-                "@smithy/types": "^4.3.1",
+                "@smithy/abort-controller": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/querystring-builder": "^4.2.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22407,11 +23353,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/property-provider": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
-            "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
+            "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22419,11 +23366,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/protocol-http": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
-            "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
+            "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22431,12 +23379,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-builder": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
-            "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
+            "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
-                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-uri-escape": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22444,11 +23393,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-parser": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
-            "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
+            "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22456,22 +23406,24 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/service-error-classification": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.5.tgz",
-            "integrity": "sha512-LvcfhrnCBvCmTee81pRlh1F39yTS/+kYleVeLCwNtkY8wtGg8V/ca9rbZZvYIl8OjlMtL6KIjaiL/lgVqHD2nA==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
+            "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1"
+                "@smithy/types": "^4.9.0"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/shared-ini-file-loader": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
-            "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
+            "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22479,17 +23431,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
-            "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
+            "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.0.0",
-                "@smithy/protocol-http": "^5.1.2",
-                "@smithy/types": "^4.3.1",
-                "@smithy/util-hex-encoding": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.4",
-                "@smithy/util-uri-escape": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/is-array-buffer": "^4.2.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-hex-encoding": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-uri-escape": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22497,16 +23450,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/smithy-client": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.3.tgz",
-            "integrity": "sha512-xxzNYgA0HD6ETCe5QJubsxP0hQH3QK3kbpJz3QrosBCuIWyEXLR/CO5hFb2OeawEKUxMNhz3a1nuJNN2np2RMA==",
+            "version": "4.9.8",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.8.tgz",
+            "integrity": "sha512-8xgq3LgKDEFoIrLWBho/oYKyWByw9/corz7vuh1upv7ZBm0ZMjGYBhbn6v643WoIqA9UTcx5A5htEp/YatUwMA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.5.3",
-                "@smithy/middleware-endpoint": "^4.1.11",
-                "@smithy/middleware-stack": "^4.0.4",
-                "@smithy/protocol-http": "^5.1.2",
-                "@smithy/types": "^4.3.1",
-                "@smithy/util-stream": "^4.2.2",
+                "@smithy/core": "^3.18.5",
+                "@smithy/middleware-endpoint": "^4.3.12",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-stream": "^4.5.6",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22514,9 +23468,10 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
-            "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
+            "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22525,12 +23480,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/url-parser": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
-            "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
+            "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/querystring-parser": "^4.0.4",
-                "@smithy/types": "^4.3.1",
+                "@smithy/querystring-parser": "^4.2.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22538,12 +23494,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-base64": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
-            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+            "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22551,9 +23508,10 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-browser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
-            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+            "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22562,9 +23520,10 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-node": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
-            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+            "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22573,11 +23532,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+            "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/is-array-buffer": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22585,9 +23545,10 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-config-provider": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
-            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+            "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22596,14 +23557,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.0.19",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.19.tgz",
-            "integrity": "sha512-mvLMh87xSmQrV5XqnUYEPoiFFeEGYeAKIDDKdhE2ahqitm8OHM3aSvhqL6rrK6wm1brIk90JhxDf5lf2hbrLbQ==",
+            "version": "4.3.11",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.11.tgz",
+            "integrity": "sha512-yHv+r6wSQXEXTPVCIQTNmXVWs7ekBTpMVErjqZoWkYN75HIFN5y9+/+sYOejfAuvxWGvgzgxbTHa/oz61YTbKw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.0.4",
-                "@smithy/smithy-client": "^4.4.3",
-                "@smithy/types": "^4.3.1",
-                "bowser": "^2.11.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22611,16 +23572,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.0.19",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.19.tgz",
-            "integrity": "sha512-8tYnx+LUfj6m+zkUUIrIQJxPM1xVxfRBvoGHua7R/i6qAxOMjqR6CpEpDwKoIs1o0+hOjGvkKE23CafKL0vJ9w==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.14.tgz",
+            "integrity": "sha512-ljZN3iRvaJUgulfvobIuG97q1iUuCMrvXAlkZ4msY+ZuVHQHDIqn7FKZCEj+bx8omz6kF5yQXms/xhzjIO5XiA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/config-resolver": "^4.1.4",
-                "@smithy/credential-provider-imds": "^4.0.6",
-                "@smithy/node-config-provider": "^4.1.3",
-                "@smithy/property-provider": "^4.0.4",
-                "@smithy/smithy-client": "^4.4.3",
-                "@smithy/types": "^4.3.1",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/smithy-client": "^4.9.8",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22628,12 +23590,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-endpoints": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
-            "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
+            "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.1.3",
-                "@smithy/types": "^4.3.1",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22641,9 +23604,10 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-hex-encoding": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+            "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22652,11 +23616,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-middleware": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
-            "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
+            "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.3.1",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22664,12 +23629,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-retry": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.5.tgz",
-            "integrity": "sha512-V7MSjVDTlEt/plmOFBn1762Dyu5uqMrV2Pl2X0dYk4XvWfdWJNe9Bs5Bzb56wkCuiWjSfClVMGcsuKrGj7S/yg==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
+            "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/service-error-classification": "^4.0.5",
-                "@smithy/types": "^4.3.1",
+                "@smithy/service-error-classification": "^4.2.5",
+                "@smithy/types": "^4.9.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22677,17 +23643,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-stream": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
-            "integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
+            "version": "4.5.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
+            "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^5.0.4",
-                "@smithy/node-http-handler": "^4.0.6",
-                "@smithy/types": "^4.3.1",
-                "@smithy/util-base64": "^4.0.0",
-                "@smithy/util-buffer-from": "^4.0.0",
-                "@smithy/util-hex-encoding": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-hex-encoding": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -22695,9 +23662,10 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-uri-escape": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+            "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -22706,16 +23674,47 @@
             }
         },
         "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-utf8": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+            "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/fast-xml-parser": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/strnum": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+            "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/@aws-sdk/lib-storage": {
             "version": "3.693.0",
@@ -23501,7 +24500,6 @@
         "node_modules/@aws-sdk/nested-clients": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -23549,7 +24547,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/core": "^3.1.5",
@@ -23570,7 +24567,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -23584,7 +24580,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -23597,7 +24592,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -23611,7 +24605,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -23628,7 +24621,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/node-config-provider": "^4.0.1",
@@ -23644,7 +24636,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -23656,7 +24647,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
             "version": "3.743.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -23670,7 +24660,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.734.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/types": "^4.1.0",
@@ -23681,7 +24670,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.758.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
@@ -23704,7 +24692,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -23716,7 +24703,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/config-resolver": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -23731,7 +24717,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/core": {
             "version": "3.1.5",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/protocol-http": "^5.0.1",
@@ -23749,7 +24734,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/credential-provider-imds": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/property-provider": "^4.0.1",
@@ -23764,7 +24748,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/fetch-http-handler": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/querystring-builder": "^4.0.1",
@@ -23779,7 +24762,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/hash-node": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-buffer-from": "^4.0.0",
@@ -23793,7 +24775,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/invalid-dependency": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -23805,7 +24786,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -23816,7 +24796,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-content-length": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/types": "^4.1.0",
@@ -23829,7 +24808,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-endpoint": {
             "version": "4.0.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
@@ -23847,7 +24825,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-retry": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -23866,7 +24843,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-serde": {
             "version": "4.0.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -23878,7 +24854,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-stack": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -23890,7 +24865,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-config-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -23904,7 +24878,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
             "version": "4.0.3",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
@@ -23919,7 +24892,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/property-provider": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -23931,7 +24903,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -23943,7 +24914,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-builder": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-uri-escape": "^4.0.0",
@@ -23956,7 +24926,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -23968,7 +24937,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/service-error-classification": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0"
             },
@@ -23979,7 +24947,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -23991,7 +24958,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/signature-v4": {
             "version": "5.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.1",
@@ -24009,7 +24975,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/smithy-client": {
             "version": "4.1.6",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.1.5",
                 "@smithy/middleware-endpoint": "^4.0.6",
@@ -24026,7 +24991,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
             "version": "4.1.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -24037,7 +25001,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/url-parser": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -24050,7 +25013,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-base64": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
@@ -24063,7 +25025,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-browser": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -24074,7 +25035,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-node": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -24085,7 +25045,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -24097,7 +25056,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-config-provider": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -24108,7 +25066,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-browser": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/smithy-client": "^4.1.6",
@@ -24123,7 +25080,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-node": {
             "version": "4.0.7",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/config-resolver": "^4.0.1",
                 "@smithy/credential-provider-imds": "^4.0.1",
@@ -24140,7 +25096,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-endpoints": {
             "version": "3.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -24153,7 +25108,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-hex-encoding": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -24164,7 +25118,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-middleware": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -24176,7 +25129,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-retry": {
             "version": "4.0.1",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/service-error-classification": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -24189,7 +25141,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-stream": {
             "version": "4.1.2",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/node-http-handler": "^4.0.3",
@@ -24207,7 +25158,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-uri-escape": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -24218,7 +25168,6 @@
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
             "version": "4.0.0",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -25384,6 +26333,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -27156,6 +28106,7 @@
         "node_modules/@types/node": {
             "version": "22.8.4",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.8"
             }
@@ -27406,6 +28357,7 @@
             "version": "7.14.1",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.14.1",
                 "@typescript-eslint/types": "7.14.1",
@@ -28248,6 +29200,7 @@
             "version": "8.14.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -28300,6 +29253,7 @@
         "node_modules/ajv": {
             "version": "6.12.6",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -29261,6 +30215,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001629",
                 "electron-to-chromium": "^1.4.796",
@@ -31070,6 +32025,7 @@
             "version": "8.56.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -31124,6 +32080,7 @@
             "version": "9.1.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -33768,6 +34725,7 @@
             "version": "7.2.3",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -34708,6 +35666,7 @@
             "version": "10.1.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
@@ -35882,6 +36841,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -36017,6 +36977,7 @@
             "version": "3.3.3",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -37114,6 +38075,7 @@
             "version": "1.69.5",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -38640,6 +39602,7 @@
             "version": "5.2.2",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -39137,6 +40100,7 @@
         "node_modules/vue": {
             "version": "3.3.4",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.3.4",
                 "@vue/compiler-sfc": "3.3.4",
@@ -39313,6 +40277,7 @@
             "version": "5.95.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.5",
                 "@webassemblyjs/ast": "^1.12.1",
@@ -39358,6 +40323,7 @@
             "version": "5.1.4",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -39432,6 +40398,7 @@
             "version": "8.11.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -39539,6 +40506,7 @@
             "version": "8.8.2",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -39892,6 +40860,7 @@
         "node_modules/ws": {
             "version": "8.17.1",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -40281,7 +41250,7 @@
                 "@aws-sdk/credential-provider-env": "<3.731.0",
                 "@aws-sdk/credential-provider-process": "<3.731.0",
                 "@aws-sdk/credential-provider-sso": "<3.731.0",
-                "@aws-sdk/credential-providers": "<3.731.0",
+                "@aws-sdk/credential-providers": "^3.936.0",
                 "@aws-sdk/lib-storage": "<3.731.0",
                 "@aws-sdk/property-provider": "<3.731.0",
                 "@aws-sdk/protocol-http": "<3.731.0",
@@ -41351,6 +42320,7 @@
         "packages/core/node_modules/@aws-sdk/client-sts": {
             "version": "3.693.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -616,7 +616,7 @@
         "@aws-sdk/credential-provider-env": "<3.731.0",
         "@aws-sdk/credential-provider-process": "<3.731.0",
         "@aws-sdk/credential-provider-sso": "<3.731.0",
-        "@aws-sdk/credential-providers": "<3.731.0",
+        "@aws-sdk/credential-providers": "^3.936.0",
         "@aws-sdk/lib-storage": "<3.731.0",
         "@aws-sdk/property-provider": "<3.731.0",
         "@aws-sdk/protocol-http": "<3.731.0",

--- a/packages/core/src/auth/credentials/types.ts
+++ b/packages/core/src/auth/credentials/types.ts
@@ -10,6 +10,7 @@ export const SharedCredentialsKeys = {
     AWS_ACCESS_KEY_ID: 'aws_access_key_id',
     AWS_SECRET_ACCESS_KEY: 'aws_secret_access_key',
     AWS_SESSION_TOKEN: 'aws_session_token',
+    CONSOLE_SESSION: 'login_session',
     CREDENTIAL_PROCESS: 'credential_process',
     CREDENTIAL_SOURCE: 'credential_source',
     ENDPOINT_URL: 'endpoint_url',

--- a/packages/core/src/test/auth/providers/sharedCredentialsProvider.test.ts
+++ b/packages/core/src/test/auth/providers/sharedCredentialsProvider.test.ts
@@ -184,3 +184,32 @@ describe('SharedCredentialsProvider - Endpoint URL', function () {
         assert.strictEqual(await provider.isAvailable(), true)
     })
 })
+
+describe('SharedCredentialsProvider - Console Session', function () {
+    it('recognizes console session profile type and validates console session profile as valid', async function () {
+        const ini = `
+            [profile console-session-profile]
+            login_session = arn:aws:iam::0123456789012:user/username
+            region = us-west-2
+        `
+        const sections = await createTestSections(ini)
+        const provider = new SharedCredentialsProvider('console-session-profile', sections)
+
+        assert.strictEqual(provider.validate(), undefined)
+        assert.strictEqual(await provider.isAvailable(), true)
+        assert.strictEqual(provider.getProviderType(), 'profile')
+        assert.strictEqual(provider.getTelemetryType(), 'consoleSessionProfile')
+    })
+
+    it('fails for profile without required properties', async function () {
+        const ini = `
+            [profile invalid-console-profile]
+            region = us-west-2
+        `
+        const sections = await createTestSections(ini)
+        const provider = new SharedCredentialsProvider('invalid-console-profile', sections)
+
+        assert.notStrictEqual(provider.validate(), undefined)
+        assert.strictEqual(await provider.isAvailable(), false)
+    })
+})

--- a/packages/toolkit/.changes/next-release/Feature-6fad621e-2928-47bb-9775-30b06548d43f.json
+++ b/packages/toolkit/.changes/next-release/Feature-6fad621e-2928-47bb-9775-30b06548d43f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "AWS Toolkit now supports console credentials, allowing you to use AWS Management Console sign-in credentials for programmatic access. This integration works with the new AWS CLI `aws login` command to enable browser-based authentication for local development."
+}


### PR DESCRIPTION
## Problem

AWS Toolkit needs to support console session credentials to enable new AWS CLI console authentication features which requires `fromLoginCredentials` from AWS SDK v3.936.0 credential providers. Currently, profiles with `login_session` credentials are not recognized as valid credentials.

Learn more: https://aws.amazon.com/about-aws/whats-new/2025/11/console-credentials-aws-cli-sdk-authentication/


## Solution

* Add CONSOLE_SESSION ('login_session') as a supported credential type
* Implement credential provider using [AWS SDK fromLoginCredentials](https://www.npmjs.com/package/@aws-sdk/credential-providers#fromLoginCredentials)
* Handle initial authentication flow and state transitions
* Maintain credential caching and validation

This change enables the basic flow of reading and using console session credentials from shared credentials files. **Credential refresh and reauthentication flow** will be implemented in a future PR.

<img width="1716" height="1001" alt="console-session-test-profile-show-in-list-connections-and-explorer" src="https://github.com/user-attachments/assets/dcbfa671-50de-4b50-b2fb-329873d6b5f0" />
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
