### PR TITLE
fix(smus): reload project node after re-authorization

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/explorer/activation.ts
+++ b/packages/core/src/sagemakerunifiedstudio/explorer/activation.ts
@@ -113,6 +113,13 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
             if (connection) {
                 try {
                     await smusAuthProvider.reauthenticate(connection)
+                    const projectNode = smusRootNode.getProjectSelectNode()
+                    if (projectNode) {
+                        const project = projectNode.getProject()
+                        if (!project) {
+                            await vscode.commands.executeCommand('aws.smus.switchProject')
+                        }
+                    }
                     treeDataProvider.refresh()
 
                     // IAM connections handle their own success messages


### PR DESCRIPTION
## Problem
- Project node is not loading automatically after re-authentication

## Solution
- After re-authentication, set the project, then refresh the node

## User experience
- the user will see select project popup after re-authentication 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
