### PR TITLE
test(lambda): remote debugging user-agent test

### DIFF
--- a/packages/core/src/test/lambda/remoteDebugging/ldkClient.test.ts
+++ b/packages/core/src/test/lambda/remoteDebugging/ldkClient.test.ts
@@ -88,9 +88,7 @@ describe('Remote Debugging User-Agent test', () => {
     after(async () => {
         globals.sdkClientBuilderV3 = sdkBuilderTmp
         // Close the server
-        await new Promise<void>((resolve) => {
-            mockServer.close(() => resolve())
-        })
+        mockServer.close()
     })
 
     for (const scenario of ['Lambda', 'IoT']) {


### PR DESCRIPTION
## Problem
We removed the test in :https://github.com/aws/aws-toolkit-vscode/pull/8318/files
due to localproxy not mocked correctly.
## Solution
Fixed the issue and now adding back these tests.
This test starts a mock server and captures the actual user-agent being sent to make sure we are sending correct UA.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
