### PR TITLE
fix(sagemaker): handle EPERM error when stopping SageMaker local server

### DIFF
--- a/packages/core/src/awsService/sagemaker/model.ts
+++ b/packages/core/src/awsService/sagemaker/model.ts
@@ -343,6 +343,8 @@ export async function stopLocalServer(ctx: vscode.ExtensionContext): Promise<voi
         } catch (err: any) {
             if (err.code === 'ESRCH') {
                 logger.warn(`no process found with PID ${pid}. It may have already exited.`)
+            } else if (err.code === 'EPERM') {
+                logger.warn(`insufficient permissions to stop process with PID ${pid}. Failed to stop local server.`)
             } else {
                 throw ToolkitError.chain(err, 'failed to stop local server')
             }


### PR DESCRIPTION
## Problem
When connecting to SageMaker spaces via SSH, the extension starts a local HTTP server. Before starting a new server, it attempts to stop any existing server by killing its process. If the process doesn't have permission to kill the old server (EPERM error).

## Solution
Added handling for the EPERM error code, similar to the existing ESRCH (process not found) handling. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
