### PR TITLE
fix(cloudformation): Only remap legacy linux builds, if they are avai…

### DIFF
--- a/packages/core/src/awsService/cloudformation/lsp-server/githubManifestAdapter.ts
+++ b/packages/core/src/awsService/cloudformation/lsp-server/githubManifestAdapter.ts
@@ -12,6 +12,7 @@ import {
     dedupeAndGetLatestVersions,
     extractPlatformAndArch,
     useOldLinuxVersion,
+    mapLegacyLinux,
 } from './utils'
 import { getLogger } from '../../../shared/logger/logger'
 import { ToolkitError } from '../../../shared/errors'
@@ -54,33 +55,11 @@ export class GitHubManifestAdapter {
             return manifest
         }
 
-        getLogger('awsCfnLsp').warn('Using GLIBC compatible version for Linux')
-        const versions = manifest.versions.map((version) => {
-            const targets = version.targets
-                .filter((target) => {
-                    return target.platform !== 'linux'
-                })
-                .map((target) => {
-                    if (target.platform !== 'linuxglib2.28') {
-                        return target
-                    }
-
-                    return {
-                        ...target,
-                        platform: 'linux',
-                    }
-                })
-
-            return {
-                ...version,
-                targets,
-            }
-        })
-
-        manifest.versions = versions
+        getLogger('awsCfnLsp').info('In a legacy or sandbox Linux environment')
+        manifest.versions = mapLegacyLinux(manifest.versions)
 
         getLogger('awsCfnLsp').info(
-            'Remapped candidate versions from platform linuxglib2.28 to linux: %s',
+            'Remapped candidate versions: %s',
             manifest.versions
                 .map(
                     (v) =>

--- a/packages/core/src/test/awsService/cloudformation/lsp-server/utils.test.ts
+++ b/packages/core/src/test/awsService/cloudformation/lsp-server/utils.test.ts
@@ -10,7 +10,9 @@ import {
     dedupeAndGetLatestVersions,
     extractPlatformAndArch,
     useOldLinuxVersion,
+    mapLegacyLinux,
     CfnTarget,
+    CfnLspVersion,
 } from '../../../../awsService/cloudformation/lsp-server/utils'
 import { CLibCheck } from '../../../../awsService/cloudformation/lsp-server/CLibCheck'
 import { LspVersion } from '../../../../shared/lsp/types'
@@ -221,4 +223,89 @@ describe('dedupeAndGetLatestVersions', () => {
             return { serverVersion: `${prefix}${version}`, targets: [], isDelisted: false }
         })
     }
+})
+
+describe('mapLegacyLinux', () => {
+    const darwinContent = { filename: 'darwin.zip', url: 'https://example.com/darwin.zip', hashes: ['abc'], bytes: 100 }
+    const linuxContent = { filename: 'linux.zip', url: 'https://example.com/linux.zip', hashes: ['def'], bytes: 200 }
+    const legacyContent = { filename: 'legacy.zip', url: 'https://example.com/legacy.zip', hashes: ['ghi'], bytes: 300 }
+    const winContent = { filename: 'win.zip', url: 'https://example.com/win.zip', hashes: ['jkl'], bytes: 400 }
+
+    it('remaps linuxglib2.28 to linux and removes original linux target', () => {
+        const versions: CfnLspVersion[] = [
+            {
+                serverVersion: '1.0.0',
+                isDelisted: false,
+                targets: [
+                    { platform: 'darwin', arch: 'arm64', contents: [darwinContent] },
+                    { platform: 'linux', arch: 'x64', contents: [linuxContent] },
+                    { platform: 'linuxglib2.28', arch: 'x64', contents: [legacyContent], nodejs: '18' },
+                    { platform: 'win32', arch: 'x64', contents: [winContent] },
+                ],
+            },
+        ]
+
+        const result = mapLegacyLinux(versions)
+
+        assert.strictEqual(result.length, 1)
+        assert.strictEqual(result[0].serverVersion, '1.0.0')
+        assert.strictEqual(result[0].isDelisted, false)
+        assert.strictEqual(result[0].targets.length, 3)
+        assert.deepStrictEqual(result[0].targets[0], { platform: 'darwin', arch: 'arm64', contents: [darwinContent] })
+        assert.deepStrictEqual(result[0].targets[1], {
+            platform: 'linux',
+            arch: 'x64',
+            contents: [legacyContent],
+            nodejs: '18',
+        })
+        assert.deepStrictEqual(result[0].targets[2], { platform: 'win32', arch: 'x64', contents: [winContent] })
+    })
+
+    it('returns version unchanged when no linuxglib2.28 target exists', () => {
+        const versions: CfnLspVersion[] = [
+            {
+                serverVersion: '2.0.0',
+                isDelisted: true,
+                targets: [
+                    { platform: 'darwin', arch: 'arm64', contents: [darwinContent] },
+                    { platform: 'linux', arch: 'x64', contents: [linuxContent] },
+                ],
+            },
+        ]
+
+        const result = mapLegacyLinux(versions)
+
+        assert.strictEqual(result.length, 1)
+        assert.deepStrictEqual(result[0], versions[0])
+    })
+
+    it('handles multiple versions with mixed legacy targets', () => {
+        const versions: CfnLspVersion[] = [
+            {
+                serverVersion: '1.0.0',
+                isDelisted: false,
+                targets: [
+                    { platform: 'darwin', arch: 'arm64', contents: [] },
+                    { platform: 'linuxglib2.28', arch: 'x64', contents: [legacyContent] },
+                ],
+            },
+            {
+                serverVersion: '2.0.0',
+                isDelisted: false,
+                targets: [{ platform: 'darwin', arch: 'arm64', contents: [] }],
+            },
+        ]
+
+        const result = mapLegacyLinux(versions)
+
+        assert.strictEqual(result.length, 2)
+        assert.strictEqual(result[0].serverVersion, '1.0.0')
+        assert.strictEqual(result[0].targets.length, 2)
+        assert.deepStrictEqual(result[0].targets[1], { platform: 'linux', arch: 'x64', contents: [legacyContent] })
+        assert.deepStrictEqual(result[1], versions[1])
+    })
+
+    it('handles empty versions array', () => {
+        assert.deepStrictEqual(mapLegacyLinux([]), [])
+    })
 })


### PR DESCRIPTION
[fix(cloudformation): Only remap legacy linux builds, if they are available](https://github.com/aws/aws-toolkit-vscode/pull/8398/commits/b5a2c7f3df8b83170c4b7da709ba25d7d0917966)

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
