### PR TITLE
feat(cloudformation): Hook invocations

### DIFF
--- a/packages/toolkit/.changes/next-release/Feature-0312f3cb-0d15-4b34-b765-e49aba2b7f6b.json
+++ b/packages/toolkit/.changes/next-release/Feature-0312f3cb-0d15-4b34-b765-e49aba2b7f6b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CloudFormation: Show hook invocations in stack events on failure"
+}


### PR DESCRIPTION
## Problem
- Hook invocations not visible in stack events

## Solution
- show Hook invocations when there is a failure caused by Hook (last column is new and shows conditionally)
<img width="1213" height="582" alt="image" src="https://github.com/user-attachments/assets/0e57407d-5fcc-415b-ae2a-e9e39d8d49dc" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
