### PR TITLE
fix(auth): Add console session profile overwrite prompt and improve credential refresh flow

### DIFF
--- a/packages/core/src/auth/providers/sharedCredentialsProvider.ts
+++ b/packages/core/src/auth/providers/sharedCredentialsProvider.ts
@@ -400,10 +400,9 @@ export class SharedCredentialsProvider implements CredentialsProvider {
         const baseProvider = fromLoginCredentials({
             profile: this.profileName,
             clientConfig: {
-                region: this.getDefaultRegion() ?? 'us-east-1',
+                region: defaultRegion,
             },
         })
-
         return async () => {
             try {
                 return await baseProvider()
@@ -434,6 +433,7 @@ export class SharedCredentialsProvider implements CredentialsProvider {
                             cancelled: true,
                         })
                     }
+
                     getLogger().info('Re-authenticating using console credentials for profile %s', this.profileName)
                     // Execute the console login command with the existing profile and region
                     try {
@@ -454,6 +454,7 @@ export class SharedCredentialsProvider implements CredentialsProvider {
                         'Authentication completed for profile %s, refreshing credentials...',
                         this.profileName
                     )
+
                     // Use the same provider instance but get fresh credentials
                     return await baseProvider()
                 }

--- a/packages/toolkit/.changes/next-release/Feature-26bab6fe-608c-41a0-a672-ca3290b61558.json
+++ b/packages/toolkit/.changes/next-release/Feature-26bab6fe-608c-41a0-a672-ca3290b61558.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "AWS Toolkit login webview now pre-selects Console credentials (previously Enterprise SSO) as the recommended authentication option. Existing Enterprise SSO users are unaffected and can still select their preferred authentication method."
+	"description": "AWS Toolkit now supports console credentials, allowing you to use AWS Management Console sign-in credentials for programmatic access. The login webview now pre-selects Console credentials as the recommended authentication option (previously Enterprise SSO was the first choice). When overwriting an existing console session on a profile, you'll be prompted to confirm whether to proceed or cancel."
 }

--- a/packages/toolkit/.changes/next-release/Feature-6fad621e-2928-47bb-9775-30b06548d43f.json
+++ b/packages/toolkit/.changes/next-release/Feature-6fad621e-2928-47bb-9775-30b06548d43f.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "AWS Toolkit now supports console credentials, allowing you to use AWS Management Console sign-in credentials for programmatic access. This integration works with the new AWS CLI `aws login` command to enable browser-based authentication for local development."
-}


### PR DESCRIPTION
## Problem
- Users were blocked when AWS CLI prompted to overwrite an existing console session, with no way to respond from VS Code
- Credential refresh flow caused hanging "Getting credentials for profile" progress messages
- Extension activation failed with "non-passive metric emitted at startup" error

## Solution
<img width="474" height="181" alt="overwrite-with-cancel" src="https://github.com/user-attachments/assets/4178486a-f66e-4e98-b01d-f04c0539d9b7" />

- Detect CLI overwrite prompts and show interactive dialog with exact CLI message
- Send user's response ("y" or "n") to CLI stdin to proceed or cancel
- Invalidate cached credentials after successful login and update connection state without triggering immediate credential fetch
- Change telemetry emission from .run() to .emit() to comply with passive telemetry rules

## Testing
- Fresh profile creation
- Profile overwrite with user confirmation
- User cancellation of overwrite
- Credential refresh when session expires

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
