### PR TITLE
fix(smus): dispose authprovider and then dz clients when signing out

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioRootNode.ts
+++ b/packages/core/src/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioRootNode.ts
@@ -394,6 +394,9 @@ export const smusSignOutCommand = Commands.declare(
                     await SmusAuthenticationPreferencesManager.clearConnectionPreferences(context)
                 }
 
+                // Dispose smusAuthProvider
+                authProvider.dispose()
+
                 // Show success message
                 void vscode.window.showInformationMessage('Successfully signed out from SageMaker Unified Studio.')
 


### PR DESCRIPTION
## Problem
- Signing out did not clear the DZ client, so when user re-tries signing in with corrected region, they cannot access the targeted domain. 

## Solution
- Dispose smuAuthProvider when signing out, within authProvider dispose, the DZ clients will also be disposed

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
