### PR TITLE
telemetry(smus): Handle async calls gracefully in telemetry

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/shared/telemetry.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/telemetry.ts
@@ -21,6 +21,7 @@ import { ConnectionCredentialsProvider } from '../auth/providers/connectionCrede
 import { DataZoneConnection } from './client/datazoneClient'
 import { createDZClientBaseOnDomainMode } from '../explorer/nodes/utils'
 
+const notSet = 'not-set'
 /**
  * Records space telemetry
  */
@@ -30,37 +31,46 @@ export async function recordSpaceTelemetry(
 ) {
     const logger = getLogger('smus')
 
+    const parent = node.resource.getParent() as SageMakerUnifiedStudioSpacesParentNode
+    const authProvider = SmusAuthenticationProvider.fromContext()
+    const projectId = parent?.getProjectId()
+    const domainId = parent?.getAuthProvider()?.getDomainId()
+
+    span.record({
+        smusAuthMode: authProvider.activeConnection?.type,
+        smusSpaceKey: node.resource.DomainSpaceKey,
+        smusDomainRegion: node.resource.regionCode,
+        smusDomainId: domainId,
+        smusProjectId: projectId,
+    })
+
     try {
-        const parent = node.resource.getParent() as SageMakerUnifiedStudioSpacesParentNode
-        const authProvider = SmusAuthenticationProvider.fromContext()
         const accountId = await authProvider.getDomainAccountId()
-        const projectId = parent?.getProjectId()
+        span.record({ smusDomainAccountId: accountId })
+    } catch (err) {
+        span.record({ smusDomainAccountId: notSet })
+        logger.warn(`Failed to record domain account Id for telemetry in domain ${domainId}: ${(err as Error).message}`)
+    }
 
-        // Get project account ID and region
-        let projectAccountId: string | undefined
-        let projectRegion: string | undefined
-
-        if (projectId) {
-            projectAccountId = await authProvider.getProjectAccountId(projectId)
-
-            // Get project region from tooling environment
-            const dzClient = await createDZClientBaseOnDomainMode(authProvider)
-            const toolingEnv = await dzClient.getToolingEnvironment(projectId)
-            projectRegion = toolingEnv.awsAccountRegion
+    if (projectId) {
+        try {
+            const projectAccountId = await authProvider.getProjectAccountId(projectId)
+            span.record({ smusProjectAccountId: projectAccountId })
+        } catch (err) {
+            span.record({ smusProjectAccountId: notSet })
+            logger.warn(
+                `Failed to record project account Id for telemetry in domain ${domainId}: ${(err as Error).message}`
+            )
         }
 
-        span.record({
-            smusAuthMode: authProvider.activeConnection?.type,
-            smusSpaceKey: node.resource.DomainSpaceKey,
-            smusDomainRegion: node.resource.regionCode,
-            smusDomainId: parent?.getAuthProvider()?.getDomainId(),
-            smusDomainAccountId: accountId,
-            smusProjectId: projectId,
-            smusProjectAccountId: projectAccountId,
-            smusProjectRegion: projectRegion,
-        })
-    } catch (err) {
-        logger.error(`Failed to record space telemetry: ${(err as Error).message}`)
+        try {
+            const dzClient = await createDZClientBaseOnDomainMode(authProvider)
+            const toolingEnv = await dzClient.getToolingEnvironment(projectId)
+            span.record({ smusProjectRegion: toolingEnv.awsAccountRegion })
+        } catch (err) {
+            span.record({ smusProjectRegion: notSet })
+            logger.warn(`Failed to get project region for telemetry: ${(err as Error).message}`)
+        }
     }
 }
 
@@ -90,6 +100,7 @@ export async function recordAuthTelemetry(
             smusDomainAccountId: accountId,
         })
     } catch (err) {
+        span.record({ smusDomainAccountId: notSet })
         logger.error(
             `Failed to record Domain AccountId in data connection telemetry for domain ${domainId} in region ${region}: ${err}`
         )
@@ -106,23 +117,25 @@ export async function recordDataConnectionTelemetry(
 ) {
     const logger = getLogger('smus')
 
-    try {
-        const isInSmusSpace = getContext('aws.smus.inSmusSpaceEnvironment')
-        const authProvider = SmusAuthenticationProvider.fromContext()
-        const accountId = await connectionCredentialsProvider.getDomainAccountId()
+    const isInSmusSpace = getContext('aws.smus.inSmusSpaceEnvironment')
+    const authProvider = SmusAuthenticationProvider.fromContext()
 
-        span.record({
-            smusAuthMode: authProvider.activeConnection?.type,
-            smusToolkitEnv: isInSmusSpace ? 'smus_space' : 'local',
-            smusDomainId: connection.domainId,
-            smusDomainAccountId: accountId,
-            smusProjectId: connection.projectId,
-            smusConnectionId: connection.connectionId,
-            smusConnectionType: connection.type,
-            smusProjectRegion: connection.location?.awsRegion,
-            smusProjectAccountId: connection.location?.awsAccountId,
-        })
+    span.record({
+        smusAuthMode: authProvider.activeConnection?.type,
+        smusToolkitEnv: isInSmusSpace ? 'smus_space' : 'local',
+        smusDomainId: connection.domainId,
+        smusProjectId: connection.projectId,
+        smusConnectionId: connection.connectionId,
+        smusConnectionType: connection.type,
+        smusProjectRegion: connection.location?.awsRegion,
+        smusProjectAccountId: connection.location?.awsAccountId,
+    })
+
+    try {
+        const accountId = await connectionCredentialsProvider.getDomainAccountId()
+        span.record({ smusDomainAccountId: accountId })
     } catch (err) {
-        logger.error(`Failed to record data connection telemetry: ${(err as Error).message}`)
+        span.record({ smusDomainAccountId: notSet })
+        logger.warn(`Failed to record domain account ID for data connection telemetry: ${(err as Error).message}`)
     }
 }

--- a/packages/core/src/test/sagemakerunifiedstudio/testUtils.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/testUtils.ts
@@ -65,25 +65,22 @@ export function createMockUnauthenticatedAuthProvider(): any {
  Creates a mock space node for SageMaker Unified Studio tests
  */
 export function createMockSpaceNode(): any {
+    const mockParent = {
+        getAuthProvider: sinon.stub().returns({
+            activeConnection: { domainId: 'test-domain' },
+            getDomainAccountId: sinon.stub().resolves('123456789012'),
+            getDomainId: sinon.stub().returns('test-domain'),
+        }),
+        getProjectId: sinon.stub().returns('test-project'),
+    }
+
     return {
         resource: {
             sageMakerClient: {},
             DomainSpaceKey: 'test-space-key',
             regionCode: 'us-east-1',
-            getParent: sinon.stub().returns({
-                getAuthProvider: sinon.stub().returns({
-                    activeConnection: { domainId: 'test-domain' },
-                    getDomainAccountId: sinon.stub().resolves('123456789012'),
-                }),
-                getProjectId: sinon.stub().returns('test-project'),
-            }),
+            getParent: sinon.stub().returns(mockParent),
         },
-        getParent: sinon.stub().returns({
-            getAuthProvider: sinon.stub().returns({
-                activeConnection: { domainId: 'test-domain' },
-                getDomainAccountId: sinon.stub().resolves('123456789012'),
-            }),
-            getProjectId: sinon.stub().returns('test-project'),
-        }),
+        getParent: sinon.stub().returns(mockParent),
     }
 }


### PR DESCRIPTION
## Problem
- sometimes custom metrics are missing from `smus_stopSpace` and `smus_openRemoteConnection`

## Solution
- Some telemetry custom variables are fetched via async calls
- This calls should gracefully handle async failures, and still being able to record what metrics are available.

### Example 
- successful async calls
```
2025-12-29 11:38:25.994 [debug] telemetry: smus_openRemoteConnection {
  Metadata: {
    metricId: 'acc0a9b4-e642-4e4f-a2a7-949879fca73d',
    traceId: '911f58fd-9f63-4a8f-8e87-590d3f46d534',
    smusAuthMode: 'iam',
    smusSpaceKey: 'd-5eomwrxzxbim__default-ce003678-576c-4253-a65f-01ef29af4f94',
    smusDomainRegion: 'us-east-2',
    smusDomainId: 'dzd-byubiyc1bebgfd',
    smusProjectId: 'b236u0pytkd02x',
    smusDomainAccountId: '619071339486',
    smusProjectAccountId: '619071339486',
    smusProjectRegion: 'us-east-2',
    duration: '20598',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-west-2'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}
```  
```
2025-12-29 11:39:28.454 [debug] telemetry: smus_stopSpace {
  Metadata: {
    metricId: '743e4212-8d6f-40bf-b2aa-a3ab45b5aa86',
    traceId: '6bfd857d-cf53-410e-9e38-d1f8b37ec833',
    smusAuthMode: 'iam',
    smusSpaceKey: 'd-5eomwrxzxbim__default-ce003678-576c-4253-a65f-01ef29af4f94',
    smusDomainRegion: 'us-east-2',
    smusDomainId: 'dzd-byubiyc1bebgfd',
    smusProjectId: 'b236u0pytkd02x',
    smusDomainAccountId: '619071339486',
    smusProjectAccountId: '619071339486',
    smusProjectRegion: 'us-east-2',
    duration: '4430',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-west-2'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}
```
- failed async calls
```
2025-12-29 12:00:12.444 [warning] smus: Failed to get project region for telemetry: The security token included in the request is expired
```
```
2025-12-29 12:00:15.237 [debug] telemetry: smus_stopSpace {
  Metadata: {
    metricId: '52e34dd6-3016-4abc-82cb-2605c2cb7e71',
    traceId: '8288d8a9-6674-4402-901a-0ebafe57ad1d',
    smusAuthMode: 'iam',
    smusSpaceKey: 'd-5eomwrxzxbim__default-ce003678-576c-4253-a65f-01ef29af4f94',
    smusDomainRegion: 'us-east-2',
    smusDomainId: 'dzd-byubiyc1bebgfd',
    smusProjectId: 'b236u0pytkd02x',
    smusDomainAccountId: '619071339486',
    smusProjectAccountId: '619071339486',
    smusProjectRegion: 'not-set',
    duration: '2973',
    result: 'Failed',
    reason: 'ExpiredTokenException',
    reasonDesc: 'ExpiredTokenException: Failed to stop space default-ce003678-576c-4253-a65f-01ef29af4f94: The security token included in the request is expired | ExpiredTokenException: The security token included in the request is expired',
    awsAccount: 'not-set',
    awsRegion: 'us-west-2'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}
```
`smusProjectRegion` is set to 'not-set` and the rest of custom metrics are recorded. 

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
