### PR TITLE
fix(sagemaker): revert presign url changes

### DIFF
--- a/packages/core/src/awsService/sagemaker/commands.ts
+++ b/packages/core/src/awsService/sagemaker/commands.ts
@@ -222,11 +222,12 @@ function createValidSshSession(
         sanitize(namespace, 63), // K8s limit
         sanitize(clusterName, 100), // EKS limit
         sanitize(region, 16), // Longest AWS region limit
-        sanitize(accountId, 4), // Truncated to allow max limit for other attrs
+        sanitize(accountId, 12), // Fixed
     ].filter((c) => c.length > 0)
-    // Total: 63 + 63 + 100 + 16 + 4 + 4 separators + 3 chars for hostname header = 253 (max limit)
+    // Total: 63 + 63 + 100 + 16 + 12 + 4 separators + 3 chars for hostname header = 261 > 253 (max limit)
+    // If all attributes max out char limit, then accountId will be truncated to the first 4 char.
 
-    const session = components.join('_').substring(0, 224)
+    const session = components.join('_').substring(0, 253)
     return session
 }
 
@@ -234,7 +235,7 @@ function createValidSshSession(
  * Validates if a string meets SSH hostname naming convention
  */
 function isValidSshHostname(label: string): boolean {
-    return /^[a-z0-9]([a-z0-9.-_]{0,222}[a-z0-9])?$/.test(label)
+    return /^[a-z0-9]([a-z0-9.-_]{0,251}[a-z0-9])?$/.test(label)
 }
 
 export async function stopSpace(

--- a/packages/core/src/awsService/sagemaker/uriHandlers.ts
+++ b/packages/core/src/awsService/sagemaker/uriHandlers.ts
@@ -38,7 +38,7 @@ export function register(ctx: ExtContext) {
                 undefined,
                 params.workspaceName,
                 params.namespace,
-                params.clusterArn
+                params.eksClusterArn
             )
         })
     }
@@ -51,7 +51,7 @@ export function register(ctx: ExtContext) {
 
 export function parseHyperpodConnectParams(query: SearchParams) {
     const requiredParams = query.getFromKeysOrThrow('sessionId', 'streamUrl', 'sessionToken', 'cell-number')
-    const optionalParams = query.getFromKeys('workspaceName', 'namespace', 'clusterArn')
+    const optionalParams = query.getFromKeys('workspaceName', 'namespace', 'eksClusterArn')
     return { ...requiredParams, ...optionalParams }
 }
 export function parseConnectParams(query: SearchParams) {

--- a/packages/core/src/shared/clients/kubectlClient.ts
+++ b/packages/core/src/shared/clients/kubectlClient.ts
@@ -35,11 +35,9 @@ export interface HyperpodCluster {
 export class KubectlClient {
     private kubeConfig: k8s.KubeConfig
     private k8sApi: k8s.CustomObjectsApi
-    private hyperpodCluster: HyperpodCluster
 
     public constructor(eksCluster: Cluster, hyperpodCluster: HyperpodCluster) {
         this.kubeConfig = new k8s.KubeConfig()
-        this.hyperpodCluster = hyperpodCluster
         this.loadKubeConfig(eksCluster, hyperpodCluster)
         this.k8sApi = this.kubeConfig.makeApiClient(k8s.CustomObjectsApi)
     }
@@ -262,18 +260,9 @@ export class KubectlClient {
                 throw new Error('No workspace connection URL returned')
             }
 
-            const url = new URL(presignedUrl)
-
-            // If eksClusterArn exists, remove it and add clusterArn instead
-            if (url.searchParams.has('eksClusterArn') && this.hyperpodCluster.clusterArn) {
-                url.searchParams.delete('eksClusterArn')
-                url.searchParams.set('clusterArn', this.hyperpodCluster.clusterArn)
-            }
-
-            const modifiedUrl = url.toString()
             getLogger().info(`Connection Type: ${connectionType}`)
-            getLogger().info(`Modified Presigned URL: ${modifiedUrl}`)
-            return { type: connectionType || 'vscode-remote', url: modifiedUrl }
+            getLogger().info(`Presigned URL: ${presignedUrl}`)
+            return { type: connectionType || 'vscode-remote', url: presignedUrl }
         } catch (error) {
             getLogger().error(`[Hyperpod] Failed to create workspace connection: ${error}`)
             throw new Error(


### PR DESCRIPTION
## Problem
- workspace connection is currently failing via presigned url due to change of attributes

## Solution
- reverting change and using eks cluster attr for hostname

## Testing
- updated unit tests
- tested locally with new vsix
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
