### PR TITLE
fix(amazonq): remove /dev amazonq settings

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -148,11 +148,6 @@
                     "markdownDescription": "%AWS.configuration.description.amazonq%",
                     "default": true
                 },
-                "amazonQ.allowFeatureDevelopmentToRunCodeAndTests": {
-                    "markdownDescription": "%AWS.configuration.description.featureDevelopment.allowRunningCodeAndTests%",
-                    "type": "object",
-                    "default": {}
-                },
                 "amazonQ.importRecommendationForInlineCodeSuggestions": {
                     "type": "boolean",
                     "description": "%AWS.configuration.description.amazonq.importRecommendation%",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -20,7 +20,6 @@
     "AWS.configuration.description.suppressPrompts": "Prompts which ask for confirmation. Checking an item suppresses the prompt.",
     "AWS.configuration.enableCodeLenses": "Enable SAM hints in source code and template.yaml files",
     "AWS.configuration.description.resources.enabledResources": "AWS resources to display in the 'Resources' portion of the explorer.",
-    "AWS.configuration.description.featureDevelopment.allowRunningCodeAndTests": "Allow /dev to run code and test commands",
     "AWS.configuration.description.experiments": "Try experimental features and give feedback. Note that experimental features may be removed at any time.\n * `jsonResourceModification` - Enables basic create, update, and delete support for cloud resources via the JSON Resources explorer component.",
     "AWS.stepFunctions.publishStateMachine.error.invalidYAML": "Cannot publish invalid YAML file",
     "AWS.stepFunctions.publishStateMachine.info.creating": "Creating state machine '{0}' in {1}...",

--- a/packages/core/src/codewhisperer/util/codewhispererSettings.ts
+++ b/packages/core/src/codewhisperer/util/codewhispererSettings.ts
@@ -16,7 +16,6 @@ const description = {
     workspaceIndexMaxFileSize: Number,
     workspaceIndexCacheDirPath: String,
     workspaceIndexIgnoreFilePatterns: ArrayConstructor(String),
-    allowFeatureDevelopmentToRunCodeAndTests: Object,
     ignoredSecurityIssues: ArrayConstructor(String),
 }
 
@@ -72,18 +71,6 @@ export class CodeWhispererSettings extends fromExtensionManifest('amazonQ', desc
 
     public getIndexIgnoreFilePatterns(): string[] {
         return this.get('workspaceIndexIgnoreFilePatterns', [])
-    }
-
-    public getAutoBuildSetting(): { [key: string]: boolean } {
-        return this.get('allowFeatureDevelopmentToRunCodeAndTests', {})
-    }
-
-    public async updateAutoBuildSetting(projectName: string, setting: boolean) {
-        const projects = this.getAutoBuildSetting()
-
-        projects[projectName] = setting
-
-        await this.update('allowFeatureDevelopmentToRunCodeAndTests', projects)
     }
 
     public getIgnoredSecurityIssues(): string[] {

--- a/packages/core/src/shared/settings-amazonq.gen.ts
+++ b/packages/core/src/shared/settings-amazonq.gen.ts
@@ -26,7 +26,6 @@ export const amazonqSettings = {
         "amazonQSelectDeveloperProfile": {}
     },
     "amazonQ.showCodeWithReferences": {},
-    "amazonQ.allowFeatureDevelopmentToRunCodeAndTests": {},
     "amazonQ.importRecommendationForInlineCodeSuggestions": {},
     "amazonQ.shareContentWithAWS": {},
     "amazonQ.workspaceIndex": {},


### PR DESCRIPTION
## Problem
- This setting is no longer used.
<img width="1276" height="242" alt="image" src="https://github.com/user-attachments/assets/71c2a761-e849-4058-ac99-41329cd32c28" />


## Solution

- Removing /dev amazonq settings
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
