### PR TITLE
fix(sagemaker): update real time transitive status for workspace

### DIFF
--- a/packages/core/src/awsService/sagemaker/hyperpodCommands.ts
+++ b/packages/core/src/awsService/sagemaker/hyperpodCommands.ts
@@ -124,8 +124,8 @@ export async function startHyperpodSpaceCommand(node: SagemakerDevSpaceNode): Pr
     }
     // Set transitional state immediately
     node.devSpace.status = 'Starting'
-    node.contextValue = 'awsSagemakerHyperpodDevSpaceTransitionalNode'
-    await node.refreshNode()
+    node.updateWorkspace()
+    await vscode.commands.executeCommand('aws.refreshAwsExplorerNode', node)
 
     const kc = node.getParent().getKubectlClient(node.hpCluster.clusterName)
     if (!kc) {
@@ -154,8 +154,8 @@ export async function stopHyperPodSpaceCommand(node: SagemakerDevSpaceNode): Pro
 
     // Set transitional state immediately
     node.devSpace.status = 'Stopping'
-    node.contextValue = 'awsSagemakerHyperpodDevSpaceTransitionalNode'
-    await node.refreshNode()
+    node.updateWorkspace()
+    await vscode.commands.executeCommand('aws.refreshAwsExplorerNode', node)
 
     const kc = node.getParent().getKubectlClient(node.hpCluster.clusterName)
     if (!kc) {


### PR DESCRIPTION
## Problem
- Transition status was not updating in real time.

## Solution
- Modify how the node is updated. This allows for the polling mechanism to fetches the real status from Kubernetes and update the UI when transition completes.

## Testing
- Tested locally via vsix

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
