### PR TITLE
telemetry(smus): Emit metric when showing the agents.md prompt and on user choice

### DIFF
--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -1777,7 +1777,7 @@
         },
         {
             "name": "smus_agentContextShowPrompt",
-            "description": "Emitted whenever is shown a prompt to add SMUS context to their AGENTS.md",
+            "description": "Emitted whenever user is shown a prompt to add SMUS context to their AGENTS.md",
             "metadata": [
                 {
                     "type": "smusDomainId",


### PR DESCRIPTION
## Problem
Previously, we emitted a metric when a user chooses Yes, No, or closes out of the prompt. However, sometimes the notification is buried or goes to the little notification bell. We also want to see if users will actually see the prompt.

## Solution

- Changed existing agent context metric to two metrics:
  - smus_agentContextShowPrompt — emitted when the prompt is displayed
  - smus_agentContextUserChoice — emitted when the user accepts, declines, or dismisses the prompt
- Both metrics include rich context: domain ID, account ID, region, project ID, project account ID, project region, space key, and auth mode.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
