### PR TITLE
fix(sagemaker): Remove sagemaker-ssh-kiro VSIX from release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
                   npm run createRelease -w packages/toolkit -w packages/amazonq  # Generate CHANGELOG.md
                   npm run -w packages/toolkit package -- --feature "$FEAT_NAME"
                   npm run -w packages/amazonq package -- --feature "$FEAT_NAME"
+                  rm -f sagemaker-ssh-kiro-*.vsix  # Remove standalone VSIX; it's already embedded inside toolkit
             - uses: actions/upload-artifact@v4
               with:
                   name: artifacts


### PR DESCRIPTION
## Problem
The `sagemaker-ssh-kiro` extension VSIX is showing up in the release artifacts for prerelease, but we don't want it to show there. It's intended only to be embedded inside of the toolkit VSIX.

## Solution
Remove the `sagemaker-ssh-kiro` extension VSIX from the top level file system during the GitHub Action workflow step which packages the VSIX files.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
