### PR TITLE
fix(sagemaker): refactor ssh config to also trigger for sm_lc and sm_dl

### DIFF
--- a/packages/core/src/awsService/sagemaker/model.ts
+++ b/packages/core/src/awsService/sagemaker/model.ts
@@ -214,39 +214,39 @@ export async function prepareDevEnvConnection(
                     logger.error(`Failed to copy hyperpod_connect script: ${err}`)
                 }
             }
+        }
 
-            const sshConfig =
-                connectionType === 'sm_hp'
-                    ? new HyperPodSshConfig(ssh, hyperpodConnectPath)
-                    : new SshConfig(ssh, 'sm_', 'sagemaker_connect')
-            const config = await sshConfig.ensureValid()
-            if (config.isErr()) {
-                const err = config.err()
-                const logPrefix = connectionType === 'sm_hp' ? 'hyperpod' : 'sagemaker'
-                logger.error(`${logPrefix}: failed to add ssh config section: ${err.message}`)
+        const sshConfig =
+            connectionType === 'sm_hp'
+                ? new HyperPodSshConfig(ssh, hyperpodConnectPath)
+                : new SshConfig(ssh, 'sm_', 'sagemaker_connect')
+        const config = await sshConfig.ensureValid()
+        if (config.isErr()) {
+            const err = config.err()
+            const logPrefix = connectionType === 'sm_hp' ? 'hyperpod' : 'sagemaker'
+            logger.error(`${logPrefix}: failed to add ssh config section: ${err.message}`)
 
-                if (err instanceof ToolkitError && err.code === 'SshCheckFailed') {
-                    const sshConfigPath = getSshConfigPath()
-                    const openConfigButton = 'Open SSH Config'
-                    const resp = await vscode.window.showErrorMessage(
-                        SshConfigErrorMessage(),
-                        { modal: true, detail: err.message },
-                        openConfigButton
-                    )
+            if (err instanceof ToolkitError && err.code === 'SshCheckFailed') {
+                const sshConfigPath = getSshConfigPath()
+                const openConfigButton = 'Open SSH Config'
+                const resp = await vscode.window.showErrorMessage(
+                    SshConfigErrorMessage(),
+                    { modal: true, detail: err.message },
+                    openConfigButton
+                )
 
-                    if (resp === openConfigButton) {
-                        void vscode.window.showTextDocument(vscode.Uri.file(sshConfigPath))
-                    }
-
-                    // Throw error to stop the connection flow
-                    // User is already notified via modal above, downstream handlers check the error code
-                    throw new ToolkitError('Unable to connect: SSH configuration contains errors', {
-                        code: SshConfigError,
-                    })
+                if (resp === openConfigButton) {
+                    void vscode.window.showTextDocument(vscode.Uri.file(sshConfigPath))
                 }
 
-                throw err
+                // Throw error to stop the connection flow
+                // User is already notified via modal above, downstream handlers check the error code
+                throw new ToolkitError('Unable to connect: SSH configuration contains errors', {
+                    code: SshConfigError,
+                })
             }
+
+            throw err
         }
     }
 


### PR DESCRIPTION
## Problem
   - When users attempted to open SageMaker spaces in vscode via SageMaker UI, they ran into connection errors. Upon investigation, we discovered that our source code was refactored when another feature was merged.

## Solution
   - Move ssh config outside sm_hp scope so it also triggers for sm_lc and sm_dl

## Testing
   - Local testing with vsix

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
