### PR TITLE
fix(amazonq): code prompt can recognize the selected code

### DIFF
--- a/packages/amazonq/src/lsp/chat/messages.ts
+++ b/packages/amazonq/src/lsp/chat/messages.ts
@@ -641,17 +641,20 @@ export function registerMessageListeners(
             params: params,
         })
     })
+
     languageClient.onNotification(
         pinnedContextNotificationType.method,
         (params: ContextCommandParams & { tabId: string; textDocument?: TextDocumentIdentifier }) => {
             const editor = vscode.window.activeTextEditor
             let textDocument = undefined
+            let cursorState = undefined
             if (editor && isTextEditor(editor)) {
-                textDocument = { uri: vscode.workspace.asRelativePath(editor.document.uri) }
+                textDocument = { uri: editor.document.uri.toString() }
+                cursorState = getCursorState(editor.selections)
             }
             void provider.webview?.postMessage({
                 command: pinnedContextNotificationType.method,
-                params: { ...params, textDocument },
+                params: { ...params, textDocument, cursorState },
             })
         }
     )


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
