### PR TITLE
fix(sagemaker): Revert "fix(sagemaker): store hyperpod connection info for reconnection (#8641)"

### DIFF
--- a/packages/core/src/awsService/sagemaker/commands.ts
+++ b/packages/core/src/awsService/sagemaker/commands.ts
@@ -36,7 +36,6 @@ import {
 import { SagemakerUnifiedStudioSpaceNode } from '../../sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpaceNode'
 import { node } from 'webpack'
 import { parse } from '@aws-sdk/util-arn-parser'
-import { storeHyperpodConnection } from './detached-server/hyperpodMappingUtils.js'
 
 const localize = nls.loadMessageBundle()
 
@@ -127,10 +126,6 @@ export async function deeplinkConnect(
         eksClusterArn: ${eksClusterArn}`
     )
 
-    getLogger().info(
-        `sm:deeplinkConnect: Condition check - !domain: ${!domain}, eksClusterArn: ${!!eksClusterArn}, workspaceName: ${!!workspaceName}, namespace: ${!!namespace}`
-    )
-
     if (isRemoteWorkspace()) {
         void vscode.window.showErrorMessage(ConnectFromRemoteWorkspaceMessage)
         return
@@ -138,30 +133,13 @@ export async function deeplinkConnect(
 
     try {
         let connectionType = 'sm_dl'
-        let clusterName: string | undefined
-        let region: string | undefined
         if (!domain && eksClusterArn && workspaceName && namespace) {
-            const parsed = parse(eksClusterArn)
-            clusterName = parsed.resource.split('/')[1]
-            region = parsed.region
+            const { accountId, region, clusterName } = parseArn(eksClusterArn)
             connectionType = 'sm_hp'
-            const proposedSession = `${workspaceName}_${namespace}_${clusterName}_${region}_${parsed.accountId}`
+            const proposedSession = `${workspaceName}_${namespace}_${clusterName}_${region}_${accountId}`
             session = isValidSshHostname(proposedSession)
                 ? proposedSession
-                : createValidSshSession(workspaceName, namespace, clusterName, region, parsed.accountId)
-
-            await storeHyperpodConnection(
-                workspaceName,
-                namespace,
-                eksClusterArn,
-                clusterName,
-                clusterName,
-                undefined,
-                undefined,
-                region,
-                wsUrl,
-                token
-            )
+                : createValidSshSession(workspaceName, namespace, clusterName, region, accountId)
         }
         const remoteEnv = await prepareDevEnvConnection(
             connectionIdentifier,
@@ -175,10 +153,8 @@ export async function deeplinkConnect(
             domain,
             appType,
             workspaceName,
-            clusterName,
-            namespace,
-            region,
-            eksClusterArn
+            undefined,
+            namespace
         )
 
         try {
@@ -217,6 +193,26 @@ export async function deeplinkConnect(
             )
             throw err
         }
+    }
+}
+
+function parseArn(arn: string): { accountId: string; region: string; clusterName: string } {
+    try {
+        const parsed = parse(arn)
+        if (!parsed.service) {
+            throw new Error('Invalid service')
+        }
+        const clusterName = parsed.resource.split('/')[1]
+        if (!clusterName) {
+            throw new Error('Invalid cluster name')
+        }
+        return {
+            accountId: parsed.accountId,
+            clusterName,
+            region: parsed.region,
+        }
+    } catch (error) {
+        throw new Error('Invalid cluster ARN')
     }
 }
 

--- a/packages/core/src/awsService/sagemaker/detached-server/utils.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/utils.ts
@@ -56,32 +56,31 @@ export async function readServerInfo(): Promise<ServerInfo> {
 }
 
 /**
- * Parses a SageMaker or EKS ARN to extract region, account ID, and space/cluster name.
+ * Parses a SageMaker ARN to extract region, account ID, and space name.
  * Supports formats like:
  *   arn:aws:sagemaker:<region>:<account_id>:space/<domain>/<space_name>
  *   arn:aws:sagemaker:<region>:<account_id>:cluster/<cluster_id>
- *   arn:aws:eks:<region>:<account>:cluster/cluster-name
  *   or sm_lc_arn:aws:sagemaker:<region>:<account_id>:space__d-xxxx__<name>
  *
  * If the input is prefixed with an identifier (e.g. "sagemaker-user@"), the function will strip it.
  *
- * @param arn - The full ARN string
+ * @param arn - The full SageMaker ARN string
  * @returns An object containing the region, accountId, and spaceName
  * @throws If the ARN format is invalid
  */
 export function parseArn(arn: string): { region: string; accountId: string; spaceName: string } {
     const cleanedArn = arn.includes('@') ? arn.split('@')[1] : arn
-    const regex = /^arn:aws:(sagemaker|eks):(?<region>[^:]+):(?<account_id>\d+):(space|cluster)[/:].+$/i
+    const regex = /^arn:aws:sagemaker:(?<region>[^:]+):(?<account_id>\d+):(space|cluster)[/:].+$/i
     const match = cleanedArn.match(regex)
 
     if (!match?.groups) {
-        throw new Error(`Invalid SageMaker/EKS ARN format: "${arn}"`)
+        throw new Error(`Invalid SageMaker ARN format: "${arn}"`)
     }
 
-    // Extract space/cluster name from the end of the ARN (after the last forward slash)
+    // Extract space name from the end of the ARN (after the last forward slash)
     const spaceName = cleanedArn.split('/').pop()
     if (!spaceName) {
-        throw new Error(`Could not extract space/cluster name from ARN: "${arn}"`)
+        throw new Error(`Could not extract space name from ARN: "${arn}"`)
     }
 
     return {

--- a/packages/toolkit/.changes/next-release/BugFix-7f4b2db6-3199-4c56-aaf6-c4be97009ced.json
+++ b/packages/toolkit/.changes/next-release/BugFix-7f4b2db6-3199-4c56-aaf6-c4be97009ced.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "SageMaker: Fixed HyperPod workspace reconnection for deeplink usecase"
-}


### PR DESCRIPTION


This reverts commit f3a9935e76b6dd20682ac539939ff760d64ccb60.

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
