### PR TITLE
feat(cloudformation): add parent resource selection for related resou…

### DIFF
--- a/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesApi.ts
+++ b/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesApi.ts
@@ -5,6 +5,7 @@
 
 import { LanguageClient } from 'vscode-languageclient/node'
 import {
+    AuthoredResource,
     GetAuthoredResourceTypesRequest,
     GetRelatedResourceTypesParams,
     GetRelatedResourceTypesRequest,
@@ -14,7 +15,10 @@ import {
     TemplateUri,
 } from './relatedResourcesProtocol'
 
-export async function getAuthoredResourceTypes(client: LanguageClient, templateUri: TemplateUri): Promise<string[]> {
+export async function getAuthoredResourceTypes(
+    client: LanguageClient,
+    templateUri: TemplateUri
+): Promise<AuthoredResource[]> {
     return client.sendRequest(GetAuthoredResourceTypesRequest, templateUri)
 }
 

--- a/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesApi.ts
+++ b/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesApi.ts
@@ -7,6 +7,7 @@ import { LanguageClient } from 'vscode-languageclient/node'
 import {
     AuthoredResource,
     GetAuthoredResourceTypesRequest,
+    GetAuthoredResourceTypesRequestV2,
     GetRelatedResourceTypesParams,
     GetRelatedResourceTypesRequest,
     InsertRelatedResourcesParams,
@@ -15,11 +16,15 @@ import {
     TemplateUri,
 } from './relatedResourcesProtocol'
 
-export async function getAuthoredResourceTypes(
+export async function getAuthoredResourceTypes(client: LanguageClient, templateUri: TemplateUri): Promise<string[]> {
+    return client.sendRequest(GetAuthoredResourceTypesRequest, templateUri)
+}
+
+export async function getAuthoredResourceTypesV2(
     client: LanguageClient,
     templateUri: TemplateUri
 ): Promise<AuthoredResource[]> {
-    return client.sendRequest(GetAuthoredResourceTypesRequest, templateUri)
+    return client.sendRequest(GetAuthoredResourceTypesRequestV2, templateUri)
 }
 
 export async function getRelatedResourceTypes(

--- a/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesManager.ts
+++ b/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesManager.ts
@@ -31,10 +31,20 @@ export class RelatedResourcesManager {
         try {
             const templateUri = activeEditor.document.uri.toString()
 
-            const selectedParentResourceType =
-                preSelectedResourceType || (await this.selector.selectAuthoredResourceType(templateUri))
-            if (!selectedParentResourceType) {
-                return
+            let parentLogicalId: string | undefined
+            let selectedParentResourceType: string
+
+            if (preSelectedResourceType) {
+                /* when pre-selected by type we don't have the logical ID,
+                fall back to using the first instance of that type*/
+                selectedParentResourceType = preSelectedResourceType
+            } else {
+                const selection = await this.selector.selectAuthoredResourceType(templateUri)
+                if (!selection) {
+                    return
+                }
+                selectedParentResourceType = selection.type
+                parentLogicalId = selection.logicalId
             }
 
             const selectedRelatedTypes = await this.selector.selectRelatedResourceTypes(selectedParentResourceType)
@@ -48,7 +58,12 @@ export class RelatedResourcesManager {
             }
 
             if (action === 'create') {
-                await this.createRelatedResources(templateUri, selectedParentResourceType, selectedRelatedTypes)
+                await this.createRelatedResources(
+                    templateUri,
+                    selectedParentResourceType,
+                    selectedRelatedTypes,
+                    parentLogicalId
+                )
             } else {
                 await this.importRelatedResources(selectedRelatedTypes, selectedParentResourceType)
             }
@@ -62,12 +77,14 @@ export class RelatedResourcesManager {
     private async createRelatedResources(
         templateUri: string,
         parentResourceType: string,
-        relatedResourceTypes: string[]
+        relatedResourceTypes: string[],
+        parentLogicalId?: string
     ): Promise<void> {
         const result = await insertRelatedResources(this.client, {
             templateUri,
             relatedResourceTypes,
             parentResourceType,
+            parentLogicalId,
         })
 
         await this.applyCodeAction(result)

--- a/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesManager.ts
+++ b/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesManager.ts
@@ -35,8 +35,8 @@ export class RelatedResourcesManager {
             let selectedParentResourceType: string
 
             if (preSelectedResourceType) {
-                /* when pre-selected by type we don't have the logical ID,
-                fall back to using the first instance of that type*/
+                // When pre-selected by type we don't have the logical ID,
+                // fall back to using the first instance of that type
                 selectedParentResourceType = preSelectedResourceType
             } else {
                 const selection = await this.selector.selectAuthoredResourceType(templateUri)

--- a/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesProtocol.ts
+++ b/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesProtocol.ts
@@ -30,8 +30,12 @@ export interface RelatedResourcesCodeAction extends CodeAction {
     }
 }
 
-export const GetAuthoredResourceTypesRequest = new RequestType<TemplateUri, AuthoredResource[], void>(
+export const GetAuthoredResourceTypesRequest = new RequestType<TemplateUri, string[], void>(
     'aws/cfn/template/resources/authored'
+)
+
+export const GetAuthoredResourceTypesRequestV2 = new RequestType<TemplateUri, AuthoredResource[], void>(
+    'aws/cfn/template/resources/authored/v2'
 )
 
 export const GetRelatedResourceTypesRequest = new RequestType<GetRelatedResourceTypesParams, string[], void>(

--- a/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesProtocol.ts
+++ b/packages/core/src/awsService/cloudformation/relatedResources/relatedResourcesProtocol.ts
@@ -11,10 +11,16 @@ export type GetRelatedResourceTypesParams = {
     parentResourceType: string
 }
 
+export type AuthoredResource = {
+    logicalId: string
+    type: string
+}
+
 export type InsertRelatedResourcesParams = {
     templateUri: string
     relatedResourceTypes: string[]
     parentResourceType: string
+    parentLogicalId?: string
 }
 
 export interface RelatedResourcesCodeAction extends CodeAction {
@@ -24,7 +30,7 @@ export interface RelatedResourcesCodeAction extends CodeAction {
     }
 }
 
-export const GetAuthoredResourceTypesRequest = new RequestType<TemplateUri, string[], void>(
+export const GetAuthoredResourceTypesRequest = new RequestType<TemplateUri, AuthoredResource[], void>(
     'aws/cfn/template/resources/authored'
 )
 

--- a/packages/core/src/awsService/cloudformation/ui/relatedResourceSelector.ts
+++ b/packages/core/src/awsService/cloudformation/ui/relatedResourceSelector.ts
@@ -5,14 +5,14 @@
 
 import { window } from 'vscode'
 import { LanguageClient } from 'vscode-languageclient/node'
-import { getAuthoredResourceTypes, getRelatedResourceTypes } from '../relatedResources/relatedResourcesApi'
+import { getAuthoredResourceTypesV2, getRelatedResourceTypes } from '../relatedResources/relatedResourcesApi'
 import { AuthoredResource } from '../relatedResources/relatedResourcesProtocol'
 
 export class RelatedResourceSelector {
     constructor(private client: LanguageClient) {}
 
     async selectAuthoredResourceType(templateUri: string): Promise<{ logicalId: string; type: string } | undefined> {
-        const authoredResources = await getAuthoredResourceTypes(this.client, templateUri)
+        const authoredResources = await getAuthoredResourceTypesV2(this.client, templateUri)
         if (authoredResources.length === 0) {
             void window.showInformationMessage('No resources found in the current template')
             return undefined

--- a/packages/core/src/awsService/cloudformation/ui/relatedResourceSelector.ts
+++ b/packages/core/src/awsService/cloudformation/ui/relatedResourceSelector.ts
@@ -6,21 +6,58 @@
 import { window } from 'vscode'
 import { LanguageClient } from 'vscode-languageclient/node'
 import { getAuthoredResourceTypes, getRelatedResourceTypes } from '../relatedResources/relatedResourcesApi'
+import { AuthoredResource } from '../relatedResources/relatedResourcesProtocol'
 
 export class RelatedResourceSelector {
     constructor(private client: LanguageClient) {}
 
-    async selectAuthoredResourceType(templateUri: string): Promise<string | undefined> {
-        const resourceTypes = await getAuthoredResourceTypes(this.client, templateUri)
-        if (resourceTypes.length === 0) {
+    async selectAuthoredResourceType(templateUri: string): Promise<{ logicalId: string; type: string } | undefined> {
+        const authoredResources = await getAuthoredResourceTypes(this.client, templateUri)
+        if (authoredResources.length === 0) {
             void window.showInformationMessage('No resources found in the current template')
             return undefined
         }
 
-        return window.showQuickPick(resourceTypes, {
+        // group resources by type
+        const resourcesByType = new Map<string, AuthoredResource[]>()
+        for (const resource of authoredResources) {
+            const resources = resourcesByType.get(resource.type) || []
+            resources.push(resource)
+            resourcesByType.set(resource.type, resources)
+        }
+
+        const uniqueTypes = [...resourcesByType.keys()]
+        const selectedType = await window.showQuickPick(uniqueTypes, {
             placeHolder: 'Select an existing resource type from your template',
             canPickMany: false,
         })
+
+        if (!selectedType) {
+            return undefined
+        }
+
+        const resourcesOfType = resourcesByType.get(selectedType)!
+
+        // iff multiple resources of this type exist, let user choose which one
+        if (resourcesOfType.length > 1) {
+            const logicalIdItems = resourcesOfType.map((resource) => ({
+                label: resource.logicalId,
+                logicalId: resource.logicalId,
+            }))
+
+            const selectedLogicalId = await window.showQuickPick(logicalIdItems, {
+                placeHolder: `Select which ${selectedType} to use`,
+                canPickMany: false,
+            })
+
+            if (!selectedLogicalId) {
+                return undefined
+            }
+
+            return { logicalId: selectedLogicalId.logicalId, type: selectedType }
+        }
+
+        return { logicalId: resourcesOfType[0].logicalId, type: selectedType }
     }
 
     async promptCreateOrImport(): Promise<'create' | 'import' | undefined> {

--- a/packages/core/src/awsService/cloudformation/ui/relatedResourceSelector.ts
+++ b/packages/core/src/awsService/cloudformation/ui/relatedResourceSelector.ts
@@ -5,14 +5,18 @@
 
 import { window } from 'vscode'
 import { LanguageClient } from 'vscode-languageclient/node'
-import { getAuthoredResourceTypes, getRelatedResourceTypes } from '../relatedResources/relatedResourcesApi'
+import {
+    getAuthoredResourceTypes,
+    getAuthoredResourceTypesV2,
+    getRelatedResourceTypes,
+} from '../relatedResources/relatedResourcesApi'
 import { AuthoredResource } from '../relatedResources/relatedResourcesProtocol'
 
 export class RelatedResourceSelector {
     constructor(private client: LanguageClient) {}
 
     async selectAuthoredResourceType(templateUri: string): Promise<{ logicalId: string; type: string } | undefined> {
-        const authoredResources = await getAuthoredResourceTypes(this.client, templateUri)
+        const authoredResources = await this.getAuthoredResources(templateUri)
         if (authoredResources.length === 0) {
             void window.showInformationMessage('No resources found in the current template')
             return undefined
@@ -36,9 +40,12 @@ export class RelatedResourceSelector {
             return undefined
         }
 
-        const resourcesOfType = resourcesByType.get(selectedType)!
+        const resourcesOfType = resourcesByType.get(selectedType)
+        if (!resourcesOfType) {
+            return undefined
+        }
 
-        // iff multiple resources of this type exist, let user choose which one
+        // if multiple resources of this type exist, let user choose which one
         if (resourcesOfType.length > 1) {
             const logicalIdItems = resourcesOfType.map((resource) => ({
                 label: resource.logicalId,
@@ -58,6 +65,19 @@ export class RelatedResourceSelector {
         }
 
         return { logicalId: resourcesOfType[0].logicalId, type: selectedType }
+    }
+
+    /**
+     * Fetches authored resources, falling back to v1 endpoint for older servers.
+     */
+    private async getAuthoredResources(templateUri: string): Promise<AuthoredResource[]> {
+        try {
+            return await getAuthoredResourceTypesV2(this.client, templateUri)
+        } catch {
+            // Fall back to v1 for older language servers that don't support v2
+            const types = await getAuthoredResourceTypes(this.client, templateUri)
+            return types.map((type, index) => ({ logicalId: `Resource${index + 1}`, type }))
+        }
     }
 
     async promptCreateOrImport(): Promise<'create' | 'import' | undefined> {

--- a/packages/core/src/awsService/cloudformation/ui/relatedResourceSelector.ts
+++ b/packages/core/src/awsService/cloudformation/ui/relatedResourceSelector.ts
@@ -4,7 +4,8 @@
  */
 
 import { window } from 'vscode'
-import { LanguageClient } from 'vscode-languageclient/node'
+import { LanguageClient, ResponseError } from 'vscode-languageclient/node'
+import { ErrorCodes } from 'vscode-jsonrpc'
 import {
     getAuthoredResourceTypes,
     getAuthoredResourceTypesV2,
@@ -73,10 +74,13 @@ export class RelatedResourceSelector {
     private async getAuthoredResources(templateUri: string): Promise<AuthoredResource[]> {
         try {
             return await getAuthoredResourceTypesV2(this.client, templateUri)
-        } catch {
-            // Fall back to v1 for older language servers that don't support v2
-            const types = await getAuthoredResourceTypes(this.client, templateUri)
-            return types.map((type, index) => ({ logicalId: `Resource${index + 1}`, type }))
+        } catch (error) {
+            // Fall back to v1 only if the server doesn't support v2 (method not found)
+            if (error instanceof ResponseError && error.code === ErrorCodes.MethodNotFound) {
+                const types = await getAuthoredResourceTypes(this.client, templateUri)
+                return types.map((type, index) => ({ logicalId: `Resource${index + 1}`, type }))
+            }
+            throw error
         }
     }
 

--- a/packages/core/src/test/awsService/cloudformation/relatedResources/relatedResourcesApi.test.ts
+++ b/packages/core/src/test/awsService/cloudformation/relatedResources/relatedResourcesApi.test.ts
@@ -32,15 +32,18 @@ describe('RelatedResourcesApi', function () {
     })
 
     describe('getAuthoredResourceTypes', function () {
-        it('should send request with template URI and return resource types', async function () {
+        it('should send request with template URI and return authored resources', async function () {
             const templateUri = 'file:///test/template.yaml'
-            const expectedTypes = ['AWS::S3::Bucket', 'AWS::Lambda::Function']
+            const expectedResources = [
+                { logicalId: 'MyBucket', type: 'AWS::S3::Bucket' },
+                { logicalId: 'MyFunction', type: 'AWS::Lambda::Function' },
+            ]
 
-            mockClient.sendRequest.resolves(expectedTypes)
+            mockClient.sendRequest.resolves(expectedResources)
 
             const result = await getAuthoredResourceTypes(mockClient, templateUri)
 
-            assert.deepStrictEqual(result, expectedTypes)
+            assert.deepStrictEqual(result, expectedResources)
             assert.ok(mockClient.sendRequest.calledOnce)
             assert.ok(mockClient.sendRequest.calledWith(GetAuthoredResourceTypesRequest, templateUri))
         })

--- a/packages/core/src/test/awsService/cloudformation/relatedResources/relatedResourcesApi.test.ts
+++ b/packages/core/src/test/awsService/cloudformation/relatedResources/relatedResourcesApi.test.ts
@@ -7,11 +7,13 @@ import assert from 'assert'
 import * as sinon from 'sinon'
 import {
     getAuthoredResourceTypes,
+    getAuthoredResourceTypesV2,
     getRelatedResourceTypes,
     insertRelatedResources,
 } from '../../../../awsService/cloudformation/relatedResources/relatedResourcesApi'
 import {
     GetAuthoredResourceTypesRequest,
+    GetAuthoredResourceTypesRequestV2,
     GetRelatedResourceTypesRequest,
     InsertRelatedResourcesRequest,
 } from '../../../../awsService/cloudformation/relatedResources/relatedResourcesProtocol'
@@ -32,18 +34,15 @@ describe('RelatedResourcesApi', function () {
     })
 
     describe('getAuthoredResourceTypes', function () {
-        it('should send request with template URI and return authored resources', async function () {
+        it('should send request with template URI and return resource types', async function () {
             const templateUri = 'file:///test/template.yaml'
-            const expectedResources = [
-                { logicalId: 'MyBucket', type: 'AWS::S3::Bucket' },
-                { logicalId: 'MyFunction', type: 'AWS::Lambda::Function' },
-            ]
+            const expectedTypes = ['AWS::S3::Bucket', 'AWS::Lambda::Function']
 
-            mockClient.sendRequest.resolves(expectedResources)
+            mockClient.sendRequest.resolves(expectedTypes)
 
             const result = await getAuthoredResourceTypes(mockClient, templateUri)
 
-            assert.deepStrictEqual(result, expectedResources)
+            assert.deepStrictEqual(result, expectedTypes)
             assert.ok(mockClient.sendRequest.calledOnce)
             assert.ok(mockClient.sendRequest.calledWith(GetAuthoredResourceTypesRequest, templateUri))
         })
@@ -54,6 +53,34 @@ describe('RelatedResourcesApi', function () {
             mockClient.sendRequest.resolves([])
 
             const result = await getAuthoredResourceTypes(mockClient, templateUri)
+
+            assert.deepStrictEqual(result, [])
+        })
+    })
+
+    describe('getAuthoredResourceTypesV2', function () {
+        it('should send request with template URI and return authored resources', async function () {
+            const templateUri = 'file:///test/template.yaml'
+            const expectedResources = [
+                { logicalId: 'MyBucket', type: 'AWS::S3::Bucket' },
+                { logicalId: 'MyFunction', type: 'AWS::Lambda::Function' },
+            ]
+
+            mockClient.sendRequest.resolves(expectedResources)
+
+            const result = await getAuthoredResourceTypesV2(mockClient, templateUri)
+
+            assert.deepStrictEqual(result, expectedResources)
+            assert.ok(mockClient.sendRequest.calledOnce)
+            assert.ok(mockClient.sendRequest.calledWith(GetAuthoredResourceTypesRequestV2, templateUri))
+        })
+
+        it('should return empty array when no resources found', async function () {
+            const templateUri = 'file:///test/empty.yaml'
+
+            mockClient.sendRequest.resolves([])
+
+            const result = await getAuthoredResourceTypesV2(mockClient, templateUri)
 
             assert.deepStrictEqual(result, [])
         })

--- a/packages/core/src/test/awsService/cloudformation/ui/relatedResourceSelector.test.ts
+++ b/packages/core/src/test/awsService/cloudformation/ui/relatedResourceSelector.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert'
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
+import { ResponseError } from 'vscode-languageclient/node'
 import { RelatedResourceSelector } from '../../../../awsService/cloudformation/ui/relatedResourceSelector'
 import * as relatedResourcesApi from '../../../../awsService/cloudformation/relatedResources/relatedResourcesApi'
 
@@ -92,8 +93,8 @@ describe('RelatedResourceSelector', function () {
             assert.strictEqual(result, undefined)
         })
 
-        it('should fall back to v1 endpoint when v2 fails', async function () {
-            getAuthoredResourceTypesV2Stub.rejects(new Error('Method not found'))
+        it('should fall back to v1 endpoint when v2 method not found', async function () {
+            getAuthoredResourceTypesV2Stub.rejects(new ResponseError(-32601, 'Method not found'))
             getAuthoredResourceTypesStub.resolves(['AWS::S3::Bucket', 'AWS::Lambda::Function'])
             showQuickPickStub.resolves('AWS::S3::Bucket')
 
@@ -102,6 +103,16 @@ describe('RelatedResourceSelector', function () {
             assert.ok(result)
             assert.strictEqual(result.type, 'AWS::S3::Bucket')
             assert.ok(getAuthoredResourceTypesStub.calledOnce)
+        })
+
+        it('should rethrow non-method-not-found errors', async function () {
+            getAuthoredResourceTypesV2Stub.rejects(new ResponseError(-32003, 'Credentials expired'))
+
+            await assert.rejects(
+                () => selector.selectAuthoredResourceType('file:///test.yaml'),
+                (error: ResponseError<unknown>) => error.code === -32003
+            )
+            assert.ok(getAuthoredResourceTypesStub.notCalled)
         })
     })
 })

--- a/packages/core/src/test/awsService/cloudformation/ui/relatedResourceSelector.test.ts
+++ b/packages/core/src/test/awsService/cloudformation/ui/relatedResourceSelector.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert'
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
 import { ResponseError } from 'vscode-languageclient/node'
+import { ErrorCodes } from 'vscode-jsonrpc'
 import { RelatedResourceSelector } from '../../../../awsService/cloudformation/ui/relatedResourceSelector'
 import * as relatedResourcesApi from '../../../../awsService/cloudformation/relatedResources/relatedResourcesApi'
 
@@ -94,7 +95,7 @@ describe('RelatedResourceSelector', function () {
         })
 
         it('should fall back to v1 endpoint when v2 method not found', async function () {
-            getAuthoredResourceTypesV2Stub.rejects(new ResponseError(-32601, 'Method not found'))
+            getAuthoredResourceTypesV2Stub.rejects(new ResponseError(ErrorCodes.MethodNotFound, 'Method not found'))
             getAuthoredResourceTypesStub.resolves(['AWS::S3::Bucket', 'AWS::Lambda::Function'])
             showQuickPickStub.resolves('AWS::S3::Bucket')
 
@@ -102,6 +103,7 @@ describe('RelatedResourceSelector', function () {
 
             assert.ok(result)
             assert.strictEqual(result.type, 'AWS::S3::Bucket')
+            assert.strictEqual(result.logicalId, 'Resource1')
             assert.ok(getAuthoredResourceTypesStub.calledOnce)
         })
 

--- a/packages/core/src/test/awsService/cloudformation/ui/relatedResourceSelector.test.ts
+++ b/packages/core/src/test/awsService/cloudformation/ui/relatedResourceSelector.test.ts
@@ -1,0 +1,107 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import * as sinon from 'sinon'
+import * as vscode from 'vscode'
+import { RelatedResourceSelector } from '../../../../awsService/cloudformation/ui/relatedResourceSelector'
+import * as relatedResourcesApi from '../../../../awsService/cloudformation/relatedResources/relatedResourcesApi'
+
+describe('RelatedResourceSelector', function () {
+    let sandbox: sinon.SinonSandbox
+    let mockClient: any
+    let selector: RelatedResourceSelector
+    let showQuickPickStub: sinon.SinonStub
+    let showInformationMessageStub: sinon.SinonStub
+    let getAuthoredResourceTypesV2Stub: sinon.SinonStub
+    let getAuthoredResourceTypesStub: sinon.SinonStub
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox()
+        mockClient = {}
+        selector = new RelatedResourceSelector(mockClient)
+
+        showQuickPickStub = sandbox.stub(vscode.window, 'showQuickPick')
+        showInformationMessageStub = sandbox.stub(vscode.window, 'showInformationMessage')
+        getAuthoredResourceTypesV2Stub = sandbox.stub(relatedResourcesApi, 'getAuthoredResourceTypesV2')
+        getAuthoredResourceTypesStub = sandbox.stub(relatedResourcesApi, 'getAuthoredResourceTypes')
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+    })
+
+    describe('selectAuthoredResourceType', function () {
+        it('should return undefined and show message when no resources found', async function () {
+            getAuthoredResourceTypesV2Stub.resolves([])
+
+            const result = await selector.selectAuthoredResourceType('file:///test.yaml')
+
+            assert.strictEqual(result, undefined)
+            assert.ok(showInformationMessageStub.calledWith('No resources found in the current template'))
+        })
+
+        it('should return selected resource when single resource of type exists', async function () {
+            getAuthoredResourceTypesV2Stub.resolves([
+                { logicalId: 'MyBucket', type: 'AWS::S3::Bucket' },
+                { logicalId: 'MyFunction', type: 'AWS::Lambda::Function' },
+            ])
+            showQuickPickStub.resolves('AWS::S3::Bucket')
+
+            const result = await selector.selectAuthoredResourceType('file:///test.yaml')
+
+            assert.deepStrictEqual(result, { logicalId: 'MyBucket', type: 'AWS::S3::Bucket' })
+            assert.ok(showQuickPickStub.calledOnce)
+        })
+
+        it('should show logical ID picker when multiple resources of same type exist', async function () {
+            getAuthoredResourceTypesV2Stub.resolves([
+                { logicalId: 'Bucket1', type: 'AWS::S3::Bucket' },
+                { logicalId: 'Bucket2', type: 'AWS::S3::Bucket' },
+            ])
+            showQuickPickStub.onFirstCall().resolves('AWS::S3::Bucket')
+            showQuickPickStub.onSecondCall().resolves({ label: 'Bucket2', logicalId: 'Bucket2' })
+
+            const result = await selector.selectAuthoredResourceType('file:///test.yaml')
+
+            assert.deepStrictEqual(result, { logicalId: 'Bucket2', type: 'AWS::S3::Bucket' })
+            assert.ok(showQuickPickStub.calledTwice)
+        })
+
+        it('should return undefined when user cancels type selection', async function () {
+            getAuthoredResourceTypesV2Stub.resolves([{ logicalId: 'MyBucket', type: 'AWS::S3::Bucket' }])
+            showQuickPickStub.resolves(undefined)
+
+            const result = await selector.selectAuthoredResourceType('file:///test.yaml')
+
+            assert.strictEqual(result, undefined)
+        })
+
+        it('should return undefined when user cancels logical ID selection', async function () {
+            getAuthoredResourceTypesV2Stub.resolves([
+                { logicalId: 'Bucket1', type: 'AWS::S3::Bucket' },
+                { logicalId: 'Bucket2', type: 'AWS::S3::Bucket' },
+            ])
+            showQuickPickStub.onFirstCall().resolves('AWS::S3::Bucket')
+            showQuickPickStub.onSecondCall().resolves(undefined)
+
+            const result = await selector.selectAuthoredResourceType('file:///test.yaml')
+
+            assert.strictEqual(result, undefined)
+        })
+
+        it('should fall back to v1 endpoint when v2 fails', async function () {
+            getAuthoredResourceTypesV2Stub.rejects(new Error('Method not found'))
+            getAuthoredResourceTypesStub.resolves(['AWS::S3::Bucket', 'AWS::Lambda::Function'])
+            showQuickPickStub.resolves('AWS::S3::Bucket')
+
+            const result = await selector.selectAuthoredResourceType('file:///test.yaml')
+
+            assert.ok(result)
+            assert.strictEqual(result.type, 'AWS::S3::Bucket')
+            assert.ok(getAuthoredResourceTypesStub.calledOnce)
+        })
+    })
+})

--- a/packages/toolkit/.changes/next-release/Feature-ea4438d3-d0a1-4589-a2f0-48cc108fe002.json
+++ b/packages/toolkit/.changes/next-release/Feature-ea4438d3-d0a1-4589-a2f0-48cc108fe002.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Users can now choose which specific resource to reference when multiple resources of the same type exist"
+}


### PR DESCRIPTION
## Problem
When multiple resources of the same type exist (e.g., MyRole1, MyRole2), the system automatically uses the first one found during the `Add Related Resources` workflow, giving users no control over which instance is referenced in `!Ref`/`!GetAtt`.


## Solution
Show resource types first, then logical IDs if duplicates exist
- Pass selected parentLogicalId through LSP protocol
- Update both client and LSP server to handle specific parent selection

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
