### PR TITLE
fix(smus): encode cell-number for smus deeplink

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/uriHandlers.ts
+++ b/packages/core/src/sagemakerunifiedstudio/uriHandlers.ts
@@ -33,7 +33,7 @@ export function register(ctx: ExtContext) {
                 ctx,
                 params.connection_identifier,
                 params.session,
-                `${params.ws_url}&cell-number=${params['cell-number']}`, // Re-append cell-number to ws_url
+                `${params.ws_url}&cell-number=${encodeURIComponent(params['cell-number'])}`, // Re-append cell-number to ws_url
                 params.token,
                 params.domain,
                 params.app_type,


### PR DESCRIPTION
## Problem
- detected issue in smus deeplink where it would get stuck in "opening" the remote window and eventually crash after timeout
- deeplink URL lacked a URL encoding which allowed query param cell-number (base64-encoded SSM session token) to convert from spec char '+' to spaces when re-appended to web socket url. this caused mismatch > corrupted token

## Solution
- wrap cell-number with encodeURIComponent() which will keep spec char as is after re-appending

## Testing
- Locally tested with vsix
- Confirmed with SMUS

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
