### PR TITLE
build(toolkit): merge release candidate version rc-20260408

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "prettier": "^3.3.3",
                 "prettier-plugin-sh": "^0.14.0",
                 "pretty-quick": "^4.0.0",
-                "ts-node": "^10.9.2",
+                "ts-node": "^10.9.1",
                 "typescript": "^5.0.4",
                 "webpack": "^5.95.0",
                 "webpack-cli": "^5.1.4",
@@ -50697,7 +50697,7 @@
         },
         "packages/toolkit": {
             "name": "aws-toolkit-vscode",
-            "version": "4.0.0",
+            "version": "4.1.0-SNAPSHOT",
             "license": "Apache-2.0",
             "dependencies": {
                 "aws-core-vscode": "file:../core/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "prettier": "^3.3.3",
                 "prettier-plugin-sh": "^0.14.0",
                 "pretty-quick": "^4.0.0",
-                "ts-node": "^10.9.1",
+                "ts-node": "^10.9.2",
                 "typescript": "^5.0.4",
                 "webpack": "^5.95.0",
                 "webpack-cli": "^5.1.4",
@@ -50697,7 +50697,7 @@
         },
         "packages/toolkit": {
             "name": "aws-toolkit-vscode",
-            "version": "4.0.0-SNAPSHOT",
+            "version": "4.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "aws-core-vscode": "file:../core/"

--- a/packages/toolkit/.changes/4.0.0.json
+++ b/packages/toolkit/.changes/4.0.0.json
@@ -1,0 +1,14 @@
+{
+	"date": "2026-04-09",
+	"version": "4.0.0",
+	"entries": [
+		{
+			"type": "Bug Fix",
+			"description": "HyperPod: Improved connection reliability with automatic token refresh and fixed connection failures on Windows."
+		},
+		{
+			"type": "Feature",
+			"description": "CloudFormation Language Server: templates exceeding 51KB now automatically enforce S3 upload instead of silently failing at deployment"
+		}
+	]
+}

--- a/packages/toolkit/.changes/next-release/Bug Fix-f7efd07f-92ac-4bbd-a212-ab87427c29d8.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-f7efd07f-92ac-4bbd-a212-ab87427c29d8.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "HyperPod: Improved connection reliability with automatic token refresh and fixed connection failures on Windows."
-}

--- a/packages/toolkit/.changes/next-release/Feature-a17c80f9-ddda-443b-bdc5-3cf5fa068508.json
+++ b/packages/toolkit/.changes/next-release/Feature-a17c80f9-ddda-443b-bdc5-3cf5fa068508.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "CloudFormation Language Server: templates exceeding 51KB now automatically enforce S3 upload instead of silently failing at deployment"
-}

--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.0 2026-04-09
+
+- **Bug Fix** HyperPod: Improved connection reliability with automatic token refresh and fixed connection failures on Windows.
+- **Feature** CloudFormation Language Server: templates exceeding 51KB now automatically enforce S3 upload instead of silently failing at deployment
+
 ## 3.101.0 2026-03-26
 
 - Miscellaneous non-user-facing changes

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -2,7 +2,7 @@
     "name": "aws-toolkit-vscode",
     "displayName": "AWS Toolkit",
     "description": "Including CodeCatalyst, Infrastructure Composer, and support for Lambda, S3, CloudWatch Logs, CloudFormation, and many other services.",
-    "version": "4.0.0",
+    "version": "4.1.0-SNAPSHOT",
     "extensionKind": [
         "workspace"
     ],

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -2,7 +2,7 @@
     "name": "aws-toolkit-vscode",
     "displayName": "AWS Toolkit",
     "description": "Including CodeCatalyst, Infrastructure Composer, and support for Lambda, S3, CloudWatch Logs, CloudFormation, and many other services.",
-    "version": "4.0.0-SNAPSHOT",
+    "version": "4.0.0",
     "extensionKind": [
         "workspace"
     ],


### PR DESCRIPTION
This merges the released changes for rc-20260408 into main.
MCM-147974930

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
