### PR TITLE
ci(sagemaker): Modified the codeowners file to support sagemaker-code-editor team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,6 @@ packages/core/src/codewhisperer/ @aws/codewhisperer-team
 packages/core/src/amazonqFeatureDev/ @aws/earlybird
 packages/core/src/awsService/accessanalyzer/ @aws/access-analyzer
 packages/core/src/awsService/cloudformation/ @aws/cfn-dev-productivity
+packages/core/src/awsService/sagemaker/ @aws/sagemaker-code-editor
+packages/core/resources/sagemaker_connect* @aws/sagemaker-code-editor
+packages/core/resources/hyperpod_connect* @aws/sagemaker-code-editor


### PR DESCRIPTION
## Problem
As the package is open-source and multiple teams contribute to the same, sometimes other team's changes leads to breakage in other team's code.

## Solution
We have added the packages and files we support so we can get notified about the changes made in the code affecting our paths.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
