### PR TITLE
fix(smus): Add Origin header to sso/login calls

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/shared/smusUtils.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/smusUtils.ts
@@ -301,6 +301,7 @@ export class SmusUtils {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
                     'User-Agent': 'aws-toolkit-vscode',
+                    Origin: new URL(domainUrl).origin,
                 },
                 body: JSON.stringify(requestBody),
                 timeout: SmusTimeouts.apiCallTimeoutMs,


### PR DESCRIPTION
## Problem
DataZone start enforcing Origin header for sso/login endpoints

## Solution
Add Origin header to sso/login endpoints

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
