### PR TITLE
fix(smus): Add check for sessionName field for space filtering in addition to principalId.

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.ts
@@ -499,7 +499,12 @@ export class DataZoneCustomClientHelper {
                 for (const profile of response.items) {
                     // Match based on session name (role ARN already filtered by searchText)
                     // principalId format: PRINCIPAL_ID:SESSION_NAME
-                    const matchesSession = profile.details?.iam?.principalId?.includes(sessionName)
+                    const matchesSession =
+                        profile.details?.iam?.principalId?.includes(sessionName) ||
+                        profile.details?.iam?.sessionName?.includes(sessionName)
+
+                    // eslint-disable-next-line aws-toolkits/no-json-stringify-in-log
+                    this.logger.info(JSON.stringify(profile))
 
                     if (matchesSession) {
                         this.logger.info(

--- a/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.ts
@@ -503,9 +503,6 @@ export class DataZoneCustomClientHelper {
                         profile.details?.iam?.principalId?.includes(sessionName) ||
                         profile.details?.iam?.sessionName?.includes(sessionName)
 
-                    // eslint-disable-next-line aws-toolkits/no-json-stringify-in-log
-                    this.logger.info(JSON.stringify(profile))
-
                     if (matchesSession) {
                         this.logger.info(
                             `DataZoneCustomClientHelper: Found matching user profile with ID: ${profile.id} (role: ${iamRoleArn}, session: ${sessionName}) after checking ${totalProfilesChecked} profiles`

--- a/packages/core/src/test/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.test.ts
@@ -759,6 +759,29 @@ describe('DataZoneCustomClientHelper', () => {
             assert.strictEqual(searchStub.firstCall.args[1].searchText, 'arn:aws:iam::123456789012:role/AdminRole')
         })
 
+        it('should find matching user profile by sessionName when principalId does not contain session name', async () => {
+            const searchStub = sinon.stub(client, 'searchUserProfiles')
+            searchStub.onFirstCall().resolves({
+                items: [
+                    {
+                        id: 'up_user1',
+                        status: 'ACTIVATED',
+                        details: {
+                            iam: {
+                                arn: 'arn:aws:iam::123456789012:role/AdminRole',
+                                principalId: 'AIDAI123456789EXAMPLE',
+                                sessionName: 'my-session',
+                            },
+                        },
+                    },
+                ],
+                nextToken: undefined,
+            })
+
+            const result = await client.getUserProfileIdForSession(mockDomainId, mockAssumedRoleArn)
+            assert.strictEqual(result, 'up_user1')
+        })
+
         it('should find matching user profile across multiple pages', async () => {
             const searchStub = sinon.stub(client, 'searchUserProfiles')
 

--- a/packages/toolkit/.changes/next-release/Bug Fix-0c90d907-f6f5-4b5e-9454-f64a7cfba8f5.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-0c90d907-f6f5-4b5e-9454-f64a7cfba8f5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix issue for IAM users who cannot see their Sagemaker Unified Studio spaces"
+}


### PR DESCRIPTION
## Problem

Datazone has stopped adding the session name as part of the principalId for new group profiles, so we should be getting it from the sessionName instead.

## Solution

Add another check to look for the session name from the SessionName field.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
