### PR TITLE
fix(cloudformation): Make CloudFormation LSP download strategy consistent

### DIFF
--- a/packages/core/src/awsService/cloudformation/extension.ts
+++ b/packages/core/src/awsService/cloudformation/extension.ts
@@ -50,7 +50,6 @@ import { openStackTemplateCommand } from './commands/openStackTemplate'
 import { selectRegionCommand } from './commands/regionCommands'
 import { AwsCredentialsService, encryptionKey } from './auth/credentials'
 import { ExtensionId, ExtensionName, CloudFormationTelemetrySettings } from './extensionConfig'
-import { VSCODE_EXTENSION_ID_CONSTANTS } from '../../shared/extensionIds'
 import { commandKey } from './utils'
 import { CloudFormationExplorer } from './explorer/explorer'
 import { handleTelemetryOptIn } from './telemetryOptIn'
@@ -150,7 +149,7 @@ async function startClient(context: ExtensionContext) {
             aws: {
                 clientInfo: {
                     extension: {
-                        name: VSCODE_EXTENSION_ID_CONSTANTS.awstoolkit,
+                        name: 'aws.toolkit.vscode',
                         version: extensionVersion,
                     },
                     clientId: getClientId(globals.globalState, telemetryEnabled),

--- a/packages/core/src/awsService/cloudformation/lsp-server/githubManifestAdapter.ts
+++ b/packages/core/src/awsService/cloudformation/lsp-server/githubManifestAdapter.ts
@@ -3,199 +3,53 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CfnLspName, CfnLspServerEnvType } from './lspServerConfig'
-import {
-    addWindows,
-    CfnManifest,
-    CfnTarget,
-    CfnLspVersion,
-    dedupeAndGetLatestVersions,
-    extractPlatformAndArch,
-    useOldLinuxVersion,
-    mapLegacyLinux,
-} from './utils'
+import { CfnLspServerEnvType } from './lspServerConfig'
+import { CfnManifest, CfnLspVersion, useOldLinuxVersion, mapLegacyLinux } from './utils'
 import { getLogger } from '../../../shared/logger/logger'
-import { ToolkitError } from '../../../shared/errors'
+
+const ManifestUrl =
+    'https://raw.githubusercontent.com/aws-cloudformation/cloudformation-languageserver/refs/heads/main/assets/release-manifest.json'
 
 export class GitHubManifestAdapter {
-    constructor(
-        private readonly repoOwner: string,
-        private readonly repoName: string,
-        readonly environment: CfnLspServerEnvType
-    ) {}
+    private lastRawManifest?: string
+
+    constructor(readonly environment: CfnLspServerEnvType) {}
+
+    getLastRawManifest(): string | undefined {
+        return this.lastRawManifest
+    }
 
     async getManifest(): Promise<CfnManifest> {
-        let manifest: CfnManifest
-        try {
-            manifest = await this.getManifestJson()
-        } catch (err) {
-            getLogger('awsCfnLsp').error(ToolkitError.chain(err, 'Failed to get CloudFormation manifest'))
-            manifest = await this.getFromReleases()
-        }
-
-        getLogger('awsCfnLsp').info(
-            'Candidate versions: %s',
-            manifest.versions
-                .map(
-                    (v) =>
-                        `${v.serverVersion}[${v.targets
-                            .sort()
-                            .map((t) => `${t.platform}-${t.arch}-${t.nodejs}`)
-                            .join(',')}]`
-                )
-                .join(', ')
-        )
-
-        if (process.platform !== 'linux') {
-            return manifest
-        }
-
-        const useFallbackLinux = useOldLinuxVersion()
-        if (!useFallbackLinux) {
-            return manifest
-        }
-
-        getLogger('awsCfnLsp').info('In a legacy or sandbox Linux environment')
-        manifest.versions = mapLegacyLinux(manifest.versions)
-
-        getLogger('awsCfnLsp').info(
-            'Remapped candidate versions: %s',
-            manifest.versions
-                .map(
-                    (v) =>
-                        `${v.serverVersion}[${v.targets
-                            .sort()
-                            .map((t) => `${t.platform}-${t.arch}-${t.nodejs}`)
-                            .join(',')}]`
-                )
-                .join(', ')
-        )
-        return manifest
-    }
-
-    private async getFromReleases(): Promise<CfnManifest> {
-        const releases = await this.fetchGitHubReleases()
-        const envReleases = this.filterByEnvironment(releases)
-        const sortedReleases = envReleases.sort((a, b) => {
-            return b.tag_name.localeCompare(a.tag_name)
-        })
-        const versions = dedupeAndGetLatestVersions(sortedReleases.map((release) => this.convertRelease(release)))
-        getLogger('awsCfnLsp').info(
-            'Candidate versions: %s',
-            versions
-                .map((v) => `${v.serverVersion}[${v.targets.map((t) => `${t.platform}-${t.arch}`).join(',')}]`)
-                .join(', ')
-        )
-        return {
-            manifestSchemaVersion: '1.0',
-            artifactId: CfnLspName,
-            artifactDescription: 'GitHub CloudFormation Language Server',
-            isManifestDeprecated: false,
-            versions: versions,
-        }
-    }
-
-    private filterByEnvironment(releases: GitHubRelease[]): GitHubRelease[] {
-        return releases.filter((release) => {
-            const tag = release.tag_name
-            if (this.environment === 'alpha') {
-                return release.prerelease && tag.endsWith('-alpha')
-            } else if (this.environment === 'beta') {
-                return release.prerelease && tag.endsWith('-beta')
-            } else {
-                return !release.prerelease
-            }
-        })
-    }
-
-    private async fetchGitHubReleases(): Promise<GitHubRelease[]> {
-        const response = await fetch(`https://api.github.com/repos/${this.repoOwner}/${this.repoName}/releases`)
+        const response = await fetch(ManifestUrl)
         if (!response.ok) {
-            throw new Error(`GitHub API error: ${response.status}`)
-        }
-        return response.json()
-    }
-
-    private convertRelease(release: GitHubRelease): CfnLspVersion {
-        return {
-            serverVersion: release.tag_name,
-            isDelisted: false,
-            targets: addWindows(this.extractTargets(release.assets)),
-        }
-    }
-
-    private extractTargets(assets: GitHubAsset[]): CfnTarget[] {
-        return assets.map((asset) => {
-            const { arch, platform, nodejs } = extractPlatformAndArch(asset.name)
-
-            return {
-                platform,
-                arch,
-                nodejs,
-                contents: [
-                    {
-                        filename: asset.name,
-                        url: asset.browser_download_url,
-                        hashes: [],
-                        bytes: asset.size,
-                    },
-                ],
-            }
-        })
-    }
-
-    private async getManifestJson(): Promise<CfnManifest> {
-        const response = await fetch(
-            `https://raw.githubusercontent.com/${this.repoOwner}/${this.repoName}/refs/heads/main/assets/release-manifest.json`
-        )
-        if (!response.ok) {
-            throw new Error(`GitHub API error: ${response.status}`)
+            throw new Error(`Manifest fetch failed: ${response.status}`)
         }
 
-        const json = (await response.json()) as Record<string, unknown>
+        const rawText = await response.text()
+        this.lastRawManifest = rawText
+        const json = JSON.parse(rawText) as Record<string, unknown>
 
-        return {
+        const versions = json[this.environment] as CfnLspVersion[] | undefined
+        const manifest: CfnManifest = {
             manifestSchemaVersion: json.manifestSchemaVersion as string,
             artifactId: json.artifactId as string,
             artifactDescription: json.artifactDescription as string,
             isManifestDeprecated: json.isManifestDeprecated as boolean,
-            versions: json[this.environment] as CfnLspVersion[],
+            versions: versions ?? [],
         }
+
+        getLogger('awsCfnLsp').info(
+            'Candidate versions: %s',
+            manifest.versions
+                .map((v) => `${v.serverVersion}[${v.targets.map((t) => `${t.platform}-${t.arch}`).join(',')}]`)
+                .join(', ')
+        )
+
+        if (process.platform === 'linux' && useOldLinuxVersion()) {
+            getLogger('awsCfnLsp').info('In a legacy or sandbox Linux environment')
+            manifest.versions = mapLegacyLinux(manifest.versions)
+        }
+
+        return manifest
     }
-}
-
-/* eslint-disable @typescript-eslint/naming-convention */
-interface GitHubAsset {
-    url: string
-    browser_download_url: string
-    id: number
-    node_id: string
-    name: string
-    label: string | null
-    state: string
-    content_type: string
-    size: number
-    download_count: number
-    created_at: string
-    updated_at: string
-}
-
-interface GitHubRelease {
-    url: string
-    html_url: string
-    assets_url: string
-    upload_url: string
-    tarball_url: string | null
-    zipball_url: string | null
-    id: number
-    node_id: string
-    tag_name: string
-    target_commitish: string
-    name: string | null
-    body: string | null
-    draft: boolean
-    prerelease: boolean
-    created_at: string // ISO 8601 date string
-    published_at: string | null // ISO 8601 date string
-    assets: GitHubAsset[]
 }

--- a/packages/core/src/awsService/cloudformation/lsp-server/lspInstaller.ts
+++ b/packages/core/src/awsService/cloudformation/lsp-server/lspInstaller.ts
@@ -7,78 +7,173 @@ import { BaseLspInstaller } from '../../../shared/lsp/baseLspInstaller'
 import { GitHubManifestAdapter } from './githubManifestAdapter'
 import { fs } from '../../../shared/fs/fs'
 import { CfnLspName, CfnLspServerEnvType, CfnLspServerFile } from './lspServerConfig'
-import { isAutomation, isBeta, isDebugInstance } from '../../../shared/vscode/env'
-import { dirname, join } from 'path'
+import { isAutomation, isBeta } from '../../../shared/vscode/env'
+import { basename, dirname, join } from 'path'
 import { getLogger } from '../../../shared/logger/logger'
-import { ResourcePaths } from '../../../shared/lsp/types'
+import { LspResolution, ResourcePaths } from '../../../shared/lsp/types'
 import * as nodeFs from 'fs' // eslint-disable-line no-restricted-imports
-import globals from '../../../shared/extensionGlobals'
+import { getDownloadedVersions } from '../../../shared/lsp/utils/cleanup'
+import { InUseTracker } from '../../../shared/lsp/utils/inUseTracker'
+import { useOldLinuxVersion, mapLegacyLinux } from './utils'
 import { toString } from '../utils'
+import { coerce, satisfies, sort } from 'semver'
 
 function determineEnvironment(): CfnLspServerEnvType {
-    if (isDebugInstance()) {
-        return 'alpha'
-    } else if (isBeta() || isAutomation()) {
+    if (isBeta() || isAutomation()) {
         return 'beta'
     }
     return 'prod'
 }
 
+const ManifestCacheFile = 'manifest.json'
+
+const SupportedVersionRange = '<2.0.0'
+
+/** CFN-specific cache root. Lazy to avoid calling fs.getCacheDir() before globals are initialized. */
+function getCfnLspRootDir() {
+    return join(fs.getCacheDir(), 'aws', 'language-servers')
+}
+
 export class CfnLspInstaller extends BaseLspInstaller {
-    private readonly githubManifest = new GitHubManifestAdapter(
-        'aws-cloudformation',
-        'cloudformation-languageserver',
-        determineEnvironment()
-    )
+    private readonly githubManifest = new GitHubManifestAdapter(determineEnvironment())
+    readonly inUseTracker = new InUseTracker()
 
     constructor() {
         super(
             {
                 manifestUrl: 'github',
-                supportedVersions: '<2.0.0',
+                supportedVersions: SupportedVersionRange,
                 id: CfnLspName,
                 suppressPromptPrefix: 'cfnLsp',
+                rootDir: getCfnLspRootDir(),
             },
             'awsCfnLsp',
             {
                 resolve: async () => {
                     const log = getLogger('awsCfnLsp')
-                    const cfnManifestStorageKey = 'aws.cloudformation.lsp.manifest'
+                    const env = determineEnvironment()
+                    const downloadRoot = join(getCfnLspRootDir(), CfnLspName)
+                    const cachePath = join(downloadRoot, ManifestCacheFile)
+
+                    const writeRawManifestCache = async () => {
+                        try {
+                            const rawManifestText = this.githubManifest.getLastRawManifest()
+                            if (!rawManifestText) {
+                                return
+                            }
+                            await fs.mkdir(downloadRoot)
+                            const tmpPath = `${cachePath}.tmp.${process.pid}`
+                            await fs.writeFile(tmpPath, rawManifestText)
+                            nodeFs.renameSync(tmpPath, cachePath)
+                        } catch (cacheErr) {
+                            log.debug(`Failed to cache manifest: ${cacheErr}`)
+                        }
+                    }
 
                     try {
                         const manifest = await this.githubManifest.getManifest()
                         log.info(
-                            `Creating CloudFormation LSP manifest for ${this.githubManifest.environment}`,
+                            `CloudFormation LSP manifest for ${env}`,
                             manifest.versions.map((v) => v.serverVersion)
                         )
 
-                        // Cache in CloudFormation-specific global state storage
-                        globals.globalState.tryUpdate(cfnManifestStorageKey, {
-                            content: JSON.stringify(manifest),
-                        })
+                        await writeRawManifestCache()
 
-                        return manifest
-                    } catch (error) {
-                        log.warn(`GitHub fetch failed, trying cached manifest: ${error}`)
-
-                        // Try cached manifest from CloudFormation-specific storage
-                        const manifestData = globals.globalState.tryGet(cfnManifestStorageKey, Object, {})
-
-                        if (manifestData?.content) {
-                            log.debug('Using cached manifest for offline mode')
-                            return JSON.parse(manifestData.content)
+                        if (!manifest.versions?.length) {
+                            throw new Error(`No versions in manifest for environment '${env}'`)
                         }
-
-                        log.error('No cached manifest found')
-                        throw error
+                        return manifest
+                    } catch (fetchError) {
+                        // Raw manifest may have been populated even if getManifest() threw later
+                        await writeRawManifestCache()
+                        log.warn(`GitHub fetch failed, trying cached manifest: ${fetchError}`)
                     }
+
+                    try {
+                        if (await fs.existsFile(cachePath)) {
+                            const cachedManifestText = await fs.readFileText(cachePath)
+                            const cachedManifest = JSON.parse(cachedManifestText)
+                            let versions = cachedManifest[env]
+                            if (!versions?.length) {
+                                throw new Error(`No versions in cached manifest for environment '${env}'`)
+                            }
+                            if (process.platform === 'linux' && useOldLinuxVersion()) {
+                                versions = mapLegacyLinux(versions)
+                            }
+                            log.info('Using cached manifest for offline mode')
+                            return {
+                                manifestSchemaVersion: cachedManifest.manifestSchemaVersion,
+                                artifactId: cachedManifest.artifactId,
+                                artifactDescription: cachedManifest.artifactDescription,
+                                isManifestDeprecated: cachedManifest.isManifestDeprecated,
+                                versions,
+                            }
+                        }
+                    } catch (cacheReadErr) {
+                        log.warn(`Failed to read cached manifest: ${cacheReadErr}`)
+                    }
+
+                    // Throw to trigger resolve() fallback to local installation
+                    throw new Error('Failed to fetch manifest and no cached manifest available')
                 },
             } as any,
             'sha256'
         )
     }
 
+    override async resolve(): Promise<LspResolution<ResourcePaths>> {
+        try {
+            return await super.resolve()
+        } catch (err) {
+            const log = getLogger('awsCfnLsp')
+            log.warn(`Standard resolve failed, searching for installed LSP: ${err}`)
+
+            const downloadRoot = join(getCfnLspRootDir(), CfnLspName)
+            const fallbackDir = await this.findLocalFallback(downloadRoot)
+            if (fallbackDir) {
+                log.info(`Using locally installed fallback: ${fallbackDir}`)
+                this.inUseTracker.writeMarker(fallbackDir, 'aws-toolkit-vscode')
+                return {
+                    assetDirectory: fallbackDir,
+                    location: 'fallback',
+                    version: basename(fallbackDir),
+                    resourcePaths: this.resourcePaths(fallbackDir),
+                }
+            }
+
+            throw err
+        }
+    }
+
+    private async findLocalFallback(downloadRoot: string): Promise<string | undefined> {
+        try {
+            const versions = await getDownloadedVersions(downloadRoot)
+            const compatible = versions.filter((v) => {
+                const parsed = coerce(v)
+                return parsed !== null && satisfies(parsed, SupportedVersionRange)
+            })
+            const sorted = sort(compatible)
+            for (const version of sorted.reverse()) {
+                const dir = join(downloadRoot, version)
+                const entries = nodeFs.readdirSync(dir, { withFileTypes: true })
+                const folders = entries.filter((e) => e.isDirectory())
+                for (const folder of folders) {
+                    const serverFile = join(dir, folder.name, CfnLspServerFile)
+                    if (nodeFs.existsSync(serverFile)) {
+                        return dir
+                    }
+                }
+            }
+        } catch (err) {
+            getLogger('awsCfnLsp').debug(`No local versions available: ${err}`)
+        }
+        return undefined
+    }
+
     protected async postInstall(assetDirectory: string): Promise<void> {
+        // Write in-use marker BEFORE cleanLspDownloads (called by base resolve) so peer cleanups see us
+        this.inUseTracker.writeMarker(assetDirectory, 'aws-toolkit-vscode')
+
         const resourcePaths = this.resourcePaths(assetDirectory)
         const rootDir = dirname(resourcePaths.lsp)
         await fs.chmod(join(rootDir, 'bin', process.platform === 'win32' ? 'cfn-init.exe' : 'cfn-init'), 0o755)
@@ -92,7 +187,6 @@ export class CfnLspInstaller extends BaseLspInstaller {
             }
         }
 
-        // Find the single extracted directory
         const entries = nodeFs.readdirSync(assetDirectory, { withFileTypes: true })
         const folders = entries.filter((entry) => entry.isDirectory())
 

--- a/packages/core/src/awsService/cloudformation/lsp-server/lspServerProvider.ts
+++ b/packages/core/src/awsService/cloudformation/lsp-server/lspServerProvider.ts
@@ -66,5 +66,11 @@ export class LspServerProvider implements LspServerResolverI, Disposable {
         }
     }
 
-    dispose() {}
+    dispose() {
+        for (const provider of this.matchedProviders) {
+            if ('dispose' in provider && typeof provider.dispose === 'function') {
+                provider.dispose()
+            }
+        }
+    }
 }

--- a/packages/core/src/awsService/cloudformation/lsp-server/remoteLspServerProvider.ts
+++ b/packages/core/src/awsService/cloudformation/lsp-server/remoteLspServerProvider.ts
@@ -10,6 +10,7 @@ import { CfnLspInstaller } from './lspInstaller'
 export class RemoteLspServerProvider implements LspServerProviderI {
     private installer = new CfnLspInstaller()
     private serverPath?: string
+    private versionDir?: string
 
     name(): string {
         return 'RemoteLspServerProvider'
@@ -26,10 +27,18 @@ export class RemoteLspServerProvider implements LspServerProviderI {
 
         const result = await this.installer.resolve()
         this.serverPath = result.resourcePaths.lsp
+        this.versionDir = result.assetDirectory
+        // Marker is written by CfnLspInstaller (postInstall / fallback) BEFORE cleanup
         return this.serverPath
     }
 
     async serverRootDir(): Promise<string> {
         return dirname(await this.serverExecutable())
+    }
+
+    dispose() {
+        if (this.versionDir) {
+            this.installer.inUseTracker.removeMarker(this.versionDir)
+        }
     }
 }

--- a/packages/core/src/shared/lsp/baseLspInstaller.ts
+++ b/packages/core/src/shared/lsp/baseLspInstaller.ts
@@ -19,6 +19,8 @@ export interface LspConfig {
     id: string
     suppressPromptPrefix: string
     path?: string
+    /** Override base cache dir for this LSP. Defaults to `LanguageServerResolver.defaultDir()`. */
+    rootDir?: string
 }
 
 export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, Config extends LspConfig = LspConfig> {
@@ -34,7 +36,7 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, 
     }
 
     async resolve(): Promise<LspResolution<T>> {
-        const { id, manifestUrl, supportedVersions, path, suppressPromptPrefix } = this.config
+        const { id, manifestUrl, supportedVersions, path, suppressPromptPrefix, rootDir } = this.config
         if (path) {
             const overrideMsg = `Using language server override location: ${path}`
             this.logger.info(overrideMsg)
@@ -58,7 +60,8 @@ export abstract class BaseLspInstaller<T extends ResourcePaths = ResourcePaths, 
             }),
             manifestUrl,
             this.downloadMessageOverride,
-            this.hashAlgorithm
+            this.hashAlgorithm,
+            rootDir
         ).resolve()
 
         const assetDirectory = installationResult.assetDirectory

--- a/packages/core/src/shared/lsp/lspResolver.ts
+++ b/packages/core/src/shared/lsp/lspResolver.ts
@@ -34,7 +34,8 @@ export class LanguageServerResolver {
          * Custom message to show user when downloading, if undefined it will use the default.
          */
         downloadMessage?: string,
-        private readonly hashAlgorithm: string = 'sha384'
+        private readonly hashAlgorithm: string = 'sha384',
+        private readonly rootDir: string = LanguageServerResolver.defaultDir()
     ) {
         this.downloadMessage = downloadMessage ?? `Updating '${this.lsName}' language server`
     }
@@ -222,9 +223,8 @@ export class LanguageServerResolver {
     }
 
     private async getCachedVersions() {
-        // determine all folders containing lsp versions in the parent folder
         return (await fs.readdir(this.defaultDownloadFolder()))
-            .filter(([_, filetype]) => filetype === FileType.Directory)
+            .filter(([pathName, filetype]) => filetype === FileType.Directory && !pathName.includes('.tmp.'))
             .map(([pathName, _]) => semver.parse(pathName))
             .filter((ver): ver is semver.SemVer => ver !== null)
             .map((x) => x.version)
@@ -265,10 +265,12 @@ export class LanguageServerResolver {
      */
     private async downloadRemoteTargetContent(contents: TargetContent[], lspVersion: LspVersion, timeout: Timeout) {
         const downloadDirectory = this.getDownloadDirectory(lspVersion.serverVersion)
+        const tmpDirectory = `${downloadDirectory}.tmp.${process.pid}`
 
-        if (!(await fs.existsDir(downloadDirectory))) {
-            await fs.mkdir(downloadDirectory)
+        if (await fs.existsDir(tmpDirectory)) {
+            await fs.delete(tmpDirectory, { force: true, recursive: true })
         }
+        await fs.mkdir(tmpDirectory)
 
         const fetchTasks = contents.map(async (content) => {
             return {
@@ -315,10 +317,26 @@ export class LanguageServerResolver {
         )
 
         for (const file of filesToDownload) {
-            await fs.writeFile(`${downloadDirectory}/${file.filename}`, file.data)
+            await fs.writeFile(`${tmpDirectory}/${file.filename}`, file.data)
         }
 
-        return this.extractZipFilesFromRemote(downloadDirectory)
+        const extracted = await this.extractZipFilesFromRemote(tmpDirectory)
+        if (!extracted) {
+            await fs.delete(tmpDirectory, { force: true, recursive: true })
+            return false
+        }
+
+        // Atomic to prevent partial installs visible to concurrent IDE instances
+        try {
+            await fs.rename(tmpDirectory, downloadDirectory)
+        } catch {
+            await fs.delete(tmpDirectory, { force: true, recursive: true }).catch(() => {})
+            if (await fs.existsDir(downloadDirectory)) {
+                return true
+            }
+            return false
+        }
+        return true
     }
 
     private async extractZipFilesFromRemote(downloadDirectory: string) {
@@ -423,19 +441,17 @@ export class LanguageServerResolver {
             throw new ToolkitError('No valid manifest')
         }
 
-        const latestCompatibleVersion =
-            this.manifest.versions
-                .filter((ver) => this.isCompatibleVersion(ver) && this.hasRequiredTargetContent(ver))
-                .sort((a, b) => semver.compare(b.serverVersion, a.serverVersion))[0] ?? undefined
+        const compatible = this.manifest.versions
+            .filter((ver) => this.isCompatibleVersion(ver) && this.hasRequiredTargetContent(ver))
+            .sort((a, b) => semver.compare(b.serverVersion, a.serverVersion))
 
-        if (latestCompatibleVersion === undefined) {
-            // TODO fix these error range names
+        if (compatible.length === 0) {
             throw new ToolkitError(
                 `Unable to find a language server that satifies one or more of these conditions: version in range [${this.versionRange.range}], matching system's architecture and platform`
             )
         }
 
-        return latestCompatibleVersion
+        return compatible.find((v) => v.latest) ?? compatible[0]
     }
 
     /**
@@ -497,7 +513,7 @@ export class LanguageServerResolver {
     }
 
     defaultDownloadFolder() {
-        return path.join(LanguageServerResolver.defaultDir(), `${this.lsName}`)
+        return path.join(this.rootDir, `${this.lsName}`)
     }
 
     private getDownloadDirectory(version: string) {

--- a/packages/core/src/shared/lsp/types.ts
+++ b/packages/core/src/shared/lsp/types.ts
@@ -72,6 +72,8 @@ export interface LspVersion {
     serverVersion: string
     isDelisted: boolean
     targets: Target[]
+    /** If true, this version is the preferred version for its environment. */
+    latest?: boolean
     /**
      * I'm not sure if this **always** exists (couldn't find it in the spec)
      */

--- a/packages/core/src/shared/lsp/utils/cleanup.ts
+++ b/packages/core/src/shared/lsp/utils/cleanup.ts
@@ -6,54 +6,70 @@
 import path from 'path'
 import { LspVersion } from '../types'
 import { fs } from '../../../shared/fs/fs'
-import { partition } from '../../../shared/utilities/tsUtils'
 import { parse, sort } from 'semver'
+import { InUseTracker } from './inUseTracker'
 
 export async function getDownloadedVersions(installLocation: string) {
     return (await fs.readdir(installLocation)).filter((x) => parse(x[0]) !== null).map(([f, _], __) => f)
 }
 
-function isDelisted(manifestVersions: LspVersion[], targetVersion: string): boolean {
-    return manifestVersions.find((v) => v.serverVersion === targetVersion)?.isDelisted ?? false
+const inUseTracker = new InUseTracker()
+
+function isPidAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0)
+        return true
+    } catch {
+        return false
+    }
+}
+
+async function sweepStaleTmpDirs(downloadDirectory: string): Promise<void> {
+    try {
+        const entries = await fs.readdir(downloadDirectory)
+        for (const [name] of entries) {
+            const match = /\.tmp\.(\d+)$/.exec(name)
+            if (!match) {
+                continue
+            }
+            const pid = parseInt(match[1], 10)
+            if (!isNaN(pid) && !isPidAlive(pid)) {
+                await fs.delete(path.join(downloadDirectory, name), { force: true, recursive: true }).catch(() => {})
+            }
+        }
+    } catch {}
 }
 
 /**
- * Delete all delisted versions and keep the two newest versions that remain
- * @param manifestVersions
- * @param downloadDirectory
- * @returns array of deleted versions.
+ * Keep the current version and one highest fallback.
+ * Skip versions that are currently in use by another IDE/session.
+ * Remove everything else.
  */
 export async function cleanLspDownloads(
     latestInstalledVersion: string,
     manifestVersions: LspVersion[],
     downloadDirectory: string
 ): Promise<string[]> {
+    await sweepStaleTmpDirs(downloadDirectory)
     const downloadedVersions = await getDownloadedVersions(downloadDirectory)
-    const [delistedVersions, remainingVersions] = partition(downloadedVersions, (v: string) =>
-        isDelisted(manifestVersions, v)
-    )
     const deletedVersions: string[] = []
 
-    for (const v of delistedVersions) {
-        await fs.delete(path.join(downloadDirectory, v), { force: true, recursive: true })
-        deletedVersions.push(v)
-    }
+    const fallbackVersion = sort(
+        downloadedVersions.filter((v) => parse(v) !== null && v !== latestInstalledVersion)
+    ).reverse()[0]
 
-    if (remainingVersions.length <= 2) {
-        return deletedVersions
-    }
+    const keep = new Set([latestInstalledVersion, ...(fallbackVersion ? [fallbackVersion] : [])])
 
-    for (const v of sort(remainingVersions).slice(0, -2)) {
-        /**
-         * When switching between different manifests, the following edge case can occur:
-         * A newly downloaded version might chronologically be older than all previously downloaded versions,
-         * even though it's marked as the latest version in its own manifest.
-         * In such cases, we skip the cleanup process to preserve this version. Otherwise we will get an EPIPE error
-         */
-        if (v === latestInstalledVersion) {
+    for (const v of downloadedVersions) {
+        if (keep.has(v)) {
             continue
         }
-        await fs.delete(path.join(downloadDirectory, v), { force: true, recursive: true })
+        const versionDir = path.join(downloadDirectory, v)
+        inUseTracker.cleanStaleMarkers(versionDir)
+        if (inUseTracker.isInUse(versionDir)) {
+            continue
+        }
+        await fs.delete(versionDir, { force: true, recursive: true })
         deletedVersions.push(v)
     }
 

--- a/packages/core/src/shared/lsp/utils/inUseTracker.ts
+++ b/packages/core/src/shared/lsp/utils/inUseTracker.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { join } from 'path'
+import * as nodeFs from 'fs' // eslint-disable-line no-restricted-imports
+
+const InUsePrefix = '.inuse.'
+
+export class InUseTracker {
+    writeMarker(versionDir: string, appName: string): void {
+        try {
+            const markerPath = join(versionDir, `${InUsePrefix}${process.pid}`)
+            const tmpPath = `${markerPath}.tmp`
+            nodeFs.writeFileSync(
+                tmpPath,
+                JSON.stringify({
+                    pid: process.pid,
+                    app: appName,
+                    timestamp: Date.now(),
+                })
+            )
+            nodeFs.renameSync(tmpPath, markerPath)
+        } catch {}
+    }
+
+    removeMarker(versionDir: string): void {
+        try {
+            nodeFs.unlinkSync(join(versionDir, `${InUsePrefix}${process.pid}`))
+        } catch {}
+    }
+
+    cleanStaleMarkers(versionDir: string): void {
+        try {
+            const entries = nodeFs.readdirSync(versionDir, { withFileTypes: true })
+            for (const entry of entries) {
+                if (entry.isFile() && entry.name.startsWith(InUsePrefix)) {
+                    const pid = parseInt(entry.name.slice(InUsePrefix.length), 10)
+                    if (!isNaN(pid) && !isPidAlive(pid)) {
+                        try {
+                            nodeFs.unlinkSync(join(versionDir, entry.name))
+                        } catch {}
+                    }
+                }
+            }
+        } catch {}
+    }
+
+    isInUse(versionDir: string): boolean {
+        try {
+            const entries = nodeFs.readdirSync(versionDir, { withFileTypes: true })
+            return entries.some((entry) => {
+                if (!entry.isFile() || !entry.name.startsWith(InUsePrefix)) {
+                    return false
+                }
+                const pid = parseInt(entry.name.slice(InUsePrefix.length), 10)
+                return !isNaN(pid) && isPidAlive(pid)
+            })
+        } catch {
+            return false
+        }
+    }
+}
+
+function isPidAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0)
+        return true
+    } catch {
+        return false
+    }
+}

--- a/packages/core/src/test/shared/lsp/utils/cleanup.test.ts
+++ b/packages/core/src/test/shared/lsp/utils/cleanup.test.ts
@@ -8,6 +8,7 @@ import { cleanLspDownloads, fs, getDownloadedVersions } from '../../../../shared
 import { createTestWorkspaceFolder } from '../../../testUtil'
 import path from 'path'
 import assert from 'assert'
+import * as nodeFs from 'fs' // eslint-disable-line no-restricted-imports
 
 async function fakeInstallVersion(version: string, installationDir: string): Promise<void> {
     const versionDir = path.join(installationDir, version)
@@ -21,7 +22,7 @@ async function fakeInstallVersions(versions: string[], installationDir: string):
     }
 }
 
-describe('cleanLSPDownloads', function () {
+describe('cleanLspDownloads', function () {
     let installationDir: Uri
 
     before(async function () {
@@ -39,82 +40,81 @@ describe('cleanLSPDownloads', function () {
         await fs.delete(installationDir, { force: true, recursive: true })
     })
 
-    it('keeps two newest versions', async function () {
+    it('keeps current version and one highest fallback, deletes the rest', async function () {
         await fakeInstallVersions(['1.0.0', '1.0.1', '1.1.1', '2.1.1'], installationDir.fsPath)
+
         const deleted = await cleanLspDownloads('2.1.1', [], installationDir.fsPath)
 
-        const result = (await fs.readdir(installationDir.fsPath)).map(([filename, _filetype], _index) => filename)
-        assert.strictEqual(result.length, 2)
-        assert.ok(result.includes('2.1.1'))
-        assert.ok(result.includes('1.1.1'))
+        const remaining = (await fs.readdir(installationDir.fsPath)).map(([name]) => name).sort()
+        assert.deepStrictEqual(remaining, ['1.1.1', '2.1.1'])
         assert.strictEqual(deleted.length, 2)
     })
 
-    it('deletes delisted versions', async function () {
-        await fakeInstallVersions(['1.0.0', '1.0.1', '1.1.1', '2.1.1'], installationDir.fsPath)
-        const deleted = await cleanLspDownloads(
-            '2.1.1',
-            [{ serverVersion: '1.1.1', isDelisted: true, targets: [] }],
-            installationDir.fsPath
-        )
-
-        const result = (await fs.readdir(installationDir.fsPath)).map(([filename, _filetype], _index) => filename)
-        assert.strictEqual(result.length, 2)
-        assert.ok(result.includes('2.1.1'))
-        assert.ok(result.includes('1.0.1'))
-        assert.strictEqual(deleted.length, 2)
-    })
-
-    it('handles case where less than 2 versions are not delisted', async function () {
-        await fakeInstallVersions(['1.0.0', '1.0.1', '1.1.1', '2.1.1'], installationDir.fsPath)
-        const deleted = await cleanLspDownloads(
-            '1.0.1',
-            [
-                { serverVersion: '1.1.1', isDelisted: true, targets: [] },
-                { serverVersion: '2.1.1', isDelisted: true, targets: [] },
-                { serverVersion: '1.0.0', isDelisted: true, targets: [] },
-            ],
-            installationDir.fsPath
-        )
-
-        const result = (await fs.readdir(installationDir.fsPath)).map(([filename, _filetype], _index) => filename)
-        assert.strictEqual(result.length, 1)
-        assert.ok(result.includes('1.0.1'))
-        assert.strictEqual(deleted.length, 3)
-    })
-
-    it('handles case where less than 2 versions exist', async function () {
+    it('keeps only current version when it is the sole downloaded version', async function () {
         await fakeInstallVersions(['1.0.0'], installationDir.fsPath)
+
         const deleted = await cleanLspDownloads('1.0.0', [], installationDir.fsPath)
 
-        const result = (await fs.readdir(installationDir.fsPath)).map(([filename, _filetype], _index) => filename)
-        assert.strictEqual(result.length, 1)
+        const remaining = (await fs.readdir(installationDir.fsPath)).map(([name]) => name)
+        assert.deepStrictEqual(remaining, ['1.0.0'])
         assert.strictEqual(deleted.length, 0)
     })
 
-    it('does not install delisted version when no other option exists', async function () {
-        await fakeInstallVersions(['1.0.0'], installationDir.fsPath)
-        const deleted = await cleanLspDownloads(
-            '1.0.0',
-            [{ serverVersion: '1.0.0', isDelisted: true, targets: [] }],
-            installationDir.fsPath
-        )
+    it('keeps current version even when it is not the highest installed', async function () {
+        await fakeInstallVersions(['1.0.0', '2.0.0', '3.0.0'], installationDir.fsPath)
 
-        const result = (await fs.readdir(installationDir.fsPath)).map(([filename, _filetype], _index) => filename)
-        assert.strictEqual(result.length, 0)
-        assert.strictEqual(deleted.length, 1)
+        await cleanLspDownloads('1.0.0', [], installationDir.fsPath)
+
+        const remaining = (await fs.readdir(installationDir.fsPath)).map(([name]) => name).sort()
+        assert.deepStrictEqual(remaining, ['1.0.0', '3.0.0'])
     })
 
-    it('ignores invalid versions', async function () {
-        await fakeInstallVersions(['1.0.0', '.DS_STORE'], installationDir.fsPath)
-        const deleted = await cleanLspDownloads(
-            '1.0.0',
-            [{ serverVersion: '1.0.0', isDelisted: true, targets: [] }],
-            installationDir.fsPath
-        )
+    it('ignores entries that are not valid semver', async function () {
+        await fakeInstallVersions(['1.0.0', '2.0.0'], installationDir.fsPath)
+        await fs.mkdir(path.join(installationDir.fsPath, '.DS_STORE'))
 
-        const result = await getDownloadedVersions(installationDir.fsPath)
-        assert.strictEqual(result.length, 0)
-        assert.strictEqual(deleted.length, 1)
+        await cleanLspDownloads('2.0.0', [], installationDir.fsPath)
+
+        const versions = await getDownloadedVersions(installationDir.fsPath)
+        assert.deepStrictEqual(versions.sort(), ['1.0.0', '2.0.0'])
+    })
+
+    it('skips deletion of versions currently in use by a live process', async function () {
+        await fakeInstallVersions(['1.0.0', '2.0.0', '3.0.0'], installationDir.fsPath)
+        // Current pid counts as "in use" — process.kill(pid, 0) succeeds
+        nodeFs.writeFileSync(path.join(installationDir.fsPath, '1.0.0', `.inuse.${process.pid}`), '{}')
+
+        const deleted = await cleanLspDownloads('3.0.0', [], installationDir.fsPath)
+
+        const remaining = (await fs.readdir(installationDir.fsPath)).map(([name]) => name).sort()
+        // keep set = {3.0.0 (current), 2.0.0 (fallback)}; 1.0.0 survives via in-use marker
+        assert.deepStrictEqual(remaining, ['1.0.0', '2.0.0', '3.0.0'])
+        assert.strictEqual(deleted.length, 0)
+    })
+
+    it('deletes versions whose markers reference dead pids', async function () {
+        await fakeInstallVersions(['1.0.0', '2.0.0', '3.0.0'], installationDir.fsPath)
+        const deadPid = 2 ** 22 // far beyond any realistic live pid
+        nodeFs.writeFileSync(path.join(installationDir.fsPath, '1.0.0', `.inuse.${deadPid}`), '{}')
+
+        const deleted = await cleanLspDownloads('3.0.0', [], installationDir.fsPath)
+
+        const remaining = (await fs.readdir(installationDir.fsPath)).map(([name]) => name).sort()
+        assert.deepStrictEqual(remaining, ['2.0.0', '3.0.0'])
+        assert.deepStrictEqual(deleted, ['1.0.0'])
+    })
+
+    it('sweeps stale tmp directories with dead pids', async function () {
+        await fakeInstallVersions(['1.0.0'], installationDir.fsPath)
+        const deadPid = 2 ** 22
+        const staleTmp = path.join(installationDir.fsPath, `1.0.0.tmp.${deadPid}`)
+        const liveTmp = path.join(installationDir.fsPath, `1.0.0.tmp.${process.pid}`)
+        await fs.mkdir(staleTmp)
+        await fs.mkdir(liveTmp)
+
+        await cleanLspDownloads('1.0.0', [], installationDir.fsPath)
+
+        assert.strictEqual(nodeFs.existsSync(staleTmp), false)
+        assert.strictEqual(nodeFs.existsSync(liveTmp), true)
     })
 })

--- a/packages/core/src/test/shared/lsp/utils/inUseTracker.test.ts
+++ b/packages/core/src/test/shared/lsp/utils/inUseTracker.test.ts
@@ -1,0 +1,107 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import path from 'path'
+import * as nodeFs from 'fs' // eslint-disable-line no-restricted-imports
+import { Uri } from 'vscode'
+import { fs } from '../../../../shared'
+import { createTestWorkspaceFolder } from '../../../testUtil'
+import { InUseTracker } from '../../../../shared/lsp/utils/inUseTracker'
+
+const DeadPid = 2 ** 22
+
+describe('InUseTracker', function () {
+    let workspaceDir: Uri
+    let versionDir: string
+    let tracker: InUseTracker
+
+    before(async function () {
+        workspaceDir = (await createTestWorkspaceFolder()).uri
+    })
+
+    beforeEach(async function () {
+        versionDir = path.join(workspaceDir.fsPath, `v-${Date.now()}-${Math.random()}`)
+        await fs.mkdir(versionDir)
+        tracker = new InUseTracker()
+    })
+
+    after(async function () {
+        await fs.delete(workspaceDir, { force: true, recursive: true })
+    })
+
+    it('writeMarker creates an .inuse.<pid> file in the version directory', function () {
+        tracker.writeMarker(versionDir, 'aws-toolkit-vscode')
+
+        const markerPath = path.join(versionDir, `.inuse.${process.pid}`)
+        assert.strictEqual(nodeFs.existsSync(markerPath), true)
+        const payload = JSON.parse(nodeFs.readFileSync(markerPath, 'utf-8'))
+        assert.strictEqual(payload.pid, process.pid)
+        assert.strictEqual(payload.app, 'aws-toolkit-vscode')
+        assert.strictEqual(typeof payload.timestamp, 'number')
+    })
+
+    it('writeMarker swallows errors when directory does not exist', function () {
+        assert.doesNotThrow(() => tracker.writeMarker(path.join(versionDir, 'missing'), 'app'))
+    })
+
+    it("removeMarker deletes this process's marker", function () {
+        tracker.writeMarker(versionDir, 'app')
+        const markerPath = path.join(versionDir, `.inuse.${process.pid}`)
+        assert.strictEqual(nodeFs.existsSync(markerPath), true)
+
+        tracker.removeMarker(versionDir)
+
+        assert.strictEqual(nodeFs.existsSync(markerPath), false)
+    })
+
+    it('removeMarker is a no-op when no marker exists', function () {
+        assert.doesNotThrow(() => tracker.removeMarker(versionDir))
+    })
+
+    it('isInUse returns true when a live-pid marker exists', function () {
+        tracker.writeMarker(versionDir, 'app')
+
+        assert.strictEqual(tracker.isInUse(versionDir), true)
+    })
+
+    it('isInUse returns false when only dead-pid markers exist', function () {
+        nodeFs.writeFileSync(path.join(versionDir, `.inuse.${DeadPid}`), '{}')
+
+        assert.strictEqual(tracker.isInUse(versionDir), false)
+    })
+
+    it('isInUse ignores non-marker files', function () {
+        nodeFs.writeFileSync(path.join(versionDir, 'readme.txt'), 'hi')
+        nodeFs.writeFileSync(path.join(versionDir, '.inuse.notanumber'), '{}')
+
+        assert.strictEqual(tracker.isInUse(versionDir), false)
+    })
+
+    it('isInUse returns false when directory does not exist', function () {
+        assert.strictEqual(tracker.isInUse(path.join(versionDir, 'missing')), false)
+    })
+
+    it('cleanStaleMarkers removes dead-pid markers and keeps live-pid markers', function () {
+        const liveMarker = path.join(versionDir, `.inuse.${process.pid}`)
+        const staleMarker = path.join(versionDir, `.inuse.${DeadPid}`)
+        nodeFs.writeFileSync(liveMarker, '{}')
+        nodeFs.writeFileSync(staleMarker, '{}')
+
+        tracker.cleanStaleMarkers(versionDir)
+
+        assert.strictEqual(nodeFs.existsSync(liveMarker), true)
+        assert.strictEqual(nodeFs.existsSync(staleMarker), false)
+    })
+
+    it('cleanStaleMarkers does not touch non-marker files', function () {
+        const unrelated = path.join(versionDir, 'data.json')
+        nodeFs.writeFileSync(unrelated, '{}')
+
+        tracker.cleanStaleMarkers(versionDir)
+
+        assert.strictEqual(nodeFs.existsSync(unrelated), true)
+    })
+})


### PR DESCRIPTION
## Summary

These changes make the CloudFormation LSP server download, installation, caching, and cleanup strategy consistent across all client plugins and safe for concurrent multi-IDE usage.

Previously each plugin had its own ad-hoc approach to downloading and managing the LSP binary. Now all clients share the same design:

- **Atomic installs** — download to a PID-stamped temp directory, then rename into place
- **PID-based in-use tracking** — marker files prevent one IDE from deleting a version another is actively using
- **File-based manifest caching** — a plain `manifest.json` on disk replaces IDE-specific storage
- **Unified cache directory** — all plugins write to the same OS-standard cache path
- **Stale temp cleanup** — sweeps orphaned `.tmp.<pid>` directories from crashed processes
- **Local fallback resolution** — when both network and cached manifest fail, scans installed versions for a usable binary

---

## Motivation

Users commonly have both the standalone CloudFormation extension AND the AWS Toolkit installed in VS Code, or use both VS Code and JetBrains. Without a shared cache directory and in-use tracking, these plugins fight over the same LSP binary — downloading redundant copies, deleting each other's active versions, and corrupting installations mid-session.

The LSP download happens over the network from GitHub. In corporate environments with proxies, air-gapped networks, or intermittent connectivity, the download can fail at any point. The previous code had minimal resilience: no atomic writes (corruption on crash), no offline fallback (complete failure), and IDE-specific caching (no cross-plugin benefit).

**`extension.ts`** — Extension name hardcoded to `"aws.toolkit.vscode"`. Removes `VSCODE_EXTENSION_ID_CONSTANTS` import.

**`githubManifestAdapter.ts`** — Massive simplification. Removes the entire GitHub Releases API fallback (`fetchGitHubReleases`, `convertRelease`, `extractTargets`, `filterByEnvironment`) and all associated interfaces (`GitHubRelease`, `GitHubAsset`). Now only fetches from the manifest JSON URL. Constructor simplified — no more `repoOwner`/`repoName` params. Stores `lastRawManifest` text so the installer can cache it to disk.

**`lspInstaller.ts`** — Major rewrite. File-based manifest cache: writes raw manifest to `manifest.json` via atomic tmp+rename, reads from cache on fetch failure. `resolve()` override adds `findLocalFallback()` which scans downloaded versions for a compatible server binary. `postInstall()` writes the in-use marker before cleanup runs. `rootDir` override via `getCfnLspRootDir()` points to the unified cross-plugin cache path.

**`lspServerProvider.ts`** — `dispose()` now iterates `matchedProviders` and calls `dispose()` on each. Previously was a no-op, which meant in-use markers were never cleaned on extension deactivation.

**`remoteLspServerProvider.ts`** — Tracks `versionDir` from resolution result. `dispose()` removes the in-use marker.

**`baseLspInstaller.ts`** — Adds `rootDir?: string` to `LspConfig` interface and passes it through to `LanguageServerResolver`. This lets the CloudFormation installer override the default cache directory (shared with other LSPs like Amazon Q).

**`lspResolver.ts`** — New `rootDir` constructor parameter (defaults to `LanguageServerResolver.defaultDir()`). `downloadRemoteTargetContent()` uses atomic tmp+rename. `getCachedVersions()` filters `.tmp.` entries. `getLatestCompatibleVersion()` prefers the version with `latest: true` flag. `defaultDownloadFolder()` uses `this.rootDir` instead of the static default.

**`types.ts`** — Adds `latest?: boolean` field to `LspVersion` interface. This lets the manifest explicitly mark a preferred version rather than relying solely on semver sorting.

**`cleanup.ts`** — Complete rewrite. Removes `isDelisted()` helper and partition-based logic. New `sweepStaleTmpDirs()` removes dead-PID tmp dirs. Cleanup uses a keep-set `{current, highestFallback}` plus `InUseTracker` checks. The delisted-version concept is removed entirely.

**`inUseTracker.ts`** *(new)* — Node.js implementation of PID-based marker tracking. Same API as the other two codebases.