### PR TITLE
fix(sagemaker): add Windows system paths for session-manager-plugin detection

### DIFF
--- a/packages/core/src/shared/utilities/cliUtils.ts
+++ b/packages/core/src/shared/utilities/cliUtils.ts
@@ -65,7 +65,19 @@ export const awsClis: { [cli in AwsClis]: Cli } & { pathResolver: Cli } = {
     'session-manager-plugin': {
         command: {
             unix: [path.join('sessionmanagerplugin', 'bin', 'session-manager-plugin')],
-            windows: [path.join('sessionmanagerplugin', 'bin', 'session-manager-plugin.exe')],
+            windows: [
+                'session-manager-plugin.exe',
+                path.join('C:', 'Program Files', 'Amazon', 'SessionManagerPlugin', 'bin', 'session-manager-plugin.exe'),
+                path.join(
+                    'C:',
+                    'Program Files (x86)',
+                    'Amazon',
+                    'SessionManagerPlugin',
+                    'bin',
+                    'session-manager-plugin.exe'
+                ),
+                path.join('sessionmanagerplugin', 'bin', 'session-manager-plugin.exe'),
+            ],
         },
         source: {
             // use pkg: zip is unsigned
@@ -75,6 +87,7 @@ export const awsClis: { [cli in AwsClis]: Cli } & { pathResolver: Cli } = {
             },
             windows: {
                 x86: 'https://session-manager-downloads.s3.amazonaws.com/plugin/latest/windows/SessionManagerPlugin.zip',
+                arm: 'https://session-manager-downloads.s3.amazonaws.com/plugin/latest/windows/SessionManagerPlugin.zip',
             },
             linux: {
                 x86: 'https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb',

--- a/packages/core/src/shared/utilities/cliUtils.ts
+++ b/packages/core/src/shared/utilities/cliUtils.ts
@@ -66,6 +66,9 @@ export const awsClis: { [cli in AwsClis]: Cli } & { pathResolver: Cli } = {
         command: {
             unix: [path.join('sessionmanagerplugin', 'bin', 'session-manager-plugin')],
             windows: [
+                // First entry must be relative path for local install (installSsmCli uses cmd[0])
+                path.join('sessionmanagerplugin', 'bin', 'session-manager-plugin.exe'),
+                // System-installed paths for global detection
                 'session-manager-plugin.exe',
                 path.join('C:', 'Program Files', 'Amazon', 'SessionManagerPlugin', 'bin', 'session-manager-plugin.exe'),
                 path.join(
@@ -76,7 +79,6 @@ export const awsClis: { [cli in AwsClis]: Cli } & { pathResolver: Cli } = {
                     'bin',
                     'session-manager-plugin.exe'
                 ),
-                path.join('sessionmanagerplugin', 'bin', 'session-manager-plugin.exe'),
             ],
         },
         source: {

--- a/packages/core/src/test/shared/utilities/cliUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/cliUtils.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import * as path from 'path'
 import sinon from 'sinon'
-import { installCli, updateAwsCli } from '../../../shared/utilities/cliUtils'
+import { awsClis, installCli, updateAwsCli } from '../../../shared/utilities/cliUtils'
 import globals from '../../../shared/extensionGlobals'
 import { ChildProcess } from '../../../shared/utilities/processUtils'
 import { SeverityLevel } from '../vscode/message'
@@ -25,6 +25,29 @@ describe('cliUtils', async function () {
     afterEach(async function () {
         sandbox.restore()
         await fs.delete(path.join(globals.context.globalStorageUri.fsPath, 'tools'), { recursive: true, force: true })
+    })
+
+    describe('awsClis config', function () {
+        it('session-manager-plugin has multiple Windows command paths', function () {
+            const windowsPaths = awsClis['session-manager-plugin'].command.windows
+            assert.ok(windowsPaths)
+            assert.ok(windowsPaths.length > 1, 'should have multiple Windows paths for fallback')
+            assert.ok(
+                windowsPaths.some((p) => p === 'session-manager-plugin.exe'),
+                'should include PATH lookup'
+            )
+            assert.ok(
+                windowsPaths.some((p) => p.includes('Program Files')),
+                'should include Program Files install location'
+            )
+        })
+
+        it('session-manager-plugin has Windows ARM source URL', function () {
+            const windowsSource = awsClis['session-manager-plugin'].source.windows
+            assert.ok(windowsSource)
+            assert.ok(windowsSource.arm, 'should have ARM URL for Windows')
+            assert.ok(windowsSource.x86, 'should have x86 URL for Windows')
+        })
     })
 
     describe('installCli', async function () {

--- a/packages/core/src/test/shared/utilities/cliUtils.test.ts
+++ b/packages/core/src/test/shared/utilities/cliUtils.test.ts
@@ -32,10 +32,7 @@ describe('cliUtils', async function () {
             const windowsPaths = awsClis['session-manager-plugin'].command.windows
             assert.ok(windowsPaths)
             assert.ok(windowsPaths.length > 1, 'should have multiple Windows paths for fallback')
-            assert.ok(
-                windowsPaths.some((p) => p === 'session-manager-plugin.exe'),
-                'should include PATH lookup'
-            )
+            assert.ok(windowsPaths.includes('session-manager-plugin.exe'), 'should include PATH lookup')
             assert.ok(
                 windowsPaths.some((p) => p.includes('Program Files')),
                 'should include Program Files install location'


### PR DESCRIPTION
**Description**
   The SSM plugin installed via MSI on Windows is placed in Program Files,
   which was not being searched. This adds standard install locations and
   PATH lookup to improve detection on Windows, including ARM support.

## Problem
1. The default SSM session plugin installation location is not used. Some customer would like to use SSM session plugin in a custom location. 
2. The ARM installation URL is missing for windows platform

## Solution
Fixed above by adding new paths to detect and ARM installation pkg URL for windows.

## Testing
This fix has been verified by SA team. 
```
1. I have tested today in CX environment and it worked well. However, for this specific environment (different researcher) he didn't have the SSM plugin installed under C:\Program Files\.. hence the AWS toolkit installed it in the C:\Users\<username>\AppData\... when establishing the remote connection.

2. I can confirm the above works well; I have tested the following scenarios on my Windows ARM VM:
   - SSM Plugin installed in Program Files path -> OK; no additional SSM plugin gets installed in AppData path
   - SSM Plugin not installed in Program Files path -> OK; SSM plugin gets installed in AppData path when the first remote IDE connection is established
   - SSM Plugin installed in both Program Files path and AppData path -> OK
```
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
