### PR TITLE
feat(threatComposer): make cdn configurable via VS Code settings

### DIFF
--- a/packages/core/src/threatComposer/threatComposerEditorProvider.ts
+++ b/packages/core/src/threatComposer/threatComposerEditorProvider.ts
@@ -20,7 +20,7 @@ const localize = nls.loadMessageBundle()
 // Change this to true for local dev
 const isLocalDev = false
 const localhost = 'http://127.0.0.1:3000'
-const cdn = 'https://ide-toolkits.threat-composer.aws.dev'
+const cdn = vscode.workspace.getConfiguration('aws.threatComposer').get('cdn', 'https://ide-toolkits.threat-composer.aws.dev')
 let clientId = ''
 
 /**

--- a/packages/core/src/threatComposer/threatComposerEditorProvider.ts
+++ b/packages/core/src/threatComposer/threatComposerEditorProvider.ts
@@ -20,7 +20,9 @@ const localize = nls.loadMessageBundle()
 // Change this to true for local dev
 const isLocalDev = false
 const localhost = 'http://127.0.0.1:3000'
-const cdn = vscode.workspace.getConfiguration('aws.threatComposer').get('cdn', 'https://ide-toolkits.threat-composer.aws.dev')
+function getCdn(): string { 
+    return vscode.workspace.getConfiguration('aws.threatComposer').get('cdn', 'https://ide-toolkits.threat-composer.aws.dev')
+}
 let clientId = ''
 
 /**
@@ -39,6 +41,23 @@ export class ThreatComposerEditorProvider implements vscode.CustomTextEditorProv
      */
     public static register(context: vscode.ExtensionContext): vscode.Disposable {
         const provider = new ThreatComposerEditorProvider(context)
+
+        context.subscriptions.push(
+            vscode.workspace.onDidChangeConfiguration(async (configurationChangeEvent: vscode.configurationChangeEvent) => {
+                if (configurationChangeEvent.affectsConfiguration('aws.threatComposer.cdn')) {
+                    // Clear cached content
+                    provider.webviewHtml = ''
+                    // Closed all open Threat Composer editors
+                    for (const visualization of provider.managedVisualizations.values()) {
+                        const panel = visualization.getPanel()
+                        if (panel) {
+                            panel.dispose()
+                        }
+                    }
+                }
+            })
+        )
+
         return vscode.window.registerCustomEditorProvider(ThreatComposerEditorProvider.viewType, provider, {
             webviewOptions: {
                 enableFindWidget: true,
@@ -63,7 +82,7 @@ export class ThreatComposerEditorProvider implements vscode.CustomTextEditorProv
      * @private
      */
     private async fetchWebviewHtml() {
-        const source = isLocalDev ? localhost : cdn
+        const source = isLocalDev ? localhost : getCdn()
         const response = await request.fetch('GET', `${source}/index.html`).response
         this.webviewHtml = await response.text()
 
@@ -83,7 +102,7 @@ export class ThreatComposerEditorProvider implements vscode.CustomTextEditorProv
         let htmlFileSplit = this.webviewHtml.split('<head>')
 
         // Set asset source to CDN
-        const source = isLocalDev ? localhost : cdn
+        const source = isLocalDev ? localhost : getCdn()
         const baseTag = `<base href='${source}'/>`
 
         // Set dark mode, locale, and feature flags

--- a/packages/toolkit/.changes/next-release/Feature-8c1333c2-d393-4cf9-8e34-d0dd8ef9ad9c.json
+++ b/packages/toolkit/.changes/next-release/Feature-8c1333c2-d393-4cf9-8e34-d0dd8ef9ad9c.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Threat Composer: The CDN used for the Threat Composer editor is now configurable via the setting `aws.threatComposer.cdn`."
+}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -531,6 +531,11 @@
                     ],
                     "default": "alwaysAsk",
                     "description": "Configure optional changeset flags for CloudFormation templates"
+                },
+                "aws.threatComposer.cdn": {
+                    "type": "string",
+                    "default": "https://ide-toolkits.threat-composer.aws.dev",
+                    "description": "CDN URL used to load IDE Threat Composer resources. Defaults to the AWS-Hosted CDN, use this to point to a custom or internal endpoint."
                 }
             }
         },


### PR DESCRIPTION
## Problem

Users are unable to utilise a customised self-hosted ide-specific threat composer deployment within vs-code unless within a private network with customised dns resolution, due to the hardcoded URL for the ide-threat-composer editor resources.

Benefit of leveraging a self-hosted deployment of threat composer is users can include customised threat/mitigation packs - outlined [here](https://github.com/awslabs/threat-composer/blob/main/docs/WEB-APP.md#customising-reference-data-in-your-build).

## Solution

Added a configurable VS-Code setting `aws.threatComposer.cdn` that allows users to override the default `cdn` value 'https://ide-toolkits.threat-composer.aws.dev'.

## Testing

Change is minimal: 2 files changed

## Caveats

Does require the users self-hosted version to update the content security policy in their deployment of the ide variant of [threat-composesr](https://github.com/awslabs/threat-composer) but that seems a reasonable expectation. 

```bash
sed -i -e `s|https://ide-toolkits.threat-composer.aws.dev|<cdn>/|g` ./threat-composer/packages/threat-composer/public/index.html
sed -i -e `s|data:|data: <cdn>/|g` ./threat-composer/packages/threat-composer/public/index.html
```

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
