### PR TITLE
fix(sagemaker): Restore session after IDE restart

### DIFF
--- a/packages/core/resources/hyperpod_connect
+++ b/packages/core/resources/hyperpod_connect
@@ -1,58 +1,13 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-# HyperPod Connection Script
-# 
-# This script establishes a connection to an AWS SageMaker HyperPod instance using AWS Systems Manager (SSM).
-# HyperPod is AWS's managed service for distributed machine learning training at scale.
-#
-# OVERVIEW:
-# The script always gets fresh credentials from the reconnection manager and uses them to establish
-# a secure session tunnel to a HyperPod compute instance.
-#
-# OPTIONAL ENVIRONMENT VARIABLES:
-#   LOG_FILE_LOCATION   - Path to log file (default: /tmp/hyperpod_connect.log)
-#   DEBUG_LOG           - Enable debug logging (default: 0)
-#
-# USAGE:
-#   ./hyperpod_connect smhp_demo1
-#
-# SECURITY NOTE:
-# This script handles sensitive authentication tokens. Ensure proper file permissions
-# and avoid logging sensitive values in production environments. 
 set -x
-set -e
-set -u
-
-_DATE_CMD=true
-
-if command > /dev/null 2>&1 -v date; then
-    _DATE_CMD=date
-elif command > /dev/null 2>&1 -v /bin/date; then
-    _DATE_CMD=/bin/date
-fi
-
-_log() {
-    echo "$("$_DATE_CMD" '+%Y/%m/%d %H:%M:%S')" "$@" >> "${LOG_FILE_LOCATION}" 2>&1
-}
-
-_require_nolog() {
-    if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
-        _log "error: missing required arg: $1"
-        exit 1
-    fi
-}
-
-_require() {
-    _require_nolog "$@"
-    _log "$1=$2"
-}
 
 _resolve_connection_key() {
     local WORKSPACE_NAME=$1
     local PROFILES_FILE="$HOME/.aws/.hyperpod-space-profiles"
-    
+
     [ ! -f "$PROFILES_FILE" ] && echo "$WORKSPACE_NAME" && return
-    
+
     python3 -c "
 import json
 try:
@@ -65,79 +20,121 @@ except:
 " 2>/dev/null
 }
 
-_hyperpod() {
-    # Function inputs
-    local AWS_SSM_CLI=$1
-    local AWS_REGION=$2
-    local STREAM_URL=$3
-    local TOKEN=$4
-    local SESSION_ID=$5
+_get_hyperpod_session() {
+    local connection_key="$1"
+    local local_endpoint_port="$2"
 
-    exec "$AWS_SSM_CLI" "{\"streamUrl\":\"$STREAM_URL\",\"tokenValue\":\"$TOKEN\",\"sessionId\":\"$SESSION_ID\"}" "$AWS_REGION" "StartSession"
+    local url="http://localhost:${local_endpoint_port}/get_hyperpod_session?connection_key=${connection_key}"
+
+    local temp_file="/tmp/hyperpod_session_response_$$_$(date +%s%N).json"
+
+    response=$(curl -s -w "%{http_code}" -o "$temp_file" "$url")
+    http_status="${response: -3}"
+    session_json=$(cat "$temp_file")
+
+    rm -f "$temp_file"
+
+    if [[ "$http_status" -ne 200 ]]; then
+        echo "Error: Failed to get HyperPod session info. HTTP status: $http_status"
+        echo "Response: $session_json"
+        exit 1
+    fi
+
+    if [ -z "$session_json" ]; then
+        echo "Error: HyperPod session info is empty."
+        exit 1
+    fi
+
+    export SSM_SESSION_JSON="$session_json"
 }
 
-_main() {
-    # Set defaults for missing environment variables
-    DEBUG_LOG=${DEBUG_LOG:-0}
-    LOG_FILE_LOCATION=${LOG_FILE_LOCATION:-/tmp/hyperpod_connect.log}
+# Validate input
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <hostname>"
+    exit 1
+fi
 
-    if [ $# -ne 1 ]; then
-        _log "Usage: $0 smhp_<workspace_name>"
-        exit 1
-    fi
+HOSTNAME="$1"
 
-    # Extract workspace name, cluster name, and namespace from hostname
-    # New format: smhp_{workspace}_{namespace}_{cluster_name}_{region}_{account_id}
-    # Old format: smhp_{workspace} (for backward compatibility)
-    if [[ "$1" =~ ^smhp_([^_]+)_([^_]+)_([^_]+)_([^_]+)_([^_]+)$ ]]; then
-        # Format: smhp_{workspace}_{namespace}_{cluster}_{region}_{account}
-        WORKSPACE_NAME="${BASH_REMATCH[1]}"
-        NAMESPACE="${BASH_REMATCH[2]}"
-        CLUSTER_NAME="${BASH_REMATCH[3]}"
-        # Construct the expected connection key (workspace:namespace:cluster)
-        CONNECTION_KEY="${WORKSPACE_NAME}:${NAMESPACE}:${CLUSTER_NAME}"
-    else
-        # Old format or fallback - extract workspace name only
-        WORKSPACE_NAME=$(echo "$1" | sed 's/smhp_//')
-        CLUSTER_NAME=""
-        NAMESPACE=""
-        CONNECTION_KEY=""
-    fi
-    
-    # For new format, we already have the connection key constructed from hostname
-    # For old format, look up the connection key from the hyperpod profiles file
-    [ -z "$CONNECTION_KEY" ] && CONNECTION_KEY=$(_resolve_connection_key "$WORKSPACE_NAME")
-    
-    if [ -z "$CONNECTION_KEY" ]; then
-        _log "Error: Could not determine connection key for workspace: $WORKSPACE_NAME"
-        exit 1
-    fi
-    
-    _log "=============================================================================="
-    _log "Connecting to HyperPod workspace: $WORKSPACE_NAME (connection key: $CONNECTION_KEY)"
-    
-    # Use env vars directly for initial connection (deeplink), call API only for reconnection
-    if [ -n "${STREAM_URL:-}" ] && [ -n "${TOKEN:-}" ]; then
-        _log "Using credentials from environment variables (initial connection)"
-    else
-        _log "No env credentials available. Reconnection via get_hyperpod_session is disabled. Please reconnect from the IDE."
-        exit 1
-    fi
-    
-    # Extract region from stream URL
-    AWS_REGION=$(echo "$STREAM_URL" | grep -o '\.[a-z0-9-]*\.amazonaws\.com' | sed 's/^\.//;s/\.amazonaws\.com$//')
-    AWS_SSM_CLI="${AWS_SSM_CLI:-session-manager-plugin}"
-    
-    # Validate required parameters (SESSION_ID, STREAM_URL, TOKEN are fetched from API, not validated here)
-    _require AWS_REGION "${AWS_REGION}"
-    _require AWS_SSM_CLI "${AWS_SSM_CLI}"
-    
-    if [ -z "${SESSION_ID}" ] || [ -z "${STREAM_URL}" ] || [ -z "${TOKEN}" ]; then
-        _log "Error: Failed to retrieve valid session credentials from API"
-        exit 1
+# Parse hostname format: smhp_{workspace}_{namespace}_{cluster_name}_{region}_{account_id}
+if [[ "$HOSTNAME" =~ ^smhp[^_]*_([^_]+)_([^_]+)_([^_]+)_([^_]+)_([^_]+)$ ]]; then
+    WORKSPACE_NAME="${BASH_REMATCH[1]}"
+    NAMESPACE="${BASH_REMATCH[2]}"
+    CLUSTER_NAME="${BASH_REMATCH[3]}"
+    CONNECTION_KEY="${WORKSPACE_NAME}:${NAMESPACE}:${CLUSTER_NAME}"
+else
+    # Old format fallback
+    WORKSPACE_NAME=$(echo "$HOSTNAME" | sed 's/^smhp[^_]*_//')
+    CONNECTION_KEY=$(_resolve_connection_key "$WORKSPACE_NAME")
+fi
+
+if [ -z "$CONNECTION_KEY" ]; then
+    echo "Error: Could not determine connection key for workspace: $WORKSPACE_NAME"
+    exit 1
+fi
+
+# Validate required env var and file
+if [ -z "$SAGEMAKER_LOCAL_SERVER_FILE_PATH" ]; then
+    echo "[Error] SAGEMAKER_LOCAL_SERVER_FILE_PATH is not set"
+    exit 1
+fi
+
+# Check if server is alive, start it if not
+_ensure_server_running() {
+    local port
+    port=$(jq -r '.port' "$SAGEMAKER_LOCAL_SERVER_FILE_PATH" 2>/dev/null)
+    if [ -n "$port" ] && [ "$port" != "null" ] && curl -s --max-time 2 "http://127.0.0.1:${port}/get_hyperpod_session" >/dev/null 2>&1; then
+        return 0
     fi
 
-    _hyperpod "$AWS_SSM_CLI" "$AWS_REGION" "$STREAM_URL" "$TOKEN" "$SESSION_ID"
+    # Server is dead — restart it
+    if [ -z "$SAGEMAKER_LOCAL_SERVER_JS_PATH" ] || [ ! -f "$SAGEMAKER_LOCAL_SERVER_JS_PATH" ]; then
+        echo "[Error] Cannot start server: SAGEMAKER_LOCAL_SERVER_JS_PATH is not set or file not found"
+        return 1
+    fi
+
+    local log_dir
+    log_dir=$(dirname "$SAGEMAKER_LOCAL_SERVER_FILE_PATH")
+    echo "Starting local server..."
+    SAGEMAKER_LOCAL_SERVER_FILE_PATH="$SAGEMAKER_LOCAL_SERVER_FILE_PATH" \
+        nohup node "$SAGEMAKER_LOCAL_SERVER_JS_PATH" \
+        >> "${log_dir}/sagemaker-local-server.out.log" \
+        2>> "${log_dir}/sagemaker-local-server.err.log" &
+
+    # Wait for info file to be written with a valid port
+    local i
+    for i in $(seq 1 20); do
+        port=$(jq -r '.port' "$SAGEMAKER_LOCAL_SERVER_FILE_PATH" 2>/dev/null)
+        if [ -n "$port" ] && [ "$port" != "null" ]; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    echo "[Error] Timed out waiting for local server to start"
+    return 1
 }
 
-_main "$@"
+if ! _ensure_server_running; then
+    exit 1
+fi
+
+# Extract port from file
+LOCAL_ENDPOINT_PORT=$(jq -r '.port' "$SAGEMAKER_LOCAL_SERVER_FILE_PATH")
+if [ -z "$LOCAL_ENDPOINT_PORT" ] || [ "$LOCAL_ENDPOINT_PORT" == "null" ]; then
+    echo "[Error] 'port' field is missing or invalid in $SAGEMAKER_LOCAL_SERVER_FILE_PATH"
+    exit 1
+fi
+
+# Retrieve HyperPod session
+_get_hyperpod_session "$CONNECTION_KEY" "$LOCAL_ENDPOINT_PORT"
+
+# Extract region from StreamUrl in session JSON
+REGION=$(echo "$SSM_SESSION_JSON" | jq -r '.StreamUrl' | grep -o '\.[a-z0-9-]*\.amazonaws\.com' | sed 's/^\.//;s/\.amazonaws\.com$//')
+if [ -z "$REGION" ]; then
+    echo "[Error] Could not extract region from StreamUrl"
+    exit 1
+fi
+
+# Execute the session
+AWS_SSM_CLI="${AWS_SSM_CLI:=session-manager-plugin}"
+exec "${AWS_SSM_CLI}" "$SSM_SESSION_JSON" "$REGION" StartSession

--- a/packages/core/resources/hyperpod_connect.ps1
+++ b/packages/core/resources/hyperpod_connect.ps1
@@ -1,97 +1,154 @@
-# HyperPod Connection Script (PowerShell)
-# 
-# This script establishes a connection to an AWS SageMaker HyperPod instance using AWS Systems Manager (SSM).
-
-param(
-    [Parameter(Mandatory=$true)]
-    [string]$HostName
+param (
+    [Parameter(Mandatory=$true)][string]$HostName
 )
 
-$ErrorActionPreference = "Stop"
+Write-Host "`n--- Script Start ---"
+Write-Host "Start Time: $(Get-Date -Format o)"
+Write-Host "Hostname argument received: $HostName"
 
-$DebugLog = $env:DEBUG_LOG -eq "1"
-$LogFileLocation = if ($env:LOG_FILE_LOCATION) { $env:LOG_FILE_LOCATION } else { "$env:TEMP\hyperpod_connect.log" }
+Set-PSDebug -Trace 1
 
-function Write-Log {
-    param([string]$Message)
-    $timestamp = Get-Date -Format "yyyy/MM/dd HH:mm:ss"
-    "$timestamp $Message" | Out-File -FilePath $LogFileLocation -Append -Encoding utf8
+function Get-HyperpodSession {
+    param (
+        [string]$ConnectionKey,
+        [int]$LocalEndpointPort
+    )
+
+    Write-Host "Calling Get-HyperpodSession with connectionKey=${ConnectionKey}, port=${LocalEndpointPort}"
+
+    $url = "http://localhost:${LocalEndpointPort}/get_hyperpod_session?connection_key=${ConnectionKey}"
+    Write-Host "Request URL: $url"
+
+    try {
+        $response = Invoke-WebRequest -Uri $url -UseBasicParsing -TimeoutSec 30 -ErrorAction Stop
+        Write-Host "Received response with status: $($response.StatusCode)"
+
+        if ($response.StatusCode -ne 200) {
+            Write-Error "Failed to get HyperPod session info. HTTP status: $($response.StatusCode)"
+            Write-Error "Response: $($response.Content)"
+            exit 1
+        }
+
+        if (-not $response.Content) {
+            Write-Error "HyperPod session info is empty."
+            exit 1
+        }
+
+        $script:SSM_SESSION_JSON = $response.Content
+        Write-Host "Session JSON successfully retrieved"
+    } catch {
+        Write-Error "Exception in Get-HyperpodSession: $_"
+        exit 1
+    }
 }
 
-function Main {
-    Write-Log "=============================================================================="
-    
-    # Parse hostname format: smhp_{workspace}_{namespace}_{cluster_name}_{region}_{account_id}
-    if ($HostName -match '^smhp_([^_]+)_([^_]+)_([^_]+)_([^_]+)_([^_]+)$') {
-        $workspaceName = $Matches[1]
-        $namespace = $Matches[2]
-        $clusterName = $Matches[3]
-        $connectionKey = "${workspaceName}:${namespace}:${clusterName}"
+# Parse hostname format: smhp_{workspace}_{namespace}_{cluster_name}_{region}_{account_id}
+Write-Host "`nParsing hostname..."
+if ($HostName -match '^smhp[^_]*_([^_]+)_([^_]+)_([^_]+)_([^_]+)_([^_]+)$') {
+    $workspaceName = $Matches[1]
+    $namespace = $Matches[2]
+    $clusterName = $Matches[3]
+    $CONNECTION_KEY = "${workspaceName}:${namespace}:${clusterName}"
+} else {
+    # Old format fallback
+    $workspaceName = $HostName -replace '^smhp[^_]*_', ''
+    $profilesFile = "$env:USERPROFILE\.aws\.hyperpod-space-profiles"
+
+    if (Test-Path $profilesFile) {
+        $profiles = Get-Content $profilesFile | ConvertFrom-Json
+        $matchedKeys = $profiles.PSObject.Properties.Name | Where-Object { $_ -match ":$workspaceName$" } | Sort-Object
+        $CONNECTION_KEY = if ($matchedKeys) { $matchedKeys[0] } else { $workspaceName }
     } else {
-        # Old format fallback
-        $workspaceName = $HostName -replace '^smhp_', ''
-        $profilesFile = "$env:USERPROFILE\.aws\.hyperpod-space-profiles"
-        
-        if (Test-Path $profilesFile) {
-            $profiles = Get-Content $profilesFile | ConvertFrom-Json
-            $matches = $profiles.PSObject.Properties.Name | Where-Object { $_ -match ":$workspaceName$" } | Sort-Object
-            $connectionKey = if ($matches) { $matches[0] } else { $workspaceName }
-        } else {
-            $connectionKey = $workspaceName
-        }
+        $CONNECTION_KEY = $workspaceName
     }
-    
-    if (-not $connectionKey) {
-        Write-Log "Error: Could not determine connection key for workspace: $workspaceName"
-        exit 1
-    }
-    
-    Write-Log "Connecting to HyperPod workspace: $workspaceName (connection key: $connectionKey)"
-    
-    # Use env vars directly for initial connection (deeplink), reconnection via API is disabled
-    if ($env:STREAM_URL -and $env:TOKEN) {
-        Write-Log "Using credentials from environment variables (initial connection)"
-        $streamUrl = $env:STREAM_URL
-        $token = $env:TOKEN
-        $sessionId = if ($env:SESSION_ID) { $env:SESSION_ID } else { $HostName }
-    } else {
-        Write-Log "No env credentials available. Reconnection via get_hyperpod_session is disabled. Please reconnect from the IDE."
-        Write-Error "No env credentials available. Please reconnect from the IDE."
-        exit 1
-    }
-    
-    # Extract region from stream URL
-    if ($streamUrl -match '\.([a-z0-9-]+)\.amazonaws\.com') {
-        $awsRegion = $Matches[1]
-    } else {
-        Write-Log "Error: Could not extract region from stream URL"
-        exit 1
-    }
-    
-    # Find session-manager-plugin
-    $awsSsmCli = $env:AWS_SSM_CLI
-    if (-not $awsSsmCli) {
-        # Try bundled version first
-        $bundledPath = "$env:APPDATA\Code\User\globalStorage\amazonwebservices.aws-toolkit-vscode\tools\Amazon\sessionmanagerplugin\bin\session-manager-plugin.exe"
-        if (Test-Path $bundledPath) {
-            $awsSsmCli = $bundledPath
-        } else {
-            # Fallback to PATH
-            $awsSsmCli = "session-manager-plugin"
-        }
-    }
-    
-    Write-Log "AWS_REGION=$awsRegion"
-    Write-Log "AWS_SSM_CLI=$awsSsmCli"
-    Write-Log "SESSION_ID=$sessionId"
-    
-    # Pass JSON via environment variable to avoid Windows command-line quoting issues.
-    # session-manager-plugin reads from env var when args[1] starts with "AWS_SSM_START_SESSION_RESPONSE".
-    $jsonObj = @{ streamUrl = $streamUrl; tokenValue = $token; sessionId = $sessionId }
-    $jsonStr = $jsonObj | ConvertTo-Json -Compress
-    $envVarName = "AWS_SSM_START_SESSION_RESPONSE"
-    $env:AWS_SSM_START_SESSION_RESPONSE = $jsonStr
-    & $awsSsmCli $envVarName "$awsRegion" "StartSession"
 }
 
-Main
+if (-not $CONNECTION_KEY) {
+    Write-Error "Could not determine connection key for workspace: $workspaceName"
+    exit 1
+}
+
+Write-Host "Parsed values:"
+Write-Host "  Workspace: ${workspaceName}"
+Write-Host "  Connection Key: ${CONNECTION_KEY}"
+
+# Ensure local server is running, restart if dead
+Write-Host "`nChecking local server..."
+$serverInfoPath = $env:SAGEMAKER_LOCAL_SERVER_FILE_PATH
+$serverAlive = $false
+
+if ($serverInfoPath -and (Test-Path $serverInfoPath)) {
+    try {
+        $jsonContent = Get-Content $serverInfoPath -Raw | ConvertFrom-Json
+        $LOCAL_ENDPOINT_PORT = $jsonContent.port
+        if ($LOCAL_ENDPOINT_PORT -and $LOCAL_ENDPOINT_PORT -ne "null") {
+            $healthCheck = Invoke-WebRequest -Uri "http://127.0.0.1:${LOCAL_ENDPOINT_PORT}/get_hyperpod_session" -UseBasicParsing -TimeoutSec 2 -ErrorAction SilentlyContinue
+            $serverAlive = $true
+            Write-Host "Local server is alive on port $LOCAL_ENDPOINT_PORT"
+        }
+    } catch {
+        Write-Host "Local server health check failed: $_"
+    }
+}
+
+if (-not $serverAlive) {
+    $serverJsPath = $env:SAGEMAKER_LOCAL_SERVER_JS_PATH
+    if (-not $serverJsPath -or -not (Test-Path $serverJsPath)) {
+        Write-Error "Cannot start server: SAGEMAKER_LOCAL_SERVER_JS_PATH is not set or file not found"
+        exit 1
+    }
+
+    $logDir = Split-Path $serverInfoPath -Parent
+    Write-Host "Starting local server..."
+    $env:SAGEMAKER_LOCAL_SERVER_FILE_PATH = $serverInfoPath
+    Start-Process -NoNewWindow -FilePath "node" -ArgumentList $serverJsPath `
+        -RedirectStandardOutput "$logDir\sagemaker-local-server.out.log" `
+        -RedirectStandardError "$logDir\sagemaker-local-server.err.log"
+
+    # Wait for info file to be written with a valid port
+    for ($i = 1; $i -le 20; $i++) {
+        try {
+            $jsonContent = Get-Content $serverInfoPath -Raw | ConvertFrom-Json
+            $LOCAL_ENDPOINT_PORT = $jsonContent.port
+            if ($LOCAL_ENDPOINT_PORT -and $LOCAL_ENDPOINT_PORT -ne "null") {
+                Write-Host "Server started on port $LOCAL_ENDPOINT_PORT"
+                break
+            }
+        } catch {}
+        Start-Sleep -Milliseconds 500
+    }
+
+    if (-not $LOCAL_ENDPOINT_PORT -or $LOCAL_ENDPOINT_PORT -eq "null") {
+        Write-Error "Timed out waiting for local server to start"
+        exit 1
+    }
+}
+
+# Retrieve HyperPod session
+Write-Host "`nStarting session retrieval..."
+Get-HyperpodSession -ConnectionKey $CONNECTION_KEY -LocalEndpointPort $LOCAL_ENDPOINT_PORT
+
+# Execute the session
+Write-Host "`nLaunching session-manager-plugin..."
+$sessionPlugin = if ($env:AWS_SSM_CLI) { $env:AWS_SSM_CLI } else { "session-manager-plugin" }
+
+$jsonObj = $script:SSM_SESSION_JSON | ConvertFrom-Json
+$streamUrl = $jsonObj.StreamUrl
+$tokenValue = $jsonObj.TokenValue
+$sessionId = $jsonObj.SessionId
+
+# Extract region from stream URL
+if ($streamUrl -match '\.([a-z0-9-]+)\.amazonaws\.com') {
+    $REGION = $Matches[1]
+} else {
+    Write-Error "Could not extract region from stream URL"
+    exit 1
+}
+
+Write-Host "Session Values:"
+Write-Host "  Stream URL: ${streamUrl}"
+Write-Host "  Token Value: ${tokenValue}"
+Write-Host "  Session ID: ${sessionId}"
+Write-Host "  Region: ${REGION}"
+
+& $sessionPlugin "{\`"streamUrl\`":\`"${streamUrl}\`",\`"tokenValue\`":\`"${tokenValue}\`",\`"sessionId\`":\`"${sessionId}\`"}" "$REGION" "StartSession"

--- a/packages/core/resources/sagemaker_connect
+++ b/packages/core/resources/sagemaker_connect
@@ -114,8 +114,42 @@ if [ -z "$SAGEMAKER_LOCAL_SERVER_FILE_PATH" ]; then
     exit 1
 fi
 
-if [ ! -f "$SAGEMAKER_LOCAL_SERVER_FILE_PATH" ]; then
-    echo "[Error] File not found at SAGEMAKER_LOCAL_SERVER_FILE_PATH: $SAGEMAKER_LOCAL_SERVER_FILE_PATH"
+# Check if server is alive, start it if not
+_ensure_server_running() {
+    local port
+    port=$(jq -r '.port' "$SAGEMAKER_LOCAL_SERVER_FILE_PATH" 2>/dev/null)
+    if [ -n "$port" ] && [ "$port" != "null" ] && curl -s --max-time 2 "http://127.0.0.1:${port}/get_session" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    # Server is dead — restart it
+    if [ -z "$SAGEMAKER_LOCAL_SERVER_JS_PATH" ] || [ ! -f "$SAGEMAKER_LOCAL_SERVER_JS_PATH" ]; then
+        echo "[Error] Cannot start server: SAGEMAKER_LOCAL_SERVER_JS_PATH is not set or file not found"
+        return 1
+    fi
+
+    local log_dir
+    log_dir=$(dirname "$SAGEMAKER_LOCAL_SERVER_FILE_PATH")
+    echo "Starting local server..."
+    SAGEMAKER_LOCAL_SERVER_FILE_PATH="$SAGEMAKER_LOCAL_SERVER_FILE_PATH" \
+        nohup node "$SAGEMAKER_LOCAL_SERVER_JS_PATH" \
+        >> "${log_dir}/sagemaker-local-server.out.log" \
+        2>> "${log_dir}/sagemaker-local-server.err.log" &
+
+    # Wait for info file to be written with a valid port
+    local i
+    for i in $(seq 1 20); do
+        port=$(jq -r '.port' "$SAGEMAKER_LOCAL_SERVER_FILE_PATH" 2>/dev/null)
+        if [ -n "$port" ] && [ "$port" != "null" ]; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    echo "[Error] Timed out waiting for local server to start"
+    return 1
+}
+
+if ! _ensure_server_running; then
     exit 1
 fi
 

--- a/packages/core/resources/sagemaker_connect.ps1
+++ b/packages/core/resources/sagemaker_connect.ps1
@@ -107,20 +107,56 @@ if ($CREDS_TYPE -ne "lc" -and $CREDS_TYPE -ne "dl") {
     exit 1
 }
 
-# Read port from local info JSON
-Write-Host "`nReading SAGEMAKER_LOCAL_SERVER_FILE_PATH: $env:SAGEMAKER_LOCAL_SERVER_FILE_PATH"
-try {
-    $jsonContent = Get-Content $env:SAGEMAKER_LOCAL_SERVER_FILE_PATH -Raw | ConvertFrom-Json
-    $LOCAL_ENDPOINT_PORT = $jsonContent.port
-    Write-Host "Extracted port: $LOCAL_ENDPOINT_PORT"
-} catch {
-    Write-Error "Failed to read or parse JSON file at $env:SAGEMAKER_LOCAL_SERVER_FILE_PATH"
-    exit 1
+# Ensure local server is running, restart if dead
+Write-Host "`nChecking local server..."
+$serverInfoPath = $env:SAGEMAKER_LOCAL_SERVER_FILE_PATH
+$serverAlive = $false
+
+if ($serverInfoPath -and (Test-Path $serverInfoPath)) {
+    try {
+        $jsonContent = Get-Content $serverInfoPath -Raw | ConvertFrom-Json
+        $LOCAL_ENDPOINT_PORT = $jsonContent.port
+        if ($LOCAL_ENDPOINT_PORT -and $LOCAL_ENDPOINT_PORT -ne "null") {
+            $healthCheck = Invoke-WebRequest -Uri "http://127.0.0.1:${LOCAL_ENDPOINT_PORT}/get_session" -UseBasicParsing -TimeoutSec 2 -ErrorAction SilentlyContinue
+            $serverAlive = $true
+            Write-Host "Local server is alive on port $LOCAL_ENDPOINT_PORT"
+        }
+    } catch {
+        Write-Host "Local server health check failed: $_"
+    }
 }
 
-if (-not $LOCAL_ENDPOINT_PORT -or $LOCAL_ENDPOINT_PORT -eq "null") {
-    Write-Error "'port' field is missing or invalid in $env:SAGEMAKER_LOCAL_SERVER_FILE_PATH"
-    exit 1
+if (-not $serverAlive) {
+    $serverJsPath = $env:SAGEMAKER_LOCAL_SERVER_JS_PATH
+    if (-not $serverJsPath -or -not (Test-Path $serverJsPath)) {
+        Write-Error "Cannot start server: SAGEMAKER_LOCAL_SERVER_JS_PATH is not set or file not found"
+        exit 1
+    }
+
+    $logDir = Split-Path $serverInfoPath -Parent
+    Write-Host "Starting local server..."
+    $env:SAGEMAKER_LOCAL_SERVER_FILE_PATH = $serverInfoPath
+    Start-Process -NoNewWindow -FilePath "node" -ArgumentList $serverJsPath `
+        -RedirectStandardOutput "$logDir\sagemaker-local-server.out.log" `
+        -RedirectStandardError "$logDir\sagemaker-local-server.err.log"
+
+    # Wait for info file to be written with a valid port
+    for ($i = 1; $i -le 20; $i++) {
+        try {
+            $jsonContent = Get-Content $serverInfoPath -Raw | ConvertFrom-Json
+            $LOCAL_ENDPOINT_PORT = $jsonContent.port
+            if ($LOCAL_ENDPOINT_PORT -and $LOCAL_ENDPOINT_PORT -ne "null") {
+                Write-Host "Server started on port $LOCAL_ENDPOINT_PORT"
+                break
+            }
+        } catch {}
+        Start-Sleep -Milliseconds 500
+    }
+
+    if (-not $LOCAL_ENDPOINT_PORT -or $LOCAL_ENDPOINT_PORT -eq "null") {
+        Write-Error "Timed out waiting for local server to start"
+        exit 1
+    }
 }
 
 # Retrieve SSM session

--- a/packages/core/src/awsService/sagemaker/model.ts
+++ b/packages/core/src/awsService/sagemaker/model.ts
@@ -212,10 +212,21 @@ export async function prepareDevEnvConnection(opts: DevEnvConnectionOptions) {
     } else {
         await removeKnownHost(hostname)
 
+        const proxyCommandEnvVars = {
+            SAGEMAKER_LOCAL_SERVER_FILE_PATH: path.join(
+                ctx.globalStorageUri.fsPath,
+                'sagemaker-local-server-info.json'
+            ),
+            SAGEMAKER_LOCAL_SERVER_JS_PATH: ctx.asAbsolutePath(
+                path.join('dist/src/awsService/sagemaker/detached-server/', 'server.js')
+            ),
+            AWS_SSM_CLI: ssm,
+        }
+
         const sshConfig =
             connectionType === 'sm_hp'
-                ? new SshConfig(ssh, sshPrefix, 'hyperpod_connect')
-                : new SshConfig(ssh, sshPrefix, 'sagemaker_connect')
+                ? new SshConfig(ssh, sshPrefix, 'hyperpod_connect', undefined, proxyCommandEnvVars)
+                : new SshConfig(ssh, sshPrefix, 'sagemaker_connect', undefined, proxyCommandEnvVars)
         const config = await sshConfig.ensureValid()
         if (config.isErr()) {
             const err = config.err()

--- a/packages/core/src/shared/sshConfig.ts
+++ b/packages/core/src/shared/sshConfig.ts
@@ -29,7 +29,8 @@ export class SshConfig {
         protected readonly sshPath: string,
         protected readonly hostNamePrefix: string,
         protected readonly scriptPrefix: string,
-        protected readonly keyPath?: string
+        protected readonly keyPath?: string,
+        protected readonly proxyCommandEnvVars?: Record<string, string>
     ) {
         this.configHostName = `${hostNamePrefix}*`
         this.proxyCommandRegExp = new RegExp(`proxycommand.{0,1024}${scriptPrefix}(.ps1)?.{0,99}`)
@@ -43,6 +44,12 @@ export class SshConfig {
         // Use %n for SageMaker to preserve original hostname case (avoids SSH canonicalization lowercasing and DNS lookup)
         const hostnameToken = this.scriptPrefix === 'sagemaker_connect' ? '%n' : '%h'
 
+        const envPrefix = this.proxyCommandEnvVars
+            ? Object.entries(this.proxyCommandEnvVars)
+                  .map(([k, v]) => (this.isWin() ? `$env:${k}='${v}';` : `${k}="${v}"`))
+                  .join(' ') + ' '
+            : ''
+
         if (this.isWin()) {
             // Some older versions of OpenSSH (7.8 and below) have a bug where attempting to use powershell.exe directly will fail without an absolute path
             const proc = new ChildProcess('powershell.exe', ['-Command', '(get-command powershell.exe).Path'])
@@ -50,9 +57,11 @@ export class SshConfig {
             if (r.exitCode !== 0) {
                 return Result.err(new ToolkitError('Failed to get absolute path for powershell', { cause: r.error }))
             }
-            return Result.ok(`"${r.stdout}" -ExecutionPolicy RemoteSigned -File "${command}" ${hostnameToken}`)
+            return Result.ok(
+                `"${r.stdout}" -ExecutionPolicy RemoteSigned -Command "${envPrefix}& '${command}' ${hostnameToken}"`
+            )
         } else {
-            return Result.ok(`'${command}' '${hostnameToken}'`)
+            return Result.ok(`${envPrefix}'${command}' '${hostnameToken}'`)
         }
     }
 
@@ -104,22 +113,22 @@ export class SshConfig {
         return Result.ok(matches?.[0])
     }
 
-    private async promptUserForOutdatedSection(configSection: string): Promise<void> {
-        getLogger().warn(`SSH config: found old/outdated "${this.configHostName}" section:\n%O`, configSection)
-        const oldConfig = localize(
-            'AWS.sshConfig.error.oldConfig',
-            'Your ~/.ssh/config has a {0} section that might be out of date. Delete it, then try again.',
-            this.configHostName
-        )
-
-        const openConfig = localize('AWS.ssh.openConfig', 'Open config...')
-        await vscode.window.showWarningMessage(oldConfig, openConfig).then((resp) => {
-            if (resp === openConfig) {
-                void vscode.window.showTextDocument(vscode.Uri.file(getSshConfigPath()))
-            }
-        })
-
-        throw new ToolkitError(oldConfig, { code: 'OldConfig' })
+    private async removeExistingSection(): Promise<void> {
+        const sshConfigPath = getSshConfigPath()
+        try {
+            const content = await readFileAsString(sshConfigPath)
+            // Match the full Host block: from "# Created by AWS Toolkit" comment (or Host line) to next Host or EOF
+            const hostPattern = new RegExp(
+                `(# Created by AWS Toolkit[^\\n]*\\n)?Host ${this.configHostName.replace('*', '\\*')}\\n([ \\t]+[^\\n]*\\n)*[ \\t]*`,
+                'g'
+            )
+            const updated = content.replace(hostPattern, '').replace(/\n{3,}/g, '\n\n')
+            await fs.writeFile(sshConfigPath, updated)
+            chmodSync(sshConfigPath, 0o600)
+            getLogger().info(`ssh: removed outdated "${this.configHostName}" section from config`)
+        } catch (e) {
+            getLogger().warn(`ssh: failed to remove outdated section: ${e}`)
+        }
     }
 
     protected async writeSectionToConfig(proxyCommand: string) {
@@ -152,20 +161,28 @@ export class SshConfig {
         configSection: string | undefined,
         proxyCommand: string
     ): Promise<void> {
-        if (configSection !== undefined) {
-            await this.promptUserForOutdatedSection(configSection)
-        }
-
-        const confirmTitle = localize(
-            'AWS.sshConfig.confirm.installSshConfig.title',
-            '{0} Toolkit will add host {1} to ~/.ssh/config to use SSH with your Dev Environments',
-            getIdeProperties().company,
-            this.configHostName
-        )
+        const confirmTitle =
+            configSection !== undefined
+                ? localize(
+                      'AWS.sshConfig.confirm.updateSshConfig.title',
+                      '{0} Toolkit needs to update the {1} section in ~/.ssh/config (current entry is outdated)',
+                      getIdeProperties().company,
+                      this.configHostName
+                  )
+                : localize(
+                      'AWS.sshConfig.confirm.installSshConfig.title',
+                      '{0} Toolkit will add host {1} to ~/.ssh/config to use SSH with your Dev Environments',
+                      getIdeProperties().company,
+                      this.configHostName
+                  )
         const confirmText = localize('AWS.sshConfig.confirm.installSshConfig.button', 'Update SSH config')
         const response = await showConfirmationMessage({ prompt: confirmTitle, confirm: confirmText })
         if (!response) {
             throw new CancellationError('user')
+        }
+
+        if (configSection !== undefined) {
+            await this.removeExistingSection()
         }
 
         await this.writeSectionToConfig(proxyCommand)

--- a/packages/core/src/test/shared/sshConfig.test.ts
+++ b/packages/core/src/test/shared/sshConfig.test.ts
@@ -93,6 +93,31 @@ describe('VscodeRemoteSshConfig', async function () {
             const command = result.unwrap()
             assert.strictEqual(command, `'sagemaker_connect' '%n'`)
         })
+
+        it('prepends env vars to proxy command on non-windows', async function () {
+            const envConfig = new MockSshConfig('sshPath', 'testHostNamePrefix', 'sagemaker_connect', undefined, {
+                SAGEMAKER_LOCAL_SERVER_FILE_PATH: '/path/to/info.json',
+                AWS_SSM_CLI: '/path/to/ssm',
+            })
+            envConfig.testIsWin = false
+
+            const result = await envConfig.getProxyCommandWrapper('sagemaker_connect')
+            assert.ok(result.isOk())
+            const command = result.unwrap()
+            assert.ok(command.includes('SAGEMAKER_LOCAL_SERVER_FILE_PATH="/path/to/info.json"'))
+            assert.ok(command.includes('AWS_SSM_CLI="/path/to/ssm"'))
+            assert.ok(command.endsWith(`'sagemaker_connect' '%n'`))
+        })
+
+        it('does not prepend env vars when proxyCommandEnvVars is undefined', async function () {
+            const noEnvConfig = new MockSshConfig('sshPath', 'testHostNamePrefix', 'sagemaker_connect')
+            noEnvConfig.testIsWin = false
+
+            const result = await noEnvConfig.getProxyCommandWrapper('sagemaker_connect')
+            assert.ok(result.isOk())
+            const command = result.unwrap()
+            assert.strictEqual(command, `'sagemaker_connect' '%n'`)
+        })
     })
 
     describe('matchSshSection', async function () {

--- a/packages/sagemaker-ssh-kiro/src/authResolver.ts
+++ b/packages/sagemaker-ssh-kiro/src/authResolver.ts
@@ -105,7 +105,21 @@ export class SageMakerSshKiroResolver implements vscode.RemoteAuthorityResolver,
                     const command = sagemakerConnectPath
 
                     let options: cp.SpawnOptions = {
-                        env: { ...process.env }, // Inherit environment variables from parent process
+                        env: {
+                            ...process.env,
+                            SAGEMAKER_LOCAL_SERVER_FILE_PATH: path.join(
+                                awsToolkitGlobalStoragePath,
+                                'sagemaker-local-server-info.json'
+                            ),
+                            SAGEMAKER_LOCAL_SERVER_JS_PATH: path.join(
+                                awsToolkitGlobalStoragePath,
+                                'dist/src/awsService/sagemaker/detached-server/server.js'
+                            ),
+                            AWS_SSM_CLI: path.join(
+                                awsToolkitGlobalStoragePath,
+                                'tools/Amazon/sessionmanagerplugin/bin/session-manager-plugin'
+                            ),
+                        },
                     }
 
                     if (isWindows && /\.ps1$/.test(command)) {

--- a/packages/toolkit/.changes/next-release/Bug Fix-6ea98c60-1658-4932-bc4e-3dc217f4ad74.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-6ea98c60-1658-4932-bc4e-3dc217f4ad74.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SageMaker: IDE session restores automatically after closing and reopening the application"
+}


### PR DESCRIPTION
## Description
- When a user closes and reopens the IDE, SSH attempts to reconnect using the ProxyCommand stored in ~/.ssh/config. The connect script calls the local detached server for session credentials, but the server has died since it exits when no IDE process is detected. The script has no way to restart the server, so the reconnection fails silently.

## Solution
- Added server restart logic to all four connect scripts (sagemaker_connect, sagemaker_connect.ps1, hyperpod_connect, hyperpod_connect.ps1). Each script now checks if the local server is alive before requesting credentials, and restarts it if dead using SAGEMAKER_LOCAL_SERVER_JS_PATH.
- Baked infrastructure env vars (SAGEMAKER_LOCAL_SERVER_FILE_PATH, SAGEMAKER_LOCAL_SERVER_JS_PATH, AWS_SSM_CLI) into the SSH config ProxyCommand so the script can locate the server and SSM plugin when running outside the IDE context.
- Updated sshConfig.ts to support prepending env vars to the ProxyCommand, and to silently replace outdated SSH config sections instead of prompting the user.
- Passed the same env vars to the Kiro sidecar (authResolver.ts) for the script spawn path.

## Testing
- Added unit tests
- Manually verified with vsix in macOS and windows
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
