### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/packages/core/src/shared/ui/prompter.ts
+++ b/packages/core/src/shared/ui/prompter.ts
@@ -23,7 +23,7 @@ export abstract class Prompter<T> {
 
     constructor() {}
 
-    /** The total number of steps that occured during the prompt */
+    /** The total number of steps that occurred during the prompt */
     public get totalSteps(): number {
         return 1
     }


### PR DESCRIPTION
Fixes a spelling typo in a JSDoc comment in prompter.ts.