### PR TITLE
feat(sagemaker): pass IDE type to WorkspaceConnection API

### DIFF
--- a/.changes/next-release/feat-workspace-connection-ide-type.json
+++ b/.changes/next-release/feat-workspace-connection-ide-type.json
@@ -1,0 +1,4 @@
+{
+  "type": "Feature",
+  "description": "HyperPod: Send correct IDE type (vscode-remote, cursor-remote, kiro-remote) when creating workspace connections, enabling proper multi-IDE support."
+}

--- a/packages/core/src/awsService/sagemaker/detached-server/kubectlClientStub.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/kubectlClientStub.ts
@@ -45,49 +45,63 @@ export class KubectlClient {
         return this.k8sApi
     }
 
-    async createWorkspaceConnection(devSpace: HyperpodDevSpace): Promise<WorkspaceConnectionResult> {
+    async createWorkspaceConnection(
+        devSpace: HyperpodDevSpace,
+        ideType: string = 'vscode'
+    ): Promise<WorkspaceConnectionResult> {
         try {
-            await this.ensureValidToken()
-
-            const group = 'connection.workspace.jupyter.org'
-            const version = 'v1alpha1'
-            const plural = 'workspaceconnections'
-
-            const workspaceConnection = {
-                apiVersion: `${group}/${version}`,
-                kind: 'WorkspaceConnection',
-                metadata: {
-                    namespace: devSpace.namespace,
-                },
-                spec: {
-                    workspaceName: devSpace.name,
-                    workspaceConnectionType: 'vscode-remote',
-                },
-            }
-
-            const response = await this.getApi().createNamespacedCustomObject(
-                group,
-                version,
-                devSpace.namespace,
-                plural,
-                workspaceConnection
-            )
-
-            const body = response.body as any
-            const status = body.status
-            const presignedUrl = status?.workspaceConnectionUrl
-            const connectionType = status?.workspaceConnectionType
-            // tokenValue and sessionId may not be present in all API responses.
-            // When empty, the existing connection flow in model.ts falls back to parsing these from the presigned URL.
-            const token = status?.tokenValue ?? ''
-            const sessionId = status?.sessionId ?? ''
-
-            return { type: connectionType || 'vscode-remote', url: presignedUrl, token, sessionId }
+            return await this.doCreateWorkspaceConnection(devSpace, `${ideType}-remote`)
         } catch (error) {
+            // Fall back to vscode-remote if the IDE-specific type is not supported (older addon versions)
+            if (ideType !== 'vscode') {
+                return await this.doCreateWorkspaceConnection(devSpace, 'vscode-remote')
+            }
             throw new Error(
                 `Failed to create workspace connection: ${error instanceof Error ? error.message : String(error)}`
             )
         }
+    }
+
+    private async doCreateWorkspaceConnection(
+        devSpace: HyperpodDevSpace,
+        workspaceConnectionType: string
+    ): Promise<WorkspaceConnectionResult> {
+        await this.ensureValidToken()
+
+        const group = 'connection.workspace.jupyter.org'
+        const version = 'v1alpha1'
+        const plural = 'workspaceconnections'
+
+        const workspaceConnection = {
+            apiVersion: `${group}/${version}`,
+            kind: 'WorkspaceConnection',
+            metadata: {
+                namespace: devSpace.namespace,
+            },
+            spec: {
+                workspaceName: devSpace.name,
+                workspaceConnectionType,
+            },
+        }
+
+        const response = await this.getApi().createNamespacedCustomObject(
+            group,
+            version,
+            devSpace.namespace,
+            plural,
+            workspaceConnection
+        )
+
+        const body = response.body as any
+        const status = body.status
+        const presignedUrl = status?.workspaceConnectionUrl
+        const connectionType = status?.workspaceConnectionType
+        // tokenValue and sessionId may not be present in all API responses.
+        // When empty, getHyperpodSession.ts falls back to parsing these from the presigned URL.
+        const token = status?.tokenValue ?? ''
+        const sessionId = status?.sessionId ?? ''
+
+        return { type: connectionType || workspaceConnectionType, url: presignedUrl, token, sessionId }
     }
 
     protected async initKubeConfig(): Promise<void> {

--- a/packages/core/src/awsService/sagemaker/detached-server/routes/getHyperpodSession.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/routes/getHyperpodSession.ts
@@ -104,12 +104,15 @@ export async function handleGetHyperpodSession(req: IncomingMessage, res: Server
 
     try {
         const kubectlClient = await KubectlClient.createForCluster(eksCluster, hyperpodCluster, mapping.credentials)
-        const connection = await kubectlClient.createWorkspaceConnection(devSpace)
+        const connection = await kubectlClient.createWorkspaceConnection(
+            devSpace,
+            process.env['PARENT_IDE_TYPE'] ?? 'vscode'
+        )
 
         attemptCount.delete(connectionKey)
         lastAttemptTime.delete(connectionKey)
 
-        // Parse response URL if the API returns a vscode:// URL with embedded params
+        // Parse response URL if the API returns a deeplink URL with embedded params
         let streamUrl = connection.url
         let token = connection.token || ''
         let sessionId = connection.sessionId || ''

--- a/packages/core/src/awsService/sagemaker/hyperpodCommands.ts
+++ b/packages/core/src/awsService/sagemaker/hyperpodCommands.ts
@@ -15,6 +15,7 @@ import { prepareDevEnvConnection, useSageMakerSshKiroExtension, startRemoteViaSa
 import { startVscodeRemote } from '../../shared/extensions/ssh'
 import { ensureSageMakerSshKiroExtension } from './sagemakerSshKiroUtils'
 import globals from '../../shared/extensionGlobals'
+import { getIdeType } from '../../shared/extensionUtilities'
 
 const localize = nls.loadMessageBundle()
 
@@ -68,7 +69,7 @@ export async function connectToHyperPodDevSpace(node: SagemakerDevSpaceNode): Pr
         const eksCluster = kubectlClient.getEksCluster()
 
         // Call createWorkspaceConnection to get presigned URL with credentials
-        const workspaceConnection = await kubectlClient.createWorkspaceConnection(node.devSpace)
+        const workspaceConnection = await kubectlClient.createWorkspaceConnection(node.devSpace, getIdeType())
         const connectionUrl = workspaceConnection.url
 
         const remoteEnv = await prepareDevEnvConnection({

--- a/packages/core/src/shared/clients/kubectlClient.ts
+++ b/packages/core/src/shared/clients/kubectlClient.ts
@@ -146,10 +146,13 @@ export class KubectlClient extends KubectlClientBase {
         }
     }
 
-    override async createWorkspaceConnection(devSpace: HyperpodDevSpace): Promise<WorkspaceConnectionResult> {
+    override async createWorkspaceConnection(
+        devSpace: HyperpodDevSpace,
+        ideType?: string
+    ): Promise<WorkspaceConnectionResult> {
         getLogger().info(`[Hyperpod] Creating workspace connection for space: ${devSpace.name}`)
         try {
-            const result = await super.createWorkspaceConnection(devSpace)
+            const result = await super.createWorkspaceConnection(devSpace, ideType)
             if (!result.url) {
                 throw new Error('No workspace connection URL returned')
             }

--- a/packages/core/src/test/shared/clients/kubectlClient.test.ts
+++ b/packages/core/src/test/shared/clients/kubectlClient.test.ts
@@ -341,5 +341,65 @@ describe('KubectlClient', function () {
             assert.strictEqual(result.token, '')
             assert.strictEqual(result.sessionId, '')
         })
+
+        it('sends ideType-remote as workspaceConnectionType in request', async function () {
+            const client = await KubectlClient.createForCluster(eksCluster, hyperpodCluster, testCredentials)
+
+            const createStub = sinon.stub().resolves({
+                body: {
+                    status: {
+                        workspaceConnectionUrl: 'https://example.com',
+                        workspaceConnectionType: 'cursor-remote',
+                        tokenValue: 'tok',
+                        sessionId: 'sess',
+                    },
+                },
+            })
+            stubGetApi(client, { createNamespacedCustomObject: createStub })
+
+            await client.createWorkspaceConnection(testDevSpace, 'cursor')
+
+            const requestBody = createStub.firstCall.args[4]
+            assert.strictEqual(requestBody.spec.workspaceConnectionType, 'cursor-remote')
+        })
+
+        it('falls back to vscode-remote when IDE-specific type is rejected', async function () {
+            const client = await KubectlClient.createForCluster(eksCluster, hyperpodCluster, testCredentials)
+
+            const createStub = sinon.stub()
+            // First call (cursor-remote) fails
+            createStub.onFirstCall().rejects(new Error('invalid workspaceConnectionType'))
+            // Second call (vscode-remote fallback) succeeds
+            createStub.onSecondCall().resolves({
+                body: {
+                    status: {
+                        workspaceConnectionUrl: 'https://example.com',
+                        workspaceConnectionType: 'vscode-remote',
+                        tokenValue: 'tok',
+                        sessionId: 'sess',
+                    },
+                },
+            })
+            stubGetApi(client, { createNamespacedCustomObject: createStub })
+
+            const result = await client.createWorkspaceConnection(testDevSpace, 'cursor')
+
+            assert.strictEqual(createStub.callCount, 2)
+            assert.strictEqual(createStub.secondCall.args[4].spec.workspaceConnectionType, 'vscode-remote')
+            assert.strictEqual(result.type, 'vscode-remote')
+        })
+
+        it('does not fall back when ideType is already vscode', async function () {
+            const client = await KubectlClient.createForCluster(eksCluster, hyperpodCluster, testCredentials)
+
+            const createStub = sinon.stub().rejects(new Error('CRD not found'))
+            stubGetApi(client, { createNamespacedCustomObject: createStub })
+
+            await assert.rejects(
+                client.createWorkspaceConnection(testDevSpace, 'vscode'),
+                /Failed to create workspace connection/
+            )
+            assert.strictEqual(createStub.callCount, 1)
+        })
     })
 })


### PR DESCRIPTION
## Problem
- HyperPod workspace connections hardcode vscode-remote as the connection type when calling the K8s WorkspaceConnection API. With Cursor and Kiro now supported, the backend needs to know which IDE is connecting to create the correct session type.

## Solution
- Pass the IDE type dynamically to createWorkspaceConnection so the K8s API receives the correct workspaceConnectionType (vscode-remote, cursor-remote, or kiro-remote).
  
## Testing
- Added unit test
- Tested locally with vsix

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
