### PR TITLE
chore(toolkit): Bump version to 4.6.1-SNAPSHOT

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -2,7 +2,7 @@
     "name": "aws-toolkit-vscode",
     "displayName": "AWS Toolkit",
     "description": "Including CodeCatalyst, Infrastructure Composer, and support for Lambda, S3, CloudWatch Logs, CloudFormation, and many other services.",
-    "version": "4.6.0-SNAPSHOT",
+    "version": "4.6.1-SNAPSHOT",
     "extensionKind": [
         "workspace"
     ],


### PR DESCRIPTION
Version 4.6.0 became stuck in a corrupt state on the VS Marketplace (partially registered but not installable). The Marketplace rejects re-publishing the same version number, so rolling forward to 4.6.1.

## Problem

The first pipeline run for v4.6.0 partially registered the version on the VS Marketplace (metadata created) but the package upload never completed. This left 4.6.0 in a corrupt state: `vsce show` reports it exists, but `code --install-extension` fails and the web UI still shows 4.5.0. Subsequent publish retries all fail with "already exists." `vsce unpublish` did not clear the stuck state.

## Solution

Bump the release version from 4.6.0 to 4.6.1. The release content (features, bug fixes) is identical — only the version number changes to bypass the Marketplace's rejection of the corrupted 4.6.0 entry.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.