### PR TITLE
Fix typo: occured → occurred in prompter.ts [fixes #8783]

### DIFF
--- a/packages/core/src/shared/ui/prompter.ts
+++ b/packages/core/src/shared/ui/prompter.ts
@@ -23,7 +23,7 @@ export abstract class Prompter<T> {
 
     constructor() {}
 
-    /** The total number of steps that occured during the prompt */
+    /** The total number of steps that occurred during the prompt */
     public get totalSteps(): number {
         return 1
     }


### PR DESCRIPTION
Fixes aws-toolkit-vscode #8783 - typo in JSDoc comment.

**Change:** `occured` → `occurred` in `packages/core/src/shared/ui/prompter.ts` (line 26)

**Why no tests:** This change is limited to a JSDoc string on the `totalSteps` getter. No runtime behavior is affected, so there is no test surface to cover. (A pre-commit grep would fail on the misspelled word, which is the appropriate guard for this class of change.)