### PR TITLE
feat(sagemaker): route detached server and SSM tunnel through IDE proxy settings

### DIFF
--- a/packages/core/src/awsService/sagemaker/detached-server/utils.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/utils.ts
@@ -9,6 +9,8 @@
 import { ServerInfo } from '../types'
 import { promises as fs } from 'fs'
 import { SageMakerClient, StartSessionCommand } from '@amzn/sagemaker-client'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
+import HttpsProxyAgent from 'https-proxy-agent'
 import os from 'os'
 import { join } from 'path'
 import { SpaceMappings } from '../types'
@@ -77,7 +79,17 @@ export function parseArn(arn: string): { region: string; accountId: string; reso
 
 export async function startSagemakerSession({ region, connectionIdentifier, credentials }: any) {
     const endpoint = process.env.SAGEMAKER_ENDPOINT || `https://sagemaker.${region}.amazonaws.com`
-    const client = new SageMakerClient({ region, credentials, endpoint, retryStrategy: startSessionRetryStrategy })
+    const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY
+    const requestHandler = proxy
+        ? new NodeHttpHandler({ httpsAgent: HttpsProxyAgent(proxy), httpAgent: HttpsProxyAgent(proxy) })
+        : undefined
+    const client = new SageMakerClient({
+        region,
+        credentials,
+        endpoint,
+        retryStrategy: startSessionRetryStrategy,
+        requestHandler,
+    })
     const command = new StartSessionCommand({ ResourceIdentifier: connectionIdentifier })
     return client.send(command)
 }

--- a/packages/core/src/awsService/sagemaker/model.ts
+++ b/packages/core/src/awsService/sagemaker/model.ts
@@ -342,7 +342,7 @@ export async function startLocalServer(ctx: vscode.ExtensionContext) {
     throw new ToolkitError(`Timed out waiting for local server info file: ${infoFilePath}`)
 }
 
-function getLocalProxyEnv(): Record<string, string> {
+export function getLocalProxyEnv(): Record<string, string> {
     const env: Record<string, string> = {}
     const httpConfig = vscode.workspace.getConfiguration('http')
     const proxyUrl = httpConfig.get<string>('proxy')
@@ -350,12 +350,13 @@ function getLocalProxyEnv(): Record<string, string> {
         env.HTTP_PROXY = proxyUrl
         env.HTTPS_PROXY = proxyUrl
     }
-    const noProxy = httpConfig.get<string>('noProxy')
-    if (noProxy) {
-        env.NO_PROXY = noProxy
+    const noProxy = httpConfig.get<string[]>('noProxy')
+    if (noProxy && noProxy.length > 0) {
+        env.NO_PROXY = noProxy.join(',')
     }
     const strictSSL = httpConfig.get<boolean>('proxyStrictSSL', true)
     if (!strictSSL) {
+        logger.warn('TLS certificate verification disabled due to http.proxyStrictSSL setting')
         env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
     }
     return env

--- a/packages/core/src/awsService/sagemaker/model.ts
+++ b/packages/core/src/awsService/sagemaker/model.ts
@@ -267,8 +267,9 @@ export async function prepareDevEnvConnection(opts: DevEnvConnectionOptions) {
 
     logger.info(`connect script logs at ${vars.LOG_FILE_LOCATION}`)
 
+    const proxyVars = getLocalProxyEnv()
     const envProvider = async () => {
-        return { [sshAgentSocketVariable]: await startSshAgent(), ...vars }
+        return { [sshAgentSocketVariable]: await startSshAgent(), ...vars, ...proxyVars }
     }
     const SessionProcess = createBoundProcess(envProvider).extend({
         onStdout: (data: string) => remoteLogger(data),
@@ -310,12 +311,15 @@ export async function startLocalServer(ctx: vscode.ExtensionContext) {
 
     await stopLocalServer(ctx)
 
+    const proxyEnv = getLocalProxyEnv()
+
     const child = spawnDetachedServer(process.execPath, [serverPath], {
         cwd: path.dirname(serverPath),
         detached: true,
         stdio: ['ignore', nodefs.openSync(outLog, 'a'), nodefs.openSync(errLog, 'a')],
         env: {
             ...process.env,
+            ...proxyEnv,
             SAGEMAKER_ENDPOINT: customEndpoint,
             SAGEMAKER_LOCAL_SERVER_FILE_PATH: infoFilePath,
             PARENT_IDE_TYPE: getIdeType(),
@@ -336,6 +340,25 @@ export async function startLocalServer(ctx: vscode.ExtensionContext) {
     }
 
     throw new ToolkitError(`Timed out waiting for local server info file: ${infoFilePath}`)
+}
+
+function getLocalProxyEnv(): Record<string, string> {
+    const env: Record<string, string> = {}
+    const httpConfig = vscode.workspace.getConfiguration('http')
+    const proxyUrl = httpConfig.get<string>('proxy')
+    if (proxyUrl) {
+        env.HTTP_PROXY = proxyUrl
+        env.HTTPS_PROXY = proxyUrl
+    }
+    const noProxy = httpConfig.get<string>('noProxy')
+    if (noProxy) {
+        env.NO_PROXY = noProxy
+    }
+    const strictSSL = httpConfig.get<boolean>('proxyStrictSSL', true)
+    if (!strictSSL) {
+        env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+    }
+    return env
 }
 
 interface LocalServerInfo {

--- a/packages/core/src/test/awsService/sagemaker/proxyEnv.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/proxyEnv.test.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as sinon from 'sinon'
+import assert from 'assert'
+import { getLocalProxyEnv } from '../../../awsService/sagemaker/model'
+
+describe('getLocalProxyEnv', function () {
+    let sandbox: sinon.SinonSandbox
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+    })
+
+    function stubConfig(values: Record<string, any>) {
+        sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+            get: (key: string, defaultValue?: any) => (key in values ? values[key] : defaultValue),
+        } as any)
+    }
+
+    it('returns empty object when no proxy is configured', function () {
+        stubConfig({})
+        const env = getLocalProxyEnv()
+        assert.deepStrictEqual(env, {})
+    })
+
+    it('sets HTTP_PROXY and HTTPS_PROXY from http.proxy', function () {
+        stubConfig({ proxy: 'http://myproxy:8080' })
+        const env = getLocalProxyEnv()
+        assert.strictEqual(env.HTTP_PROXY, 'http://myproxy:8080')
+        assert.strictEqual(env.HTTPS_PROXY, 'http://myproxy:8080')
+    })
+
+    it('joins noProxy array into comma-separated NO_PROXY', function () {
+        stubConfig({ proxy: 'http://myproxy:8080', noProxy: ['localhost', '127.0.0.1', '.internal.com'] })
+        const env = getLocalProxyEnv()
+        assert.strictEqual(env.NO_PROXY, 'localhost,127.0.0.1,.internal.com')
+    })
+
+    it('does not set NO_PROXY when noProxy is empty array', function () {
+        stubConfig({ proxy: 'http://myproxy:8080', noProxy: [] })
+        const env = getLocalProxyEnv()
+        assert.strictEqual(env.NO_PROXY, undefined)
+    })
+
+    it('sets NODE_TLS_REJECT_UNAUTHORIZED when proxyStrictSSL is false', function () {
+        stubConfig({ proxy: 'http://myproxy:8080', proxyStrictSSL: false })
+        const env = getLocalProxyEnv()
+        assert.strictEqual(env.NODE_TLS_REJECT_UNAUTHORIZED, '0')
+    })
+
+    it('does not set NODE_TLS_REJECT_UNAUTHORIZED when proxyStrictSSL is true', function () {
+        stubConfig({ proxy: 'http://myproxy:8080', proxyStrictSSL: true })
+        const env = getLocalProxyEnv()
+        assert.strictEqual(env.NODE_TLS_REJECT_UNAUTHORIZED, undefined)
+    })
+})


### PR DESCRIPTION

## Problem
The detached server (sagemaker-local-server) runs as a separate process from the IDE. When it calls StartSession to establish the SSM tunnel, it uses the AWS SDK — which doesn't automatically honor proxy environment variables. So even if the user configures http.proxy in their IDE settings, the detached server ignores it and tries to connect directly to AWS. On a corporate network where direct AWS access is blocked, this times out.

## Solution
Read the IDE's http.proxy setting, pass it as environment variables to the detached server and the connect script, and configure the SDK client to explicitly route through the proxy when those variables are set.

## Testing

  1. Baseline repro (no fix) — proved the bug exists:
  - Called the toolkit's own compiled startSagemakerSession from dist/ with HTTP_PROXY/HTTPS_PROXY set, local Squid running
  - Result: request went direct to AWS, zero Squid log lines → SDK ignores proxy env vars

  2. Full end-to-end repro — matched the customer's exact failure:
  - Built a VPC with Squid proxy EC2 + OpenVPN EC2 (egress locked to proxy-only), VpcOnly SMUS domain + space in us-east-2
  - Connected Mac to VPN (redirect-gateway → all traffic through VPC, direct AWS blocked)
  - Configured Kiro with http.proxy pointing at Squid, connected to space
  - Result: AggregateError [ETIMEDOUT] connecting to SageMaker IPs on :443 — identical to customer's sagemaker-local-server.err.log

  3. Fix applied — validated end-to-end:
  - Applied three changes (proxy env injection into detached server + connect script, explicit proxy-aware requestHandler on SDK client)
  - Rebuilt extension, reconnected VPN, same Kiro proxy settings, connected to space
  - Result: StartSession returned HTTP 200, SSM tunnel established, SSH handshake succeeded, Kiro remote server installed and listening — full connection through proxy on a
  proxy-only network

  4. Backward compatibility:
  - When http.proxy is not set, getLocalProxyEnv() returns {}, requestHandler is undefined — SDK uses its default handler with no proxy. Behavior is identical to before the fix.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
