### PR TITLE
deps: Update transitive jsonpath-plus dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33356,6 +33356,28 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@jsep-plugin/assignment": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+            "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+            "engines": {
+                "node": ">= 10.16.0"
+            },
+            "peerDependencies": {
+                "jsep": "^0.4.0||^1.0.0"
+            }
+        },
+        "node_modules/@jsep-plugin/regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+            "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+            "engines": {
+                "node": ">= 10.16.0"
+            },
+            "peerDependencies": {
+                "jsep": "^0.4.0||^1.0.0"
+            }
+        },
         "node_modules/@koa/cors": {
             "version": "5.0.0",
             "dev": true,
@@ -41828,6 +41850,14 @@
                 "node": ">= 14"
             }
         },
+        "node_modules/jsep": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+            "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+            "engines": {
+                "node": ">= 10.16.0"
+            }
+        },
         "node_modules/jsesc": {
             "version": "3.0.2",
             "dev": true,
@@ -42006,12 +42036,20 @@
             }
         },
         "node_modules/jsonpath-plus": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-            "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
-            "license": "MIT",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+            "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+            "dependencies": {
+                "@jsep-plugin/assignment": "^1.3.0",
+                "@jsep-plugin/regex": "^1.0.4",
+                "jsep": "^1.4.0"
+            },
+            "bin": {
+                "jsonpath": "bin/jsonpath-cli.js",
+                "jsonpath-plus": "bin/jsonpath-cli.js"
+            },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/jsprim": {

--- a/package.json
+++ b/package.json
@@ -79,5 +79,8 @@
         "jaro-winkler": "^0.2.8",
         "vscode-nls": "^5.2.0",
         "vscode-nls-dev": "^4.0.4"
+    },
+    "overrides": {
+        "jsonpath-plus": "^10.3.0"
     }
 }


### PR DESCRIPTION
## Problem

The transitive dependency `jsonpath-plus` (pulled in via `@kubernetes/client-node`) was outdated at version 7.2.0.

## Solution

Add an npm `overrides` field in root `package.json` to pin `jsonpath-plus` to `^10.3.0`, updating it to 10.4.0.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.