### PR TITLE
feat(sagemaker): Added the validation for refresh url and updated the uri handler

### DIFF
--- a/packages/core/src/awsService/sagemaker/detached-server/routes/getHyperpodSessionAsync.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/routes/getHyperpodSessionAsync.ts
@@ -70,6 +70,21 @@ export async function handleGetHyperpodSessionAsync(req: IncomingMessage, res: S
     }
 }
 
+function isValidReconnectUrl(refreshUrl: string): boolean {
+    try {
+        const parsed = new URL(refreshUrl)
+        if (parsed.protocol === 'http:') {
+            return parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1'
+        }
+        if (parsed.protocol === 'https:') {
+            return parsed.hostname.endsWith('.sagemaker.aws') || parsed.hostname.endsWith('.asfiovnxocqpcry.com')
+        }
+        return false
+    } catch {
+        return false
+    }
+}
+
 async function triggerBrowserReconnectionAsync(connectionKey: string, res: ServerResponse): Promise<void> {
     try {
         const allMappings = await readHyperpodMapping()
@@ -78,6 +93,13 @@ async function triggerBrowserReconnectionAsync(connectionKey: string, res: Serve
         if (!mapping?.refreshUrl) {
             res.writeHead(202, { 'Content-Type': 'text/plain' })
             res.end('Session is not ready yet. Please retry in a few seconds.')
+            return
+        }
+
+        if (!isValidReconnectUrl(mapping.refreshUrl)) {
+            console.error(`Invalid refreshUrl for ${connectionKey}: ${mapping.refreshUrl}`)
+            res.writeHead(400, { 'Content-Type': 'text/plain' })
+            res.end('Invalid reconnection URL.')
             return
         }
 

--- a/packages/core/src/shared/vscode/uriHandler.ts
+++ b/packages/core/src/shared/vscode/uriHandler.ts
@@ -48,8 +48,17 @@ export class UriHandler implements vscode.UriHandler {
 
         // Ensure '+' is treated as a literal plus sign, not a space, by encoding it as '%2B'
         // Also decode HTML entities like &amp; to & to ensure proper parameter parsing
+        // Decode %3D → = and %26 → & in the query string so URLSearchParams can parse
+        // individual params — OS protocol handlers for non-http schemes (cursor://, kiro://)
+        // percent-encode these delimiters before delivering the URI to the extension.
         const originalUri = uri.toString(true)
-        const uriString = originalUri.replace(/&amp;/g, '&').replace(/\+/g, '%2B')
+        let uriString = originalUri.replace(/&amp;/g, '&').replace(/\+/g, '%2B')
+        const qIdx = uriString.indexOf('?')
+        if (qIdx !== -1) {
+            const base = uriString.slice(0, qIdx + 1)
+            const query = uriString.slice(qIdx + 1).replace(/%3D/gi, '=').replace(/%26/gi, '&')
+            uriString = base + query
+        }
         const url = new URL(uriString)
         const params = new SearchParams(url.searchParams)
 

--- a/packages/core/src/shared/vscode/uriHandler.ts
+++ b/packages/core/src/shared/vscode/uriHandler.ts
@@ -56,7 +56,10 @@ export class UriHandler implements vscode.UriHandler {
         const qIdx = uriString.indexOf('?')
         if (qIdx !== -1) {
             const base = uriString.slice(0, qIdx + 1)
-            const query = uriString.slice(qIdx + 1).replace(/%3D/gi, '=').replace(/%26/gi, '&')
+            const query = uriString
+                .slice(qIdx + 1)
+                .replace(/%3D/gi, '=')
+                .replace(/%26/gi, '&')
             uriString = base + query
         }
         const url = new URL(uriString)

--- a/packages/core/src/test/awsService/sagemaker/detached-server/routes/getHyperpodSessionAsync.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/detached-server/routes/getHyperpodSessionAsync.test.ts
@@ -132,4 +132,125 @@ describe('handleGetHyperpodSessionAsync', () => {
 
         assert(getFreshEntryStub.calledWith('other:ns:cluster', 'initial-connection'))
     })
+
+    describe('isValidReconnectUrl (via triggerBrowserReconnectionAsync)', () => {
+        beforeEach(() => {
+            getFreshEntryStub.resolves(undefined)
+            getStatusStub.resolves('consumed')
+        })
+
+        it('rejects http:// URLs pointing to non-localhost hosts', async () => {
+            req = { url: '/get_hyperpod_session_async?connection_key=ws:ns:cluster&request_id=123' }
+            sinon.stub(hyperpodMappingUtils, 'readHyperpodMapping').resolves({
+                localCredential: {
+                    'ws:ns:cluster': {
+                        namespace: 'ns',
+                        clusterArn: 'arn:aws:eks:us-west-2:123:cluster/cluster',
+                        clusterName: 'cluster',
+                        refreshUrl: 'http://evil.com/steal',
+                    },
+                },
+            })
+
+            await handleGetHyperpodSessionAsync(req as http.IncomingMessage, res as http.ServerResponse)
+
+            assert(resWriteHead.calledWith(400))
+            assert(resEnd.calledWith('Invalid reconnection URL.'))
+        })
+
+        it('rejects https:// URLs with non-SageMaker hostnames', async () => {
+            req = { url: '/get_hyperpod_session_async?connection_key=ws:ns:cluster&request_id=123' }
+            sinon.stub(hyperpodMappingUtils, 'readHyperpodMapping').resolves({
+                localCredential: {
+                    'ws:ns:cluster': {
+                        namespace: 'ns',
+                        clusterArn: 'arn:aws:eks:us-west-2:123:cluster/cluster',
+                        clusterName: 'cluster',
+                        refreshUrl: 'https://evil.sagemaker.aws.attacker.com/phish',
+                    },
+                },
+            })
+
+            await handleGetHyperpodSessionAsync(req as http.IncomingMessage, res as http.ServerResponse)
+
+            assert(resWriteHead.calledWith(400))
+        })
+
+        it('rejects javascript: protocol URLs', async () => {
+            req = { url: '/get_hyperpod_session_async?connection_key=ws:ns:cluster&request_id=123' }
+            sinon.stub(hyperpodMappingUtils, 'readHyperpodMapping').resolves({
+                localCredential: {
+                    'ws:ns:cluster': {
+                        namespace: 'ns',
+                        clusterArn: 'arn:aws:eks:us-west-2:123:cluster/cluster',
+                        clusterName: 'cluster',
+                        refreshUrl: 'javascript:alert(1)',
+                    },
+                },
+            })
+
+            await handleGetHyperpodSessionAsync(req as http.IncomingMessage, res as http.ServerResponse)
+
+            assert(resWriteHead.calledWith(400))
+        })
+
+        it('rejects ftp:// protocol URLs', async () => {
+            req = { url: '/get_hyperpod_session_async?connection_key=ws:ns:cluster&request_id=123' }
+            sinon.stub(hyperpodMappingUtils, 'readHyperpodMapping').resolves({
+                localCredential: {
+                    'ws:ns:cluster': {
+                        namespace: 'ns',
+                        clusterArn: 'arn:aws:eks:us-west-2:123:cluster/cluster',
+                        clusterName: 'cluster',
+                        refreshUrl: 'ftp://localhost/file',
+                    },
+                },
+            })
+
+            await handleGetHyperpodSessionAsync(req as http.IncomingMessage, res as http.ServerResponse)
+
+            assert(resWriteHead.calledWith(400))
+        })
+
+        it('accepts valid https://*.sagemaker.aws URLs', async () => {
+            req = { url: '/get_hyperpod_session_async?connection_key=ws:ns:cluster&request_id=123' }
+            sinon.stub(hyperpodMappingUtils, 'readHyperpodMapping').resolves({
+                localCredential: {
+                    'ws:ns:cluster': {
+                        namespace: 'ns',
+                        clusterArn: 'arn:aws:eks:us-west-2:123:cluster/cluster',
+                        clusterName: 'cluster',
+                        refreshUrl: 'https://studio-d-abc123.studio.us-west-2.sagemaker.aws/hyperPod/clusters/c1/ws1',
+                    },
+                },
+            })
+            sinon.stub(utils, 'readServerInfo').resolves({ port: 9999, pid: 1234 })
+            sinon.stub(utils, 'open').resolves()
+
+            await handleGetHyperpodSessionAsync(req as http.IncomingMessage, res as http.ServerResponse)
+
+            // 202 = browser reconnection initiated (not 400)
+            assert(resWriteHead.calledWith(202))
+        })
+
+        it('accepts http://localhost URLs', async () => {
+            req = { url: '/get_hyperpod_session_async?connection_key=ws:ns:cluster&request_id=123' }
+            sinon.stub(hyperpodMappingUtils, 'readHyperpodMapping').resolves({
+                localCredential: {
+                    'ws:ns:cluster': {
+                        namespace: 'ns',
+                        clusterArn: 'arn:aws:eks:us-west-2:123:cluster/cluster',
+                        clusterName: 'cluster',
+                        refreshUrl: 'http://localhost:4011/hyperPod/clusters/c1/ws1',
+                    },
+                },
+            })
+            sinon.stub(utils, 'readServerInfo').resolves({ port: 9999, pid: 1234 })
+            sinon.stub(utils, 'open').resolves()
+
+            await handleGetHyperpodSessionAsync(req as http.IncomingMessage, res as http.ServerResponse)
+
+            assert(resWriteHead.calledWith(202))
+        })
+    })
 })

--- a/packages/core/src/test/shared/vscode/uriHandler.test.ts
+++ b/packages/core/src/test/shared/vscode/uriHandler.test.ts
@@ -88,3 +88,58 @@ describe('SearchParams', function () {
         assert.throws(() => params.getOrThrow('foob', new Error()))
     })
 })
+
+describe('UriHandler query decoding', function () {
+    let uriHandler: UriHandler
+
+    function makeUri(query: string): vscode.Uri {
+        return vscode.Uri.parse(`scheme://authority/my/path?${query}`)
+    }
+
+    beforeEach(function () {
+        uriHandler = new UriHandler()
+    })
+
+    it('decodes %3D and %26 in query string for non-http protocol handlers (Cursor/Kiro)', async function () {
+        let receivedParams: SearchParams | undefined
+        uriHandler.onPath('/my/path', (q) => {
+            receivedParams = q as SearchParams
+        })
+
+        // Simulate what Cursor/Kiro OS protocol handlers do: encode = as %3D and & as %26
+        const uri = makeUri('refreshUrl%3Dhttps%253A%252F%252Fexample.com%26sessionId%3Ds1')
+        await uriHandler.handleUri(uri)
+
+        assert.ok(receivedParams)
+        assert.strictEqual(receivedParams!.get('refreshUrl'), 'https%3A%2F%2Fexample.com')
+        assert.strictEqual(receivedParams!.get('sessionId'), 's1')
+    })
+
+    it('preserves + as literal plus (not space) in query values', async function () {
+        let receivedParams: SearchParams | undefined
+        uriHandler.onPath('/my/path', (q) => {
+            receivedParams = q as SearchParams
+        })
+
+        const uri = makeUri('token=abc+def+ghi')
+        await uriHandler.handleUri(uri)
+
+        assert.ok(receivedParams)
+        assert.strictEqual(receivedParams!.get('token'), 'abc+def+ghi')
+    })
+
+    it('normal VS Code URIs with real delimiters still parse correctly', async function () {
+        let receivedParams: SearchParams | undefined
+        uriHandler.onPath('/my/path', (q) => {
+            receivedParams = q as SearchParams
+        })
+
+        const uri = makeUri('sessionId=s1&streamUrl=wss%3A%2F%2Fhost&token=tok1')
+        await uriHandler.handleUri(uri)
+
+        assert.ok(receivedParams)
+        assert.strictEqual(receivedParams!.get('sessionId'), 's1')
+        assert.strictEqual(receivedParams!.get('streamUrl'), 'wss://host')
+        assert.strictEqual(receivedParams!.get('token'), 'tok1')
+    })
+})


### PR DESCRIPTION
 ##Problem

When Cursor (cursor://) or Kiro (kiro://) handle deep link URIs, their OS protocol handlers percent-encode the query string delimiters before delivering the URI to the extension:
  - = becomes %3D
  - & becomes %26
  
This causes URLSearchParams to see the entire query as a single malformed parameter, so fields like refreshUrl, sessionId, and streamUrl cannot be parsed. As a result, reconnection never works for Cursor/Kiro — the refreshUrl is lost and the toolkit cannot trigger browser-based session refresh.
VS Code does not exhibit this behavior — it preserves real delimiters in the query string.

##Solution

After the existing + → %2B and &amp; → & normalizations, decode %3D → = and %26 → & in the query string (only after the ?, not in the path) before constructing the URL object.
This is a no-op for VS Code (which never has %3D/%26 as encoded delimiters in the query), so existing Studio and HyperPod VS Code flows are unaffected.

##Testing

- Verified VS Code deep links still parse correctly (no %3D/%26 in query from VS Code)
- Verified Cursor/Kiro deep links now parse all params including refreshUrl
- Reconnection flow tested end-to-end with Cursor


Note: This PR is a follow up of the main PR: https://github.com/aws/aws-toolkit-vscode/pull/8779
Hence, it will not include changelog entry.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
