### PR TITLE
fix(amazonq): remove "Try Amazon Q" install prompt from AWS Toolkit (#8809)

### DIFF
--- a/.changes/next-release/Removal-remove-amazon-q-install-prompt.json
+++ b/.changes/next-release/Removal-remove-amazon-q-install-prompt.json
@@ -1,0 +1,4 @@
+{
+    "type": "Removal",
+    "description": "No longer prompts users to install Amazon Q on startup"
+}

--- a/packages/core/src/extensionNode.ts
+++ b/packages/core/src/extensionNode.ts
@@ -51,7 +51,6 @@ import globals from './shared/extensionGlobals'
 import { Experiments, Settings, showSettingsFailedMsg } from './shared/settings'
 import { isReleaseVersion } from './shared/vscode/env'
 import { AuthStatus, AuthUserState, telemetry } from './shared/telemetry/telemetry'
-import { ExtStartUpSources } from './shared/telemetry/util'
 import { Auth } from './auth/auth'
 import { getTelemetryMetadataForConn } from './auth/connection'
 import { registerSubmitFeedback } from './feedback/vue/submitFeedback'
@@ -59,8 +58,6 @@ import { activateCommon, deactivateCommon } from './extension'
 import { learnMoreAmazonQCommand, qExtensionPageCommand, dismissQTree } from './amazonq/explorer/amazonQChildrenNodes'
 import { codeWhispererCoreScopes } from './codewhisperer/util/authUtil'
 import { installAmazonQExtension } from './codewhisperer/commands/basicCommands'
-import { VSCODE_EXTENSION_ID } from './shared/extensions'
-import { isExtensionInstalled } from './shared/utilities/vsCodeUtils'
 import { ExtensionUse, getAuthFormIdsFromConnection, initializeCredentialsProviderManager } from './auth/utils'
 import { activate as activateThreatComposerEditor } from './threatComposer/activation'
 import { isSsoConnection, hasScopes } from './auth/connection'
@@ -202,8 +199,6 @@ export async function activate(context: vscode.ExtensionContext) {
             qExtensionPageCommand.register()
             dismissQTree.register()
             installAmazonQExtension.register()
-
-            await handleAmazonQInstall()
         }
 
         await activateSageMakerUnifiedStudio(extContext)
@@ -280,52 +275,6 @@ export async function deactivate() {
     await Promise.all([await (await CrashMonitoring.instance())?.shutdown(), deactivateCommon(), deactivateEc2()])
     globals.sdkClientBuilderV3.clearServiceCache()
     await globals.resourceManager.dispose()
-}
-
-async function handleAmazonQInstall() {
-    const dismissedInstall = globals.globalState.get<boolean>('aws.toolkit.amazonqInstall.dismissed')
-    if (dismissedInstall) {
-        return
-    }
-
-    if (isExtensionInstalled(VSCODE_EXTENSION_ID.amazonq)) {
-        await globals.globalState.update('aws.toolkit.amazonqInstall.dismissed', true)
-        return
-    }
-
-    await telemetry.toolkit_showNotification.run(async () => {
-        telemetry.record({ id: 'amazonQStandaloneChange' })
-        void vscode.window
-            .showInformationMessage(
-                'Try Amazon Q, a generative AI assistant, with chat and code suggestions.',
-                'Install',
-                'Learn More'
-            )
-            .then(async (resp) => {
-                await telemetry.toolkit_invokeAction.run(async () => {
-                    telemetry.record({
-                        source: ExtensionUse.instance.isFirstUse()
-                            ? ExtStartUpSources.firstStartUp
-                            : ExtStartUpSources.none,
-                    })
-
-                    if (resp === 'Learn More') {
-                        // Clicking learn more will open the q extension page
-                        telemetry.record({ action: 'learnMore' })
-                        await qExtensionPageCommand.execute()
-                        return
-                    }
-
-                    if (resp === 'Install') {
-                        telemetry.record({ action: 'installAmazonQ' })
-                        await installAmazonQExtension.execute()
-                    } else {
-                        telemetry.record({ action: 'dismissQNotification' })
-                    }
-                    await globals.globalState.update('aws.toolkit.amazonqInstall.dismissed', true)
-                })
-            })
-    })
 }
 
 function recordToolkitInitialization(activationStartedOn: number, settingsValid: boolean, logger?: Logger) {


### PR DESCRIPTION
## Problem

Closes #8809.

A fresh install of the AWS Toolkit for VS Code shows an unsolicited notification on startup:

> Try Amazon Q, a generative AI assistant, with chat and code suggestions.

Per the [Amazon Q Developer end-of-support announcement](https://aws.amazon.com/blogs/devops/amazon-q-developer-end-of-support-announcement/) (new signups end **2026-05-15**, end of support **2027-04-30**), this prompt should no longer be shown.

## Change

Removes the install prompt from the AWS Toolkit node activation path (`packages/core/src/extensionNode.ts`):

- Deletes `handleAmazonQInstall()` — the `showInformationMessage` toast with **Install** / **Learn More** actions and its telemetry/dismissal handling.
- Removes its single call site in `activate()` (inside the `if (!isSageMaker())` block).
- Removes the now-unused imports `ExtStartUpSources`, `VSCODE_EXTENSION_ID`, and `isExtensionInstalled`.

### Intentionally unchanged (out of scope)

- The Amazon Q **explorer tree** nodes (`learnMoreAmazonQCommand`, `qExtensionPageCommand`, `dismissQTree`, `installAmazonQExtension` registrations) — a separate UI surface not referenced by the issue. `qExtensionPageCommand` and `installAmazonQExtension` remain imported because they are still used by those registrations.

## Changelog

Added `.changes/next-release/Removal-remove-amazon-q-install-prompt.json` (type `Removal`).

## Testing

- `git diff` confirms a pure deletion of the prompt function, its call site, and the three now-unused imports (`2 files changed, 4 insertions(+), 51 deletions(-)`).
- Verified no remaining references to the removed symbols (`handleAmazonQInstall`, `ExtStartUpSources`, `VSCODE_EXTENSION_ID`, `isExtensionInstalled`), and that the retained Amazon Q imports are still used by the explorer-tree registrations.

> Note: I was unable to run the full monorepo `npm install` + build/lint locally; the GitHub Actions CI on this PR will exercise compile, lint, and tests. This is a deletion-only change.
