### PR TITLE
fix(sagemaker): broker stays alive when local process list is large

### DIFF
--- a/.changes/next-release/Bug Fix-af1ed8c2-9c47-484d-8412-e10953b0c6e4.json
+++ b/.changes/next-release/Bug Fix-af1ed8c2-9c47-484d-8412-e10953b0c6e4.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SageMaker remote connection fails to start when many processes are running on the local machine"
+}

--- a/packages/core/src/awsService/sagemaker/detached-server/server.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/server.ts
@@ -19,6 +19,10 @@ import { execFile } from 'child_process'
 
 const pollInterval = 30 * 60 * 100 // 30 minutes
 
+// Allow a large process table: the default execFile maxBuffer (1 MiB) can be exceeded by `ps`
+// output when other processes have large argv, causing the liveness check to fail spuriously.
+const psMaxBuffer = 1024 * 1024 * 64
+
 /**
  * Generic IDE process patterns for detection across all VS Code forks.
  * Darwin uses a broad pattern to automatically support new Electron-based IDE forks.
@@ -84,7 +88,7 @@ function checkVSCodeWindows(): Promise<boolean> {
 
         if (platform === 'win32') {
             // Check for any VS Code fork process
-            execFile('tasklist', [], (err, stdout) => {
+            execFile('tasklist', [], { maxBuffer: psMaxBuffer }, (err, stdout) => {
                 if (err) {
                     resolve(false)
                     return
@@ -92,7 +96,7 @@ function checkVSCodeWindows(): Promise<boolean> {
                 resolve(ideProcessPatterns.windows.test(stdout))
             })
         } else if (platform === 'darwin') {
-            execFile('ps', ['aux'], (err, stdout) => {
+            execFile('ps', ['aux'], { maxBuffer: psMaxBuffer }, (err, stdout) => {
                 if (err) {
                     resolve(false)
                     return
@@ -102,7 +106,7 @@ function checkVSCodeWindows(): Promise<boolean> {
                 resolve(found)
             })
         } else {
-            execFile('ps', ['-A', '-o', 'comm'], (err, stdout) => {
+            execFile('ps', ['-A', '-o', 'comm'], { maxBuffer: psMaxBuffer }, (err, stdout) => {
                 if (err) {
                     resolve(false)
                     return


### PR DESCRIPTION
Problem: The SageMaker detached SSM-broker server's IDE-liveness watchdog runs `ps` (darwin/linux) / `tasklist` (windows) via Node's `child_process.execFile`, whose default `maxBuffer` is 1 MiB. The detection treats *any* `execFile` error as "no IDE running" and calls `process.exit(0)`. When the local process table is large — easy to hit when another process has a big argv — `ps aux` output exceeds 1 MiB, the first watchdog check fails with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`, and the broker exits right after starting. Every subsequent SageMaker remote-SSH connection then fails with `Failed to get SSM session info. HTTP status: 000` (the `sagemaker_connect` ProxyCommand curls a port nothing is listening on).

Solution: Pass an explicit larger `maxBuffer` (64 MiB) to the three process-detection `execFile` calls (`ps aux`, `ps -A -o comm`, `tasklist`) so a large process table no longer produces a spurious `maxBuffer` error and shutdown. Detection logic and regexes are unchanged; the diff is limited to the touched function.

Tests: No unit test added. The change only passes an `execFile` options object.

Fixes #8811