### PR TITLE
fix: Audit codebase and fix uses of path.join with unsanitized user input

### DIFF
--- a/packages/core/src/applicationcomposer/messageHandlers/loadFileMessageHandler.ts
+++ b/packages/core/src/applicationcomposer/messageHandlers/loadFileMessageHandler.ts
@@ -32,6 +32,10 @@ export async function loadFileMessageHandler(request: LoadFileRequestMessage, co
             }
             default: {
                 const filePath = path.join(context.workSpacePath, request.fileName)
+                const normalizedPath = path.resolve(filePath)
+                if (!normalizedPath.startsWith(path.resolve(context.workSpacePath) + path.sep)) {
+                    throw new Error(`Path is outside of workspace: ${request.fileName}`)
+                }
                 const fileContents = (await vscode.workspace.fs.readFile(vscode.Uri.file(filePath))).toString()
                 loadFileResponseMessage = {
                     messageType: MessageType.RESPONSE,

--- a/packages/core/src/applicationcomposer/messageHandlers/saveFileMessageHandler.ts
+++ b/packages/core/src/applicationcomposer/messageHandlers/saveFileMessageHandler.ts
@@ -12,6 +12,21 @@ export async function saveFileMessageHandler(request: SaveFileRequestMessage, co
     // If filePath is empty, save contents in default template file
     const filePath =
         request.filePath === '' ? context.defaultTemplatePath : path.join(context.workSpacePath, request.filePath)
+    const normalizedPath = path.resolve(filePath)
+    if (
+        !normalizedPath.startsWith(path.resolve(context.workSpacePath) + path.sep) &&
+        normalizedPath !== path.resolve(context.defaultTemplatePath)
+    ) {
+        await context.panel.webview.postMessage({
+            messageType: MessageType.RESPONSE,
+            command: Command.SAVE_FILE,
+            eventId: request.eventId,
+            filePath: filePath,
+            isSuccess: false,
+            failureReason: `Path is outside of workspace: ${request.filePath}`,
+        } satisfies SaveFileResponseMessage)
+        return
+    }
     try {
         if (!context.textDocument.isDirty) {
             const contents = Buffer.from(request.fileContents, 'utf8')

--- a/packages/core/src/auth/sso/server.ts
+++ b/packages/core/src/auth/sso/server.ts
@@ -87,16 +87,23 @@ export class AuthSSOServer {
                     break
                 }
                 default: {
+                    const extensionRoot = path.resolve(globals.context.extensionUri.fsPath)
                     if (url.pathname.startsWith('/resources')) {
-                        const iconPath = path.join(globals.context.extensionUri.fsPath, url.pathname)
+                        const iconPath = path.resolve(extensionRoot, url.pathname.slice(1))
+                        if (!iconPath.startsWith(extensionRoot + path.sep)) {
+                            res.writeHead(403)
+                            res.end()
+                            break
+                        }
                         await this.loadResource(res, iconPath)
                         break
                     }
-                    const resourcePath = path.join(
-                        globals.context.extensionUri.fsPath,
-                        'dist/src/auth/sso/vue',
-                        url.pathname
-                    )
+                    const resourcePath = path.resolve(extensionRoot, 'dist/src/auth/sso/vue', url.pathname.slice(1))
+                    if (!resourcePath.startsWith(extensionRoot + path.sep)) {
+                        res.writeHead(403)
+                        res.end()
+                        break
+                    }
                     await this.loadResource(res, resourcePath)
                     break
                 }

--- a/packages/core/src/codewhisperer/vue/backend.ts
+++ b/packages/core/src/codewhisperer/vue/backend.ts
@@ -28,8 +28,12 @@ export class CodeWhispererWebview extends VueWebview {
 
     private isFileSaved: boolean = false
     private getLocalFilePath(fileName: string): string {
-        // This will store the files in the global storage path of VSCode
-        return path.join(globals.context.globalStorageUri.fsPath, fileName)
+        const baseDir = path.resolve(globals.context.globalStorageUri.fsPath)
+        const resolved = path.resolve(baseDir, fileName)
+        if (!resolved.startsWith(baseDir + path.sep)) {
+            throw new Error(`Path is outside of storage directory: ${fileName}`)
+        }
+        return resolved
     }
 
     // This function opens TypeScript/JavaScript/Python/Java/C# file in the editor.

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -588,10 +588,12 @@ export class ChatController {
             const userPromptsDirectory = getUserPromptsDirectory()
 
             const title = message.action.formItemValues?.['prompt-name']
-            const newFilePath = path.join(
-                userPromptsDirectory,
-                title ? `${title}${promptFileExtension}` : `default${promptFileExtension}`
-            )
+            const fileName = title ? `${title}${promptFileExtension}` : `default${promptFileExtension}`
+            if (fileName.includes('/') || fileName.includes('\\') || fileName.includes('..')) {
+                getLogger().warn(`warn: caller attempted to break out of userPromptsDirectory with path ${fileName}`)
+                return
+            }
+            const newFilePath = path.join(userPromptsDirectory, fileName)
             const newFileContent = new Uint8Array(Buffer.from(''))
             await fs.writeFile(newFilePath, newFileContent, { mode: 0o600 })
             const newFileDoc = await vscode.workspace.openTextDocument(newFilePath)
@@ -619,14 +621,22 @@ export class ChatController {
         if (!projectRoot) {
             return
         }
-        let absoluteFilePath = path.join(projectRoot, message.filePath)
+        let absoluteFilePath = path.resolve(projectRoot, message.filePath)
+        if (!absoluteFilePath.startsWith(path.resolve(projectRoot) + path.sep)) {
+            getLogger().warn(`warn: caller attempted to break out of projectRoot with path ${message.filePath}`)
+            return
+        }
 
         // Handle clicking on a user prompt outside the workspace
         if (message.filePath.endsWith(promptFileExtension)) {
             try {
                 await vscode.workspace.fs.stat(vscode.Uri.file(absoluteFilePath))
             } catch {
-                absoluteFilePath = path.join(getUserPromptsDirectory(), message.filePath)
+                const promptsDir = path.resolve(getUserPromptsDirectory())
+                absoluteFilePath = path.resolve(promptsDir, message.filePath)
+                if (!absoluteFilePath.startsWith(promptsDir + path.sep)) {
+                    return
+                }
             }
         }
 

--- a/packages/core/src/codewhispererChat/controllers/chat/tabBarController.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/tabBarController.ts
@@ -22,6 +22,11 @@ export class TabBarController {
     private loadedChats: boolean = false
     private searchTimeout: NodeJS.Timeout | undefined = undefined
     private readonly DebounceTime = 300 // milliseconds
+    // The Uri where chats will be saved is passed through multiple components. In order to prevent intermediate
+    // components from manipulating the save destination, we record the user-chosen location the moment the user
+    // clicks the save button and validate that the passed-through value still matches when we get to the point
+    // of performing the export.
+    private readonly pendingSaveUris = new Set<string>()
 
     constructor(messenger: Messenger) {
         this.messenger = messenger
@@ -132,6 +137,10 @@ export class TabBarController {
     }
 
     async processSaveChat(message: SaveChatMessage) {
+        if (!this.pendingSaveUris.delete(message.uri)) {
+            void vscode.window.showErrorMessage('An error occurred while exporting your chat.')
+            return
+        }
         try {
             await fs.writeFile(message.uri, message.serializedChat)
         } catch (error) {
@@ -175,6 +184,7 @@ export class TabBarController {
         if (saveUri) {
             // Determine format from file extension
             const format = saveUri.fsPath.endsWith('.md') ? 'markdown' : 'html'
+            this.pendingSaveUris.add(saveUri.fsPath)
             this.messenger.sendSerializeTabMessage(message.tabID, saveUri.fsPath, format)
         }
     }

--- a/packages/core/src/test/applicationcomposer/messageHandlers/loadFileMessageHandler.test.ts
+++ b/packages/core/src/test/applicationcomposer/messageHandlers/loadFileMessageHandler.test.ts
@@ -1,0 +1,93 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import sinon from 'sinon'
+import { createTemplate, createWebviewContext } from '../utils'
+import { loadFileMessageHandler } from '../../../applicationcomposer/messageHandlers/loadFileMessageHandler'
+import { Command, MessageType } from '../../../applicationcomposer/types'
+
+describe('loadFileMessageHandler', function () {
+    afterEach(function () {
+        sinon.restore()
+    })
+
+    it('rejects path traversal via relative path', async function () {
+        const panel = await createTemplate()
+        const postMessageSpy = sinon.spy(panel.webview, 'postMessage')
+        const context = await createWebviewContext({
+            panel,
+            workSpacePath: '/workspace/project',
+            defaultTemplatePath: '/workspace/project/template.yaml',
+        })
+
+        await loadFileMessageHandler(
+            {
+                command: Command.LOAD_FILE,
+                messageType: MessageType.REQUEST,
+                eventId: '1',
+                fileName: '../../etc/passwd',
+            },
+            context
+        )
+
+        assert.ok(postMessageSpy.calledOnce)
+        const response = postMessageSpy.getCall(0).args[0]
+        assert.strictEqual(response.isSuccess, false)
+        assert.ok(response.failureReason.includes('outside of workspace'))
+    })
+
+    it('rejects deeply nested traversal', async function () {
+        const panel = await createTemplate()
+        const postMessageSpy = sinon.spy(panel.webview, 'postMessage')
+        const context = await createWebviewContext({
+            panel,
+            workSpacePath: '/workspace/project',
+            defaultTemplatePath: '/workspace/project/template.yaml',
+        })
+
+        await loadFileMessageHandler(
+            {
+                command: Command.LOAD_FILE,
+                messageType: MessageType.REQUEST,
+                eventId: '2',
+                fileName: 'subdir/../../../etc/shadow',
+            },
+            context
+        )
+
+        assert.ok(postMessageSpy.calledOnce)
+        const response = postMessageSpy.getCall(0).args[0]
+        assert.strictEqual(response.isSuccess, false)
+        assert.ok(response.failureReason.includes('outside of workspace'))
+    })
+
+    it('allows valid relative path within workspace', async function () {
+        const panel = await createTemplate()
+        const postMessageSpy = sinon.spy(panel.webview, 'postMessage')
+        const context = await createWebviewContext({
+            panel,
+            workSpacePath: '/workspace/project',
+            defaultTemplatePath: '/workspace/project/template.yaml',
+        })
+
+        await loadFileMessageHandler(
+            {
+                command: Command.LOAD_FILE,
+                messageType: MessageType.REQUEST,
+                eventId: '3',
+                fileName: 'subdir/template.yaml',
+            },
+            context
+        )
+
+        assert.ok(postMessageSpy.calledOnce)
+        const response = postMessageSpy.getCall(0).args[0]
+        // Should not fail with "outside of workspace" — may fail for file-not-found, which is fine
+        if (!response.isSuccess) {
+            assert.ok(!response.failureReason.includes('outside of workspace'))
+        }
+    })
+})

--- a/packages/core/src/test/applicationcomposer/messageHandlers/saveFileMessageHandler.test.ts
+++ b/packages/core/src/test/applicationcomposer/messageHandlers/saveFileMessageHandler.test.ts
@@ -1,0 +1,100 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import sinon from 'sinon'
+import path from 'path'
+import { createTemplate, createWebviewContext } from '../utils'
+import { saveFileMessageHandler } from '../../../applicationcomposer/messageHandlers/saveFileMessageHandler'
+import { Command, MessageType } from '../../../applicationcomposer/types'
+
+describe('saveFileMessageHandler', function () {
+    afterEach(function () {
+        sinon.restore()
+    })
+
+    it('rejects path traversal via relative path', async function () {
+        const panel = await createTemplate()
+        const postMessageSpy = sinon.spy(panel.webview, 'postMessage')
+        const context = await createWebviewContext({
+            panel,
+            workSpacePath: '/workspace/project',
+            defaultTemplatePath: '/workspace/project/template.yaml',
+        })
+
+        await saveFileMessageHandler(
+            {
+                command: Command.SAVE_FILE,
+                messageType: MessageType.REQUEST,
+                eventId: '1',
+                filePath: '../../etc/malicious',
+                fileContents: 'malicious content',
+            },
+            context
+        )
+
+        assert.ok(postMessageSpy.calledOnce)
+        const response = postMessageSpy.getCall(0).args[0]
+        assert.strictEqual(response.isSuccess, false)
+        assert.ok(response.failureReason.includes('outside of workspace'))
+    })
+
+    it('rejects path traversal via absolute path component', async function () {
+        const panel = await createTemplate()
+        const postMessageSpy = sinon.spy(panel.webview, 'postMessage')
+        const context = await createWebviewContext({
+            panel,
+            workSpacePath: '/workspace/project',
+            defaultTemplatePath: '/workspace/project/template.yaml',
+        })
+
+        await saveFileMessageHandler(
+            {
+                command: Command.SAVE_FILE,
+                messageType: MessageType.REQUEST,
+                eventId: '2',
+                filePath: '../../../tmp/evil',
+                fileContents: 'malicious content',
+            },
+            context
+        )
+
+        assert.ok(postMessageSpy.calledOnce)
+        const response = postMessageSpy.getCall(0).args[0]
+        assert.strictEqual(response.isSuccess, false)
+        assert.ok(response.failureReason.includes('outside of workspace'))
+    })
+
+    it('allows valid relative path within workspace', async function () {
+        const panel = await createTemplate()
+        const postMessageSpy = sinon.spy(panel.webview, 'postMessage')
+        const tmpDir = path.join(__dirname, 'tmp-test-workspace')
+        const context = await createWebviewContext({
+            panel,
+            workSpacePath: tmpDir,
+            defaultTemplatePath: path.join(tmpDir, 'template.yaml'),
+        })
+
+        // This should NOT be rejected by the path traversal check
+        // (it may fail for other reasons like the directory not existing, which is fine)
+        await saveFileMessageHandler(
+            {
+                command: Command.SAVE_FILE,
+                messageType: MessageType.REQUEST,
+                eventId: '3',
+                filePath: 'subdir/file.yaml',
+                fileContents: 'safe content',
+            },
+            context
+        )
+
+        assert.ok(postMessageSpy.calledOnce)
+        const response = postMessageSpy.getCall(0).args[0]
+        // Should not fail with "outside of workspace" error
+        if (!response.isSuccess) {
+            assert.ok(!response.failureReason.includes('outside of workspace'))
+        }
+    })
+})

--- a/packages/core/src/test/codewhispererChat/controllers/chat/pathTraversal.test.ts
+++ b/packages/core/src/test/codewhispererChat/controllers/chat/pathTraversal.test.ts
@@ -1,0 +1,77 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import * as path from 'path'
+
+/**
+ * Tests for the path traversal validation patterns used in:
+ * - controller.ts processCustomFormAction (filename check)
+ * - controller.ts processFileClickMessage (path.resolve + startsWith check)
+ * - backend.ts getLocalFilePath (path.resolve + startsWith check)
+ */
+describe('path traversal validation', function () {
+    describe('filename validation (processCustomFormAction pattern)', function () {
+        function isValidFileName(fileName: string): boolean {
+            return !fileName.includes('/') && !fileName.includes('\\') && !fileName.includes('..')
+        }
+
+        it('rejects path with forward slash', function () {
+            assert.strictEqual(isValidFileName('../../etc/passwd.md'), false)
+        })
+
+        it('rejects path with backslash', function () {
+            assert.strictEqual(isValidFileName('..\\..\\etc\\passwd.md'), false)
+        })
+
+        it('rejects path with double dots', function () {
+            assert.strictEqual(isValidFileName('..secret.md'), false)
+        })
+
+        it('allows simple filename', function () {
+            assert.strictEqual(isValidFileName('my-prompt.md'), true)
+        })
+
+        it('allows filename with spaces', function () {
+            assert.strictEqual(isValidFileName('my prompt name.md'), true)
+        })
+
+        it('allows filename with single dot', function () {
+            assert.strictEqual(isValidFileName('my.prompt.md'), true)
+        })
+    })
+
+    describe('directory containment check (processFileClickMessage pattern)', function () {
+        function isInsideDirectory(baseDir: string, filePath: string): boolean {
+            const resolvedBase = path.resolve(baseDir)
+            const resolvedPath = path.resolve(baseDir, filePath)
+            return resolvedPath.startsWith(resolvedBase + path.sep)
+        }
+
+        it('rejects traversal above base directory', function () {
+            assert.strictEqual(isInsideDirectory('/workspace/project', '../../etc/passwd'), false)
+        })
+
+        it('rejects embedded traversal', function () {
+            assert.strictEqual(isInsideDirectory('/workspace/project', 'subdir/../../../etc/shadow'), false)
+        })
+
+        it('rejects path that resolves to base dir itself', function () {
+            assert.strictEqual(isInsideDirectory('/workspace/project', ''), false)
+        })
+
+        it('allows valid relative path', function () {
+            assert.strictEqual(isInsideDirectory('/workspace/project', 'src/main.ts'), true)
+        })
+
+        it('allows nested valid path', function () {
+            assert.strictEqual(isInsideDirectory('/workspace/project', 'a/b/c/file.ts'), true)
+        })
+
+        it('allows path with harmless dot-dot that stays within base', function () {
+            assert.strictEqual(isInsideDirectory('/workspace/project', 'a/../b/file.ts'), true)
+        })
+    })
+})

--- a/packages/core/src/test/codewhispererChat/controllers/chat/tabBarController.test.ts
+++ b/packages/core/src/test/codewhispererChat/controllers/chat/tabBarController.test.ts
@@ -1,0 +1,70 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import sinon from 'sinon'
+import fs from '../../../../shared/fs/fs'
+import { TabBarController } from '../../../../codewhispererChat/controllers/chat/tabBarController'
+import { Messenger } from '../../../../codewhispererChat/controllers/chat/messenger/messenger'
+
+describe('TabBarController', function () {
+    let tabBarController: TabBarController
+    let writeFileStub: sinon.SinonStub
+
+    beforeEach(function () {
+        const messenger = sinon.createStubInstance(Messenger) as unknown as Messenger
+        tabBarController = new TabBarController(messenger)
+        writeFileStub = sinon.stub(fs, 'writeFile').resolves()
+    })
+
+    afterEach(function () {
+        sinon.restore()
+    })
+
+    describe('processSaveChat', function () {
+        it('rejects write to uri that was not approved via save dialog', async function () {
+            await tabBarController.processSaveChat({
+                uri: '/tmp/malicious-path.md',
+                serializedChat: 'evil content',
+            })
+
+            assert.ok(writeFileStub.notCalled, 'writeFile should not be called for unapproved URI')
+        })
+
+        it('allows write to uri that was previously approved', async function () {
+            const approvedUri = '/home/user/workspace/chat-export.md'
+
+            ;(tabBarController as any).pendingSaveUris.add(approvedUri)
+
+            await tabBarController.processSaveChat({
+                uri: approvedUri,
+                serializedChat: '# Chat Export',
+            })
+
+            assert.ok(writeFileStub.calledOnce, 'writeFile should be called for approved URI')
+            assert.strictEqual(writeFileStub.getCall(0).args[0], approvedUri)
+            assert.strictEqual(writeFileStub.getCall(0).args[1], '# Chat Export')
+        })
+
+        it('does not allow reuse of an approved uri', async function () {
+            const approvedUri = '/home/user/workspace/chat-export.md'
+            ;(tabBarController as any).pendingSaveUris.add(approvedUri)
+
+            // First call succeeds
+            await tabBarController.processSaveChat({
+                uri: approvedUri,
+                serializedChat: 'content',
+            })
+            assert.ok(writeFileStub.calledOnce)
+
+            // Second call with same URI is rejected (one-time use)
+            await tabBarController.processSaveChat({
+                uri: approvedUri,
+                serializedChat: 'different content',
+            })
+            assert.ok(writeFileStub.calledOnce, 'writeFile should not be called again for consumed URI')
+        })
+    })
+})

--- a/packages/core/src/test/credentials/sso/server.test.ts
+++ b/packages/core/src/test/credentials/sso/server.test.ts
@@ -134,6 +134,24 @@ describe('AuthSSOServer', function () {
         assert.ok(isUserCancelledError(err.inner), 'CancellationError not thrown.')
     })
 
+    it('rejects path traversal in resource requests', async function () {
+        const address = server.getAddress()
+        assert.ok(address instanceof Object)
+        const baseUrl = `http://127.0.0.1:${address.port}`
+
+        const response = await request.fetch('GET', `${baseUrl}/resources/../../etc/passwd`).response
+        assert.strictEqual(response.status, 403)
+    })
+
+    it('rejects path traversal in default resource requests', async function () {
+        const address = server.getAddress()
+        assert.ok(address instanceof Object)
+        const baseUrl = `http://127.0.0.1:${address.port}`
+
+        const response = await request.fetch('GET', `${baseUrl}/../../etc/passwd`).response
+        assert.strictEqual(response.status, 403)
+    })
+
     it('initializes and closes instances', async function () {
         const newServer = AuthSSOServer.init('1234')
         assert.equal(AuthSSOServer.lastInstance, newServer)


### PR DESCRIPTION
which could lead to unintentional path traversal outside the expected directory

## Problem

We received a report from a bug bounty hunter pointing out a path traversal in the application composer save/load handlers. As part of resolution, I audited other parts of the code to find places where untrusted input could be used to read or write files outside of the intended directory, so I've replaced those path.join statements with path.resolve to fetch the on-disk path and validate it's still inside the directory.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
