### PR TITLE
Add changelog entry for path traversal validation fix

### DIFF
--- a/packages/toolkit/.changes/next-release/bugfix-path-traversal-validation.json
+++ b/packages/toolkit/.changes/next-release/bugfix-path-traversal-validation.json
@@ -1,0 +1,4 @@
+{
+  "type": "Bug Fix",
+  "description": "Added enhanced validation when handling user input filesystem paths for Application Composer, auth server, and CodeWhisperer Chat to ensure files are not read or written outside the intended directory."
+}


### PR DESCRIPTION
## Problem

This file is needed to appear in the changelog for the upcoming release.

## Solution

Added the file

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
