### PR TITLE
fix(threatcomposer): fix ConfigurationChangeEvent type casing

### DIFF
--- a/packages/core/src/threatComposer/threatComposerEditorProvider.ts
+++ b/packages/core/src/threatComposer/threatComposerEditorProvider.ts
@@ -43,7 +43,7 @@ export class ThreatComposerEditorProvider implements vscode.CustomTextEditorProv
         const provider = new ThreatComposerEditorProvider(context)
 
         context.subscriptions.push(
-            vscode.workspace.onDidChangeConfiguration(async (configurationChangeEvent: vscode.configurationChangeEvent) => {
+            vscode.workspace.onDidChangeConfiguration(async (configurationChangeEvent: vscode.ConfigurationChangeEvent) => {
                 if (configurationChangeEvent.affectsConfiguration('aws.threatComposer.cdn')) {
                     // Clear cached content
                     provider.webviewHtml = ''


### PR DESCRIPTION
## Problem
Commit be2201004 introduced a type annotation typo: `vscode.configurationChangeEvent` (lowercase 'c') instead of the correct `vscode.ConfigurationChangeEvent`. This causes a TS2724 compilation error that breaks 27/36 CI checks.

## Fix
Corrected the casing of `ConfigurationChangeEvent` in `packages/core/src/threatComposer/threatComposerEditorProvider.ts` line 46.

## Tests
- TypeScript compilation passes for the affected file
- No other instances of this typo exist in the codebase