### PR TITLE
fix(threatcomposer): fix ConfigurationChangeEvent type casing

### DIFF
--- a/packages/core/src/threatComposer/threatComposerEditorProvider.ts
+++ b/packages/core/src/threatComposer/threatComposerEditorProvider.ts
@@ -20,8 +20,10 @@ const localize = nls.loadMessageBundle()
 // Change this to true for local dev
 const isLocalDev = false
 const localhost = 'http://127.0.0.1:3000'
-function getCdn(): string { 
-    return vscode.workspace.getConfiguration('aws.threatComposer').get('cdn', 'https://ide-toolkits.threat-composer.aws.dev')
+function getCdn(): string {
+    return vscode.workspace
+        .getConfiguration('aws.threatComposer')
+        .get('cdn', 'https://ide-toolkits.threat-composer.aws.dev')
 }
 let clientId = ''
 
@@ -43,19 +45,21 @@ export class ThreatComposerEditorProvider implements vscode.CustomTextEditorProv
         const provider = new ThreatComposerEditorProvider(context)
 
         context.subscriptions.push(
-            vscode.workspace.onDidChangeConfiguration(async (configurationChangeEvent: vscode.configurationChangeEvent) => {
-                if (configurationChangeEvent.affectsConfiguration('aws.threatComposer.cdn')) {
-                    // Clear cached content
-                    provider.webviewHtml = ''
-                    // Closed all open Threat Composer editors
-                    for (const visualization of provider.managedVisualizations.values()) {
-                        const panel = visualization.getPanel()
-                        if (panel) {
-                            panel.dispose()
+            vscode.workspace.onDidChangeConfiguration(
+                async (configurationChangeEvent: vscode.ConfigurationChangeEvent) => {
+                    if (configurationChangeEvent.affectsConfiguration('aws.threatComposer.cdn')) {
+                        // Clear cached content
+                        provider.webviewHtml = ''
+                        // Closed all open Threat Composer editors
+                        for (const visualization of provider.managedVisualizations.values()) {
+                            const panel = visualization.getPanel()
+                            if (panel) {
+                                panel.dispose()
+                            }
                         }
                     }
                 }
-            })
+            )
         )
 
         return vscode.window.registerCustomEditorProvider(ThreatComposerEditorProvider.viewType, provider, {


### PR DESCRIPTION
## Problem

Commit be2201004 introduced a type annotation typo: `vscode.configurationChangeEvent` (lowercase 'c') instead of the correct `vscode.ConfigurationChangeEvent`. This causes a TS2724 compilation error that breaks 27/36 CI checks.

## Solution

Corrected the casing of `ConfigurationChangeEvent` in `packages/core/src/threatComposer/threatComposerEditorProvider.ts` line 46.