### PR TITLE
feat(cloudformation): Update how cloudformation lsp determines clientId

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 packages/core/src/codewhisperer/ @aws/codewhisperer-team
 packages/core/src/amazonqFeatureDev/ @aws/earlybird
 packages/core/src/awsService/accessanalyzer/ @aws/access-analyzer
-packages/core/src/awsService/cloudformation/ @aws/cfn-dev-productivity
+packages/core/src/awsService/cloudformation/ @aws-cloudformation/cfn-dev-productivity
 packages/core/src/awsService/sagemaker/ @aws/sagemaker-code-editor
 packages/core/resources/sagemaker_connect* @aws/sagemaker-code-editor
 packages/core/resources/hyperpod_connect* @aws/sagemaker-code-editor

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -198,12 +198,18 @@ jobs:
                     - os: macos-latest
                       node-version: 18.x
                       vscode-version: stable
+                      test-user-dir: '/tmp/.vscode-test/user-data/'
                     - os: windows-latest
                       node-version: 20.x
                       vscode-version: stable
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
+            # Keep the VS Code user-data-dir path short on the POSIX runners. The default
+            # path under the checkout dir exceeds the Unix-domain-socket path limit (~103
+            # on macOS), so VS Code fails to launch with "listen EINVAL".
+            # Honored by launchTestUtilities.ts (adds --user-data-dir); empty = unset.
+            AWS_TOOLKIT_TEST_USER_DIR: ${{ matrix.test-user-dir }}
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}

--- a/packages/core/src/awsService/cloudformation/extension.ts
+++ b/packages/core/src/awsService/cloudformation/extension.ts
@@ -50,7 +50,6 @@ import { openStackTemplateCommand } from './commands/openStackTemplate'
 import { selectRegionCommand } from './commands/regionCommands'
 import { AwsCredentialsService, encryptionKey } from './auth/credentials'
 import { ExtensionId, ExtensionName, CloudFormationTelemetrySettings } from './extensionConfig'
-import { VSCODE_EXTENSION_ID_CONSTANTS } from '../../shared/extensionIds'
 import { commandKey } from './utils'
 import { CloudFormationExplorer } from './explorer/explorer'
 import { handleTelemetryOptIn } from './telemetryOptIn'
@@ -71,7 +70,7 @@ import { RelatedResourceSelector } from './ui/relatedResourceSelector'
 
 import { StackActionCodeLensProvider } from './codelens/stackActionCodeLensProvider'
 import { registerStatusBarCommand } from './ui/statusBar'
-import { getClientId } from '../../shared/telemetry/util'
+import { getClientId, isAnonymousClientId } from '../../shared/telemetry/util'
 import { SettingsLspServerProvider } from './lsp-server/settingsLspServerProvider'
 import { DevLspServerProvider } from './lsp-server/devLspServerProvider'
 import { RemoteLspServerProvider } from './lsp-server/remoteLspServerProvider'
@@ -97,6 +96,8 @@ async function startClient(context: ExtensionContext) {
         ...DevSettings.instance.getServiceConfig('cloudformationLsp', {}),
         ...getServiceEnvVarConfig('cloudformationLsp', ['path', 'cloudformationEndpoint']),
     }
+
+    const clientId = getClientId(globals.globalState, telemetryEnabled)
 
     const serverProvider = new LspServerProvider([
         new DevLspServerProvider(context),
@@ -150,10 +151,10 @@ async function startClient(context: ExtensionContext) {
             aws: {
                 clientInfo: {
                     extension: {
-                        name: VSCODE_EXTENSION_ID_CONSTANTS.awstoolkit,
+                        name: 'toolkit-vscode',
                         version: extensionVersion,
                     },
-                    clientId: getClientId(globals.globalState, telemetryEnabled),
+                    clientId: isAnonymousClientId(clientId) ? undefined : clientId, // Only forward a real client id, otherwise let server handle it
                 },
                 telemetryEnabled: telemetryEnabled,
                 ...(cfnLspConfig.cloudformationEndpoint && {

--- a/packages/core/src/shared/telemetry/util.ts
+++ b/packages/core/src/shared/telemetry/util.ts
@@ -39,6 +39,14 @@ const legacySettingsTelemetryValueEnable = 'Enable'
 const TelemetryFlag = addTypeName('boolean', convertLegacy)
 export const telemetryClientIdEnvKey = '__TELEMETRY_CLIENT_ID'
 
+export const testClientId = 'ffffffff-ffff-ffff-ffff-ffffffffffff' // test/automation environments
+export const telemetryDisabledClientId = '11111111-1111-1111-1111-111111111111' // telemetry disabled
+export const nilClientId = '00000000-0000-0000-0000-000000000000' // client id could not be created or persisted
+
+export function isAnonymousClientId(clientId: string): boolean {
+    return [testClientId, telemetryDisabledClientId, nilClientId].includes(clientId)
+}
+
 export class TelemetryConfig {
     private readonly _toolkitConfig
     private readonly _amazonQConfig
@@ -169,10 +177,10 @@ export const getClientId = memoize(
         nonce?: string
     ) => {
         if (isTest ?? isAutomation()) {
-            return 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+            return testClientId
         }
         if (!isTelemetryEnabled) {
-            return '11111111-1111-1111-1111-111111111111'
+            return telemetryDisabledClientId
         }
         try {
             const globalClientId = process.env[telemetryClientIdEnvKey] // truly global across all extensions
@@ -208,8 +216,7 @@ export const getClientId = memoize(
             return clientId
         } catch (e) {
             getLogger().error('getClientId: failed to create client id: %O', e)
-            const clientId = '00000000-0000-0000-0000-000000000000'
-            return clientId
+            return nilClientId
         }
     }
 )

--- a/packages/core/src/test/shared/telemetry/util.test.ts
+++ b/packages/core/src/test/shared/telemetry/util.test.ts
@@ -18,6 +18,10 @@ import {
     telemetryClientIdEnvKey,
     TelemetryConfig,
     validateMetricEvent,
+    isAnonymousClientId,
+    testClientId,
+    telemetryDisabledClientId,
+    nilClientId,
 } from '../../../shared/telemetry/util'
 import { extensionVersion } from '../../../shared/vscode/env'
 import { FakeMemento } from '../../fakeExtensionContext'
@@ -255,6 +259,24 @@ describe('getClientId', function () {
             await globalState.update('telemetryClientId', 'bbb-222')
             assert.strictEqual(hadClientIdOnStartup(globalState, testGetClientId), true)
         })
+    })
+})
+
+describe('isAnonymousClientId', function () {
+    it('is true for the test/automation sentinel', function () {
+        assert.strictEqual(isAnonymousClientId(testClientId), true)
+    })
+
+    it('is true for the telemetry-disabled sentinel', function () {
+        assert.strictEqual(isAnonymousClientId(telemetryDisabledClientId), true)
+    })
+
+    it('is true for the nil (error) sentinel', function () {
+        assert.strictEqual(isAnonymousClientId(nilClientId), true)
+    })
+
+    it('is false for a real client id', function () {
+        assert.strictEqual(isAnonymousClientId(randomUUID()), false)
     })
 })
 


### PR DESCRIPTION
## Problem
* CloudFormation LSP telemetry enablement and ToolKit telemetry enablement settings are separate, so they cannot share clientId when ToolKit sets it to be anonymous

## Solution
* Use ToolKit clientId when its a valid non anonymous id

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
