### PR TITLE
fix(codecatalyst): Restrict bearer token file permissions to owner-only

### DIFF
--- a/packages/core/src/codecatalyst/commands.ts
+++ b/packages/core/src/codecatalyst/commands.ts
@@ -14,7 +14,7 @@ import { openCodeCatalystUrl } from './utils'
 import { CodeCatalystAuthenticationProvider } from './auth'
 import { Commands, VsCodeCommandArg, placeholder } from '../shared/vscode/commands2'
 import { CodeCatalystClient, CodeCatalystResource, createClient } from '../shared/clients/codecatalystClient'
-import { DevEnvironmentId, getConnectedDevEnv, openDevEnv } from './model'
+import { DevEnvironmentId, deleteBearerTokenCache, getConnectedDevEnv, openDevEnv } from './model'
 import { showConfigureDevEnv } from './vue/configure/backend'
 import { showCreateDevEnv } from './vue/create/backend'
 import { CancellationError } from '../shared/utilities/timeoutUtils'
@@ -99,6 +99,8 @@ export async function stopDevEnv(
         projectName: devenv.project.name,
         spaceName: devenv.org.name,
     })
+
+    await deleteBearerTokenCache(devenv.id)
 }
 
 export async function deleteDevEnv(client: CodeCatalystClient, devenv: DevEnvironmentId): Promise<void> {

--- a/packages/core/src/codecatalyst/model.ts
+++ b/packages/core/src/codecatalyst/model.ts
@@ -79,7 +79,11 @@ export function createCodeCatalystEnvProvider(
 }
 
 export async function cacheBearerToken(bearerToken: string, devenvId: string): Promise<void> {
-    await fs.writeFile(bearerTokenCacheLocation(devenvId), `${bearerToken}`, 'utf8')
+    await fs.writeFile(bearerTokenCacheLocation(devenvId), `${bearerToken}`, { mode: 0o600, atomic: true })
+}
+
+export async function deleteBearerTokenCache(devenvId: string): Promise<void> {
+    await fs.delete(bearerTokenCacheLocation(devenvId), { force: true })
 }
 
 export function bearerTokenCacheLocation(devenvId: string): string {


### PR DESCRIPTION
Set mode 0o600 and atomic write on cached Dev Environment bearer token to prevent world-readable credentials on disk. Add cleanup to delete the token file when the Dev Environment is stopped.

Previously the token was written with default 0644 permissions and persisted indefinitely after session disconnect.

sim: https://t.corp.amazon.com/P465138201

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
