### PR TITLE
fix(applicationcomposer): Prevent initialization failure when html is…

### DIFF
--- a/.changes/next-release/bugfix-infrastructure-composer-initialization.json
+++ b/.changes/next-release/bugfix-infrastructure-composer-initialization.json
@@ -1,0 +1,4 @@
+{
+  "type": "Bug Fix",
+  "description": "Infrastructure Composer: A failure to initialize (eg when 'https://ide-toolkits.app-composer.aws.dev' is not reachable) no longer prevents the rest of Toolkit from activating."
+}

--- a/packages/core/src/applicationcomposer/activation.ts
+++ b/packages/core/src/applicationcomposer/activation.ts
@@ -4,13 +4,31 @@
  */
 
 import * as vscode from 'vscode'
+import * as nls from 'vscode-nls'
 import { ApplicationComposerManager } from './webviewManager'
 import { ApplicationComposerCodeLensProvider } from './codeLensProvider'
 import { openTemplateInComposerCommand } from './commands/openTemplateInComposer'
 import { openInComposerDialogCommand } from './commands/openInComposerDialog'
+import { getLogger } from '../shared/logger/logger'
+import { showViewLogsMessage } from '../shared/utilities/messages'
+
+const localize = nls.loadMessageBundle()
 
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
-    const visualizationManager = await ApplicationComposerManager.create(extensionContext)
+    let visualizationManager: ApplicationComposerManager
+    try {
+        visualizationManager = await ApplicationComposerManager.create(extensionContext)
+    } catch (err) {
+        // The webview HTML could not be fetched, skip infrastrucuture composer activation
+        void showViewLogsMessage(
+            localize(
+                "AWS.ApplicationComposer.visualization.errors.rendering",
+                "There was an error rendering Infrastructure Composer, check logs for details"
+            ), 'error'
+        )
+        getLogger().error('Failed to initalise Infrastructure Composer: skipping initialization : ${err}')
+        return
+    }
 
     extensionContext.subscriptions.push(
         openTemplateInComposerCommand.register(visualizationManager),

--- a/packages/core/src/applicationcomposer/activation.ts
+++ b/packages/core/src/applicationcomposer/activation.ts
@@ -22,9 +22,10 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         // The webview HTML could not be fetched, skip infrastrucuture composer activation
         void showViewLogsMessage(
             localize(
-                "AWS.ApplicationComposer.visualization.errors.rendering",
-                "There was an error rendering Infrastructure Composer, check logs for details"
-            ), 'error'
+                'AWS.ApplicationComposer.visualization.errors.rendering',
+                'There was an error rendering Infrastructure Composer, check logs for details'
+            ),
+            'error'
         )
         getLogger().error('Failed to initalise Infrastructure Composer: skipping initialization : ${err}')
         return

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -235,6 +235,10 @@
                         "ssoCacheError": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "applicationComposerInitFail": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -235,10 +235,6 @@
                         "ssoCacheError": {
                             "type": "boolean",
                             "default": false
-                        },
-                        "applicationComposerInitFail": {
-                            "type": "boolean",
-                            "default": false
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
## Problem

If Application/Infrastructure Composer's html is not resolvable the aws toolkit extension fails to initialize.


## Solution

Try Catch (similar to threat composer loading) around the loading of the html so that if unresolvable, the entire toolkit extension does not fail to initialize.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
