### PR TITLE
docs: Add changelog entry for bearer token permissions fix

### DIFF
--- a/.changes/next-release/Bug Fix-codecatalyst-token-permissions.json
+++ b/.changes/next-release/Bug Fix-codecatalyst-token-permissions.json
@@ -1,0 +1,4 @@
+{
+  "type": "Bug Fix",
+  "description": "CodeCatalyst: Dev Environment connection token stored with insecure file permissions"
+}


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
