### PR TITLE
feat(sagemaker): detect IdC domains and redirect to Studio UI for remote connect

### DIFF
--- a/.changes/next-release/Feature-3f8c1a74-9b2e-4d05-a6c3-1e7d92f4b8a1.json
+++ b/.changes/next-release/Feature-3f8c1a74-9b2e-4d05-a6c3-1e7d92f4b8a1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SageMaker Studio: Support connecting to spaces in domains that use IAM Identity Center (SSO) authentication"
+}

--- a/packages/core/src/awsService/sagemaker/commands.ts
+++ b/packages/core/src/awsService/sagemaker/commands.ts
@@ -5,6 +5,8 @@
 
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
+import * as path from 'path'
+import { fs } from '../../shared/fs/fs'
 import { SagemakerConstants } from './explorer/constants'
 import { SagemakerStudioNode } from './explorer/sagemakerStudioNode'
 import { DomainKeyDelimiter } from './utils'
@@ -20,10 +22,12 @@ import {
     useSageMakerSshKiroExtension,
 } from './model'
 import { ensureSageMakerSshKiroExtension } from './sagemakerSshKiroUtils'
+import { preRegisterIdcConnection, buildStudioRemoteConnectUrl, getIdcConnectionStatus } from './credentialMapping'
 import { ExtContext } from '../../shared/extensions'
 import { SagemakerClient } from '../../shared/clients/sagemaker'
 import { AccessDeniedException } from '@amzn/sagemaker-client'
 import { ToolkitError, isUserCancelledError } from '../../shared/errors'
+import { sleep } from '../../shared/utilities/timeoutUtils'
 import { showConfirmationMessage } from '../../shared/utilities/messages'
 import {
     ConnectFromRemoteWorkspaceMessage,
@@ -35,7 +39,7 @@ import {
 } from './constants'
 import { SagemakerUnifiedStudioSpaceNode } from '../../sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpaceNode'
 import { node } from 'webpack'
-import { parseArn } from './utils'
+import { getDomainUserProfileKey, parseArn } from './utils'
 
 const localize = nls.loadMessageBundle()
 
@@ -276,6 +280,11 @@ export async function openRemoteConnect(
         const remoteAccess = node.spaceApp.SpaceSettingsSummary?.RemoteAccess
         const nodeStatus = node.getStatus()
 
+        // For IdC (SSO) domains, redirect to Studio UI for session creation
+        if (isIdcDomain(node)) {
+            return await handleIdcDomainConnect(node as SagemakerSpaceNode, ctx, sageMakerClient)
+        }
+
         // Route to appropriate handler based on space state
         if (nodeStatus === SpaceStatus.RUNNING && remoteAccess !== RemoteAccess.ENABLED) {
             return await handleRunningSpaceWithDisabledAccess(node, ctx, spaceName, sageMakerClient)
@@ -344,6 +353,102 @@ export async function checkInstanceTypeUpgradeNeeded(
 }
 
 /**
+ * Asks the user to confirm the app restart that enabling remote access requires, naming the
+ * instance-type change when one is needed.
+ *
+ * Consent MUST be obtained here, at the call site, because {@link restartSpaceWithRemoteAccess}
+ * passes `skipInstanceTypePrompts: true` to `startSpace` -- that flag asserts the user has
+ * already agreed to any instance-type change, it does not mean "never ask".
+ *
+ * @returns false if the user declined. Callers MUST NOT proceed to connect.
+ */
+async function confirmRemoteAccessRestart(
+    node: SagemakerSpaceNode | SagemakerUnifiedStudioSpaceNode,
+    spaceName: string,
+    sageMakerClient?: SagemakerClient
+): Promise<boolean> {
+    const instanceTypeInfo = await checkInstanceTypeUpgradeNeeded(node, sageMakerClient)
+
+    const prompt = instanceTypeInfo.upgradeNeeded
+        ? InstanceTypeInsufficientMemoryMessage(
+              spaceName,
+              instanceTypeInfo.currentType!,
+              instanceTypeInfo.recommendedType!
+          )
+        : // Only remote access needs to be enabled.
+          RemoteAccessRequiredMessage
+
+    return await showConfirmationMessage({
+        prompt,
+        confirm: 'Restart Space and Connect',
+        cancel: 'Cancel',
+        type: 'warning',
+    })
+}
+
+/**
+ * Stops the space's running app and restarts it with remote access enabled.
+ *
+ * The app MUST be stopped first: `RemoteAccess` and `InstanceType` are space settings that
+ * cannot be changed while an app is live, and `startSpace` ends in
+ * `createApp({ AppName: 'default' })`, which fails when an app of that name already exists.
+ *
+ * Requires prior consent via {@link confirmRemoteAccessRestart}, since this skips `startSpace`'s
+ * own instance-type prompts.
+ */
+async function restartSpaceWithRemoteAccess(
+    node: SagemakerSpaceNode | SagemakerUnifiedStudioSpaceNode,
+    spaceName: string,
+    client: SagemakerClient,
+    progress: vscode.Progress<{ message?: string; increment?: number }>
+): Promise<void> {
+    progress.report({ message: 'Stopping the space' })
+
+    await client.deleteApp({
+        DomainId: node.spaceApp.DomainId!,
+        SpaceName: spaceName,
+        AppType: node.spaceApp.SpaceSettingsSummary!.AppType!,
+        AppName: node.spaceApp.App?.AppName,
+    })
+
+    progress.report({ message: 'Starting the space' })
+
+    // Skip prompts: confirmRemoteAccessRestart already obtained consent.
+    await client.startSpace(spaceName, node.spaceApp.DomainId!, true)
+    await tryRefreshNode(node)
+    await client.waitForAppInService(
+        node.spaceApp.DomainId!,
+        spaceName,
+        node.spaceApp.SpaceSettingsSummary!.AppType!,
+        progress
+    )
+}
+
+/**
+ * Starts a stopped space and waits for its app to come into service.
+ *
+ * No skip flag is passed: `startSpace` prompts for any required instance-type change itself, so
+ * the user is still asked before a larger instance is selected.
+ */
+async function startStoppedSpaceAndWait(
+    node: SagemakerSpaceNode | SagemakerUnifiedStudioSpaceNode,
+    spaceName: string,
+    client: SagemakerClient,
+    progress: vscode.Progress<{ message?: string; increment?: number }>
+): Promise<void> {
+    progress.report({ message: 'Starting the space' })
+
+    await client.startSpace(spaceName, node.spaceApp.DomainId!)
+    await tryRefreshNode(node)
+    await client.waitForAppInService(
+        node.spaceApp.DomainId!,
+        spaceName,
+        node.spaceApp.SpaceSettingsSummary!.AppType!,
+        progress
+    )
+}
+
+/**
  * Handles connecting to a running space with disabled remote access
  * Requires stopping the space, enabling remote access, and restarting
  */
@@ -353,29 +458,7 @@ async function handleRunningSpaceWithDisabledAccess(
     spaceName: string,
     sageMakerClient?: SagemakerClient
 ) {
-    // Check if instance type upgrade will be needed
-    const instanceTypeInfo = await checkInstanceTypeUpgradeNeeded(node, sageMakerClient)
-
-    let prompt: string
-    if (instanceTypeInfo.upgradeNeeded) {
-        prompt = InstanceTypeInsufficientMemoryMessage(
-            spaceName,
-            instanceTypeInfo.currentType!,
-            instanceTypeInfo.recommendedType!
-        )
-    } else {
-        // Only remote access needs to be enabled
-        prompt = RemoteAccessRequiredMessage
-    }
-
-    const confirmed = await showConfirmationMessage({
-        prompt,
-        confirm: 'Restart Space and Connect',
-        cancel: 'Cancel',
-        type: 'warning',
-    })
-
-    if (!confirmed) {
+    if (!(await confirmRemoteAccessRestart(node, spaceName, sageMakerClient))) {
         return
     }
 
@@ -390,29 +473,7 @@ async function handleRunningSpaceWithDisabledAccess(
         },
         async (progress) => {
             try {
-                // Show initial progress message
-                progress.report({ message: 'Stopping the space' })
-
-                // Stop the running space
-                await client.deleteApp({
-                    DomainId: node.spaceApp.DomainId!,
-                    SpaceName: spaceName,
-                    AppType: node.spaceApp.SpaceSettingsSummary!.AppType!,
-                    AppName: node.spaceApp.App?.AppName,
-                })
-
-                // Update progress message
-                progress.report({ message: 'Starting the space' })
-
-                // Start the space with remote access enabled (skip prompts since user already consented)
-                await client.startSpace(spaceName, node.spaceApp.DomainId!, true)
-                await tryRefreshNode(node)
-                await client.waitForAppInService(
-                    node.spaceApp.DomainId!,
-                    spaceName,
-                    node.spaceApp.SpaceSettingsSummary!.AppType!,
-                    progress
-                )
+                await restartSpaceWithRemoteAccess(node, spaceName, client, progress)
                 await tryRemoteConnection(node, ctx, progress)
             } catch (err: any) {
                 // Suppress errors that don't need additional error messages:
@@ -497,4 +558,188 @@ async function handleRunningSpaceWithEnabledAccess(
             await tryRemoteConnection(node, ctx, progress)
         }
     )
+}
+
+/**
+ * Checks if the domain associated with a space node uses IdC (SSO) authentication.
+ */
+function isIdcDomain(node: SagemakerSpaceNode | SagemakerUnifiedStudioSpaceNode): boolean {
+    if (!(node instanceof SagemakerSpaceNode)) {
+        return false
+    }
+
+    const domainId = node.spaceApp.DomainId
+    const userProfile = node.spaceApp.OwnershipSettingsSummary?.OwnerUserProfileName
+    if (!domainId || !userProfile) {
+        return false
+    }
+
+    const key = getDomainUserProfileKey(domainId, userProfile)
+    const metadata = node.parent.domainUserProfiles.get(key)
+    return metadata?.domain?.AuthMode === 'SSO'
+}
+
+/**
+ * Handles connection for IdC (SSO) domains by redirecting to the Studio UI
+ * /remote-connect page, which validates the IdC session and creates the
+ * remote session via LLAPS.
+ */
+async function handleIdcDomainConnect(
+    node: SagemakerSpaceNode,
+    ctx: vscode.ExtensionContext,
+    sageMakerClient?: SagemakerClient
+) {
+    const spaceArn = await node.getSpaceArn()
+    if (!spaceArn) {
+        void vscode.window.showErrorMessage('Unable to determine Space ARN.')
+        return
+    }
+    const domainId = node.spaceApp.DomainId!
+    const appType = node.spaceApp.SpaceSettingsSummary?.AppType || 'JupyterLab'
+    const region = node.regionCode
+
+    // Ensure the space app is running (and remote access enabled) before opening the
+    // browser. Without a running app there is no SSM target, so LLAPS StartSession fails
+    // with a 500.
+    //
+    // The routing below deliberately mirrors openRemoteConnect's IAM dispatch so IdC and IAM
+    // behave identically for the same space state.
+    const client = sageMakerClient || new SagemakerClient(region)
+    const spaceName = node.spaceApp.SpaceName!
+    const remoteAccess = node.spaceApp.SpaceSettingsSummary?.RemoteAccess
+    const nodeStatus = node.getStatus()
+
+    const progressOptions = {
+        location: vscode.ProgressLocation.Notification,
+        cancellable: false,
+        title: `Preparing ${spaceName}`,
+    }
+
+    if (nodeStatus === SpaceStatus.RUNNING && remoteAccess !== RemoteAccess.ENABLED) {
+        // Remote access cannot be turned on while the app is live, so the app must be stopped
+        // and recreated. Ask first -- the restart may also move the space to a larger instance.
+        if (!(await confirmRemoteAccessRestart(node, spaceName, client))) {
+            return
+        }
+        await vscode.window.withProgress(progressOptions, async (progress) =>
+            restartSpaceWithRemoteAccess(node, spaceName, client, progress)
+        )
+    } else if (nodeStatus === SpaceStatus.STOPPED) {
+        // startSpace enables remote access on its own (it recomputes needsRemoteAccess from
+        // describeSpace) and prompts for any instance-type change, so no consent is needed here.
+        await vscode.window.withProgress(progressOptions, async (progress) =>
+            startStoppedSpaceAndWait(node, spaceName, client, progress)
+        )
+    } else if (nodeStatus !== SpaceStatus.RUNNING) {
+        // Starting / Stopping: the app is mid-transition. Issuing deleteApp or createApp now
+        // would fail, so surface the state instead of acting on it.
+        void vscode.window.showErrorMessage(
+            `Space "${spaceName}" is ${nodeStatus}. Wait for it to finish, then try connecting again.`
+        )
+        return
+    }
+    // Running with remote access already enabled: nothing to prepare.
+
+    // Seed the pending 'initial-connection' entry so /refresh_token can update it and the
+    // ProxyCommand gets 204 (pending) until the browser posts real creds.
+    await preRegisterIdcConnection(spaceArn, domainId, appType)
+
+    // Prepare SSH config + start the SINGLE detached callback server + persist the pending
+    // SSM connection. This must be the ONLY startLocalServer call: starting one earlier made
+    // prepareDevEnvConnection's internal restart rotate the port, leaving the browser's
+    // callbackUrl pointing at a dead server.
+    const remoteEnv = await prepareDevEnvConnection({
+        spaceArn,
+        ctx,
+        connectionType: 'sm_dl',
+        isSMUS: false,
+        node,
+        domain: domainId,
+        appType,
+    })
+
+    // Read the port of the server prepareDevEnvConnection just started (the live one).
+    const infoFilePath = path.join(ctx.globalStorageUri.fsPath, 'sagemaker-local-server-info.json')
+    const infoContent = await fs.readFileText(infoFilePath)
+    const serverInfo = JSON.parse(infoContent) as { pid: number; port: number }
+
+    // Build the Studio URL whose callbackUrl points at THAT server, then open the browser.
+    const callbackUrl = `http://localhost:${serverInfo.port}/refresh_token`
+    const studioUrl = buildStudioRemoteConnectUrl({
+        spaceArn,
+        domain: domainId,
+        region,
+        appType,
+        callbackUrl,
+    })
+
+    const opened = await vscode.env.openExternal(vscode.Uri.parse(studioUrl))
+    if (!opened) {
+        void vscode.window.showErrorMessage('Failed to open browser. Please navigate to the Studio UI manually.')
+        return
+    }
+
+    void vscode.window.showInformationMessage(
+        'Complete authentication in your browser to connect to the Space. ' +
+            'The connection will be established automatically once authenticated.'
+    )
+
+    // Wait for the browser to complete IdC auth and post the session before opening the remote
+    // window. If the user is already authenticated, creds arrive within seconds and the window
+    // opens right after the redirect page. If not, the user completes IdC login first (which can
+    // take longer than the ProxyCommand's poll budget) -- opening the window only after creds
+    // land avoids a premature 'connecting' window racing a slow login. It also means the
+    // ProxyCommand's first poll gets fresh creds immediately (no reconnect-URL/second-tab path).
+    const authResult = await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            cancellable: true,
+            title: `Connecting to ${spaceName}`,
+        },
+        async (progress, token): Promise<'authenticated' | 'cancelled' | 'timeout'> => {
+            progress.report({ message: 'Waiting for authentication in the browser...' })
+            const authTimeoutMs = 5 * 60 * 1000
+            const pollIntervalMs = 2000
+            const start = Date.now()
+            while (Date.now() - start < authTimeoutMs) {
+                if (token.isCancellationRequested) {
+                    return 'cancelled'
+                }
+                if ((await getIdcConnectionStatus(spaceArn)) === 'fresh') {
+                    return 'authenticated'
+                }
+                await sleep(pollIntervalMs)
+            }
+            return 'timeout'
+        }
+    )
+
+    if (authResult === 'timeout') {
+        // Auth never completed within the window. A late sign-in would post creds with no window
+        // to receive them, so surface a clear retry hint instead of a silent dead-end.
+        void vscode.window.showErrorMessage(
+            `Timed out waiting for authentication to connect to ${spaceName}. Click Connect to try again.`
+        )
+        return
+    }
+    if (authResult !== 'authenticated') {
+        // User cancelled the connection; exit quietly without opening a window.
+        return
+    }
+
+    // Creds are ready. Open the remote window; its ProxyCommand's first poll gets them immediately.
+    const remotePath = '/home/sagemaker-user'
+    const username = 'sagemaker-user'
+    if (useSageMakerSshKiroExtension()) {
+        await ensureSageMakerSshKiroExtension(ctx)
+        await startRemoteViaSageMakerSshKiro(
+            remoteEnv.SessionProcess,
+            remoteEnv.hostname,
+            remotePath,
+            remoteEnv.vscPath,
+            username
+        )
+    } else {
+        await startVscodeRemote(remoteEnv.SessionProcess, remoteEnv.hostname, remotePath, remoteEnv.vscPath, username)
+    }
 }

--- a/packages/core/src/awsService/sagemaker/credentialMapping.ts
+++ b/packages/core/src/awsService/sagemaker/credentialMapping.ts
@@ -97,6 +97,67 @@ export async function persistSmusProjectCreds(spaceArn: string, node: SagemakerU
  * @param isSMUS - If true, use providedRefreshUrl instead of deriving one from region/endpoint.
  * @param providedRefreshUrl - Console-supplied refresh URL for SMUS connections; ignored for SM-AI.
  */
+
+/**
+ * Constructs the Studio refresh URL for a given space.
+ * Used by both persistSSMConnection and preRegisterIdcConnection.
+ */
+/**
+ * Resolves the stage-appropriate Studio base domain (prod / devo / gamma) from the
+ * SageMaker endpoint dev setting. Shared by the reconnect refresh URL and the IdC
+ * /remote-connect flow so both target the same environment.
+ */
+export function buildStudioBaseDomain(region: string): string {
+    const endpoint = DevSettings.instance.get('endpoints', {})['sagemaker'] ?? ''
+
+    let envSubdomain: string
+    if (endpoint.includes('beta')) {
+        envSubdomain = 'devo'
+    } else if (endpoint.includes('gamma')) {
+        envSubdomain = 'loadtest'
+    } else {
+        envSubdomain = 'studio'
+    }
+
+    return envSubdomain === 'studio'
+        ? `studio.${region}.sagemaker.aws`
+        : `${envSubdomain}.studio.${region}.asfiovnxocqpcry.com`
+}
+
+function buildStudioRefreshUrl(spaceArn: string, domain: string, appType?: string): string {
+    const { region } = parseArn(spaceArn)
+
+    let appSubDomain = 'jupyterlab'
+    if (appType && appType.toLowerCase() === 'codeeditor') {
+        appSubDomain = 'code-editor'
+    }
+
+    return `https://studio-${domain}.${buildStudioBaseDomain(region)}/${appSubDomain}`
+}
+
+/**
+ * Builds the Studio `/remote-connect` URL the Toolkit opens in the browser for IdC (SSO)
+ * domains. The page validates the IdC session, asks LLAPS to create the remote session, and
+ * POSTs the credentials back to `callbackUrl`.
+ *
+ * @param callbackUrl Must point at the *currently live* detached callback server. The server's
+ * port rotates when it restarts, so read the port immediately before calling this.
+ */
+export function buildStudioRemoteConnectUrl(params: {
+    spaceArn: string
+    domain: string
+    region: string
+    appType: string
+    callbackUrl: string
+}): string {
+    return (
+        `https://studio-${params.domain}.${buildStudioBaseDomain(params.region)}/remote-connect` +
+        `?spaceArn=${encodeURIComponent(params.spaceArn)}` +
+        `&appType=${encodeURIComponent(params.appType)}` +
+        `&callbackUrl=${encodeURIComponent(params.callbackUrl)}`
+    )
+}
+
 export async function persistSSMConnection(
     spaceArn: string,
     domain: string,
@@ -111,33 +172,7 @@ export async function persistSSMConnection(
     let refreshUrl: string | undefined = providedRefreshUrl
 
     if (!isSMUS) {
-        // Construct refreshUrl for SageMaker AI connections
-        const { region } = parseArn(spaceArn)
-        const endpoint = DevSettings.instance.get('endpoints', {})['sagemaker'] ?? ''
-
-        let appSubDomain = 'jupyterlab'
-        if (appType && appType.toLowerCase() === 'codeeditor') {
-            appSubDomain = 'code-editor'
-        }
-
-        let envSubdomain: string
-
-        if (endpoint.includes('beta')) {
-            envSubdomain = 'devo'
-        } else if (endpoint.includes('gamma')) {
-            envSubdomain = 'loadtest'
-        } else {
-            envSubdomain = 'studio'
-        }
-
-        // Use the standard AWS domain for 'studio' (prod).
-        // For non-prod environments, use the obfuscated domain 'asfiovnxocqpcry.com'.
-        const baseDomain =
-            envSubdomain === 'studio'
-                ? `studio.${region}.sagemaker.aws`
-                : `${envSubdomain}.studio.${region}.asfiovnxocqpcry.com`
-
-        refreshUrl = `https://studio-${domain}.${baseDomain}/${appSubDomain}`
+        refreshUrl = buildStudioRefreshUrl(spaceArn, domain, appType)
     }
     // For SMUS, refreshUrl is the console-supplied `providedRefreshUrl` (undefined = cannot refresh).
 
@@ -151,6 +186,43 @@ export async function persistSSMConnection(
         },
         isSMUS
     )
+}
+
+/**
+ * Pre-registers a deepLink entry for an IdC domain connection with 'pending' status.
+ * Called before opening the browser for IdC authentication so that:
+ * 1. /refresh_token can find and update the entry when the browser redirects back
+ * 2. ProxyCommand gets HTTP 204 (pending) and retries until real creds arrive via /refresh_token
+ *
+ * Unlike persistSSMConnection which stores with 'fresh' status (for immediate use),
+ * this stores with 'pending' status because creds arrive asynchronously via browser redirect.
+ *
+ * @param spaceArn - The Space ARN to register
+ * @param domain - The domain ID (e.g. 'd-iignhvvcwrql')
+ * @param appType - The app type (e.g. 'JupyterLab', 'CodeEditor')
+ */
+export async function preRegisterIdcConnection(spaceArn: string, domain: string, appType: string): Promise<void> {
+    const refreshUrl = buildStudioRefreshUrl(spaceArn, domain, appType)
+
+    const data = await loadMappings()
+    data.deepLink ??= {}
+    data.deepLink[spaceArn] = {
+        refreshUrl,
+        requests: {
+            'initial-connection': { sessionId: '', token: '', url: '', status: 'pending' },
+        },
+    }
+    await saveMappings(data)
+}
+
+/**
+ * Returns the status of the 'initial-connection' entry for an IdC domain connect, or undefined
+ * if none exists. Read-only (does not consume the entry), so callers can poll for the browser
+ * callback to deposit fresh creds without racing the ProxyCommand's getFreshEntry consumption.
+ */
+export async function getIdcConnectionStatus(spaceArn: string): Promise<string | undefined> {
+    const data = await loadMappings()
+    return data.deepLink?.[spaceArn]?.requests?.['initial-connection']?.status
 }
 
 /**

--- a/packages/core/src/awsService/sagemaker/model.ts
+++ b/packages/core/src/awsService/sagemaker/model.ts
@@ -199,7 +199,15 @@ export async function prepareDevEnvConnection(opts: DevEnvConnectionOptions) {
             await persistSmusProjectCreds(spaceArn, node as SagemakerUnifiedStudioSpaceNode)
         }
     } else if (connectionType === 'sm_dl') {
-        await persistSSMConnection(spaceArn, domain ?? '', session, wsUrl, token, appType, isSMUS, refreshUrl)
+        // The deeplink flow supplies real SSM creds up-front, so persist them as 'fresh' for
+        // immediate use by the ProxyCommand. The IdC /remote-connect flow supplies NO session
+        // here: creds arrive asynchronously via the browser -> /refresh_token callback, and
+        // preRegisterIdcConnection has already seeded a 'pending' entry. Persisting with an
+        // undefined session would write placeholder '-' creds as 'fresh', clobbering that
+        // pending entry and making the ProxyCommand consume invalid creds on its first poll.
+        if (session) {
+            await persistSSMConnection(spaceArn, domain ?? '', session, wsUrl, token, appType, isSMUS, refreshUrl)
+        }
     } else if (connectionType.startsWith('smhp_')) {
         await persistHyperpodConnection(
             workspaceName!,

--- a/packages/core/src/test/awsService/sagemaker/commands.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/commands.test.ts
@@ -4,12 +4,16 @@
  */
 import * as sinon from 'sinon'
 import assert from 'assert'
+import * as vscode from 'vscode'
 import { SagemakerClient } from '../../../shared/clients/sagemaker'
 import { getTestWindow } from '../../shared/vscode/window'
 import {
     RemoteAccessRequiredMessage,
     InstanceTypeInsufficientMemoryMessage,
 } from '../../../awsService/sagemaker/constants'
+import { getDomainUserProfileKey } from '../../../awsService/sagemaker/utils'
+import { SessionStore } from '../../../awsService/sagemaker/detached-server/sessionStore'
+import { handleRefreshToken } from '../../../awsService/sagemaker/detached-server/routes/refreshToken'
 
 // Import types only, actual functions will be dynamically imported
 import type { openRemoteConnect as openRemoteConnectStatic } from '../../../awsService/sagemaker/commands'
@@ -397,6 +401,442 @@ describe('SageMaker Commands', () => {
                 assert(mockClient.waitForAppInService.notCalled)
                 // Only remote connection should be attempted
                 assert(mockTryRemoteConnection.calledOnce)
+            })
+        })
+
+        describe('handleIdcDomainConnect', () => {
+            const spaceArn = 'arn:aws:sagemaker:us-west-2:123456789:space/d-abc123/my-space'
+            const idcContext = {
+                globalStorageUri: { fsPath: '/test-storage' },
+            } as any
+
+            let mockOpenExternal: sinon.SinonStub
+            let mockPrepareDevEnvConnection: sinon.SinonStub
+            let mockUseSageMakerSshKiroExtension: sinon.SinonStub
+            let mockPreRegisterIdcConnection: sinon.SinonStub
+            let mockGetIdcConnectionStatus: sinon.SinonStub
+            let mockReadFileText: sinon.SinonStub
+            let mockSleep: sinon.SinonStub
+            let mockStartVscodeRemote: sinon.SinonStub
+            let SagemakerSpaceNodeClass: any
+
+            function makeSagemakerNode(
+                options: {
+                    authMode?: 'SSO' | 'IAM'
+                    status?: string
+                    remoteAccess?: string
+                    domainId?: string
+                    userProfile?: string
+                    spaceName?: string
+                } = {}
+            ) {
+                const authMode = options.authMode ?? 'SSO'
+                const status = options.status ?? 'Running'
+                const remoteAccess = Object.prototype.hasOwnProperty.call(options, 'remoteAccess')
+                    ? options.remoteAccess
+                    : 'ENABLED'
+                const domainId = options.domainId ?? 'd-abc123'
+                const userProfile = options.userProfile ?? 'user-profile-1'
+                const spaceName = options.spaceName ?? 'my-space'
+                const key = getDomainUserProfileKey(domainId, userProfile)
+                const node = Object.create(SagemakerSpaceNodeClass.prototype)
+
+                Object.assign(node, {
+                    regionCode: 'us-west-2',
+                    spaceApp: {
+                        DomainId: domainId,
+                        SpaceName: spaceName,
+                        App: { AppType: 'JupyterLab', AppName: 'default' },
+                        OwnershipSettingsSummary: { OwnerUserProfileName: userProfile },
+                        SpaceSettingsSummary: { AppType: 'JupyterLab', RemoteAccess: remoteAccess },
+                    },
+                    parent: {
+                        domainUserProfiles: new Map([[key, { domain: { AuthMode: authMode } }]]),
+                    },
+                    getStatus: sandbox.stub().returns(status),
+                    getSpaceArn: sandbox.stub().resolves(spaceArn),
+                })
+
+                return node
+            }
+
+            beforeEach(() => {
+                mockOpenExternal = sandbox.stub().resolves(true)
+                mockPrepareDevEnvConnection = sandbox.stub().resolves({
+                    SessionProcess: { pid: 1234 },
+                    hostname: 'sagemaker-space',
+                    vscPath: '/path/to/vscode',
+                })
+                mockUseSageMakerSshKiroExtension = sandbox.stub().returns(false)
+                mockPreRegisterIdcConnection = sandbox.stub().resolves()
+                mockGetIdcConnectionStatus = sandbox.stub().resolves('fresh')
+                mockReadFileText = sandbox.stub().resolves(JSON.stringify({ pid: 1234, port: 54321 }))
+                mockSleep = sandbox.stub().resolves()
+                mockStartVscodeRemote = sandbox.stub().resolves()
+
+                sandbox.replace(vscode.env, 'openExternal', mockOpenExternal)
+                sandbox.stub(require('../../../shared/settings').DevSettings.instance, 'get').returns({})
+
+                SagemakerSpaceNodeClass =
+                    require('../../../awsService/sagemaker/explorer/sagemakerSpaceNode').SagemakerSpaceNode
+
+                const model = require('../../../awsService/sagemaker/model')
+                sandbox.replace(model, 'prepareDevEnvConnection', mockPrepareDevEnvConnection)
+                sandbox.replace(model, 'useSageMakerSshKiroExtension', mockUseSageMakerSshKiroExtension)
+
+                const credentialMapping = require('../../../awsService/sagemaker/credentialMapping')
+                sandbox.replace(credentialMapping, 'preRegisterIdcConnection', mockPreRegisterIdcConnection)
+                sandbox.replace(credentialMapping, 'getIdcConnectionStatus', mockGetIdcConnectionStatus)
+
+                sandbox.replace(require('../../../shared/fs/fs').fs, 'readFileText', mockReadFileText)
+                sandbox.replace(require('../../../shared/utilities/timeoutUtils'), 'sleep', mockSleep)
+                sandbox.replace(require('../../../shared/extensions/ssh'), 'startVscodeRemote', mockStartVscodeRemote)
+
+                for (const key of Object.keys(require.cache)) {
+                    if (key.includes('awsService/sagemaker/commands')) {
+                        delete require.cache[key]
+                    }
+                }
+                openRemoteConnect = require('../../../awsService/sagemaker/commands').openRemoteConnect
+            })
+
+            it('opens Studio without a requestId and launches the remote after the 302 callback', async () => {
+                const session = {
+                    sessionId: 'stub-session',
+                    token: 'stub-token',
+                    url: 'wss://stub-session.example.test',
+                }
+                let connectionStatus = 'pending'
+                let studioRedirect: { status: 302; headers: { location: string } } | undefined
+                const callbackWriteHead = sandbox.stub()
+                const callbackEnd = sandbox.stub()
+                const setSession = sandbox
+                    .stub(SessionStore.prototype, 'setSession')
+                    .callsFake(async (connectionIdentifier, requestId, connection) => {
+                        assert.strictEqual(connectionIdentifier, spaceArn)
+                        assert.strictEqual(requestId, 'initial-connection')
+                        assert.deepStrictEqual(connection, session)
+                        connectionStatus = 'fresh'
+                    })
+
+                mockGetIdcConnectionStatus.resetBehavior()
+                mockGetIdcConnectionStatus.callsFake(async () => connectionStatus)
+                mockOpenExternal.resetBehavior()
+                mockOpenExternal.callsFake(async (uri: vscode.Uri) => {
+                    // Studio returns 'initial-connection' on the callback when the launch URL omits requestId.
+                    const callbackUrl = new URLSearchParams(uri.query).get('callbackUrl')
+                    assert.ok(callbackUrl)
+
+                    const location = new URL(callbackUrl)
+                    location.searchParams.set('connection_identifier', spaceArn)
+                    location.searchParams.set('request_id', 'initial-connection')
+                    location.searchParams.set('ws_url', session.url)
+                    location.searchParams.set('token', session.token)
+                    location.searchParams.set('session', session.sessionId)
+                    studioRedirect = { status: 302, headers: { location: location.toString() } }
+                    return true
+                })
+                mockSleep.resetBehavior()
+                mockSleep.callsFake(async () => {
+                    assert.strictEqual(mockSleep.callCount, 1, 'the callback should complete during the first poll')
+                    assert.ok(studioRedirect)
+                    assert.strictEqual(studioRedirect.status, 302)
+                    const location = new URL(studioRedirect.headers.location)
+                    await handleRefreshToken(
+                        { url: `${location.pathname}${location.search}` } as any,
+                        { writeHead: callbackWriteHead, end: callbackEnd } as any
+                    )
+                })
+                const idcNode = makeSagemakerNode()
+
+                await openRemoteConnect(idcNode, idcContext, mockClient)
+
+                sinon.assert.calledOnceWithExactly(mockPreRegisterIdcConnection, spaceArn, 'd-abc123', 'JupyterLab')
+                sinon.assert.calledOnce(mockPrepareDevEnvConnection)
+                assert.deepStrictEqual(mockPrepareDevEnvConnection.firstCall.args[0], {
+                    spaceArn,
+                    ctx: idcContext,
+                    connectionType: 'sm_dl',
+                    isSMUS: false,
+                    node: idcNode,
+                    domain: 'd-abc123',
+                    appType: 'JupyterLab',
+                })
+                sinon.assert.calledOnce(mockReadFileText)
+                sinon.assert.calledOnce(mockOpenExternal)
+
+                const uri = mockOpenExternal.firstCall.args[0]
+                const query = new URLSearchParams(uri.query)
+                assert.strictEqual(uri.scheme, 'https')
+                assert.strictEqual(uri.authority, 'studio-d-abc123.studio.us-west-2.sagemaker.aws')
+                assert.strictEqual(uri.path, '/remote-connect')
+                assert.strictEqual(query.get('spaceArn'), spaceArn)
+                assert.strictEqual(query.get('appType'), 'JupyterLab')
+                assert.strictEqual(query.get('callbackUrl'), 'http://localhost:54321/refresh_token')
+                assert.strictEqual(query.has('requestId'), false)
+
+                assert.ok(studioRedirect)
+                const callbackUrl = new URL(studioRedirect.headers.location)
+                assert.strictEqual(callbackUrl.pathname, '/refresh_token')
+                assert.strictEqual(callbackUrl.searchParams.get('connection_identifier'), spaceArn)
+                assert.strictEqual(callbackUrl.searchParams.get('request_id'), 'initial-connection')
+                sinon.assert.calledOnceWithExactly(setSession, spaceArn, 'initial-connection', session)
+                sinon.assert.calledWith(callbackWriteHead, 200)
+                sinon.assert.callCount(mockGetIdcConnectionStatus, 2)
+                sinon.assert.calledOnceWithExactly(mockSleep, 2000)
+                sinon.assert.calledWith(
+                    mockStartVscodeRemote,
+                    sinon.match({ pid: 1234 }),
+                    'sagemaker-space',
+                    '/home/sagemaker-user',
+                    '/path/to/vscode',
+                    'sagemaker-user'
+                )
+                assert(mockOpenExternal.calledBefore(mockGetIdcConnectionStatus))
+                assert(setSession.calledBefore(mockStartVscodeRemote))
+                assert(mockGetIdcConnectionStatus.calledBefore(mockStartVscodeRemote))
+                sinon.assert.notCalled(mockTryRemoteConnection)
+                sinon.assert.notCalled(mockClient.createApp)
+                sinon.assert.notCalled(mockClient.deleteApp)
+                sinon.assert.notCalled(mockClient.startSpace)
+                sinon.assert.notCalled(mockClient.updateSpace)
+            })
+
+            it('does not redirect for IAM domains', async () => {
+                const iamNode = makeSagemakerNode({
+                    authMode: 'IAM',
+                    domainId: 'd-iam456',
+                    userProfile: 'iam-user',
+                    spaceName: 'iam-space',
+                })
+
+                await openRemoteConnect(iamNode, idcContext, mockClient)
+
+                sinon.assert.notCalled(mockOpenExternal)
+                sinon.assert.notCalled(mockPreRegisterIdcConnection)
+                sinon.assert.calledOnce(mockTryRemoteConnection)
+            })
+
+            it('does not redirect for SMUS nodes', async () => {
+                mockNode.spaceApp.SpaceSettingsSummary.RemoteAccess = 'ENABLED'
+
+                await openRemoteConnect(mockNode, idcContext, mockClient)
+
+                sinon.assert.notCalled(mockOpenExternal)
+                sinon.assert.notCalled(mockPreRegisterIdcConnection)
+                sinon.assert.calledOnce(mockTryRemoteConnection)
+            })
+
+            it('does not poll or launch a remote when the browser cannot be opened', async () => {
+                mockOpenExternal.resolves(false)
+
+                await openRemoteConnect(makeSagemakerNode(), idcContext, mockClient)
+
+                sinon.assert.notCalled(mockGetIdcConnectionStatus)
+                sinon.assert.notCalled(mockStartVscodeRemote)
+                assert(
+                    getTestWindow().shownMessages.some((message) => message.message.includes('Failed to open browser'))
+                )
+            })
+
+            it('stops waiting when authentication is cancelled', async () => {
+                mockGetIdcConnectionStatus.resolves('pending')
+                getTestWindow().onDidShowMessage((message) => {
+                    if (message.message === 'Connecting to my-space') {
+                        message.selectItem('Cancel')
+                    }
+                })
+
+                await openRemoteConnect(makeSagemakerNode(), idcContext, mockClient)
+
+                sinon.assert.calledOnce(mockOpenExternal)
+                sinon.assert.notCalled(mockStartVscodeRemote)
+            })
+
+            it('reports a timeout when the browser callback never supplies credentials', async () => {
+                let now = 0
+                sandbox.stub(Date, 'now').callsFake(() => now)
+                mockGetIdcConnectionStatus.resolves('pending')
+                mockSleep.callsFake(async () => {
+                    now = 5 * 60 * 1000
+                })
+
+                await openRemoteConnect(makeSagemakerNode(), idcContext, mockClient)
+
+                sinon.assert.calledOnceWithExactly(mockGetIdcConnectionStatus, spaceArn)
+                sinon.assert.calledOnceWithExactly(mockSleep, 2000)
+                sinon.assert.notCalled(mockStartVscodeRemote)
+                assert(
+                    getTestWindow().shownMessages.some((message) =>
+                        message.message.includes('Timed out waiting for authentication')
+                    )
+                )
+            })
+
+            /**
+             * Space preparation parity with the IAM path.
+             *
+             * The IdC handler has to reproduce openRemoteConnect's state routing, because it
+             * intercepts before the IAM dispatch. These tests pin that routing so it cannot
+             * silently drift from handleRunningSpaceWithDisabledAccess / handleStoppedSpace.
+             */
+            describe('space preparation', () => {
+                function makeIdcNode(status: string, remoteAccess?: string) {
+                    return makeSagemakerNode({
+                        status,
+                        remoteAccess,
+                    })
+                }
+
+                beforeEach(() => {
+                    mockClient.describeSpace.resolves({
+                        $metadata: {},
+                        SpaceSettings: {
+                            AppType: 'JupyterLab',
+                            JupyterLabAppSettings: {
+                                DefaultResourceSpec: { InstanceType: 'ml.t3.medium' }, // insufficient memory
+                            },
+                        },
+                    })
+                    mockClient.deleteApp.resolves()
+                    mockClient.startSpace.resolves()
+                    mockClient.waitForAppInService.resolves()
+                })
+
+                it('asks for confirmation before restarting a running space with remote access off', async () => {
+                    let shown = false
+                    getTestWindow().onDidShowMessage((message) => {
+                        if (message.message.includes('does not support remote access')) {
+                            shown = true
+                        }
+                        message.selectItem('Cancel')
+                    })
+
+                    await openRemoteConnect(makeIdcNode('Running', 'DISABLED'), idcContext, mockClient)
+
+                    assert(shown, 'should prompt before changing the instance type')
+                })
+
+                it('makes no changes when the user declines the restart', async () => {
+                    getTestWindow().onDidShowMessage((message) => message.selectItem('Cancel'))
+
+                    await openRemoteConnect(makeIdcNode('Running', 'DISABLED'), idcContext, mockClient)
+
+                    assert(mockClient.deleteApp.notCalled, 'must not stop the app after a cancel')
+                    assert(mockClient.startSpace.notCalled, 'must not start the space after a cancel')
+                    assert(mockOpenExternal.notCalled, 'must not open the browser after a cancel')
+                })
+
+                it('stops the running app before restarting it with remote access enabled', async () => {
+                    getTestWindow().onDidShowMessage((message) => {
+                        if (message.items.some((item) => item.title === 'Restart Space and Connect')) {
+                            message.selectItem('Restart Space and Connect')
+                        }
+                    })
+
+                    await openRemoteConnect(makeIdcNode('Running', 'DISABLED'), idcContext, mockClient)
+
+                    // deleteApp first: startSpace ends in createApp('default'), which fails if an
+                    // app of that name is already running.
+                    assert(mockClient.deleteApp.calledOnce, 'should stop the live app')
+                    assert(mockClient.startSpace.calledOnce)
+                    assert(
+                        mockClient.startSpace.calledAfter(mockClient.deleteApp),
+                        'startSpace must run after deleteApp'
+                    )
+                    // Skipping the prompts is only legitimate because consent was just obtained.
+                    assert(mockClient.startSpace.calledWith('my-space', 'd-abc123', true))
+                })
+
+                it('starts a stopped space without suppressing the instance-type prompt', async () => {
+                    await openRemoteConnect(makeIdcNode('Stopped', 'DISABLED'), idcContext, mockClient)
+
+                    assert(mockClient.deleteApp.notCalled, 'nothing to stop on a stopped space')
+                    assert(mockClient.startSpace.calledOnce)
+                    // The third argument must not be true here: startSpace has to keep its own
+                    // instance-type prompt so the user still consents to any upgrade.
+                    assert(
+                        mockClient.startSpace.neverCalledWith('my-space', 'd-abc123', true),
+                        'must not skip the instance-type prompt for a stopped space'
+                    )
+                })
+
+                it('does not touch a running space that already has remote access enabled', async () => {
+                    await openRemoteConnect(makeIdcNode('Running', 'ENABLED'), idcContext, mockClient)
+
+                    assert(mockClient.deleteApp.notCalled)
+                    assert(mockClient.startSpace.notCalled)
+                    sinon.assert.calledOnce(mockStartVscodeRemote)
+                })
+
+                it('refuses to act on a space that is mid-transition', async () => {
+                    await openRemoteConnect(makeIdcNode('Starting', 'ENABLED'), idcContext, mockClient)
+
+                    assert(mockClient.deleteApp.notCalled)
+                    assert(mockClient.startSpace.notCalled)
+                    assert(mockOpenExternal.notCalled)
+                    const messages = getTestWindow().shownMessages
+                    assert(
+                        messages.some((m) => m.message.includes('is Starting')),
+                        'should tell the user the space is still transitioning'
+                    )
+                })
+
+                it('refuses to act on a space that is stopping', async () => {
+                    await openRemoteConnect(makeIdcNode('Stopping', 'ENABLED'), idcContext, mockClient)
+
+                    assert(mockClient.deleteApp.notCalled)
+                    assert(mockClient.startSpace.notCalled)
+                    assert(mockOpenExternal.notCalled)
+                    const messages = getTestWindow().shownMessages
+                    assert(
+                        messages.some((m) => m.message.includes('is Stopping')),
+                        'should tell the user the space is still transitioning'
+                    )
+                })
+
+                it('starts a stopped space whose remote access is already enabled, without stopping it first', async () => {
+                    await openRemoteConnect(makeIdcNode('Stopped', 'ENABLED'), idcContext, mockClient)
+
+                    assert(mockClient.deleteApp.notCalled, 'there is no live app to stop')
+                    assert(mockClient.startSpace.calledOnce)
+                    // The remote-access value must not leak into the stopped path: this is the one
+                    // state the old single-guard code got right, so it is the likeliest regression.
+                    assert(
+                        mockClient.startSpace.neverCalledWith('my-space', 'd-abc123', true),
+                        'must not skip the instance-type prompt for a stopped space'
+                    )
+                })
+
+                // RemoteAccess is simply absent on a space that never had it set, and the routing
+                // treats absent and DISABLED alike (remoteAccess !== ENABLED).
+                it('treats absent RemoteAccess on a running space the same as disabled', async () => {
+                    getTestWindow().onDidShowMessage((message) => {
+                        if (message.items.some((item) => item.title === 'Restart Space and Connect')) {
+                            message.selectItem('Restart Space and Connect')
+                        }
+                    })
+
+                    await openRemoteConnect(makeIdcNode('Running', undefined), idcContext, mockClient)
+
+                    assert(mockClient.deleteApp.calledOnce, 'should stop the live app')
+                    assert(
+                        mockClient.startSpace.calledAfter(mockClient.deleteApp),
+                        'startSpace must run after deleteApp'
+                    )
+                    assert(mockClient.startSpace.calledWith('my-space', 'd-abc123', true))
+                })
+
+                it('treats absent RemoteAccess on a stopped space the same as disabled', async () => {
+                    await openRemoteConnect(makeIdcNode('Stopped', undefined), idcContext, mockClient)
+
+                    assert(mockClient.deleteApp.notCalled)
+                    assert(mockClient.startSpace.calledOnce)
+                    assert(
+                        mockClient.startSpace.neverCalledWith('my-space', 'd-abc123', true),
+                        'must not skip the instance-type prompt for a stopped space'
+                    )
+                })
             })
         })
     })

--- a/packages/core/src/test/awsService/sagemaker/credentialMapping.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/credentialMapping.test.ts
@@ -16,6 +16,9 @@ import {
     setSpaceSsoProfile,
     setSmusSpaceProfile,
     setSpaceCredentials,
+    buildStudioRemoteConnectUrl,
+    preRegisterIdcConnection,
+    getIdcConnectionStatus,
 } from '../../../awsService/sagemaker/credentialMapping'
 import { Auth } from '../../../auth'
 import { DevSettings, fs } from '../../../shared'
@@ -25,6 +28,230 @@ import { SageMakerUnifiedStudioSpacesParentNode } from '../../../sagemakerunifie
 import * as hyperpodMappingUtils from '../../../awsService/sagemaker/detached-server/hyperpodMappingUtils'
 
 describe('credentialMapping', () => {
+    describe('buildStudioRemoteConnectUrl', () => {
+        const spaceArn = 'arn:aws:sagemaker:us-west-2:123456789012:space/d-abc123/my-space'
+        const baseParams = {
+            spaceArn,
+            domain: 'd-abc123',
+            region: 'us-west-2',
+            appType: 'JupyterLab',
+            callbackUrl: 'http://localhost:54321/refresh_token',
+        }
+
+        let sandbox: sinon.SinonSandbox
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox()
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('targets the prod Studio host when no dev endpoint is set', () => {
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+
+            const url = buildStudioRemoteConnectUrl(baseParams)
+
+            assert.ok(
+                url.startsWith('https://studio-d-abc123.studio.us-west-2.sagemaker.aws/remote-connect?'),
+                `unexpected host: ${url}`
+            )
+        })
+
+        it('targets the devo Studio host for a beta endpoint', () => {
+            sandbox.stub(DevSettings.instance, 'get').returns({ sagemaker: 'https://beta.whatever' })
+
+            const url = buildStudioRemoteConnectUrl(baseParams)
+
+            assert.ok(
+                url.startsWith('https://studio-d-abc123.devo.studio.us-west-2.asfiovnxocqpcry.com/remote-connect?'),
+                `unexpected host: ${url}`
+            )
+        })
+
+        it('uses the region argument rather than the region embedded in the space ARN', () => {
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+
+            const url = buildStudioRemoteConnectUrl({ ...baseParams, region: 'eu-west-1' })
+
+            assert.ok(url.includes('studio.eu-west-1.sagemaker.aws'), `unexpected host: ${url}`)
+        })
+
+        it('url-encodes the callback parameters and omits requestId', () => {
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+
+            const url = buildStudioRemoteConnectUrl(baseParams)
+            const query = new URLSearchParams(url.slice(url.indexOf('?') + 1))
+
+            // The ARN's colons and slashes must be escaped, not passed through raw.
+            assert.ok(!url.includes('arn:aws:sagemaker'), 'spaceArn was not encoded')
+            assert.strictEqual(query.get('spaceArn'), spaceArn)
+            assert.strictEqual(query.get('appType'), 'JupyterLab')
+            assert.strictEqual(query.get('callbackUrl'), baseParams.callbackUrl)
+            assert.strictEqual(query.has('requestId'), false)
+        })
+
+        it('points callbackUrl at the supplied local server port', () => {
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+
+            const url = buildStudioRemoteConnectUrl({
+                ...baseParams,
+                callbackUrl: 'http://localhost:9999/refresh_token',
+            })
+            const query = new URLSearchParams(url.slice(url.indexOf('?') + 1))
+
+            assert.strictEqual(query.get('callbackUrl'), 'http://localhost:9999/refresh_token')
+        })
+    })
+
+    describe('preRegisterIdcConnection', () => {
+        const spaceArn = 'arn:aws:sagemaker:us-west-2:123456789012:space/d-abc123/my-space'
+
+        let sandbox: sinon.SinonSandbox
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox()
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function writtenData(writeStub: sinon.SinonStub) {
+            const raw = writeStub.firstCall.args[1]
+            return JSON.parse(typeof raw === 'string' ? raw : raw.toString())
+        }
+
+        it("seeds a pending 'initial-connection' entry for the space", async () => {
+            sandbox.stub(fs, 'existsFile').resolves(false)
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            await preRegisterIdcConnection(spaceArn, 'd-abc123', 'JupyterLab')
+
+            const entry = writtenData(writeStub).deepLink?.[spaceArn]
+            assert.ok(entry, 'expected a deepLink entry for the space')
+            assert.deepStrictEqual(entry.requests['initial-connection'], {
+                sessionId: '',
+                token: '',
+                url: '',
+                status: 'pending',
+            })
+        })
+
+        it('stores a jupyterlab refresh URL for a JupyterLab space', async () => {
+            sandbox.stub(fs, 'existsFile').resolves(false)
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            await preRegisterIdcConnection(spaceArn, 'd-abc123', 'JupyterLab')
+
+            assert.strictEqual(
+                writtenData(writeStub).deepLink[spaceArn].refreshUrl,
+                'https://studio-d-abc123.studio.us-west-2.sagemaker.aws/jupyterlab'
+            )
+        })
+
+        it('stores a code-editor refresh URL for a CodeEditor space', async () => {
+            sandbox.stub(fs, 'existsFile').resolves(false)
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            await preRegisterIdcConnection(spaceArn, 'd-abc123', 'CodeEditor')
+
+            assert.strictEqual(
+                writtenData(writeStub).deepLink[spaceArn].refreshUrl,
+                'https://studio-d-abc123.studio.us-west-2.sagemaker.aws/code-editor'
+            )
+        })
+
+        it('leaves deepLink entries for other spaces intact', async () => {
+            const otherArn = 'arn:aws:sagemaker:us-west-2:123456789012:space/d-abc123/other-space'
+            sandbox.stub(fs, 'existsFile').resolves(true)
+            sandbox.stub(fs, 'readFileText').resolves(
+                JSON.stringify({
+                    deepLink: {
+                        [otherArn]: { refreshUrl: 'https://example.com/other', requests: {} },
+                    },
+                })
+            )
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            await preRegisterIdcConnection(spaceArn, 'd-abc123', 'JupyterLab')
+
+            const data = writtenData(writeStub)
+            assert.strictEqual(data.deepLink[otherArn].refreshUrl, 'https://example.com/other')
+            assert.ok(data.deepLink[spaceArn], 'expected the new entry to be added alongside')
+        })
+    })
+
+    describe('getIdcConnectionStatus', () => {
+        const spaceArn = 'arn:aws:sagemaker:us-west-2:123456789012:space/d-abc123/my-space'
+
+        let sandbox: sinon.SinonSandbox
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox()
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function stubMappings(data: unknown) {
+            sandbox.stub(fs, 'existsFile').resolves(true)
+            sandbox.stub(fs, 'readFileText').resolves(JSON.stringify(data))
+        }
+
+        it("returns the status of the 'initial-connection' request", async () => {
+            stubMappings({
+                deepLink: {
+                    [spaceArn]: {
+                        refreshUrl: 'https://example.com',
+                        requests: { 'initial-connection': { status: 'fresh' } },
+                    },
+                },
+            })
+
+            assert.strictEqual(await getIdcConnectionStatus(spaceArn), 'fresh')
+        })
+
+        it('returns undefined when no mappings file exists', async () => {
+            sandbox.stub(fs, 'existsFile').resolves(false)
+
+            assert.strictEqual(await getIdcConnectionStatus(spaceArn), undefined)
+        })
+
+        it('returns undefined when the space has no deepLink entry', async () => {
+            stubMappings({ deepLink: {} })
+
+            assert.strictEqual(await getIdcConnectionStatus(spaceArn), undefined)
+        })
+
+        it("returns undefined when the entry has no 'initial-connection' request", async () => {
+            stubMappings({
+                deepLink: { [spaceArn]: { refreshUrl: 'https://example.com', requests: {} } },
+            })
+
+            assert.strictEqual(await getIdcConnectionStatus(spaceArn), undefined)
+        })
+
+        it('does not consume or modify the entry, so polling is safe', async () => {
+            stubMappings({
+                deepLink: {
+                    [spaceArn]: {
+                        refreshUrl: 'https://example.com',
+                        requests: { 'initial-connection': { status: 'pending' } },
+                    },
+                },
+            })
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            assert.strictEqual(await getIdcConnectionStatus(spaceArn), 'pending')
+            assert.strictEqual(await getIdcConnectionStatus(spaceArn), 'pending')
+            assert.ok(writeStub.notCalled, 'reading the status must not write mappings')
+        })
+    })
+
     describe('persistLocalCredentials', () => {
         const appArn = 'arn:aws:sagemaker:us-west-2:123456789012:space/d-f0lwireyzpjp/test-space'
 

--- a/packages/core/src/test/awsService/sagemaker/model.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/model.test.ts
@@ -186,6 +186,98 @@ describe('SageMaker Model', () => {
         })
     })
 
+    describe('prepareDevEnvConnection', function () {
+        /**
+         * These tests pin the `if (session)` guard on the 'sm_dl' branch. They assert only on
+         * whether persistSSMConnection is called; everything after that point (SSH config, local
+         * server startup) needs infrastructure that isn't stubbed here and is expected to reject.
+         */
+        const spaceArn = 'arn:aws:sagemaker:us-west-2:123456789012:space/d-abc123/my-space'
+        const ctx = {
+            globalStorageUri: vscode.Uri.file(path.join(os.tmpdir(), 'test-storage')),
+            extensionPath: path.join(os.tmpdir(), 'extension'),
+            asAbsolutePath: (relPath: string) => path.join(path.join(os.tmpdir(), 'extension'), relPath),
+        } as vscode.ExtensionContext
+
+        let sandbox: sinon.SinonSandbox
+        let persistStub: sinon.SinonStub
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox()
+
+            // ensureDependencies() returns a Result that prepareDevEnvConnection immediately
+            // unwraps; supply the ssm/vsc/ssh paths it expects.
+            sandbox.replace(require('../../../shared/remoteSession'), 'ensureDependencies', () =>
+                Promise.resolve({ unwrap: () => ({ ssm: 'ssm', vsc: 'vsc', ssh: 'ssh' }) })
+            )
+
+            persistStub = sandbox.stub().resolves()
+            sandbox.replace(
+                require('../../../awsService/sagemaker/credentialMapping'),
+                'persistSSMConnection',
+                persistStub
+            )
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        async function runIgnoringDownstream(opts: any) {
+            const { prepareDevEnvConnection } = require('../../../awsService/sagemaker/model')
+            try {
+                await prepareDevEnvConnection(opts)
+            } catch {
+                // intentionally ignored -- see the note on this describe block
+            }
+        }
+
+        it('persists the connection when the deeplink flow supplies a session', async function () {
+            await runIgnoringDownstream({
+                spaceArn,
+                ctx,
+                connectionType: 'sm_dl',
+                domain: 'd-abc123',
+                appType: 'JupyterLab',
+                session: 'session-id',
+                wsUrl: 'wss://example.com',
+                token: 'token',
+            })
+
+            assert.ok(persistStub.calledOnce, 'a supplied session must be persisted for the ProxyCommand')
+            assert.strictEqual(persistStub.firstCall.args[2], 'session-id')
+        })
+
+        it('does not persist when the IdC flow supplies no session', async function () {
+            // The IdC /remote-connect flow has no creds yet -- they arrive later via the browser
+            // callback, and preRegisterIdcConnection has already seeded a 'pending' entry.
+            // Persisting here would write placeholder creds as 'fresh' and clobber it.
+            await runIgnoringDownstream({
+                spaceArn,
+                ctx,
+                connectionType: 'sm_dl',
+                domain: 'd-abc123',
+                appType: 'JupyterLab',
+                session: undefined,
+            })
+
+            assert.ok(persistStub.notCalled, 'must not clobber the pending entry when there is no session')
+        })
+
+        it('does not persist when the session is an empty string', async function () {
+            await runIgnoringDownstream({
+                spaceArn,
+                ctx,
+                connectionType: 'sm_dl',
+                domain: 'd-abc123',
+                appType: 'JupyterLab',
+                session: '',
+            })
+
+            assert.ok(persistStub.notCalled)
+        })
+    })
+
     describe('removeKnownHost', function () {
         const knownHostsPath = path.join(os.homedir(), '.ssh', 'known_hosts')
         const hostname = 'test.host.com'


### PR DESCRIPTION
## Problem
Customers using SageMaker Studio with IAM Identity Center (IdC/SSO) authentication cannot connect to their Spaces from the AWS Toolkit (VS Code, Cursor, Kiro). The existing connection flow calls sagemaker:StartSession directly using SigV4 credentials, but IdC users don't have SigV4 credentials available in their local IDE — they authenticate through their organization's SSO identity provider via a browser session.

## Solution
Detect IdC-managed domains and redirect users through a browser-based authentication flow instead of attempting direct connection.

Flow:
  1. User clicks Connect on an IdC Space in the Toolkit explorer
  2. Toolkit detects AuthMode === 'SSO' → opens browser to https:// studio-<domainId>.studio.<region>.sagemaker.aws/remote-connect?...
  3. Browser authenticates via IdC (existing LLAPS SSO flow)
  4. Studio page calls LLAPS to create a session, then fires a vscode:// deep link back
  5. Toolkit's existing URI handler (uriHandlers.ts) receives the deep link and establishes the SSH-over-SSM tunnel

  Unaffected paths:
  - IAM domains → continue using direct StartSession connection
  - SMUS (Unified Studio) nodes → continue using existing flow
  - Deep link handling (deeplinkConnect) → no changes needed, already handles pre-provided session params

## Testing
  - Unit tests
    - IdC (SSO) domain → redirects to Studio UI, does not call tryRemoteConnection
    - IAM domain → does not redirect, calls tryRemoteConnection directly
    - SMUS node → does not redirect, calls tryRemoteConnection directly
  - E2E validated locally: Toolkit (debug mode) → detected SSO domain → opened browser to /remote-connect → C3 page called mock LLAPS → fired vscode:// deep link → Toolkit URI handler received it (confirmed via log: UriHandler: query parsing failed for path "/connect/sagemaker" — expected with mock session data)

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
