### PR TITLE
feat(toolkit): add cdk lsp

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -13,6 +13,8 @@
     "AWS.configuration.description.s3.maxItemsPerPage": "Controls how many S3 items are listed before showing a node to `Load More...`.\nThis corresponds to the `MaxKeys` requested in a single call to S3. [Learn More](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#AmazonS3-ListObjectsV2-response-MaxKeys)",
     "AWS.configuration.description.samcli.lambdaTimeout": "Maximum time (in milliseconds) to wait for SAM output while starting a Local Lambda session",
     "AWS.configuration.description.samcli.location": "Location of SAM CLI. SAM CLI is used to create, build, package, and deploy Serverless Applications. [Learn More](https://aws.amazon.com/serverless/sam/)",
+    "AWS.configuration.description.cdk.cliPath": "Absolute path to the AWS CDK CLI (`cdk`) used to start the CDK language server. Leave empty to auto-discover from the workspace's `node_modules` or your shell PATH.",
+    "AWS.configuration.description.cdk.appDir": "Directory of the CDK app (the folder containing `cdk.json`) that the CDK language server should analyze. Relative paths resolve against the first workspace folder. Leave empty to auto-detect; set this when a workspace has more than one CDK app.",
     "AWS.configuration.description.samcli.legacyDeploy": "Use the legacy SAM deploy experience, disabling all SAM sync functionality.",
     "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS. [Details](https://docs.aws.amazon.com/sdkref/latest/guide/support-maint-idetoolkits.html)",
     "AWS.configuration.description.telemetry.cn": "Enable Amazon Toolkit to send usage data to Amazon.",

--- a/packages/core/src/awsService/cdk/lsp/cdkCliResolver.ts
+++ b/packages/core/src/awsService/cdk/lsp/cdkCliResolver.ts
@@ -1,0 +1,154 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path'
+import * as semver from 'semver'
+import * as vscode from 'vscode'
+import fs from '../../../shared/fs/fs'
+import { getLogger } from '../../../shared/logger/logger'
+import { ChildProcess } from '../../../shared/utilities/processUtils'
+import { getResolvedShellEnv, mergeResolvedShellPath } from '../../../shared/env/resolveEnv'
+
+const logger = getLogger('cdkLsp')
+
+/**
+ * First GA `aws-cdk` release that ships the `cdk lsp` command (integrated via
+ * aws/aws-cdk-cli#1681, tagged aws-cdk@v2.1132.0). Older CLIs have no `lsp`
+ * subcommand, so we refuse to wire the client and prompt for an upgrade.
+ */
+export const minimumCdkLspVersion = '2.1132.0'
+
+/** Where in the discovery ladder a `cdk` binary was found. */
+export type CdkCliSource = 'setting' | 'nodeModules' | 'path'
+
+export interface ResolvedCdkCli {
+    /** Absolute path to the `cdk` executable, or the bare name to resolve via PATH. */
+    readonly command: string
+    readonly source: CdkCliSource
+    /** Parsed CLI version once probed. */
+    readonly version?: string
+}
+
+/**
+ * Build the environment the spawned `cdk lsp` (and its synth subprocess) needs.
+ *
+ * `cdk lsp` synthesizes the user's app as a child process (npx/ts-node, python,
+ * mvn), so it must inherit a login-shell PATH even when VS Code was launched
+ * from the Dock. We reuse the toolkit's shell resolver:
+ *  - `mergeResolvedShellPath` folds the login-shell PATH into process.env.PATH.
+ *  - JAVA_HOME is NOT carried by that merge, so we pull it from the full
+ *    resolved env for Java synth. Both calls hit the same 5-min cache, so only
+ *    one shell spawn happens.
+ *
+ * We do NOT inject AWS credentials: synth does not need them (only context
+ * lookups do), and triggering an auth prompt on editor open is unacceptable.
+ */
+export async function buildCdkSpawnEnv(): Promise<NodeJS.ProcessEnv> {
+    const merged = await mergeResolvedShellPath(process.env)
+    const env: NodeJS.ProcessEnv = { ...merged }
+
+    const resolved = await getResolvedShellEnv(process.env)
+    if (resolved?.JAVA_HOME && !env.JAVA_HOME) {
+        env.JAVA_HOME = resolved.JAVA_HOME
+    }
+    return env
+}
+
+/**
+ * Resolve the `cdk` CLI for a given CDK app directory using the full ladder:
+ *   1. explicit `aws.cdk.cliPath` setting (escape hatch),
+ *   2. workspace-local install (node_modules/.bin/cdk, walking up from appDir),
+ *   3. `cdk` on the resolved shell PATH.
+ * Returns undefined when no candidate exists on disk.
+ */
+export async function resolveCdkCli(appDir: string, env: NodeJS.ProcessEnv): Promise<ResolvedCdkCli | undefined> {
+    // 1. Setting override.
+    const configured = vscode.workspace.getConfiguration('aws.cdk').get<string>('cliPath')?.trim()
+    if (configured) {
+        if (await fs.existsFile(configured)) {
+            return { command: configured, source: 'setting' }
+        }
+        logger.warn(`aws.cdk.cliPath is set to a missing path: ${configured}`)
+    }
+
+    // 2. Workspace-local node_modules/.bin/cdk, walking up from the app dir.
+    const local = await findInNodeModules(appDir)
+    if (local) {
+        return { command: local, source: 'nodeModules' }
+    }
+
+    // 3. PATH (using the shell-resolved PATH).
+    const onPath = await findOnPath('cdk', env)
+    if (onPath) {
+        return { command: onPath, source: 'path' }
+    }
+
+    return undefined
+}
+
+/** Walk up from appDir looking for node_modules/.bin/cdk. */
+async function findInNodeModules(appDir: string): Promise<string | undefined> {
+    const binName = process.platform === 'win32' ? 'cdk.cmd' : 'cdk'
+    let dir = appDir
+    // Walk up to the filesystem root.
+    for (;;) {
+        const candidate = path.join(dir, 'node_modules', '.bin', binName)
+        if (await fs.existsFile(candidate)) {
+            return candidate
+        }
+        const parent = path.dirname(dir)
+        if (parent === dir) {
+            return undefined
+        }
+        dir = parent
+    }
+}
+
+/** `which`-style scan of env.PATH for an executable. */
+async function findOnPath(name: string, env: NodeJS.ProcessEnv): Promise<string | undefined> {
+    const rawPath = env.PATH ?? process.env.PATH ?? ''
+    const exts = process.platform === 'win32' ? ['.cmd', '.exe', '.bat', ''] : ['']
+    for (const dir of rawPath.split(path.delimiter)) {
+        if (!dir) {
+            continue
+        }
+        for (const ext of exts) {
+            const candidate = path.join(dir, name + ext)
+            if (await fs.existsFile(candidate)) {
+                return candidate
+            }
+        }
+    }
+    return undefined
+}
+
+/**
+ * Run `<cdk> --version` and return the parsed semver, or undefined if the
+ * command fails or its output is unrecognizable.
+ */
+export async function probeCdkVersion(command: string, env: NodeJS.ProcessEnv): Promise<string | undefined> {
+    try {
+        const proc = new ChildProcess(command, ['--version'], { spawnOptions: { env }, collect: true })
+        const result = await proc.run()
+        if (result.exitCode !== 0) {
+            logger.warn(`\`${command} --version\` exited ${result.exitCode}`)
+            return undefined
+        }
+        return parseCliVersion(result.stdout)
+    } catch (err) {
+        logger.warn(`Failed to probe cdk version: %O`, err)
+        return undefined
+    }
+}
+
+/** Extract the leading `X.Y.Z` from `cdk --version` output (e.g. "2.1132.0 (build abc)"). */
+export function parseCliVersion(out: string): string | undefined {
+    return out.match(/(\d+\.\d+\.\d+)/)?.[1]
+}
+
+/** True when `version` >= minimumCdkLspVersion. */
+export function meetsMinimum(version: string): boolean {
+    return semver.valid(version) !== null && semver.gte(version, minimumCdkLspVersion)
+}

--- a/packages/core/src/awsService/cdk/lsp/cdkCliResolver.ts
+++ b/packages/core/src/awsService/cdk/lsp/cdkCliResolver.ts
@@ -35,25 +35,26 @@ export interface ResolvedCdkCli {
  * Build the environment the spawned `cdk lsp` (and its synth subprocess) needs.
  *
  * `cdk lsp` synthesizes the user's app as a child process (npx/ts-node, python,
- * mvn), so it must inherit a login-shell PATH even when VS Code was launched
- * from the Dock. We reuse the toolkit's shell resolver:
- *  - `mergeResolvedShellPath` folds the login-shell PATH into process.env.PATH.
- *  - JAVA_HOME is NOT carried by that merge, so we pull it from the full
- *    resolved env for Java synth. Both calls hit the same 5-min cache, so only
- *    one shell spawn happens.
+ * mvn), so it must inherit the user's login-shell environment even when VS Code
+ * was launched from the Dock. We reuse the toolkit's shell resolver:
+ *  - `getResolvedShellEnv` returns the full login-shell env (PATH, JAVA_HOME,
+ *    MAVEN_OPTS, pyenv, ...), or undefined on Windows / when already launched
+ *    from a terminal / on failure.
+ *  - `mergeResolvedShellPath` folds the shell PATH into process.env.PATH as a
+ *    union, so VS Code's own PATH entries survive an rc file that resets PATH.
+ *
+ * The resolved env is spread underneath the merged env, so the extension-host
+ * env wins on collisions and PATH stays the union, while every other shell var
+ * fills in. Both calls share the resolver's 5-min cache, so only one shell
+ * spawn happens.
  *
  * We do NOT inject AWS credentials: synth does not need them (only context
  * lookups do), and triggering an auth prompt on editor open is unacceptable.
  */
 export async function buildCdkSpawnEnv(): Promise<NodeJS.ProcessEnv> {
     const merged = await mergeResolvedShellPath(process.env)
-    const env: NodeJS.ProcessEnv = { ...merged }
-
     const resolved = await getResolvedShellEnv(process.env)
-    if (resolved?.JAVA_HOME && !env.JAVA_HOME) {
-        env.JAVA_HOME = resolved.JAVA_HOME
-    }
-    return env
+    return resolved ? { ...resolved, ...merged } : merged
 }
 
 /**
@@ -90,6 +91,8 @@ export async function resolveCdkCli(appDir: string, env: NodeJS.ProcessEnv): Pro
 
 /** Walk up from appDir looking for node_modules/.bin/cdk. */
 async function findInNodeModules(appDir: string): Promise<string | undefined> {
+    // npm only writes a `.cmd` shim into node_modules/.bin (plus a `.ps1` and a POSIX
+    // shell script); `.cmd` is the only one Node can spawn on Windows.
     const binName = process.platform === 'win32' ? 'cdk.cmd' : 'cdk'
     let dir = appDir
     // Walk up to the filesystem root.
@@ -109,7 +112,9 @@ async function findInNodeModules(appDir: string): Promise<string | undefined> {
 /** `which`-style scan of env.PATH for an executable. */
 async function findOnPath(name: string, env: NodeJS.ProcessEnv): Promise<string | undefined> {
     const rawPath = env.PATH ?? process.env.PATH ?? ''
-    const exts = process.platform === 'win32' ? ['.cmd', '.exe', '.bat', ''] : ['']
+    // A cdk on PATH may be an npm `.cmd` shim, a native `.exe`, or a POSIX binary;
+    // npm never produces a `.bat`.
+    const exts = process.platform === 'win32' ? ['.cmd', '.exe', ''] : ['']
     for (const dir of rawPath.split(path.delimiter)) {
         if (!dir) {
             continue

--- a/packages/core/src/awsService/cdk/lsp/client.ts
+++ b/packages/core/src/awsService/cdk/lsp/client.ts
@@ -1,0 +1,225 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path'
+import * as vscode from 'vscode'
+import {
+    Executable,
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    TransportKind,
+} from 'vscode-languageclient/node'
+import { getLogger } from '../../../shared/logger/logger'
+import { telemetry } from '../../../shared/telemetry/telemetry'
+import { detectCdkProjects } from '../explorer/detectCdkProjects'
+import { buildCdkSpawnEnv, meetsMinimum, minimumCdkLspVersion, probeCdkVersion, resolveCdkCli } from './cdkCliResolver'
+
+const logger = getLogger('cdkLsp')
+
+/**
+ * A single CDK language server serves one app directory (the server accepts one
+ * `applicationDir`). We deliberately run ONE client per window rather than one
+ * per cdk.json: vscode-languageclient auto-registers the server's
+ * executeCommandProvider commands via `vscode.commands.registerCommand`, which
+ * throws on a duplicate id, so N clients in a multi-app workspace would fail to
+ * start. The app dir is the `aws.cdk.appDir` setting, else the sole detected
+ * CDK app (with a hint to set the setting when several are found).
+ */
+let client: LanguageClient | undefined
+let outputChannel: vscode.OutputChannel | undefined
+/** Message kinds surfaced since the last (re)start, so we notify at most once. */
+const notified = new Set<string>()
+
+/**
+ * Wire the CDK language server. Registers listeners synchronously and starts
+ * the server in the background; never blocks extension activation on the
+ * shell-env resolve or version probe. Safe when there is no CDK project (no-op).
+ */
+export function activateCdkLsp(context: vscode.ExtensionContext): void {
+    // CodeLens command the server emits (OPEN_RESOURCE_COMMAND in cdk-explorer):
+    // open a synthesized-template resource, or a picker when several share a line.
+    context.subscriptions.push(vscode.commands.registerCommand('cdkExplorer.openResource', openResourceCommand), {
+        dispose: () => void stopClient(),
+    })
+
+    // Re-resolve on the events that can change which app dir (if any) we serve,
+    // so the server starts/stops without a window reload.
+    const cdkJsonWatcher = vscode.workspace.createFileSystemWatcher('**/cdk.json')
+    context.subscriptions.push(
+        cdkJsonWatcher,
+        cdkJsonWatcher.onDidCreate((uri) => {
+            // A CDK project appeared where we weren't serving one. Ignore vendored
+            // fixtures under node_modules.
+            if (!client && !uri.fsPath.includes(`${path.sep}node_modules${path.sep}`)) {
+                void restartClient(context)
+            }
+        }),
+        vscode.workspace.onDidChangeWorkspaceFolders(() => void restartClient(context)),
+        vscode.workspace.onDidChangeConfiguration((e) => {
+            if (e.affectsConfiguration('aws.cdk.appDir') || e.affectsConfiguration('aws.cdk.cliPath')) {
+                void restartClient(context)
+            }
+        })
+    )
+
+    void restartClient(context)
+}
+
+export async function deactivateCdkLsp(): Promise<void> {
+    await stopClient()
+}
+
+/** Resolve the single CDK app directory to serve, or undefined to stay off. */
+async function resolveAppDir(): Promise<string | undefined> {
+    const configured = vscode.workspace.getConfiguration('aws.cdk').get<string>('appDir')?.trim()
+    if (configured) {
+        return path.isAbsolute(configured)
+            ? configured
+            : path.join(vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '', configured)
+    }
+
+    // Activation gate: reuse the explorer's cdk.json detection so we never spawn
+    // in a non-CDK workspace.
+    const dirs = (await detectCdkProjects()).map((p) => path.dirname(p.cdkJsonUri.fsPath)).sort()
+    if (dirs.length === 0) {
+        return undefined
+    }
+    if (dirs.length > 1) {
+        notifyOnce(
+            'multipleApps',
+            `Multiple CDK apps found. Using ${dirs[0]}. Set aws.cdk.appDir to choose a different one.`
+        )
+    }
+    return dirs[0]
+}
+
+/** Stop any running client, then (re)resolve and start one for the current app dir. */
+async function restartClient(context: vscode.ExtensionContext): Promise<void> {
+    await stopClient()
+    try {
+        const appDir = await resolveAppDir()
+        if (!appDir) {
+            return
+        }
+
+        // Resolve the shell env once; the ladder's PATH rung and the spawn reuse it.
+        const env = await buildCdkSpawnEnv()
+
+        const resolved = await resolveCdkCli(appDir, env)
+        if (!resolved) {
+            notifyOnce(
+                'missing',
+                `CDK language features need the AWS CDK CLI. Install it (>= ${minimumCdkLspVersion}) or set aws.cdk.cliPath.`
+            )
+            telemetry.cdk_startLanguageServer.emit({ result: 'Failed', reason: 'cdkCliNotFound' })
+            return
+        }
+
+        // Version gate: `cdk lsp` only exists on >= minimumCdkLspVersion.
+        const version = await probeCdkVersion(resolved.command, env)
+        if (!version || !meetsMinimum(version)) {
+            logger.info(`cdk at ${resolved.command} is ${version ?? 'unknown'}; need >= ${minimumCdkLspVersion}`)
+            notifyOnce(
+                'outdated',
+                `AWS CDK CLI ${version ?? ''} is too old for language features. Upgrade to >= ${minimumCdkLspVersion}.`
+            )
+            telemetry.cdk_startLanguageServer.emit({
+                result: 'Failed',
+                reason: 'cdkCliOutdated',
+                cdkCliVersion: version,
+            })
+            return
+        }
+
+        const executable: Executable = {
+            command: resolved.command,
+            args: ['lsp'],
+            transport: TransportKind.stdio,
+            options: { cwd: appDir, env },
+        }
+        const serverOptions: ServerOptions = { run: executable, debug: executable }
+
+        outputChannel = vscode.window.createOutputChannel('CDK Language Server')
+        const clientOptions: LanguageClientOptions = {
+            // Source-linked features cover TypeScript + jsii host languages, plus
+            // synthesized templates for template -> construct go-to-definition.
+            documentSelector: [
+                { scheme: 'file', language: 'typescript' },
+                { scheme: 'file', language: 'python' },
+                { scheme: 'file', language: 'java' },
+                { scheme: 'file', pattern: '**/*.template.json' },
+            ],
+            initializationOptions: { applicationDir: appDir },
+            outputChannel,
+            workspaceFolder: vscode.workspace.getWorkspaceFolder(vscode.Uri.file(appDir)),
+        }
+
+        client = new LanguageClient('cdkLsp', 'CDK Language Server', serverOptions, clientOptions)
+        logger.info(`Starting \`cdk lsp\` for ${appDir} (cdk ${version} via ${resolved.source})`)
+        await client.start()
+        telemetry.cdk_startLanguageServer.emit({
+            result: 'Succeeded',
+            cdkCliSource: resolved.source,
+            cdkCliVersion: version,
+        })
+    } catch (err) {
+        logger.error(`Failed to start cdk lsp: %O`, err)
+        telemetry.cdk_startLanguageServer.emit({ result: 'Failed', reason: 'startError' })
+        await stopClient()
+    }
+}
+
+async function stopClient(): Promise<void> {
+    const stopping = client?.stop().catch(() => {})
+    client = undefined
+    outputChannel?.dispose()
+    outputChannel = undefined
+    notified.clear()
+    await stopping
+}
+
+function notifyOnce(kind: string, message: string): void {
+    if (notified.has(kind)) {
+        return
+    }
+    notified.add(kind)
+    // Non-blocking, dismissible.
+    void vscode.window.showInformationMessage(message)
+}
+
+/**
+ * Handler for the `cdkExplorer.openResource` CodeLens command the server emits.
+ * `choices` are QuickPick-shaped resource targets ({ label: CFN type,
+ * description: construct name, target: { uri, range } }).
+ */
+async function openResourceCommand(
+    choices: Array<{
+        label: string
+        description: string
+        target: {
+            uri: string
+            range: { start: { line: number; character: number }; end: { line: number; character: number } }
+        }
+    }>
+): Promise<void> {
+    const chosen =
+        choices.length === 1
+            ? choices[0]
+            : await vscode.window.showQuickPick(choices, {
+                  placeHolder: 'Open resource in synthesized template',
+                  matchOnDescription: true,
+              })
+    if (!chosen) {
+        return
+    }
+    const { uri, range } = chosen.target
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(uri))
+    const editor = await vscode.window.showTextDocument(document)
+    const start = new vscode.Position(range.start.line, range.start.character)
+    const end = new vscode.Position(range.end.line, range.end.character)
+    editor.selection = new vscode.Selection(start, end)
+    editor.revealRange(new vscode.Range(start, end), vscode.TextEditorRevealType.InCenter)
+}

--- a/packages/core/src/awsService/cdk/lsp/client.ts
+++ b/packages/core/src/awsService/cdk/lsp/client.ts
@@ -154,11 +154,16 @@ async function restartClient(context: vscode.ExtensionContext): Promise<void> {
             return
         }
 
+        // On Windows the resolved cdk is a `.cmd` shim, which child_process.spawn
+        // (used by vscode-languageclient) can only run through a shell. shell:true
+        // routes it via cmd.exe; quoting the command keeps a path with spaces
+        // (C:\Users\First Last\...) parseable, since spawn+shell does not quote args.
+        const isWindows = process.platform === 'win32'
         const executable: Executable = {
-            command: resolved.command,
+            command: isWindows ? `"${resolved.command}"` : resolved.command,
             args: ['lsp'],
             transport: TransportKind.stdio,
-            options: { cwd: appDir, env },
+            options: { cwd: appDir, env, shell: isWindows },
         }
         const serverOptions: ServerOptions = { run: executable, debug: executable }
 

--- a/packages/core/src/awsService/cdk/lsp/client.ts
+++ b/packages/core/src/awsService/cdk/lsp/client.ts
@@ -32,6 +32,9 @@ let client: LanguageClient | undefined
 let outputChannel: vscode.OutputChannel | undefined
 /** Message kinds surfaced since the last (re)start, so we notify at most once. */
 const notified = new Set<string>()
+/** Serializes (re)starts into a queue-of-one so overlapping triggers never leak a client. */
+let restartInFlight: Promise<void> = Promise.resolve()
+let restartQueued = false
 
 /**
  * Wire the CDK language server. Registers listeners synchronously and starts
@@ -54,18 +57,35 @@ export function activateCdkLsp(context: vscode.ExtensionContext): void {
             // A CDK project appeared where we weren't serving one. Ignore vendored
             // fixtures under node_modules.
             if (!client && !uri.fsPath.includes(`${path.sep}node_modules${path.sep}`)) {
-                void restartClient(context)
+                scheduleRestart(context)
             }
         }),
-        vscode.workspace.onDidChangeWorkspaceFolders(() => void restartClient(context)),
+        vscode.workspace.onDidChangeWorkspaceFolders(() => scheduleRestart(context)),
         vscode.workspace.onDidChangeConfiguration((e) => {
             if (e.affectsConfiguration('aws.cdk.appDir') || e.affectsConfiguration('aws.cdk.cliPath')) {
-                void restartClient(context)
+                scheduleRestart(context)
             }
         })
     )
 
-    void restartClient(context)
+    scheduleRestart(context)
+}
+
+/**
+ * Serialize (re)starts into a queue-of-one. Overlapping triggers (activation,
+ * config/folder changes, a new cdk.json) must not run two starts concurrently,
+ * or the second would overwrite `client` and leak the first. A burst coalesces
+ * into at most one trailing restart, which observes the latest state.
+ */
+function scheduleRestart(context: vscode.ExtensionContext): void {
+    if (restartQueued) {
+        return
+    }
+    restartQueued = true
+    restartInFlight = restartInFlight.then(() => {
+        restartQueued = false
+        return restartClient(context)
+    })
 }
 
 export async function deactivateCdkLsp(): Promise<void> {

--- a/packages/core/src/awsexplorer/activation.ts
+++ b/packages/core/src/awsexplorer/activation.ts
@@ -24,6 +24,7 @@ import { checkExplorerForDefaultRegion } from './defaultRegion'
 import { ToolView } from './toolView'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { CdkRootNode } from '../awsService/cdk/explorer/rootNode'
+import { activateCdkLsp } from '../awsService/cdk/lsp/client'
 import { CodeCatalystRootNode } from '../codecatalyst/explorer'
 import { CodeCatalystAuthenticationProvider } from '../codecatalyst/auth'
 import { S3FolderNode } from '../awsService/s3/explorer/s3FolderNode'
@@ -136,6 +137,10 @@ export async function activate(args: {
     for (const viewNode of viewNodes) {
         registerToolView(viewNode, args.context.extensionContext)
     }
+
+    // Start `cdk lsp` (discovered from the user's installed CDK CLI) for the CDK app in the workspace.
+    // Non-blocking: registers listeners synchronously and starts the server in the background.
+    activateCdkLsp(args.context.extensionContext)
 
     const toolkitAuthProvider = new CommonAuthViewProvider(args.context.extensionContext, 'toolkit')
     args.context.extensionContext.subscriptions.push(

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -16,6 +16,7 @@ export type LogTopic =
     | 'amazonqLsp'
     | 'amazonqLsp.lspClient'
     | 'awsCfnLsp'
+    | 'cdkLsp'
     | 'chat'
     | 'stepfunctions'
     | 'unknown'

--- a/packages/core/src/shared/settings-toolkit.gen.ts
+++ b/packages/core/src/shared/settings-toolkit.gen.ts
@@ -15,6 +15,8 @@ export const toolkitSettings = {
     "aws.iot.maxItemsPerPage": {},
     "aws.s3.maxItemsPerPage": {},
     "aws.samcli.location": {},
+    "aws.cdk.cliPath": {},
+    "aws.cdk.appDir": {},
     "aws.samcli.lambdaTimeout": {},
     "aws.samcli.legacyDeploy": {},
     "aws.telemetry": {},

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -343,6 +343,17 @@
             "type": "string",
             "allowedValues": ["accepted", "declined", "dismissed"],
             "description": "Whether the user accepted, declined or dismissed the smus context prompt to add to AGENTS.md"
+        },
+        {
+            "name": "cdkCliSource",
+            "type": "string",
+            "allowedValues": ["setting", "nodeModules", "path"],
+            "description": "Where the CDK CLI was found in the discovery ladder (setting override, workspace node_modules, or shell PATH)."
+        },
+        {
+            "name": "cdkCliVersion",
+            "type": "string",
+            "description": "Version of the discovered AWS CDK CLI."
         }
     ],
     "metrics": [
@@ -1916,6 +1927,16 @@
                     "type": "smusAcceptAgentContextAction",
                     "required": false
                 }
+            ]
+        },
+        {
+            "name": "cdk_startLanguageServer",
+            "description": "Result of starting the CDK language server (`cdk lsp`) discovered from the user's installed CDK CLI.",
+            "metadata": [
+                { "type": "result" },
+                { "type": "reason", "required": false },
+                { "type": "cdkCliSource", "required": false },
+                { "type": "cdkCliVersion", "required": false }
             ]
         }
     ]

--- a/packages/toolkit/.changes/next-release/Feature-cdk-language-server.json
+++ b/packages/toolkit/.changes/next-release/Feature-cdk-language-server.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "CDK: start the CDK Language Server (`cdk lsp`) from your installed CDK CLI, linking construct source, synthesized template, and policy violations"
+}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -123,6 +123,18 @@
                     "default": "",
                     "markdownDescription": "%AWS.configuration.description.samcli.location%"
                 },
+                "aws.cdk.cliPath": {
+                    "type": "string",
+                    "scope": "machine",
+                    "default": "",
+                    "markdownDescription": "%AWS.configuration.description.cdk.cliPath%"
+                },
+                "aws.cdk.appDir": {
+                    "type": "string",
+                    "scope": "window",
+                    "default": "",
+                    "markdownDescription": "%AWS.configuration.description.cdk.appDir%"
+                },
                 "aws.samcli.lambdaTimeout": {
                     "type": "number",
                     "default": 90000,


### PR DESCRIPTION
The CDK CLI now ships a language server (`cdk lsp`, added in aws-cdk 2.1132.0) that links construct source, the synthesized template, and policy violations. This PR starts `cdk lsp` from the user's own CDK CLI as a stdio language client for the CDK app in the workspace.

Design:
- Discover the CLI in order: `aws.cdk.cliPath` setting, workspace `node_modules/.bin/cdk`, then PATH. Local first, so the server matches the version the project synths with.
- Require cdk >= 2.1132.0 (the first release with `cdk lsp`). Older or missing CLIs get a dismissible prompt instead of a broken start.
- Gate activation on `detectCdkProjects` so nothing spawns outside a CDK workspace, and resolve a login-shell PATH via `resolveEnv` so the server's
  synth subprocess finds node and java. Credentials are not injected.
- Run one client per window; `aws.cdk.appDir` selects the app when a workspace has more than one. A single client avoids the duplicate `executeCommand`registration that multiple clients would hit.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
