### PR TITLE
feat(toolkit): cdk tree lsp source link

### DIFF
--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -13,6 +13,8 @@
     "AWS.configuration.description.s3.maxItemsPerPage": "Controls how many S3 items are listed before showing a node to `Load More...`.\nThis corresponds to the `MaxKeys` requested in a single call to S3. [Learn More](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#AmazonS3-ListObjectsV2-response-MaxKeys)",
     "AWS.configuration.description.samcli.lambdaTimeout": "Maximum time (in milliseconds) to wait for SAM output while starting a Local Lambda session",
     "AWS.configuration.description.samcli.location": "Location of SAM CLI. SAM CLI is used to create, build, package, and deploy Serverless Applications. [Learn More](https://aws.amazon.com/serverless/sam/)",
+    "AWS.configuration.description.cdk.cliPath": "Absolute path to the AWS CDK CLI (`cdk`) used to start the CDK language server. Leave empty to auto-discover from the workspace's `node_modules` or your shell PATH.",
+    "AWS.configuration.description.cdk.appDir": "Directory of the CDK app (the folder containing `cdk.json`) that the CDK language server should analyze. Relative paths resolve against the first workspace folder. Leave empty to auto-detect; set this when a workspace has more than one CDK app.",
     "AWS.configuration.description.samcli.legacyDeploy": "Use the legacy SAM deploy experience, disabling all SAM sync functionality.",
     "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS. [Details](https://docs.aws.amazon.com/sdkref/latest/guide/support-maint-idetoolkits.html)",
     "AWS.configuration.description.telemetry.cn": "Enable Amazon Toolkit to send usage data to Amazon.",

--- a/packages/core/package.nls.json
+++ b/packages/core/package.nls.json
@@ -243,6 +243,7 @@
     "AWS.command.stepFunctions.publishStateMachine": "Publish state machine to Step Functions",
     "AWS.command.stepFunctions.openWithWorkflowStudio": "Open with Workflow Studio",
     "AWS.command.cdk.previewStateMachine": "Render state machine graph from CDK application",
+    "AWS.command.cdk.openTemplate": "Open CloudFormation Template",
     "AWS.command.copyLogResource": "Copy Log Stream or Group",
     "AWS.command.saveCurrentLogDataContent": "Save Log to File",
     "AWS.command.cwl.changeFilterPattern": "Search by Pattern...",

--- a/packages/core/src/awsService/cdk/explorer/cdkProject.ts
+++ b/packages/core/src/awsService/cdk/explorer/cdkProject.ts
@@ -6,10 +6,13 @@
 import * as vscode from 'vscode'
 import fs from '../../../shared/fs/fs'
 import { ConstructTree } from './tree/types'
+import { fetchConstructSourceMap, type ConstructSourceInfo } from './sourceLinks'
 
 export interface CdkApp {
     location: CdkAppLocation
     constructTree: ConstructTree
+    /** Construct path -> resolved source/template info, from the CDK language server. Absent when unavailable. */
+    sourceMap?: ReadonlyMap<string, ConstructSourceInfo>
 }
 
 export interface CdkAppLocation {
@@ -19,6 +22,7 @@ export interface CdkAppLocation {
 
 export async function getApp(location: CdkAppLocation): Promise<CdkApp> {
     const constructTree = JSON.parse(await fs.readFileText(location.treeUri)) as ConstructTree
+    const sourceMap = await fetchConstructSourceMap()
 
-    return { location, constructTree }
+    return { location, constructTree, sourceMap }
 }

--- a/packages/core/src/awsService/cdk/explorer/nodes/appNode.ts
+++ b/packages/core/src/awsService/cdk/explorer/nodes/appNode.ts
@@ -32,7 +32,7 @@ export class AppNode implements TreeNode {
 
             const constructsInTree = successfulApp.constructTree.tree.children
             if (constructsInTree) {
-                constructs.push(...generateConstructNodes(this.location, constructsInTree))
+                constructs.push(...generateConstructNodes(this.location, constructsInTree, successfulApp.sourceMap))
             }
 
             // indicate that App exists, but it is empty

--- a/packages/core/src/awsService/cdk/explorer/nodes/constructNode.ts
+++ b/packages/core/src/awsService/cdk/explorer/nodes/constructNode.ts
@@ -3,10 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
 import * as vscode from 'vscode'
 import { getIcon } from '../../../../shared/icons'
 import { TreeNode } from '../../../../shared/treeview/resourceTreeDataProvider'
 import { CdkAppLocation } from '../cdkProject'
+import { ConstructSourceInfo } from '../sourceLinks'
 import * as treeInspector from '../tree/treeInspector'
 import { ConstructTreeEntity } from '../tree/types'
 import { generatePropertyNodes } from './propertyNode'
@@ -18,20 +22,26 @@ export class ConstructNode implements TreeNode {
 
     public constructor(
         private readonly location: CdkAppLocation,
-        private readonly construct: ConstructTreeEntity
+        private readonly construct: ConstructTreeEntity,
+        private readonly sourceMap?: ReadonlyMap<string, ConstructSourceInfo>
     ) {}
 
     public get resource() {
+        const info = this.sourceMap?.get(this.construct.path)
         return {
             construct: this.construct,
             location: this.location.treeUri.with({ fragment: this.construct.path }),
+            templateFile: info?.templateFile,
+            templateOffset: info?.templateOffset,
         }
     }
 
     public getChildren() {
         const propertyNodes = this.properties !== undefined ? generatePropertyNodes(this.properties) : []
         const constructNodes =
-            this.construct.children !== undefined ? generateConstructNodes(this.location, this.construct.children) : []
+            this.construct.children !== undefined
+                ? generateConstructNodes(this.location, this.construct.children, this.sourceMap)
+                : []
 
         return [...propertyNodes, ...constructNodes]
     }
@@ -43,18 +53,42 @@ export class ConstructNode implements TreeNode {
                 : vscode.TreeItemCollapsibleState.None
 
         const item = new vscode.TreeItem(treeInspector.getDisplayLabel(this.construct), collapsibleState)
-        item.contextValue = isStateMachine(this.construct) ? 'awsCdkStateMachineNode' : 'awsCdkConstructNode'
+        // What the CDK language server resolved for this construct (source
+        // location and/or template target); absent when the server is unavailable.
+        const info = this.sourceMap?.get(this.construct.path)
+        const baseContext = isStateMachine(this.construct) ? 'awsCdkStateMachineNode' : 'awsCdkConstructNode'
+        // Mark nodes that map to a template resource so the inline "open template"
+        // icon (contributed for viewItem =~ /WithTemplate$/) shows only where it applies.
+        item.contextValue = info?.templateFile ? `${baseContext}WithTemplate` : baseContext
         item.tooltip = this.type || this.construct.path
         item.iconPath = this.type ? getIcon('aws-cloudformation-stack') : getIcon('aws-cdk-logo')
+
+        // Source link: when the CDK language server resolved this construct to a
+        // source location, open it on click. Nodes with no resolved location (or
+        // when the server is unavailable) keep their original click behavior.
+        const source = info?.sourceLocation
+        if (source) {
+            // SourceLocation is 1-based; vscode.Position is 0-based.
+            const position = new vscode.Position(Math.max(0, source.line - 1), Math.max(0, source.column - 1))
+            item.command = {
+                command: 'vscode.open',
+                title: localize('AWS.cdk.explorerNode.openSource', 'Open Source'),
+                arguments: [vscode.Uri.file(source.file), { selection: new vscode.Range(position, position) }],
+            }
+        }
 
         return item
     }
 }
 
-export function generateConstructNodes(app: CdkAppLocation, children: NonNullable<ConstructTreeEntity['children']>) {
+export function generateConstructNodes(
+    app: CdkAppLocation,
+    children: NonNullable<ConstructTreeEntity['children']>,
+    sourceMap?: ReadonlyMap<string, ConstructSourceInfo>
+) {
     return Object.values(children)
         .filter((c) => treeInspector.includeConstructInTree(c))
-        .map((c) => new ConstructNode(app, c))
+        .map((c) => new ConstructNode(app, c, sourceMap))
 }
 
 /**

--- a/packages/core/src/awsService/cdk/explorer/openTemplate.ts
+++ b/packages/core/src/awsService/cdk/explorer/openTemplate.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { isTreeNode } from '../../../shared/treeview/resourceTreeDataProvider'
+import { unboxTreeNode } from '../../../shared/treeview/utils'
+
+interface TemplateTarget {
+    templateFile: string
+    templateOffset?: number
+}
+
+function isTemplateTarget(resource: unknown): resource is TemplateTarget {
+    return (
+        !!resource &&
+        typeof resource === 'object' &&
+        typeof (resource as { templateFile?: unknown }).templateFile === 'string'
+    )
+}
+
+/**
+ * Open the synthesized CloudFormation template for a construct, positioned on
+ * the resource's block when the language server provided an offset. Wired to the
+ * inline "open template" icon shown on construct nodes whose context value ends
+ * in `WithTemplate`.
+ */
+export async function openCdkTemplate(input?: unknown): Promise<void> {
+    const target = isTreeNode(input) ? unboxTreeNode(input, isTemplateTarget) : undefined
+    if (!target) {
+        return
+    }
+
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.file(target.templateFile))
+    const options: vscode.TextDocumentShowOptions = {}
+    if (target.templateOffset !== undefined) {
+        // templateOffset is a 0-based character offset into the template text.
+        const position = document.positionAt(target.templateOffset)
+        options.selection = new vscode.Range(position, position)
+    }
+    await vscode.window.showTextDocument(document, options)
+}

--- a/packages/core/src/awsService/cdk/explorer/rootNode.ts
+++ b/packages/core/src/awsService/cdk/explorer/rootNode.ts
@@ -12,6 +12,7 @@ import { localize, openUrl } from '../../../shared/utilities/vsCodeUtils'
 import { Commands } from '../../../shared/vscode/commands2'
 import { detectCdkProjects } from './detectCdkProjects'
 import { AppNode } from './nodes/appNode'
+import { openCdkTemplate } from './openTemplate'
 
 export async function getAppNodes(): Promise<TreeNode[]> {
     const appsFound = await detectCdkProjects(vscode.workspace.workspaceFolders)
@@ -35,6 +36,9 @@ export class CdkRootNode implements TreeNode {
             void openUrl(vscode.Uri.parse(cdkDocumentationUrl))
             telemetry.aws_help.emit({ name: 'cdk' })
         })
+        // Open a construct's resource in its synthesized template (inline icon on
+        // nodes the language server mapped to a template resource).
+        Commands.register('aws.cdk.openTemplate', (input?: unknown) => openCdkTemplate(input))
         this._refreshCdkExplorer = (provider?: ResourceTreeDataProvider) =>
             Commands.register('aws.cdk.refresh', () => {
                 this.refresh()

--- a/packages/core/src/awsService/cdk/explorer/sourceLinks.ts
+++ b/packages/core/src/awsService/cdk/explorer/sourceLinks.ts
@@ -1,0 +1,94 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { State } from 'vscode-languageclient/node'
+import { getLogger } from '../../../shared/logger/logger'
+import { getCdkLanguageClient } from '../lsp/client'
+
+/**
+ * Source location of a construct, as resolved by the CDK language server.
+ * 1-based line and column, mirroring the server's `cdk/getConstructTree` result.
+ */
+export interface SourceLocation {
+    readonly file: string
+    readonly line: number
+    readonly column: number
+}
+
+// Mirror of cdk-explorer's LSP `cdk/getConstructTree` contract. The Toolkit
+// consumes it over the protocol (method + JSON), so it declares matching shapes
+// rather than importing across repos.
+const getConstructTreeMethod = 'cdk/getConstructTree'
+
+interface ConstructSourceEntry {
+    readonly path: string
+    readonly sourceLocation?: SourceLocation
+    readonly templateFile?: string
+    readonly templateOffset?: number
+}
+
+interface GetConstructTreeResult {
+    readonly status: 'ok' | 'no-assembly'
+    readonly entries: readonly ConstructSourceEntry[]
+}
+
+/**
+ * What the server resolved for one construct: where it was created in source,
+ * and/or where its resource lives in the synthesized template. Either half may
+ * be absent.
+ */
+export interface ConstructSourceInfo {
+    readonly sourceLocation?: SourceLocation
+    readonly templateFile?: string
+    readonly templateOffset?: number
+}
+
+// The server reads the assembly asynchronously on startup, so getConstructTree
+// can briefly return 'no-assembly' right after the client connects. Retry a few
+// times before giving up (the client-state refresh in client.ts re-runs this
+// once the client reaches Running, so this only bridges the server-side read).
+const noAssemblyRetries = 8
+const noAssemblyRetryDelayMs = 250
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Ask the running CDK language server to resolve each construct's source
+ * location and template target, returned as a map keyed by construct path (the
+ * same path tree.json uses). Returns an empty map when the server is not running
+ * or the app is not synthesized, so the tree simply renders without links.
+ */
+export async function fetchConstructSourceMap(): Promise<ReadonlyMap<string, ConstructSourceInfo>> {
+    const client = getCdkLanguageClient()
+    if (!client || client.state !== State.Running) {
+        return new Map()
+    }
+
+    try {
+        let result = await client.sendRequest<GetConstructTreeResult>(getConstructTreeMethod)
+        // We only reach here once tree.json exists, so 'no-assembly' means the
+        // server has not finished its initial read yet — a transient startup race.
+        for (let attempt = 0; result.status === 'no-assembly' && attempt < noAssemblyRetries; attempt++) {
+            await sleep(noAssemblyRetryDelayMs)
+            result = await client.sendRequest<GetConstructTreeResult>(getConstructTreeMethod)
+        }
+        const map = new Map<string, ConstructSourceInfo>()
+        for (const entry of result.entries) {
+            if (entry.sourceLocation || entry.templateFile) {
+                map.set(entry.path, {
+                    sourceLocation: entry.sourceLocation,
+                    templateFile: entry.templateFile,
+                    templateOffset: entry.templateOffset,
+                })
+            }
+        }
+        return map
+    } catch (err) {
+        getLogger('cdkLsp').warn('CDK source links unavailable: %s', (err as Error).message)
+        return new Map()
+    }
+}

--- a/packages/core/src/awsService/cdk/lsp/cdkCliResolver.ts
+++ b/packages/core/src/awsService/cdk/lsp/cdkCliResolver.ts
@@ -1,0 +1,154 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path'
+import * as semver from 'semver'
+import * as vscode from 'vscode'
+import fs from '../../../shared/fs/fs'
+import { getLogger } from '../../../shared/logger/logger'
+import { ChildProcess } from '../../../shared/utilities/processUtils'
+import { getResolvedShellEnv, mergeResolvedShellPath } from '../../../shared/env/resolveEnv'
+
+const logger = getLogger('cdkLsp')
+
+/**
+ * First GA `aws-cdk` release that ships the `cdk lsp` command (integrated via
+ * aws/aws-cdk-cli#1681, tagged aws-cdk@v2.1132.0). Older CLIs have no `lsp`
+ * subcommand, so we refuse to wire the client and prompt for an upgrade.
+ */
+export const minimumCdkLspVersion = '2.1132.0'
+
+/** Where in the discovery ladder a `cdk` binary was found. */
+export type CdkCliSource = 'setting' | 'nodeModules' | 'path'
+
+export interface ResolvedCdkCli {
+    /** Absolute path to the `cdk` executable, or the bare name to resolve via PATH. */
+    readonly command: string
+    readonly source: CdkCliSource
+    /** Parsed CLI version once probed. */
+    readonly version?: string
+}
+
+/**
+ * Build the environment the spawned `cdk lsp` (and its synth subprocess) needs.
+ *
+ * `cdk lsp` synthesizes the user's app as a child process (npx/ts-node, python,
+ * mvn), so it must inherit a login-shell PATH even when VS Code was launched
+ * from the Dock. We reuse the toolkit's shell resolver:
+ *  - `mergeResolvedShellPath` folds the login-shell PATH into process.env.PATH.
+ *  - JAVA_HOME is NOT carried by that merge, so we pull it from the full
+ *    resolved env for Java synth. Both calls hit the same 5-min cache, so only
+ *    one shell spawn happens.
+ *
+ * We do NOT inject AWS credentials: synth does not need them (only context
+ * lookups do), and triggering an auth prompt on editor open is unacceptable.
+ */
+export async function buildCdkSpawnEnv(): Promise<NodeJS.ProcessEnv> {
+    const merged = await mergeResolvedShellPath(process.env)
+    const env: NodeJS.ProcessEnv = { ...merged }
+
+    const resolved = await getResolvedShellEnv(process.env)
+    if (resolved?.JAVA_HOME && !env.JAVA_HOME) {
+        env.JAVA_HOME = resolved.JAVA_HOME
+    }
+    return env
+}
+
+/**
+ * Resolve the `cdk` CLI for a given CDK app directory using the full ladder:
+ *   1. explicit `aws.cdk.cliPath` setting (escape hatch),
+ *   2. workspace-local install (node_modules/.bin/cdk, walking up from appDir),
+ *   3. `cdk` on the resolved shell PATH.
+ * Returns undefined when no candidate exists on disk.
+ */
+export async function resolveCdkCli(appDir: string, env: NodeJS.ProcessEnv): Promise<ResolvedCdkCli | undefined> {
+    // 1. Setting override.
+    const configured = vscode.workspace.getConfiguration('aws.cdk').get<string>('cliPath')?.trim()
+    if (configured) {
+        if (await fs.existsFile(configured)) {
+            return { command: configured, source: 'setting' }
+        }
+        logger.warn(`aws.cdk.cliPath is set to a missing path: ${configured}`)
+    }
+
+    // 2. Workspace-local node_modules/.bin/cdk, walking up from the app dir.
+    const local = await findInNodeModules(appDir)
+    if (local) {
+        return { command: local, source: 'nodeModules' }
+    }
+
+    // 3. PATH (using the shell-resolved PATH).
+    const onPath = await findOnPath('cdk', env)
+    if (onPath) {
+        return { command: onPath, source: 'path' }
+    }
+
+    return undefined
+}
+
+/** Walk up from appDir looking for node_modules/.bin/cdk. */
+async function findInNodeModules(appDir: string): Promise<string | undefined> {
+    const binName = process.platform === 'win32' ? 'cdk.cmd' : 'cdk'
+    let dir = appDir
+    // Walk up to the filesystem root.
+    for (;;) {
+        const candidate = path.join(dir, 'node_modules', '.bin', binName)
+        if (await fs.existsFile(candidate)) {
+            return candidate
+        }
+        const parent = path.dirname(dir)
+        if (parent === dir) {
+            return undefined
+        }
+        dir = parent
+    }
+}
+
+/** `which`-style scan of env.PATH for an executable. */
+async function findOnPath(name: string, env: NodeJS.ProcessEnv): Promise<string | undefined> {
+    const rawPath = env.PATH ?? process.env.PATH ?? ''
+    const exts = process.platform === 'win32' ? ['.cmd', '.exe', '.bat', ''] : ['']
+    for (const dir of rawPath.split(path.delimiter)) {
+        if (!dir) {
+            continue
+        }
+        for (const ext of exts) {
+            const candidate = path.join(dir, name + ext)
+            if (await fs.existsFile(candidate)) {
+                return candidate
+            }
+        }
+    }
+    return undefined
+}
+
+/**
+ * Run `<cdk> --version` and return the parsed semver, or undefined if the
+ * command fails or its output is unrecognizable.
+ */
+export async function probeCdkVersion(command: string, env: NodeJS.ProcessEnv): Promise<string | undefined> {
+    try {
+        const proc = new ChildProcess(command, ['--version'], { spawnOptions: { env }, collect: true })
+        const result = await proc.run()
+        if (result.exitCode !== 0) {
+            logger.warn(`\`${command} --version\` exited ${result.exitCode}`)
+            return undefined
+        }
+        return parseCliVersion(result.stdout)
+    } catch (err) {
+        logger.warn(`Failed to probe cdk version: %O`, err)
+        return undefined
+    }
+}
+
+/** Extract the leading `X.Y.Z` from `cdk --version` output (e.g. "2.1132.0 (build abc)"). */
+export function parseCliVersion(out: string): string | undefined {
+    return out.match(/(\d+\.\d+\.\d+)/)?.[1]
+}
+
+/** True when `version` >= minimumCdkLspVersion. */
+export function meetsMinimum(version: string): boolean {
+    return semver.valid(version) !== null && semver.gte(version, minimumCdkLspVersion)
+}

--- a/packages/core/src/awsService/cdk/lsp/client.ts
+++ b/packages/core/src/awsService/cdk/lsp/client.ts
@@ -1,0 +1,225 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path'
+import * as vscode from 'vscode'
+import {
+    Executable,
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    TransportKind,
+} from 'vscode-languageclient/node'
+import { getLogger } from '../../../shared/logger/logger'
+import { telemetry } from '../../../shared/telemetry/telemetry'
+import { detectCdkProjects } from '../explorer/detectCdkProjects'
+import { buildCdkSpawnEnv, meetsMinimum, minimumCdkLspVersion, probeCdkVersion, resolveCdkCli } from './cdkCliResolver'
+
+const logger = getLogger('cdkLsp')
+
+/**
+ * A single CDK language server serves one app directory (the server accepts one
+ * `applicationDir`). We deliberately run ONE client per window rather than one
+ * per cdk.json: vscode-languageclient auto-registers the server's
+ * executeCommandProvider commands via `vscode.commands.registerCommand`, which
+ * throws on a duplicate id, so N clients in a multi-app workspace would fail to
+ * start. The app dir is the `aws.cdk.appDir` setting, else the sole detected
+ * CDK app (with a hint to set the setting when several are found).
+ */
+let client: LanguageClient | undefined
+let outputChannel: vscode.OutputChannel | undefined
+/** Message kinds surfaced since the last (re)start, so we notify at most once. */
+const notified = new Set<string>()
+
+/**
+ * Wire the CDK language server. Registers listeners synchronously and starts
+ * the server in the background; never blocks extension activation on the
+ * shell-env resolve or version probe. Safe when there is no CDK project (no-op).
+ */
+export function activateCdkLsp(context: vscode.ExtensionContext): void {
+    // CodeLens command the server emits (OPEN_RESOURCE_COMMAND in cdk-explorer):
+    // open a synthesized-template resource, or a picker when several share a line.
+    context.subscriptions.push(vscode.commands.registerCommand('cdkExplorer.openResource', openResourceCommand), {
+        dispose: () => void stopClient(),
+    })
+
+    // Re-resolve on the events that can change which app dir (if any) we serve,
+    // so the server starts/stops without a window reload.
+    const cdkJsonWatcher = vscode.workspace.createFileSystemWatcher('**/cdk.json')
+    context.subscriptions.push(
+        cdkJsonWatcher,
+        cdkJsonWatcher.onDidCreate((uri) => {
+            // A CDK project appeared where we weren't serving one. Ignore vendored
+            // fixtures under node_modules.
+            if (!client && !uri.fsPath.includes(`${path.sep}node_modules${path.sep}`)) {
+                void restartClient(context)
+            }
+        }),
+        vscode.workspace.onDidChangeWorkspaceFolders(() => void restartClient(context)),
+        vscode.workspace.onDidChangeConfiguration((e) => {
+            if (e.affectsConfiguration('aws.cdk.appDir') || e.affectsConfiguration('aws.cdk.cliPath')) {
+                void restartClient(context)
+            }
+        })
+    )
+
+    void restartClient(context)
+}
+
+export async function deactivateCdkLsp(): Promise<void> {
+    await stopClient()
+}
+
+/** Resolve the single CDK app directory to serve, or undefined to stay off. */
+async function resolveAppDir(): Promise<string | undefined> {
+    const configured = vscode.workspace.getConfiguration('aws.cdk').get<string>('appDir')?.trim()
+    if (configured) {
+        return path.isAbsolute(configured)
+            ? configured
+            : path.join(vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '', configured)
+    }
+
+    // Activation gate: reuse the explorer's cdk.json detection so we never spawn
+    // in a non-CDK workspace.
+    const dirs = (await detectCdkProjects()).map((p) => path.dirname(p.cdkJsonUri.fsPath)).sort()
+    if (dirs.length === 0) {
+        return undefined
+    }
+    if (dirs.length > 1) {
+        notifyOnce(
+            'multipleApps',
+            `Multiple CDK apps found. Using ${dirs[0]}. Set aws.cdk.appDir to choose a different one.`
+        )
+    }
+    return dirs[0]
+}
+
+/** Stop any running client, then (re)resolve and start one for the current app dir. */
+async function restartClient(context: vscode.ExtensionContext): Promise<void> {
+    await stopClient()
+    try {
+        const appDir = await resolveAppDir()
+        if (!appDir) {
+            return
+        }
+
+        // Resolve the shell env once; the ladder's PATH rung and the spawn reuse it.
+        const env = await buildCdkSpawnEnv()
+
+        const resolved = await resolveCdkCli(appDir, env)
+        if (!resolved) {
+            notifyOnce(
+                'missing',
+                `CDK language features need the AWS CDK CLI. Install it (>= ${minimumCdkLspVersion}) or set aws.cdk.cliPath.`
+            )
+            telemetry.cdk_startLanguageServer.emit({ result: 'Failed', reason: 'cdkCliNotFound' })
+            return
+        }
+
+        // Version gate: `cdk lsp` only exists on >= minimumCdkLspVersion.
+        const version = await probeCdkVersion(resolved.command, env)
+        if (!version || !meetsMinimum(version)) {
+            logger.info(`cdk at ${resolved.command} is ${version ?? 'unknown'}; need >= ${minimumCdkLspVersion}`)
+            notifyOnce(
+                'outdated',
+                `AWS CDK CLI ${version ?? ''} is too old for language features. Upgrade to >= ${minimumCdkLspVersion}.`
+            )
+            telemetry.cdk_startLanguageServer.emit({
+                result: 'Failed',
+                reason: 'cdkCliOutdated',
+                cdkCliVersion: version,
+            })
+            return
+        }
+
+        const executable: Executable = {
+            command: resolved.command,
+            args: ['lsp'],
+            transport: TransportKind.stdio,
+            options: { cwd: appDir, env },
+        }
+        const serverOptions: ServerOptions = { run: executable, debug: executable }
+
+        outputChannel = vscode.window.createOutputChannel('CDK Language Server')
+        const clientOptions: LanguageClientOptions = {
+            // Source-linked features cover TypeScript + jsii host languages, plus
+            // synthesized templates for template -> construct go-to-definition.
+            documentSelector: [
+                { scheme: 'file', language: 'typescript' },
+                { scheme: 'file', language: 'python' },
+                { scheme: 'file', language: 'java' },
+                { scheme: 'file', pattern: '**/*.template.json' },
+            ],
+            initializationOptions: { applicationDir: appDir },
+            outputChannel,
+            workspaceFolder: vscode.workspace.getWorkspaceFolder(vscode.Uri.file(appDir)),
+        }
+
+        client = new LanguageClient('cdkLsp', 'CDK Language Server', serverOptions, clientOptions)
+        logger.info(`Starting \`cdk lsp\` for ${appDir} (cdk ${version} via ${resolved.source})`)
+        await client.start()
+        telemetry.cdk_startLanguageServer.emit({
+            result: 'Succeeded',
+            cdkCliSource: resolved.source,
+            cdkCliVersion: version,
+        })
+    } catch (err) {
+        logger.error(`Failed to start cdk lsp: %O`, err)
+        telemetry.cdk_startLanguageServer.emit({ result: 'Failed', reason: 'startError' })
+        await stopClient()
+    }
+}
+
+async function stopClient(): Promise<void> {
+    const stopping = client?.stop().catch(() => {})
+    client = undefined
+    outputChannel?.dispose()
+    outputChannel = undefined
+    notified.clear()
+    await stopping
+}
+
+function notifyOnce(kind: string, message: string): void {
+    if (notified.has(kind)) {
+        return
+    }
+    notified.add(kind)
+    // Non-blocking, dismissible.
+    void vscode.window.showInformationMessage(message)
+}
+
+/**
+ * Handler for the `cdkExplorer.openResource` CodeLens command the server emits.
+ * `choices` are QuickPick-shaped resource targets ({ label: CFN type,
+ * description: construct name, target: { uri, range } }).
+ */
+async function openResourceCommand(
+    choices: Array<{
+        label: string
+        description: string
+        target: {
+            uri: string
+            range: { start: { line: number; character: number }; end: { line: number; character: number } }
+        }
+    }>
+): Promise<void> {
+    const chosen =
+        choices.length === 1
+            ? choices[0]
+            : await vscode.window.showQuickPick(choices, {
+                  placeHolder: 'Open resource in synthesized template',
+                  matchOnDescription: true,
+              })
+    if (!chosen) {
+        return
+    }
+    const { uri, range } = chosen.target
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(uri))
+    const editor = await vscode.window.showTextDocument(document)
+    const start = new vscode.Position(range.start.line, range.start.character)
+    const end = new vscode.Position(range.end.line, range.end.character)
+    editor.selection = new vscode.Selection(start, end)
+    editor.revealRange(new vscode.Range(start, end), vscode.TextEditorRevealType.InCenter)
+}

--- a/packages/core/src/awsService/cdk/lsp/client.ts
+++ b/packages/core/src/awsService/cdk/lsp/client.ts
@@ -10,6 +10,7 @@ import {
     LanguageClient,
     LanguageClientOptions,
     ServerOptions,
+    State,
     TransportKind,
 } from 'vscode-languageclient/node'
 import { getLogger } from '../../../shared/logger/logger'
@@ -90,6 +91,15 @@ function scheduleRestart(context: vscode.ExtensionContext): void {
 
 export async function deactivateCdkLsp(): Promise<void> {
     await stopClient()
+}
+
+/**
+ * The running CDK language server client, if one is started. Exposed so tree
+ * features can query server routes (e.g. `cdk/getConstructTree`); undefined when
+ * no CDK app is served or the server has not started yet.
+ */
+export function getCdkLanguageClient(): LanguageClient | undefined {
+    return client
 }
 
 /** Resolve the single CDK app directory to serve, or undefined to stay off. */
@@ -178,6 +188,17 @@ async function restartClient(context: vscode.ExtensionContext): Promise<void> {
         }
 
         client = new LanguageClient('cdkLsp', 'CDK Language Server', serverOptions, clientOptions)
+        // The CDK tree can render before the server is ready to answer
+        // cdk/getConstructTree (its source map comes back empty until then), which
+        // otherwise forces a manual refresh. Refresh the tree whenever the client
+        // reaches Running so source links and template icons appear on their own
+        // (also covers reconnects). Guarded: the refresh command may not be
+        // registered yet on a very early start.
+        client.onDidChangeState((e) => {
+            if (e.newState === State.Running) {
+                void vscode.commands.executeCommand('aws.cdk.refresh').then(undefined, () => {})
+            }
+        })
         logger.info(`Starting \`cdk lsp\` for ${appDir} (cdk ${version} via ${resolved.source})`)
         await client.start()
         telemetry.cdk_startLanguageServer.emit({

--- a/packages/core/src/awsService/cdk/lsp/client.ts
+++ b/packages/core/src/awsService/cdk/lsp/client.ts
@@ -32,6 +32,9 @@ let client: LanguageClient | undefined
 let outputChannel: vscode.OutputChannel | undefined
 /** Message kinds surfaced since the last (re)start, so we notify at most once. */
 const notified = new Set<string>()
+/** Serializes (re)starts into a queue-of-one so overlapping triggers never leak a client. */
+let restartInFlight: Promise<void> = Promise.resolve()
+let restartQueued = false
 
 /**
  * Wire the CDK language server. Registers listeners synchronously and starts
@@ -54,18 +57,35 @@ export function activateCdkLsp(context: vscode.ExtensionContext): void {
             // A CDK project appeared where we weren't serving one. Ignore vendored
             // fixtures under node_modules.
             if (!client && !uri.fsPath.includes(`${path.sep}node_modules${path.sep}`)) {
-                void restartClient(context)
+                scheduleRestart(context)
             }
         }),
-        vscode.workspace.onDidChangeWorkspaceFolders(() => void restartClient(context)),
+        vscode.workspace.onDidChangeWorkspaceFolders(() => scheduleRestart(context)),
         vscode.workspace.onDidChangeConfiguration((e) => {
             if (e.affectsConfiguration('aws.cdk.appDir') || e.affectsConfiguration('aws.cdk.cliPath')) {
-                void restartClient(context)
+                scheduleRestart(context)
             }
         })
     )
 
-    void restartClient(context)
+    scheduleRestart(context)
+}
+
+/**
+ * Serialize (re)starts into a queue-of-one. Overlapping triggers (activation,
+ * config/folder changes, a new cdk.json) must not run two starts concurrently,
+ * or the second would overwrite `client` and leak the first. A burst coalesces
+ * into at most one trailing restart, which observes the latest state.
+ */
+function scheduleRestart(context: vscode.ExtensionContext): void {
+    if (restartQueued) {
+        return
+    }
+    restartQueued = true
+    restartInFlight = restartInFlight.then(() => {
+        restartQueued = false
+        return restartClient(context)
+    })
 }
 
 export async function deactivateCdkLsp(): Promise<void> {

--- a/packages/core/src/awsexplorer/activation.ts
+++ b/packages/core/src/awsexplorer/activation.ts
@@ -24,6 +24,7 @@ import { checkExplorerForDefaultRegion } from './defaultRegion'
 import { ToolView } from './toolView'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { CdkRootNode } from '../awsService/cdk/explorer/rootNode'
+import { activateCdkLsp } from '../awsService/cdk/lsp/client'
 import { CodeCatalystRootNode } from '../codecatalyst/explorer'
 import { CodeCatalystAuthenticationProvider } from '../codecatalyst/auth'
 import { S3FolderNode } from '../awsService/s3/explorer/s3FolderNode'
@@ -136,6 +137,10 @@ export async function activate(args: {
     for (const viewNode of viewNodes) {
         registerToolView(viewNode, args.context.extensionContext)
     }
+
+    // Start `cdk lsp` (discovered from the user's installed CDK CLI) for the CDK app in the workspace.
+    // Non-blocking: registers listeners synchronously and starts the server in the background.
+    activateCdkLsp(args.context.extensionContext)
 
     const toolkitAuthProvider = new CommonAuthViewProvider(args.context.extensionContext, 'toolkit')
     args.context.extensionContext.subscriptions.push(

--- a/packages/core/src/shared/logger/logger.ts
+++ b/packages/core/src/shared/logger/logger.ts
@@ -16,6 +16,7 @@ export type LogTopic =
     | 'amazonqLsp'
     | 'amazonqLsp.lspClient'
     | 'awsCfnLsp'
+    | 'cdkLsp'
     | 'chat'
     | 'stepfunctions'
     | 'unknown'

--- a/packages/core/src/shared/settings-toolkit.gen.ts
+++ b/packages/core/src/shared/settings-toolkit.gen.ts
@@ -15,6 +15,8 @@ export const toolkitSettings = {
     "aws.iot.maxItemsPerPage": {},
     "aws.s3.maxItemsPerPage": {},
     "aws.samcli.location": {},
+    "aws.cdk.cliPath": {},
+    "aws.cdk.appDir": {},
     "aws.samcli.lambdaTimeout": {},
     "aws.samcli.legacyDeploy": {},
     "aws.telemetry": {},

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -343,6 +343,17 @@
             "type": "string",
             "allowedValues": ["accepted", "declined", "dismissed"],
             "description": "Whether the user accepted, declined or dismissed the smus context prompt to add to AGENTS.md"
+        },
+        {
+            "name": "cdkCliSource",
+            "type": "string",
+            "allowedValues": ["setting", "nodeModules", "path"],
+            "description": "Where the CDK CLI was found in the discovery ladder (setting override, workspace node_modules, or shell PATH)."
+        },
+        {
+            "name": "cdkCliVersion",
+            "type": "string",
+            "description": "Version of the discovered AWS CDK CLI."
         }
     ],
     "metrics": [
@@ -1916,6 +1927,16 @@
                     "type": "smusAcceptAgentContextAction",
                     "required": false
                 }
+            ]
+        },
+        {
+            "name": "cdk_startLanguageServer",
+            "description": "Result of starting the CDK language server (`cdk lsp`) discovered from the user's installed CDK CLI.",
+            "metadata": [
+                { "type": "result" },
+                { "type": "reason", "required": false },
+                { "type": "cdkCliSource", "required": false },
+                { "type": "cdkCliVersion", "required": false }
             ]
         }
     ]

--- a/packages/core/src/stepFunctions/wizards/previewStateMachineCDKWizard.ts
+++ b/packages/core/src/stepFunctions/wizards/previewStateMachineCDKWizard.ts
@@ -9,7 +9,7 @@ const localize = nls.loadMessageBundle()
 import * as vscode from 'vscode'
 import * as path from 'path'
 import { CdkAppLocation, getApp } from '../../awsService/cdk/explorer/cdkProject'
-import { ConstructNode, isStateMachine } from '../../awsService/cdk/explorer/nodes/constructNode'
+import { isStateMachine } from '../../awsService/cdk/explorer/nodes/constructNode'
 import { detectCdkProjects } from '../../awsService/cdk/explorer/detectCdkProjects'
 import { Wizard, WIZARD_BACK } from '../../shared/wizards/wizard'
 import { createQuickPick } from '../../shared/ui/pickerPrompter'
@@ -76,7 +76,7 @@ function createResourcePrompter(location: CdkAppLocation) {
 
 interface State {
     readonly location: CdkAppLocation
-    readonly resource: ConstructNode['resource']
+    readonly resource: { readonly construct: ConstructTreeEntity; readonly location: vscode.Uri }
 }
 
 export class PreviewStateMachineCDKWizard extends Wizard<State> {

--- a/packages/core/src/test/awsService/cdk/explorer/constructNode.test.ts
+++ b/packages/core/src/test/awsService/cdk/explorer/constructNode.test.ts
@@ -129,6 +129,53 @@ describe('ConstructNode', function () {
         assert.strictEqual(childNodes[0] instanceof ConstructNode, true, 'Expected child node to be a ConstructNode')
     })
 
+    it('opens the source location on click when the source map has an entry', function () {
+        const sourceFile = path.join('/', 'project', 'lib', 'my-stack.ts')
+        const sourceMap = new Map([[constructTreePath, { sourceLocation: { file: sourceFile, line: 12, column: 5 } }]])
+        const construct = treeUtils.generateConstructTreeEntity(label, constructTreePath)
+
+        const item = new ConstructNode(location, construct, sourceMap).getTreeItem()
+
+        assert.ok(item.command, 'Expected a command to open source')
+        assert.strictEqual(item.command.command, 'vscode.open')
+        const [uri, options] = item.command.arguments as [vscode.Uri, vscode.TextDocumentShowOptions]
+        assert.strictEqual(uri.fsPath, vscode.Uri.file(sourceFile).fsPath)
+        // SourceLocation is 1-based; vscode.Position is 0-based.
+        assert.strictEqual(options.selection?.start.line, 11)
+        assert.strictEqual(options.selection?.start.character, 4)
+    })
+
+    it('sets no command when the source map has no entry for the construct', function () {
+        const sourceMap = new Map([['some/other/path', { sourceLocation: { file: '/x.ts', line: 1, column: 1 } }]])
+        const construct = treeUtils.generateConstructTreeEntity(label, constructTreePath)
+
+        const item = new ConstructNode(location, construct, sourceMap).getTreeItem()
+
+        assert.strictEqual(item.command, undefined)
+    })
+
+    it('marks nodes with a template file and exposes the template target', function () {
+        const templateFile = path.join('/', 'project', 'cdk.out', 'Stack.template.json')
+        const sourceMap = new Map([[constructTreePath, { templateFile, templateOffset: 42 }]])
+        const construct = treeUtils.generateConstructTreeEntity(label, constructTreePath)
+
+        const node = new ConstructNode(location, construct, sourceMap)
+        const item = node.getTreeItem()
+
+        assert.ok((item.contextValue ?? '').endsWith('WithTemplate'), 'Expected a WithTemplate context value')
+        assert.strictEqual(node.resource.templateFile, templateFile)
+        assert.strictEqual(node.resource.templateOffset, 42)
+    })
+
+    it('does not mark nodes that have no template file', function () {
+        const sourceMap = new Map([[constructTreePath, { sourceLocation: { file: '/x.ts', line: 1, column: 1 } }]])
+        const construct = treeUtils.generateConstructTreeEntity(label, constructTreePath)
+
+        const item = new ConstructNode(location, construct, sourceMap).getTreeItem()
+
+        assert.strictEqual(item.contextValue, 'awsCdkConstructNode')
+    })
+
     function generateTestNode(displayLabel: string): ConstructNode {
         return new ConstructNode(location, treeUtils.generateConstructTreeEntity(displayLabel, constructTreePath))
     }

--- a/packages/toolkit/.changes/next-release/Feature-cdk-language-server.json
+++ b/packages/toolkit/.changes/next-release/Feature-cdk-language-server.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "CDK: start the CDK Language Server (`cdk lsp`) from your installed CDK CLI, linking construct source, synthesized template, and policy violations"
+}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -123,6 +123,18 @@
                     "default": "",
                     "markdownDescription": "%AWS.configuration.description.samcli.location%"
                 },
+                "aws.cdk.cliPath": {
+                    "type": "string",
+                    "scope": "machine",
+                    "default": "",
+                    "markdownDescription": "%AWS.configuration.description.cdk.cliPath%"
+                },
+                "aws.cdk.appDir": {
+                    "type": "string",
+                    "scope": "window",
+                    "default": "",
+                    "markdownDescription": "%AWS.configuration.description.cdk.appDir%"
+                },
                 "aws.samcli.lambdaTimeout": {
                     "type": "number",
                     "default": 90000,

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1221,6 +1221,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.cdk.openTemplate",
+                    "when": "false"
+                },
+                {
                     "command": "aws.appBuilder.refresh",
                     "when": "false"
                 },
@@ -2185,6 +2189,16 @@
                     "command": "aws.cdk.renderStateMachineGraph",
                     "when": "viewItem == awsCdkStateMachineNode",
                     "group": "0@1"
+                },
+                {
+                    "command": "aws.cdk.openTemplate",
+                    "when": "view == aws.cdk && viewItem =~ /WithTemplate$/",
+                    "group": "inline@2"
+                },
+                {
+                    "command": "aws.cdk.openTemplate",
+                    "when": "view == aws.cdk && viewItem =~ /WithTemplate$/",
+                    "group": "0@2"
                 },
                 {
                     "command": "aws.executeStateMachine",
@@ -4274,6 +4288,12 @@
                 "enablement": "isCloud9 || !aws.isWebExtHost",
                 "category": "AWS",
                 "icon": "$(aws-stepfunctions-preview)"
+            },
+            {
+                "command": "aws.cdk.openTemplate",
+                "title": "%AWS.command.cdk.openTemplate%",
+                "category": "AWS",
+                "icon": "$(go-to-file)"
             },
             {
                 "command": "aws.toolkit.aboutExtension",


### PR DESCRIPTION
Draft, stacked on #8828. GitHub shows #8828's commits here too; the new work is the overlay, the open-template action, and the client refresh below.

Overlays source navigation onto the existing CDK construct tree, sourced from the language server: click a construct to open its source at the creation line, and an inline icon on resource rows opens the synthesized template at that resource's block. The tree keeps its structure and behavior, and no-ops when the server is unavailable.

Design:
- All data comes from the server's `cdk/getConstructTree`. `sourceLinks` builds a path to { source, template, offset } map; nothing here resolves source. The map is empty when the server is not running, so the tree renders unchanged.
- The open-template icon is a `WithTemplate` context value plus an inline `view/item/context` entry, set only on resource rows the server maps to a template. Source links are a plain `vscode.open` command on any row with a source location.
- Refresh the tree when the client reaches Running, plus a short retry while the server finishes its first assembly read. The tree can render before the server is ready, which otherwise needed a manual refresh.
- `previewStateMachineCDKWizard` now declares the `{ construct, location }` shape it needs instead of reusing `ConstructNode`'s resource type, so enriching that getter did not widen the wizard.

Needs the `cdk/getConstructTree` route in the CDK CLI (open at https://github.com/aws/aws-cdk-cli/pull/1746). Without it the tree degrades to no links.


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
