### PR TITLE
fix(auth): restrict SSO endpoint overrides to user-level settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -400,6 +400,8 @@ If you need to report an issue attach these to give the most detailed informatio
 
 Endpoint overrides can be set per-service using the `aws.dev.endpoints` settings. This is a JSON object where each key is the service ID (case-insensitive) and each value is the endpoint. Refer to the SDK [API models](https://github.com/aws/aws-sdk-js/tree/master/apis) to find relevant service IDs.
 
+**Note:** The `ssooidc` and `sso` endpoint overrides are only read from **user-level settings** (not workspace or folder settings). Set them via `Preferences: Open User Settings (JSON)` in VS Code.
+
 Example:
 
 ```json

--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -4,6 +4,7 @@
  */
 
 import globals from '../../shared/extensionGlobals'
+import { workspace } from 'vscode'
 
 import {
     AccountInfo,
@@ -29,7 +30,6 @@ import { assertHasProps, isNonNullable, RequiredProps, selectFrom } from '../../
 import { getLogger } from '../../shared/logger/logger'
 import { SsoAccessTokenProvider } from './ssoAccessTokenProvider'
 import { AwsClientResponseError, isClientFault } from '../../shared/errors'
-import { DevSettings } from '../../shared/settings'
 import { HttpRequest, HttpResponse } from '@smithy/protocol-http'
 import { StandardRetryStrategy, defaultRetryDecider } from '@smithy/middleware-retry'
 import { AuthenticationFlow } from './model'
@@ -132,7 +132,7 @@ export class OidcClient {
     public static create(region: string) {
         const client = new SSOOIDC({
             region,
-            endpoint: DevSettings.instance.get('endpoints', {})['ssooidc'],
+            endpoint: getUserScopedEndpoint('ssooidc'),
             retryStrategy: new StandardRetryStrategy(
                 () => Promise.resolve(3), // Maximum number of retries
                 { retryDecider: defaultRetryDecider }
@@ -259,12 +259,43 @@ export class SsoClient {
         return new this(
             new SSO({
                 region,
-                endpoint: DevSettings.instance.get('endpoints', {})['sso'],
+                endpoint: getUserScopedEndpoint('sso'),
                 customUserAgent: getUserAgent({ includePlatform: true, includeClientId: true }),
             }),
             provider
         )
     }
+}
+
+/**
+ * Gets an endpoint override from user-level settings ONLY, ignoring workspace and
+ * workspace-folder scoped values.
+ *
+ * @param serviceKey The service identifier (e.g. 'ssooidc', 'sso')
+ * @returns The endpoint URL if set in user-level settings, otherwise undefined
+ */
+export function getUserScopedEndpoint(serviceKey: string): string | undefined {
+    const config = workspace.getConfiguration('aws.dev')
+    const inspected = config.inspect<Record<string, string>>('endpoints')
+
+    // Only use globalValue (user-level settings). Never trust workspace or workspace-folder values
+    // for authentication endpoints.
+    const endpoints = inspected?.globalValue
+
+    if (inspected?.workspaceValue?.['ssooidc'] || inspected?.workspaceValue?.['sso']) {
+        getLogger().warn(
+            'auth: Ignoring workspace-scoped aws.dev.endpoints for SSO/OIDC services. ' +
+                'These settings must be configured in user-level settings for security.'
+        )
+    }
+    if (inspected?.workspaceFolderValue?.['ssooidc'] || inspected?.workspaceFolderValue?.['sso']) {
+        getLogger().warn(
+            'auth: Ignoring workspace-folder-scoped aws.dev.endpoints for SSO/OIDC services. ' +
+                'These settings must be configured in user-level settings for security.'
+        )
+    }
+
+    return endpoints?.[serviceKey]
 }
 
 function addLoggingMiddleware(client: SSOOIDCClient) {

--- a/packages/core/src/test/credentials/sso/getUserScopedEndpoint.test.ts
+++ b/packages/core/src/test/credentials/sso/getUserScopedEndpoint.test.ts
@@ -1,0 +1,110 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import sinon from 'sinon'
+import { workspace } from 'vscode'
+import { getUserScopedEndpoint } from '../../../auth/sso/clients'
+
+describe('getUserScopedEndpoint', function () {
+    let sandbox: sinon.SinonSandbox
+    let inspectStub: sinon.SinonStub
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox()
+        inspectStub = sandbox.stub()
+        sandbox.stub(workspace, 'getConfiguration').returns({
+            inspect: inspectStub,
+        } as any)
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+    })
+
+    it('returns endpoint from user-level (global) settings', function () {
+        inspectStub.withArgs('endpoints').returns({
+            globalValue: { ssooidc: 'https://gamma.example.com' },
+        })
+
+        const result = getUserScopedEndpoint('ssooidc')
+        assert.strictEqual(result, 'https://gamma.example.com')
+    })
+
+    it('returns undefined when no endpoint is configured', function () {
+        inspectStub.withArgs('endpoints').returns({
+            globalValue: undefined,
+        })
+
+        const result = getUserScopedEndpoint('ssooidc')
+        assert.strictEqual(result, undefined)
+    })
+
+    it('returns undefined when globalValue exists but does not contain the requested key', function () {
+        inspectStub.withArgs('endpoints').returns({
+            globalValue: { other: 'https://other.example.com' },
+        })
+
+        const result = getUserScopedEndpoint('ssooidc')
+        assert.strictEqual(result, undefined)
+    })
+
+    it('ignores workspace-scoped ssooidc endpoint', function () {
+        inspectStub.withArgs('endpoints').returns({
+            globalValue: undefined,
+            workspaceValue: { ssooidc: 'https://evil.attacker.com' },
+        })
+
+        const result = getUserScopedEndpoint('ssooidc')
+        assert.strictEqual(result, undefined)
+    })
+
+    it('ignores workspace-scoped sso endpoint', function () {
+        inspectStub.withArgs('endpoints').returns({
+            globalValue: undefined,
+            workspaceValue: { sso: 'https://evil.attacker.com' },
+        })
+
+        const result = getUserScopedEndpoint('sso')
+        assert.strictEqual(result, undefined)
+    })
+
+    it('ignores workspaceFolder-scoped endpoint', function () {
+        inspectStub.withArgs('endpoints').returns({
+            globalValue: undefined,
+            workspaceFolderValue: { ssooidc: 'https://evil.attacker.com' },
+        })
+
+        const result = getUserScopedEndpoint('ssooidc')
+        assert.strictEqual(result, undefined)
+    })
+
+    it('prefers user-level value even when workspace value is also set', function () {
+        inspectStub.withArgs('endpoints').returns({
+            globalValue: { ssooidc: 'https://gamma.internal.aws' },
+            workspaceValue: { ssooidc: 'https://evil.attacker.com' },
+        })
+
+        const result = getUserScopedEndpoint('ssooidc')
+        assert.strictEqual(result, 'https://gamma.internal.aws')
+    })
+
+    it('does not log a warning when only user-level settings are configured', function () {
+        inspectStub.withArgs('endpoints').returns({
+            globalValue: { ssooidc: 'https://gamma.internal.aws' },
+        })
+
+        // Should not throw or fail - just returns the value cleanly
+        const result = getUserScopedEndpoint('ssooidc')
+        assert.strictEqual(result, 'https://gamma.internal.aws')
+    })
+
+    it('returns undefined when inspect returns undefined', function () {
+        inspectStub.withArgs('endpoints').returns(undefined)
+
+        const result = getUserScopedEndpoint('ssooidc')
+        assert.strictEqual(result, undefined)
+    })
+})


### PR DESCRIPTION
## Problem

The `aws.dev.endpoints` setting for `ssooidc` and `sso` services could be read from workspace-level settings (`.vscode/settings.json`), which is not appropriate for authentication endpoint configuration.

## Solution

Restrict `ssooidc` and `sso` endpoint overrides to only be read from user-level (global) settings using `workspace.getConfiguration().inspect()`. Workspace and workspace-folder scoped values are now ignored for these service keys. A warning is logged when workspace-level values are detected.

Updated `CONTRIBUTING.md` to document the user-level requirement for SSO/OIDC endpoint overrides.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*