### PR TITLE
fix(sagemaker): Filter space listing to JupyterLab and CodeEditor

### DIFF
--- a/packages/core/src/shared/clients/sagemaker.ts
+++ b/packages/core/src/shared/clients/sagemaker.ts
@@ -324,6 +324,11 @@ export class SagemakerClient extends ClientWrapper<SageMakerClient> {
         const spaceApps: Map<string, SagemakerSpaceApp> = await this.listSpaces(options)
             .flatten()
             .filter((space) => !!space.DomainId && !!space.SpaceName)
+            .filter(
+                (space) =>
+                    space.SpaceSettingsSummary?.AppType === AppType.JupyterLab ||
+                    space.SpaceSettingsSummary?.AppType === AppType.CodeEditor
+            )
             .map((space) => {
                 const key = getDomainSpaceKey(space.DomainId || '', space.SpaceName || '')
                 return { ...space, App: appMap.get(key), DomainSpaceKey: key }

--- a/packages/core/src/test/shared/clients/sagemakerClient.test.ts
+++ b/packages/core/src/test/shared/clients/sagemakerClient.test.ts
@@ -25,10 +25,10 @@ describe('SagemakerClient.fetchSpaceAppsAndDomains', function () {
     ]
 
     const spaceDetails: SpaceDetails[] = [
-        { SpaceName: 'space1', DomainId: 'domain1' },
-        { SpaceName: 'space2', DomainId: 'domain2' },
-        { SpaceName: 'space3', DomainId: 'domain2' },
-        { SpaceName: 'space4', DomainId: 'domain3' },
+        { SpaceName: 'space1', DomainId: 'domain1', SpaceSettingsSummary: { AppType: 'CodeEditor' } },
+        { SpaceName: 'space2', DomainId: 'domain2', SpaceSettingsSummary: { AppType: 'CodeEditor' } },
+        { SpaceName: 'space3', DomainId: 'domain2', SpaceSettingsSummary: { AppType: 'JupyterLab' } },
+        { SpaceName: 'space4', DomainId: 'domain3', SpaceSettingsSummary: { AppType: 'JupyterLab' } },
     ]
 
     const domain1: DescribeDomainResponse = { DomainId: 'domain1', DomainName: 'domainName1' }
@@ -138,9 +138,9 @@ describe('SagemakerClient.listSpaceApps', function () {
     ]
 
     const spaceDetails: SpaceDetails[] = [
-        { SpaceName: 'space1', DomainId: 'domain1' },
-        { SpaceName: 'space2', DomainId: 'domain2' },
-        { SpaceName: 'space3', DomainId: 'domain2' },
+        { SpaceName: 'space1', DomainId: 'domain1', SpaceSettingsSummary: { AppType: AppType.CodeEditor } },
+        { SpaceName: 'space2', DomainId: 'domain2', SpaceSettingsSummary: { AppType: AppType.JupyterLab } },
+        { SpaceName: 'space3', DomainId: 'domain2', SpaceSettingsSummary: { AppType: AppType.JupyterLab } },
     ]
 
     beforeEach(function () {
@@ -171,6 +171,39 @@ describe('SagemakerClient.listSpaceApps', function () {
 
         sinon.assert.calledWith(listAppsStub, { DomainIdEquals: 'domain1' })
         sinon.assert.calledWith(listSpacesStub, { DomainIdEquals: 'domain1' })
+    })
+
+    it('filters out spaces with non-IDE app types', async function () {
+        const newClient = new SagemakerClient(region)
+        sinon.stub(newClient, 'listApps').returns(intoCollection([[]]))
+        sinon.stub(newClient, 'listSpaces').returns(
+            intoCollection([
+                [
+                    {
+                        SpaceName: 'jupyterlab-space',
+                        DomainId: 'domain1',
+                        SpaceSettingsSummary: { AppType: AppType.JupyterLab },
+                    },
+                    {
+                        SpaceName: 'canvas-space',
+                        DomainId: 'domain1',
+                        SpaceSettingsSummary: { AppType: AppType.Canvas },
+                    },
+                    {
+                        SpaceName: 'codeeditor-space',
+                        DomainId: 'domain1',
+                        SpaceSettingsSummary: { AppType: AppType.CodeEditor },
+                    },
+                ],
+            ])
+        )
+
+        const spaceApps = await newClient.listSpaceApps()
+
+        assert.strictEqual(spaceApps.size, 2)
+        assert.ok(spaceApps.has('domain1__jupyterlab-space'))
+        assert.ok(!spaceApps.has('domain1__canvas-space'))
+        assert.ok(spaceApps.has('domain1__codeeditor-space'))
     })
 })
 

--- a/packages/toolkit/.changes/next-release/Bug Fix-51317e51-0c78-46c8-9077-134238722b38.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-51317e51-0c78-46c8-9077-134238722b38.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SageMaker: Spaces with unsupported app types (e.g. Canvas) are no longer shown in the explorer tree."
+}


### PR DESCRIPTION
## Problem
In the AWS Toolkit extension, the Space list in the SageMaker AI Studio and SageMaker Unified Studio views should show only JupyterLab and CodeEditor Spaces because those are the only Space types that support remote access, but currently other Space types can be shown such as Canvas.

## Solution
Filter the ListSpaces API result to only JupyterLab and CodeEditor Spaces. This filter was already being applied to the ListApps API result, but needed to be done for Spaces as well.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
