### PR TITLE
fix(smus): Filter unsupported Local IDE spaces, such as canvas

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode.ts
+++ b/packages/core/src/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import { SageMakerUnifiedStudioComputeNode } from './sageMakerUnifiedStudioComputeNode'
 import { updateInPlace } from '../../../shared/utilities/collectionUtils'
-import { DescribeDomainResponse } from '@amzn/sagemaker-client'
+import { AppType, DescribeDomainResponse } from '@amzn/sagemaker-client'
 import { getDomainUserProfileKey } from '../../../awsService/sagemaker/utils'
 import { getLogger } from '../../../shared/logger/logger'
 import { TreeNode } from '../../../shared/treeview/resourceTreeDataProvider'
@@ -23,6 +23,12 @@ import { createDZClientBaseOnDomainMode } from './utils'
 import { SmusIamConnection } from '../../auth/model'
 import { DataZoneCustomClientHelper } from '../../shared/client/datazoneCustomClientHelper'
 import { ToolkitError } from '../../../shared/errors'
+
+const supportedSpaceAppTypes = new Set<string>([AppType.JupyterLab.toLowerCase(), AppType.CodeEditor.toLowerCase()])
+
+function isSupportedSpaceApp(app: SagemakerSpaceApp): boolean {
+    return supportedSpaceAppTypes.has(app.SpaceSettingsSummary?.AppType?.toLowerCase() ?? '')
+}
 
 export class SageMakerUnifiedStudioSpacesParentNode implements TreeNode {
     public readonly id = 'smusSpacesParentNode'
@@ -363,7 +369,7 @@ export class SageMakerUnifiedStudioSpacesParentNode implements TreeNode {
         const filteredSpaceApps = new Map<string, SagemakerSpaceApp>()
         for (const [key, app] of spaceApps.entries()) {
             const userProfile = app.OwnershipSettingsSummary?.OwnerUserProfileName
-            if (userProfileId === userProfile) {
+            if (userProfileId === userProfile && isSupportedSpaceApp(app)) {
                 filteredSpaceApps.set(key, app)
             }
         }

--- a/packages/core/src/test/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert'
 import sinon from 'sinon'
 import * as vscode from 'vscode'
+import { AppType } from '@amzn/sagemaker-client'
 import { SageMakerUnifiedStudioSpacesParentNode } from '../../../../sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode'
 import { SageMakerUnifiedStudioComputeNode } from '../../../../sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioComputeNode'
 import { SagemakerUnifiedStudioSpaceNode } from '../../../../sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpaceNode'
@@ -381,16 +382,27 @@ describe('SageMakerUnifiedStudioSpacesParentNode', function () {
             } as any)
         })
 
-        function stubSpaceApps(ownerProfiles: Record<string, string | undefined>) {
+        function stubSpaceApps(
+            spaces: Record<string, string | undefined | { owner?: string; appType?: string | undefined }>
+        ) {
             const spaceApps = new Map(
-                Object.entries(ownerProfiles).map(([key, owner]) => [
-                    key,
-                    {
-                        DomainId: 'domain-123',
-                        OwnershipSettingsSummary: { OwnerUserProfileName: owner },
-                        DomainSpaceKey: key,
-                    },
-                ])
+                Object.entries(spaces).map(([key, space]) => {
+                    const config = typeof space === 'object' && space !== null ? space : { owner: space }
+                    const appType = Object.prototype.hasOwnProperty.call(config, 'appType')
+                        ? config.appType
+                        : AppType.JupyterLab
+
+                    return [
+                        key,
+                        {
+                            DomainId: 'domain-123',
+                            SpaceName: key,
+                            OwnershipSettingsSummary: { OwnerUserProfileName: config.owner },
+                            SpaceSettingsSummary: { AppType: appType },
+                            DomainSpaceKey: key,
+                        },
+                    ]
+                })
             )
             const domains = new Map([['domain-123', { DomainId: 'domain-123' }]])
             mockSagemakerClient.fetchSpaceAppsAndDomains.resetBehavior()
@@ -405,6 +417,25 @@ describe('SageMakerUnifiedStudioSpacesParentNode', function () {
             assert.strictEqual(spacesNode['spaceApps'].size, 1)
             assert(spacesNode['spaceApps'].has('space1'))
             assert(!spacesNode['spaceApps'].has('space2'))
+        })
+
+        it('filters spaces to supported local IDE app types', async function () {
+            stubSpaceApps({
+                jupyterLabSpace: { owner: 'user-12345', appType: AppType.JupyterLab },
+                codeEditorSpace: { owner: 'user-12345', appType: AppType.CodeEditor },
+                lowercaseJupyterLabSpace: { owner: 'user-12345', appType: 'jupyterlab' },
+                mixedCaseCodeEditorSpace: { owner: 'user-12345', appType: 'cOdEeDiToR' },
+                canvasSpace: { owner: 'user-12345', appType: 'Canvas' },
+                missingAppTypeSpace: { owner: 'user-12345', appType: undefined },
+                otherUserCodeEditorSpace: { owner: 'other-user', appType: AppType.CodeEditor },
+            })
+
+            await spacesNode['updateChildren']()
+
+            assert.deepStrictEqual(
+                [...spacesNode['spaceApps'].keys()],
+                ['jupyterLabSpace', 'codeEditorSpace', 'lowercaseJupyterLabSpace', 'mixedCaseCodeEditorSpace']
+            )
         })
 
         it('creates space nodes for filtered spaces', async function () {

--- a/packages/toolkit/.changes/next-release/Bug Fix-smus-local-ide-space-filter.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-smus-local-ide-space-filter.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Hide unsupported SageMaker Unified Studio spaces from the Local IDE space list."
+}


### PR DESCRIPTION
- ## Problem

  Canvas spaces are browser-only and do not support Local IDE remote connections, but they were appearing in the SageMaker Unified Studio spaces list in the Toolkit. This could confuse customers and expose connection actions for spaces that cannot be connected through Local IDE.

  - ## Solution

  Filter the SMUS spaces list to show only Local IDE-supported app types: JupyterLab and Code Editor. Added unit coverage to verify JupyterLab and Code Editor spaces remain visible while Canvas, missing app types, and unsupported app types are hidden.
  
  
<img width="1056" height="420" alt="image" src="https://github.com/user-attachments/assets/aa4ef689-0634-4969-9994-4764570172b2" />

<img width="2304" height="702" alt="image" src="https://github.com/user-attachments/assets/953b4a63-af12-4c80-a3a3-44bc75fa43a5" />

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
