### PR TITLE
feat(lambda): add java8.al2023, java11.al2023, java17.al2023 runtime …

### DIFF
--- a/.changes/next-release/feat-java-al2023-runtimes.json
+++ b/.changes/next-release/feat-java-al2023-runtimes.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Lambda: Add support for java8.al2023, java11.al2023, and java17.al2023 runtimes"
+}

--- a/packages/core/src/lambda/models/samLambdaRuntime.ts
+++ b/packages/core/src/lambda/models/samLambdaRuntime.ts
@@ -64,9 +64,12 @@ export const pythonRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
 export const goRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['go1.x'])
 export const javaRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
     'java17',
+    'java17.al2023' as Runtime,
     'java11',
+    'java11.al2023' as Runtime,
     'java8',
     'java8.al2',
+    'java8.al2023' as Runtime,
     'java21',
     'java25' as Runtime,
 ])
@@ -132,8 +135,11 @@ export const samArmLambdaRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>
     'nodejs16.x',
     'nodejs14.x',
     'java17',
+    'java17.al2023' as Runtime,
     'java11',
+    'java11.al2023' as Runtime,
     'java8.al2',
+    'java8.al2023' as Runtime,
 ])
 
 // Cloud9 supports a subset of runtimes for debugging.

--- a/packages/core/src/shared/sam/debugger/javaSamDebug.ts
+++ b/packages/core/src/shared/sam/debugger/javaSamDebug.ts
@@ -53,9 +53,11 @@ export async function invokeJavaLambda(ctx: ExtContext, config: SamLaunchRequest
 function getJavaOptionsEnvVar(config: SamLaunchRequestArgs): string {
     switch (config.runtime) {
         case 'java11':
+        case 'java11.al2023' as Runtime:
             // https://github.com/aws/aws-sam-cli/blob/86f88cbd7df365960f7015c5d086b0db7aedd9d5/samcli/local/docker/lambda_debug_settings.py#L53
             return `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=*:${config.debugPort} -XX:MaxHeapSize=2834432k -XX:MaxMetaspaceSize=163840k -XX:ReservedCodeCacheSize=81920k -XX:+UseSerialGC -XX:-TieredCompilation -Djava.net.preferIPv4Stack=true`
         case 'java17':
+        case 'java17.al2023' as Runtime:
         case 'java21':
         case 'java25' as Runtime:
             // https://github.com/aws/aws-sam-cli/blob/90aa5cf11e1c5cbfbe66aea2e2de10d478d48231/samcli/local/docker/lambda_debug_settings.py#L96

--- a/packages/core/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/packages/core/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -102,16 +102,19 @@ describe('runtimes', function () {
         ])
     })
     it('vscode', function () {
-        assert.deepStrictEqual(samLambdaCreatableRuntimes(false).toArray().sort(), [
+        const vscodeZipRuntimes = [
             'dotnet6',
             'dotnet8',
             'go1.x',
             'java11',
+            'java11.al2023',
             'java17',
+            'java17.al2023',
             'java21',
             'java25',
             'java8',
             'java8.al2',
+            'java8.al2023',
             'nodejs14.x',
             'nodejs16.x',
             'nodejs18.x',
@@ -126,33 +129,9 @@ describe('runtimes', function () {
             'python3.7',
             'python3.8',
             'python3.9',
-        ])
-        assert.deepStrictEqual(samImageLambdaRuntimes(false).toArray().sort(), [
-            'dotnet5.0',
-            'dotnet6',
-            'dotnet8',
-            'go1.x',
-            'java11',
-            'java17',
-            'java21',
-            'java25',
-            'java8',
-            'java8.al2',
-            'nodejs14.x',
-            'nodejs16.x',
-            'nodejs18.x',
-            'nodejs20.x',
-            'nodejs22.x',
-            'nodejs24.x',
-            'python3.10',
-            'python3.11',
-            'python3.12',
-            'python3.13',
-            'python3.14',
-            'python3.7',
-            'python3.8',
-            'python3.9',
-        ])
+        ]
+        assert.deepStrictEqual(samLambdaCreatableRuntimes(false).toArray().sort(), vscodeZipRuntimes)
+        assert.deepStrictEqual(samImageLambdaRuntimes(false).toArray().sort(), ['dotnet5.0', ...vscodeZipRuntimes])
     })
 })
 

--- a/packages/core/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/packages/core/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -2884,6 +2884,38 @@ describe('SamDebugConfigurationProvider', async function () {
             }
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
+
+        function makeJavaImageDebugInput(runtime: Runtime) {
+            return {
+                type: AWS_SAM_DEBUG_TYPE,
+                name: `test-${runtime}-image`,
+                request: DIRECT_INVOKE_TYPE,
+                invokeTarget: {
+                    target: TEMPLATE_TARGET_TYPE,
+                    templatePath: 'template.yaml',
+                    logicalId: 'HelloWorldFunction',
+                },
+                lambda: { runtime },
+            }
+        }
+
+        it('AL2023 java runtimes produce _JAVA_OPTIONS for image debugging', async function () {
+            const fixture = pathutil.normalize(
+                path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/java17-image')
+            )
+            const folder = testutil.getWorkspaceFolder(fixture)
+            for (const runtime of ['java11.al2023', 'java17.al2023'] as unknown as Runtime[]) {
+                const actual = (await debugConfigProvider.makeConfig(
+                    folder,
+                    makeJavaImageDebugInput(runtime)
+                ))! as SamLaunchRequestArgs
+                assert.strictEqual(actual.runtimeFamily, lambdaModel.RuntimeFamily.Java)
+                assert.ok(
+                    actual.containerEnvVars?._JAVA_OPTIONS?.includes('agentlib:jdwp'),
+                    `${runtime} missing _JAVA_OPTIONS`
+                )
+            }
+        })
     })
 })
 

--- a/packages/core/src/testInteg/sam.test.ts
+++ b/packages/core/src/testInteg/sam.test.ts
@@ -131,8 +131,11 @@ const scenarios: TestScenario[] = [
     generateScenario('python', '3.13', { vscodeMinimum: '1.78.0' }),
     generateScenario('dotnet', '6'),
     generateScenario('java', '8.al2', { sourceTag: 'Maven', dependencyManager: 'maven' }),
+    generateScenario('java', '8.al2023', { sourceTag: 'Maven', dependencyManager: 'maven' }),
     generateScenario('java', '11', { sourceTag: 'Gradle' }),
+    generateScenario('java', '11.al2023', { sourceTag: 'Gradle' }),
     generateScenario('java', '17', { sourceTag: 'Gradle' }),
+    generateScenario('java', '17.al2023', { sourceTag: 'Gradle' }),
     // images
     generateScenario('nodejs', '20.x', { baseImage: 'amazon/nodejs20.x-base' }, true),
     generateScenario('nodejs', '22.x', { baseImage: 'amazon/nodejs22.x-base', vscodeMinimum: '1.78.0' }, true),
@@ -147,8 +150,16 @@ const scenarios: TestScenario[] = [
         { baseImage: 'amazon/java8.al2-base', sourceTag: 'Maven', dependencyManager: 'maven' },
         true
     ),
+    generateScenario(
+        'java',
+        '8.al2023',
+        { baseImage: 'amazon/java8.al2023-base', sourceTag: 'Maven', dependencyManager: 'maven' },
+        true
+    ),
     generateScenario('java', '11', { baseImage: 'amazon/java11-base', sourceTag: 'Gradle' }, true),
+    generateScenario('java', '11.al2023', { baseImage: 'amazon/java11.al2023-base', sourceTag: 'Gradle' }, true),
     generateScenario('java', '17', { baseImage: 'amazon/java17-base', sourceTag: 'Gradle' }, true),
+    generateScenario('java', '17.al2023', { baseImage: 'amazon/java17.al2023-base', sourceTag: 'Gradle' }, true),
 ]
 
 async function openSamAppFile(applicationPath: string): Promise<vscode.Uri> {


### PR DESCRIPTION
feat(lambda): add java8.al2023, java11.al2023, java17.al2023 runtime support

  Add AL2023-based Java Lambda runtimes according to [Lambda upcoming runtimes documentation ](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-future)to SAM init, local invoke, and image-based debugging workflows.

  ## Problem

  - Lambda is launching java8.al2023, java11.al2023, and java17.al2023 runtimes. The toolkit does not recognize these runtimes, so users cannot create, debug, or locally invoke SAM applications targeting them.
  - Refactored duplicate runtime arrays in unit tests to fix jscpd CI check.


  ## Solution

  - Add the three runtimes to `javaRuntimes` and `samArmLambdaRuntimes` sets
  - Add debug configuration cases in `javaSamDebug.ts` (al2023 variants use the same JVM debug args as their base version)
  - Update unit and integration test assertions

  ---

  - Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
  - Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
  - License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
