### PR TITLE
fix(cloudformation): Cap CloudFormation LSP server heap at 384MB

### DIFF
--- a/packages/core/src/awsService/cloudformation/extension.ts
+++ b/packages/core/src/awsService/cloudformation/extension.ts
@@ -112,7 +112,7 @@ async function startClient(context: ExtensionContext) {
     const serverRootDir = await serverProvider.serverRootDir()
 
     const envOptions = {
-        NODE_OPTIONS: '--enable-source-maps',
+        NODE_OPTIONS: '--enable-source-maps --max-old-space-size=384',
     }
 
     const serverOptions: ServerOptions = {


### PR DESCRIPTION
Set `NODE_OPTIONS --max-old-space-size=384` when spawning the CloudFormation language server process. Without this, V8 uses its default ~4GB ceiling and the process grows unbounded

This is to partially address memory consumption issues of the language server: https://github.com/aws/aws-toolkit-jetbrains/issues/6380 

The original issue was for jetbrains but it is applicable to the vscode client as well.

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
