### PR TITLE
fix(ec2): support KMS encryption in SSM terminal sessions

### DIFF
--- a/packages/core/src/awsService/ec2/model.ts
+++ b/packages/core/src/awsService/ec2/model.ts
@@ -33,7 +33,9 @@ import { SshConfig } from '../../shared/sshConfig'
 import { SshKeyPair } from './sshKeyPair'
 import { Ec2SessionTracker } from './remoteSessionManager'
 import { getEc2SsmEnv } from './utils'
-import { Session, StartSessionResponse } from '@aws-sdk/client-ssm'
+import { StartSessionResponse } from '@aws-sdk/client-ssm'
+import globals from '../../shared/extensionGlobals'
+import { asEnvironmentVariables } from '../../auth/credentials/utils'
 
 export type Ec2ConnectErrorCode = 'EC2SSMStatus' | 'EC2SSMPermission' | 'EC2SSMTestConnect' | 'EC2SSMAgentStatus'
 
@@ -41,6 +43,21 @@ export interface Ec2RemoteEnv extends VscodeRemoteConnection {
     selection: Ec2Selection
     keyPair: SshKeyPair
     ssmSession: StartSessionResponse
+}
+
+export function getSsmPluginArgs(
+    session: StartSessionResponse,
+    selection: Ec2Selection,
+    endpointUrl: string
+): string[] {
+    return [
+        JSON.stringify(session),
+        selection.region,
+        'StartSession',
+        '',
+        JSON.stringify({ Target: selection.instanceId }),
+        endpointUrl,
+    ]
 }
 
 export type Ec2OS = 'Amazon Linux' | 'Ubuntu' | 'macOS'
@@ -174,13 +191,16 @@ export class Ec2Connecter implements vscode.Disposable {
         await this.checkForInstanceSsmError(selection)
     }
 
-    private async openSessionInTerminal(session: Session, selection: Ec2Selection) {
-        const ssmPlugin = await getOrInstallCli('session-manager-plugin', !isCloud9)
-        const shellArgs = [JSON.stringify(session), selection.region, 'StartSession']
+    private async openSessionInTerminal(session: StartSessionResponse, selection: Ec2Selection) {
+        const ssmPlugin = await getOrInstallCli('session-manager-plugin', !isCloud9())
+        const endpointUrl = await this.ssm.getEndpointUrl()
+        const credentials = await globals.awsContext.getCredentials()
+        const env = credentials ? { ...process.env, ...asEnvironmentVariables(credentials) } : process.env
         const terminalOptions = {
             name: `${selection.region}/${selection.instanceId}`,
             shellPath: ssmPlugin,
-            shellArgs: shellArgs,
+            shellArgs: getSsmPluginArgs(session, selection, endpointUrl),
+            env,
         }
 
         await openRemoteTerminal(terminalOptions, () => this.ssm.terminateSession(session)).catch((err) => {
@@ -194,7 +214,9 @@ export class Ec2Connecter implements vscode.Disposable {
             const response = await this.ssm.startSession(selection.instanceId)
             await this.openSessionInTerminal(response, selection)
         } catch (err: unknown) {
-            this.throwConnectionError('', selection, err as Error)
+            const message = err instanceof Error ? err.message : String(err)
+            getLogger().error('ec2: failed to open terminal: %O', err)
+            this.throwConnectionError(message, selection, err as Error)
         }
     }
 

--- a/packages/core/src/shared/clients/ssm.ts
+++ b/packages/core/src/shared/clients/ssm.ts
@@ -51,6 +51,23 @@ export class SsmClient extends ClientWrapper<SSMClient> {
         })
     }
 
+    public async getEndpointUrl(): Promise<string> {
+        const client = this.getClient()
+        const customEndpointProvider = client.config.endpoint
+        if (customEndpointProvider !== undefined) {
+            const endpoint = await customEndpointProvider()
+            const port = endpoint.port === undefined ? '' : `:${endpoint.port}`
+            return `${endpoint.protocol}//${endpoint.hostname}${port}${endpoint.path}`
+        }
+
+        const endpoint = client.config.endpointProvider({
+            Region: await client.config.region(),
+            UseDualStack: await client.config.useDualstackEndpoint(),
+            UseFIPS: await client.config.useFipsEndpoint(),
+        })
+        return endpoint.url.toString()
+    }
+
     public async describeInstance(target: string): Promise<InstanceInformation> {
         return await this.getFirst(
             paginateDescribeInstanceInformation,

--- a/packages/core/src/test/awsService/ec2/model.test.ts
+++ b/packages/core/src/test/awsService/ec2/model.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert'
 import * as sinon from 'sinon'
-import { Ec2Connecter, getRemoveLinesCommand } from '../../../awsService/ec2/model'
+import { Ec2Connecter, getRemoveLinesCommand, getSsmPluginArgs } from '../../../awsService/ec2/model'
 import { SsmClient } from '../../../shared/clients/ssm'
 import { Ec2Client } from '../../../shared/clients/ec2'
 import { Ec2Selection } from '../../../awsService/ec2/prompter'
@@ -20,6 +20,29 @@ import { isMac, isWin } from '../../../shared/vscode/env'
 import { inspect } from '../../../shared/utilities/collectionUtils'
 import { assertLogsContain } from '../../globalSetup.test'
 import { InstanceStateName } from '@aws-sdk/client-ec2'
+import { StartSessionResponse } from '@aws-sdk/client-ssm'
+
+describe('getSsmPluginArgs', function () {
+    it('uses the modern Session Manager plugin invocation format', function () {
+        const session: StartSessionResponse = {
+            SessionId: 'test-session',
+            StreamUrl: 'wss://test-stream',
+            TokenValue: 'test-token',
+        }
+        const selection = { instanceId: 'i-1234567890abcdef0', region: 'us-west-2' }
+
+        const args = getSsmPluginArgs(session, selection, 'https://ssm.us-west-2.amazonaws.com/')
+
+        assert.deepStrictEqual(args, [
+            JSON.stringify(session),
+            'us-west-2',
+            'StartSession',
+            '',
+            JSON.stringify({ Target: 'i-1234567890abcdef0' }),
+            'https://ssm.us-west-2.amazonaws.com/',
+        ])
+    })
+})
 
 describe('Ec2ConnectClient', function () {
     let client: Ec2Connecter

--- a/packages/toolkit/.changes/next-release/Bug Fix-cd934039-b121-4c5a-a371-bc446fba84c0.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-cd934039-b121-4c5a-a371-bc446fba84c0.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "EC2 Open Terminal supports Session Manager sessions configured with KMS encryption"
+}


### PR DESCRIPTION
Problem:

EC2 Open Terminal invokes session-manager-plugin using its legacy argument format. When Session Manager KMS encryption is enabled, the plugin rejects the encryption handshake and reports that the installed CLI does not support encryption.

Solution:

- Use the complete modern session-manager-plugin invocation.
- Pass the StartSession target and effective SSM endpoint.
- Supply the Toolkit's resolved credentials to the plugin environment.
- Preserve the underlying terminal startup error for troubleshooting.
- Add unit coverage for the modern plugin argument format.

Testing:

- Core TypeScript compilation passes.
- Core webpack build completes.
- Focused EC2 tests pass: 18 passing, 1 platform-specific test pending on Windows.
- Verified locally through the Extension Development Host on Windows.
- Verified EC2 Open Terminal with `Standard_Stream` and a nonempty `kmsKeyId`.
- Verified commands execute successfully in the encrypted terminal.
- Verified closing the terminal terminates the SSM session.

Fixes #8840


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
