### PR TITLE
fix(smus): Make AWS partition and endpoint handling GovCloud-resilient

### DIFF
--- a/packages/core/src/auth/sso/clients.ts
+++ b/packages/core/src/auth/sso/clients.ts
@@ -4,6 +4,7 @@
  */
 
 import globals from '../../shared/extensionGlobals'
+import { defaultDnsSuffix } from '../../shared/regions/regionProvider'
 import { workspace } from 'vscode'
 
 import {
@@ -84,7 +85,8 @@ export class OidcClient {
         const params = toSnakeCase(request)
         const searchParams = new URLSearchParams(params).toString()
         const region = await this.client.config.region()
-        return `https://oidc.${region}.amazonaws.com/authorize?${searchParams}`
+        const dnsSuffix = globals.regionProvider.getDnsSuffixForRegion(region) || defaultDnsSuffix
+        return `https://oidc.${region}.${dnsSuffix}/authorize?${searchParams}`
     }
 
     public async createToken(request: CreateTokenRequest) {

--- a/packages/core/src/awsService/sagemaker/detached-server/utils.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/utils.ts
@@ -58,7 +58,8 @@ export async function readServerInfo(): Promise<ServerInfo> {
 
 export function parseArn(arn: string): { region: string; accountId: string; resourceName: string } {
     const cleanedArn = arn.includes('@') ? arn.split('@')[1] : arn
-    const regex = /^arn:aws:[^:]+:(?<region>[^:]+):(?<account_id>\d+):(space|cluster)[/:].+$/i
+    // Match all AWS partitions (aws, aws-cn, aws-us-gov, etc.)
+    const regex = /^arn:aws[a-z-]*:[^:]+:(?<region>[^:]+):(?<account_id>\d+):(space|cluster)[/:].+$/i
     const match = cleanedArn.match(regex)
 
     if (!match?.groups) {
@@ -78,7 +79,10 @@ export function parseArn(arn: string): { region: string; accountId: string; reso
 }
 
 export async function startSagemakerSession({ region, connectionIdentifier, credentials }: any) {
-    const endpoint = process.env.SAGEMAKER_ENDPOINT || `https://sagemaker.${region}.amazonaws.com`
+    // Only override the endpoint when explicitly configured. Otherwise let the SDK's
+    // endpoint resolver derive the correct host for the region's partition (e.g. aws-us-gov),
+    // rather than hardcoding the commercial `amazonaws.com` DNS suffix.
+    const endpoint = process.env.SAGEMAKER_ENDPOINT
     const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY
     const requestHandler = proxy
         ? new NodeHttpHandler({ httpsAgent: HttpsProxyAgent(proxy), httpAgent: HttpsProxyAgent(proxy) })
@@ -86,7 +90,7 @@ export async function startSagemakerSession({ region, connectionIdentifier, cred
     const client = new SageMakerClient({
         region,
         credentials,
-        endpoint,
+        ...(endpoint ? { endpoint } : {}),
         retryStrategy: startSessionRetryStrategy,
         requestHandler,
     })

--- a/packages/core/src/sagemakerunifiedstudio/shared/client/sqlWorkbenchClient.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/client/sqlWorkbenchClient.ts
@@ -19,6 +19,8 @@ import { v4 as uuidv4 } from 'uuid'
 import { getRedshiftTypeFromHost } from '../../explorer/nodes/utils'
 import { RedshiftType } from '../../explorer/nodes/types'
 import { ConnectionCredentialsProvider } from '../../auth/providers/connectionCredentialsProvider'
+import globals from '../../../shared/extensionGlobals'
+import { defaultDnsSuffix, defaultPartition } from '../../../shared/regions/regionProvider'
 
 /**
  * Connection configuration for SQL Workbench
@@ -33,7 +35,8 @@ export type ConnectionConfig = DatabaseConnectionConfiguration
  * @returns SQL Workbench ARN
  */
 export async function generateSqlWorkbenchArn(region: string, accountId: string): Promise<string> {
-    return `arn:aws:sqlworkbench:${region}:${accountId}:connection/${uuidv4()}`
+    const partition = globals.regionProvider.getPartitionId(region) ?? defaultPartition
+    return `arn:${partition}:sqlworkbench:${region}:${accountId}:connection/${uuidv4()}`
 }
 
 /**
@@ -248,7 +251,8 @@ export class SQLWorkbenchClient {
      * @returns SQL Workbench endpoint URL
      */
     private getSQLWorkbenchEndpoint(region: string): string {
-        return `https://api-v2.sqlworkbench.${region}.amazonaws.com`
+        const dnsSuffix = globals.regionProvider.getDnsSuffixForRegion(region) || defaultDnsSuffix
+        return `https://api-v2.sqlworkbench.${region}.${dnsSuffix}`
     }
 
     /**

--- a/packages/core/src/sagemakerunifiedstudio/shared/smusUtils.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/smusUtils.ts
@@ -604,8 +604,9 @@ export async function isExpressDomain(client: DataZoneClient, domainId: string, 
 
 /**
  * Extracts the account ID from a SageMaker ARN.
- * Supports formats like:
+ * Supports all AWS partitions (aws, aws-cn, aws-us-gov, etc.), e.g.:
  *   arn:aws:sagemaker:<region>:<account_id>:app/*
+ *   arn:aws-us-gov:sagemaker:<region>:<account_id>:space/*
  *
  * @param arn - The full SageMaker ARN string
  * @returns The account ID from the ARN
@@ -613,7 +614,7 @@ export async function isExpressDomain(client: DataZoneClient, domainId: string, 
  */
 export function extractAccountIdFromSageMakerArn(arn: string): string {
     // Match the ARN components to extract account ID
-    const regex = /^arn:aws:sagemaker:(?<region>[^:]+):(?<accountId>\d+):(app|space)\/.+$/i
+    const regex = /^arn:(?<partition>aws[a-z-]*):sagemaker:(?<region>[^:]+):(?<accountId>\d+):(app|space)\/.+$/i
     const match = arn.match(regex)
 
     if (!match?.groups) {

--- a/packages/core/src/test/awsService/sagemaker/detached-server/utils.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/detached-server/utils.test.ts
@@ -33,6 +33,16 @@ describe('parseArn', () => {
         })
     })
 
+    it('parses a GovCloud (aws-us-gov) partition ARN', () => {
+        const arn = 'arn:aws-us-gov:sagemaker:us-gov-west-1:123456789012:space/domain-name/my-space-name'
+        const result = parseArn(arn)
+        assert.deepStrictEqual(result, {
+            region: 'us-gov-west-1',
+            accountId: '123456789012',
+            resourceName: 'my-space-name',
+        })
+    })
+
     it('throws on malformed ARN', () => {
         const invalidArn = 'arn:aws:invalid:format'
         assert.throws(() => parseArn(invalidArn), /Invalid ARN format/)

--- a/packages/core/src/test/sagemakerunifiedstudio/shared/smusUtils.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/shared/smusUtils.test.ts
@@ -606,6 +606,13 @@ describe('extractAccountIdFromSageMakerArn', () => {
 
             assert.strictEqual(result, '123456789012')
         })
+
+        it('should extract account ID from a GovCloud (aws-us-gov) partition ARN', () => {
+            const arn = 'arn:aws-us-gov:sagemaker:us-gov-west-1:123456789012:space/domain-id/my-space'
+            const result = extractAccountIdFromSageMakerArn(arn)
+
+            assert.strictEqual(result, '123456789012')
+        })
     })
 
     describe('invalid ARN formats', () => {


### PR DESCRIPTION
Local IDE hardcoded the commercial `aws` partition and `.amazonaws.com` DNS suffix in several ARN and endpoint constructions, which break in GovCloud (aws-us-gov partition). Route these through the existing regionProvider (getPartitionId / getDnsSuffixForRegion) so they resolve correctly per partition.

- smusUtils.extractAccountIdFromSageMakerArn: match any partition (arn:aws[a-z-]*:) instead of literal arn:aws:
- detached-server parseArn: match any partition
- detached-server startSagemakerSession: only override the endpoint when SAGEMAKER_ENDPOINT is set; otherwise let the SDK resolver derive the partition-correct host (this file cannot import vscode/globals)
- sqlWorkbenchClient: derive partition for the ARN and dnsSuffix for the endpoint from regionProvider
- auth/sso OidcClient.authorize: derive dnsSuffix for the OIDC endpoint

Added GovCloud (aws-us-gov) test cases for both ARN parsers.

Note: two hardcoded endpoints were intentionally left for follow-up as they need endpoint-format confirmation, not a mechanical fix:
  - datazoneCustomClientHelper `datazone.{region}.api.aws`
  - smusUtils Identity Center issuer `identitycenter.amazonaws.com` (coupled to a validation regex in auth/sso/constants.ts)

## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
