### PR TITLE
fix(smus): Use exact match for DataZone session-name resolution

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.ts
@@ -548,8 +548,8 @@ export class DataZoneCustomClientHelper {
                     // Match based on session name (role ARN already filtered by searchText)
                     // principalId format: PRINCIPAL_ID:SESSION_NAME
                     const matchesSession =
-                        profile.details?.iam?.principalId?.includes(sessionName) ||
-                        profile.details?.iam?.sessionName?.includes(sessionName)
+                        profile.details?.iam?.sessionName === sessionName ||
+                        profile.details?.iam?.principalId?.endsWith(`:${sessionName}`)
 
                     if (matchesSession) {
                         this.logger.info(

--- a/packages/core/src/test/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.test.ts
@@ -929,6 +929,105 @@ describe('DataZoneCustomClientHelper', () => {
                 searchStub.restore()
             }
         })
+
+        it('should NOT match when session name is a substring of principalId session (regression)', async function () {
+            // Regression: old .includes() logic would match "foo" against "foo-bar".
+            // The fix uses endsWith(`:${sessionName}`) so "foo" must NOT match ":foo-bar".
+            const fooArn = 'arn:aws:sts::123456789012:assumed-role/AdminRole/foo'
+            const searchStub = sinon.stub(client, 'searchUserProfiles')
+            searchStub.resolves({
+                items: [
+                    {
+                        id: 'up_foobar_profile',
+                        status: 'ACTIVATED',
+                        details: {
+                            iam: {
+                                arn: 'arn:aws:iam::123456789012:role/AdminRole',
+                                principalId: 'AIDAI123456789EXAMPLE:foo-bar',
+                                sessionName: 'foo-bar',
+                            },
+                        },
+                    },
+                ],
+                nextToken: undefined,
+            })
+
+            const result = await client.getUserProfileIdForSession(mockDomainId, fooArn)
+            assert.strictEqual(result, '', 'substring "foo" must not match principalId ending in ":foo-bar"')
+        })
+
+        it('should disambiguate by exact principalId suffix, not substring match', async function () {
+            // Two profiles share the same role but have different sessions.
+            // Session "foo" must resolve to the profile whose principalId ends in ":foo",
+            // not the one ending in ":foo-bar" (which the old .includes() matched first).
+            const fooArn = 'arn:aws:sts::123456789012:assumed-role/AdminRole/foo'
+            const searchStub = sinon.stub(client, 'searchUserProfiles')
+            searchStub.resolves({
+                items: [
+                    {
+                        id: 'up_foobar_profile',
+                        status: 'ACTIVATED',
+                        details: {
+                            iam: {
+                                arn: 'arn:aws:iam::123456789012:role/AdminRole',
+                                principalId: 'AIDAI123456789EXAMPLE:foo-bar',
+                            },
+                        },
+                    },
+                    {
+                        id: 'up_foo_profile',
+                        status: 'ACTIVATED',
+                        details: {
+                            iam: {
+                                arn: 'arn:aws:iam::123456789012:role/AdminRole',
+                                principalId: 'AIDAI987654321EXAMPLE:foo',
+                            },
+                        },
+                    },
+                ],
+                nextToken: undefined,
+            })
+
+            const result = await client.getUserProfileIdForSession(mockDomainId, fooArn)
+            assert.strictEqual(result, 'up_foo_profile')
+        })
+
+        it('should disambiguate by exact sessionName field, not substring match', async function () {
+            // Two profiles with sessionName field set — "foo" must match sessionName === "foo",
+            // not the one with sessionName "foo-bar".
+            const fooArn = 'arn:aws:sts::123456789012:assumed-role/AdminRole/foo'
+            const searchStub = sinon.stub(client, 'searchUserProfiles')
+            searchStub.resolves({
+                items: [
+                    {
+                        id: 'up_foobar_profile',
+                        status: 'ACTIVATED',
+                        details: {
+                            iam: {
+                                arn: 'arn:aws:iam::123456789012:role/AdminRole',
+                                principalId: 'AIDAI123456789EXAMPLE',
+                                sessionName: 'foo-bar',
+                            },
+                        },
+                    },
+                    {
+                        id: 'up_foo_profile',
+                        status: 'ACTIVATED',
+                        details: {
+                            iam: {
+                                arn: 'arn:aws:iam::123456789012:role/AdminRole',
+                                principalId: 'AIDAI987654321EXAMPLE',
+                                sessionName: 'foo',
+                            },
+                        },
+                    },
+                ],
+                nextToken: undefined,
+            })
+
+            const result = await client.getUserProfileIdForSession(mockDomainId, fooArn)
+            assert.strictEqual(result, 'up_foo_profile')
+        })
     })
 
     describe('Project and Space Filtering', () => {


### PR DESCRIPTION
## Problem
Each IAM role can be tied to multiple named sessions, and SMUS relies on the session name to figure out which DataZone user profile you are. That profile determines which spaces you see. The matching logic involves loose substring matching, so the wrong profile can be selected when session names overlap, causing your spaces to not show in the SMUS tree.

`getUserProfileIdForSession()` maps an IAM role session to a DataZone user profile using `.includes()`. This is a substring match. When multiple sessions on the same role share a common prefix (e.g. `akshay`, `akshay-session`, `akshay-session2`), a shorter name matches all of them. Which profile is returned depends on pagination order from `searchUserProfiles`, making the result non-deterministic.

In practice this means you authenticate as one session but the extension resolves a *different* user's DataZone profile. Spaces owned by your actual profile are filtered out and do not show in the tree. Projects are unaffected because they resolve via the shared group profile, not the per-session user profile.

## Solution

Replace the `.includes()` substring check with exact matching:

```ts
const matchesSession =
    profile.details?.iam?.sessionName === sessionName ||
    profile.details?.iam?.principalId?.endsWith(`:${sessionName}`)
```

- `sessionName === sessionName` — direct equality, no false positives from shared prefixes.
- `principalId.endsWith(":${sessionName}")` — safe fallback given the `PRINCIPAL_ID:SESSION_NAME` format

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
