### PR TITLE
feat(smus): deeplink auto refresh

### DIFF
--- a/packages/core/src/awsService/sagemaker/credentialMapping.ts
+++ b/packages/core/src/awsService/sagemaker/credentialMapping.ts
@@ -94,7 +94,8 @@ export async function persistSmusProjectCreds(spaceArn: string, node: SagemakerU
  * @param wsUrl - SSM WebSocket URL.
  * @param token - Bearer token for the session.
  * @param appType - Application type (e.g., 'jupyterlab', 'codeeditor').
- * @param isSMUS - If true, skip refreshUrl construction (SMUS connections cannot refresh).
+ * @param isSMUS - If true, use providedRefreshUrl instead of deriving one from region/endpoint.
+ * @param providedRefreshUrl - Console-supplied refresh URL for SMUS connections; ignored for SM-AI.
  */
 export async function persistSSMConnection(
     spaceArn: string,
@@ -103,9 +104,11 @@ export async function persistSSMConnection(
     wsUrl?: string,
     token?: string,
     appType?: string,
-    isSMUS?: boolean
+    isSMUS?: boolean,
+    providedRefreshUrl?: string
 ): Promise<void> {
-    let refreshUrl: string | undefined
+    // SageMaker AI derives its refresh URL below; SMUS uses the console-supplied one as-is.
+    let refreshUrl: string | undefined = providedRefreshUrl
 
     if (!isSMUS) {
         // Construct refreshUrl for SageMaker AI connections
@@ -136,13 +139,21 @@ export async function persistSSMConnection(
 
         refreshUrl = `https://studio-${domain}.${baseDomain}/${appSubDomain}`
     }
-    // For SMUS connections, refreshUrl remains undefined
+    // For SMUS, refreshUrl is the console-supplied `providedRefreshUrl` (undefined = cannot refresh).
 
-    await setSpaceCredentials(spaceArn, refreshUrl, {
-        sessionId: session ?? '-',
-        url: wsUrl ?? '-',
-        token: token ?? '-',
-    })
+    const autoRefreshEnabled = isSMUS ? DevSettings.instance.get('smusDeeplinkAutoRefresh', false) : undefined
+
+    await setSpaceCredentials(
+        spaceArn,
+        refreshUrl,
+        {
+            sessionId: session ?? '-',
+            url: wsUrl ?? '-',
+            token: token ?? '-',
+        },
+        isSMUS,
+        autoRefreshEnabled
+    )
 }
 
 /**
@@ -197,19 +208,25 @@ export async function setSmusSpaceProfile(
  * Stores SSM connection information for a given space, typically from a deep link session.
  * This initializes the request as 'fresh' and includes a refresh URL if provided.
  * @param spaceArn - The arn of the SageMaker space.
- * @param refreshUrl - URL to use for refreshing session tokens (undefined for SMUS connections).
+ * @param refreshUrl - URL to use for refreshing session tokens (undefined for SMUS connections without auto-refresh).
  * @param credentials - The session information used to initiate the connection.
+ * @param isSMUS - Whether this is a SMUS connection (vs SageMaker AI).
+ * @param autoRefreshEnabled - Gates SMUS auto-refresh in the detached server.
  */
 export async function setSpaceCredentials(
     spaceArn: string,
     refreshUrl: string | undefined,
-    credentials: SsmConnectionInfo
+    credentials: SsmConnectionInfo,
+    isSMUS?: boolean,
+    autoRefreshEnabled?: boolean
 ): Promise<void> {
     const data = await loadMappings()
     data.deepLink ??= {}
 
     data.deepLink[spaceArn] = {
         refreshUrl,
+        isSMUS,
+        autoRefreshEnabled,
         requests: {
             'initial-connection': {
                 ...credentials,

--- a/packages/core/src/awsService/sagemaker/detached-server/routes/getSessionAsync.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/routes/getSessionAsync.ts
@@ -49,10 +49,16 @@ export async function handleGetSessionAsync(req: IncomingMessage, res: ServerRes
             return
         } else if (status === 'not-started') {
             const refreshUrl = await store.getRefreshUrl(connectionIdentifier)
+            const autoRefreshEnabled = await store.getAutoRefreshEnabled(connectionIdentifier)
 
-            // Check if this is a SMUS connection (no refreshUrl available)
-            if (refreshUrl === undefined) {
-                console.log(`SMUS session expired for connection: ${connectionIdentifier}`)
+            const isSMUS = await store.getIsSMUS(connectionIdentifier)
+
+            // SMUS: gate reconnect on the smusDeeplinkAutoRefresh DevSetting.
+            // SM-AI: always reconnect if refreshUrl exists (unaffected by the setting).
+            const canReconnect = isSMUS ? autoRefreshEnabled : refreshUrl !== undefined
+
+            if (!canReconnect) {
+                console.log(`Session expired for connection: ${connectionIdentifier} (isSMUS=${isSMUS})`)
 
                 // Clean up the expired connection entry
                 try {
@@ -74,15 +80,20 @@ export async function handleGetSessionAsync(req: IncomingMessage, res: ServerRes
                 return
             }
 
-            // Continue with existing SageMaker AI refresh flow
+            // Continue with refresh flow (SM-AI or SMUS)
             const serverInfo = await readServerInfo()
             const { resourceName: spaceName } = parseArn(connectionIdentifier)
 
-            const url = `${refreshUrl}/${encodeURIComponent(spaceName)}?remote_access_token_refresh=true&reconnect_identifier=${encodeURIComponent(
+            const baseUrl = `${refreshUrl}/${encodeURIComponent(spaceName)}?remote_access_token_refresh=true&reconnect_identifier=${encodeURIComponent(
                 connectionIdentifier
-            )}&reconnect_request_id=${encodeURIComponent(requestId)}&reconnect_callback_url=${encodeURIComponent(
-                `http://localhost:${serverInfo.port}/refresh_token`
-            )}`
+            )}&reconnect_request_id=${encodeURIComponent(requestId)}`
+
+            // SMUS sends only port (Maxdome WAF blocks localhost URLs); SM AI sends full callback URL.
+            const url = isSMUS
+                ? `${baseUrl}&reconnect_callback_port=${encodeURIComponent(String(serverInfo.port))}`
+                : `${baseUrl}&reconnect_callback_url=${encodeURIComponent(
+                      `http://localhost:${serverInfo.port}/refresh_token`
+                  )}`
 
             await open(url)
             res.writeHead(202, { 'Content-Type': 'text/plain' })

--- a/packages/core/src/awsService/sagemaker/detached-server/routes/refreshToken.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/routes/refreshToken.ts
@@ -63,5 +63,5 @@ export async function handleRefreshToken(req: IncomingMessage, res: ServerRespon
     }
 
     res.writeHead(200)
-    res.end('Session token refreshed successfully')
+    res.end('Reconnection successful. You can close this tab and return to your IDE.')
 }

--- a/packages/core/src/awsService/sagemaker/detached-server/sessionStore.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/sessionStore.ts
@@ -24,6 +24,28 @@ export class SessionStore {
         return entry.refreshUrl
     }
 
+    /** Returns true if this is a SMUS connection. Defaults to false for legacy entries. */
+    async getIsSMUS(connectionId: string): Promise<boolean> {
+        const mapping = await readMapping()
+
+        if (!mapping.deepLink) {
+            throw new Error('No deepLink mapping found')
+        }
+
+        const entry = mapping.deepLink[connectionId]
+        if (!entry) {
+            throw new Error(`No mapping found for connectionId: "${connectionId}"`)
+        }
+
+        return entry.isSMUS ?? false
+    }
+
+    async getAutoRefreshEnabled(connectionId: string): Promise<boolean> {
+        const mapping = await readMapping()
+        const entry = mapping.deepLink?.[connectionId]
+        return entry?.autoRefreshEnabled === true
+    }
+
     async getFreshEntry(connectionId: string, requestId: string) {
         const mapping = await readMapping()
 

--- a/packages/core/src/awsService/sagemaker/model.ts
+++ b/packages/core/src/awsService/sagemaker/model.ts
@@ -199,7 +199,7 @@ export async function prepareDevEnvConnection(opts: DevEnvConnectionOptions) {
             await persistSmusProjectCreds(spaceArn, node as SagemakerUnifiedStudioSpaceNode)
         }
     } else if (connectionType === 'sm_dl') {
-        await persistSSMConnection(spaceArn, domain ?? '', session, wsUrl, token, appType, isSMUS)
+        await persistSSMConnection(spaceArn, domain ?? '', session, wsUrl, token, appType, isSMUS, refreshUrl)
     } else if (connectionType.startsWith('smhp_')) {
         await persistHyperpodConnection(
             workspaceName!,

--- a/packages/core/src/awsService/sagemaker/reconnectTelemetry.ts
+++ b/packages/core/src/awsService/sagemaker/reconnectTelemetry.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { telemetry } from '../../shared/telemetry/telemetry'
+import { Result } from '../../shared/telemetry/telemetry.gen'
+
+/** Emits `sagemaker_reconnect` from the extension host (detached server has no vscode context). */
+export function emitReconnectMetric(opts: {
+    result: Result
+    isSmus: boolean
+    duration?: number
+    reason?: string
+}): void {
+    telemetry.sagemaker_reconnect.emit({
+        result: opts.result,
+        isSmus: opts.isSmus,
+        duration: opts.duration,
+        reason: opts.reason,
+    })
+}

--- a/packages/core/src/awsService/sagemaker/types.ts
+++ b/packages/core/src/awsService/sagemaker/types.ts
@@ -17,6 +17,10 @@ export type LocalCredentialProfile =
 export interface DeeplinkSession {
     requests: Record<string, SsmConnectionInfo>
     refreshUrl?: string
+    /** Whether this is a SMUS connection (vs SageMaker AI). */
+    isSMUS?: boolean
+    /** Gates SMUS auto-refresh in the detached server. */
+    autoRefreshEnabled?: boolean
 }
 
 export interface SsmConnectionInfo {

--- a/packages/core/src/sagemakerunifiedstudio/uriHandlers.ts
+++ b/packages/core/src/sagemakerunifiedstudio/uriHandlers.ts
@@ -68,7 +68,8 @@ export function register(ctx: ExtContext) {
                 undefined,
                 undefined,
                 undefined,
-                true // isSMUS=true for SMUS connections
+                true, // isSMUS
+                params.reconnect_base_url
             )
         })
     }
@@ -95,6 +96,7 @@ export function register(ctx: ExtContext) {
  * - smus_project_id: SMUS project identifier
  * - smus_domain_region: SMUS domain region
  * - smus_auth_mode: Authentication mode (sso or iam)
+ * - reconnect_base_url: Console base URL for session reconnect (absent on older consoles)
  *
  * Note: The ws_url from startSession API originally includes cell-number as a query parameter.
  * However, when the deeplink URL is processed, the URI handler extracts cell-number as a
@@ -134,7 +136,8 @@ export function parseConnectParams(query: SearchParams) {
         'smus_project_id',
         'smus_domain_region',
         'smus_auth_mode',
-        'smus_domain_mode'
+        'smus_domain_mode',
+        'reconnect_base_url'
     )
 
     const amzHeaderParams = query.getFromKeys(...amzHeaders)

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -784,6 +784,7 @@ const devSettings = {
     webAuth: Boolean,
     notificationsPollInterval: Number,
     datazoneScope: String,
+    smusDeeplinkAutoRefresh: Boolean,
 }
 type ResolvedDevSettings = FromDescriptor<typeof devSettings>
 type AwsDevSetting = keyof ResolvedDevSettings

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -359,6 +359,11 @@
             "type": "string",
             "allowedValues": ["accepted", "declined", "dismissed"],
             "description": "Whether the user accepted, declined or dismissed the smus context prompt to add to AGENTS.md"
+        },
+        {
+            "name": "isSmus",
+            "type": "boolean",
+            "description": "Whether the operation is for a SageMaker Unified Studio connection"
         }
     ],
     "metrics": [
@@ -395,6 +400,24 @@
             "metadata": [
                 {
                     "type": "result"
+                }
+            ]
+        },
+        {
+            "name": "sagemaker_reconnect",
+            "description": "Reconnect a dropped SageMaker deeplink SSH/SSM session",
+            "metadata": [
+                {
+                    "type": "result"
+                },
+                {
+                    "type": "isSmus"
+                },
+                {
+                    "type": "duration"
+                },
+                {
+                    "type": "reason"
                 }
             ]
         },

--- a/packages/core/src/test/awsService/sagemaker/credentialMapping.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/credentialMapping.test.ts
@@ -221,7 +221,7 @@ describe('credentialMapping', () => {
             })
         })
 
-        it('stores undefined refreshUrl when isSMUS=true', async () => {
+        it('stores undefined refreshUrl when isSMUS=true and no providedRefreshUrl (older console)', async () => {
             sandbox.stub(DevSettings.instance, 'get').returns({})
             sandbox.stub(fs, 'existsFile').resolves(false)
             const writeStub = sandbox.stub(fs, 'writeFile').resolves()
@@ -231,7 +231,7 @@ describe('credentialMapping', () => {
             const raw = writeStub.firstCall.args[1]
             const data = JSON.parse(typeof raw === 'string' ? raw : raw.toString())
 
-            // Verify refreshUrl is undefined for SMUS connections
+            // No providedRefreshUrl → refreshUrl stays undefined (connection cannot refresh)
             assert.strictEqual(data.deepLink?.[appArn]?.refreshUrl, undefined)
 
             // Verify SSM connection info is stored correctly
@@ -241,6 +241,61 @@ describe('credentialMapping', () => {
                 token: 'token-xyz',
                 status: 'fresh',
             })
+        })
+
+        it('persists the console-supplied refreshUrl when isSMUS=true', async () => {
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+            sandbox.stub(fs, 'existsFile').resolves(false)
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            const reconnectBaseUrl =
+                'https://d-abc123xyz789.sagemaker-gamma.us-west-2.on.aws/projects/4m8bqfexample/code-spaces'
+
+            await persistSSMConnection(
+                appArn,
+                domain,
+                'sess-smus',
+                'wss://smus-ws',
+                'token-smus',
+                'jupyterlab',
+                true,
+                reconnectBaseUrl
+            )
+
+            const raw = writeStub.firstCall.args[1]
+            const data = JSON.parse(typeof raw === 'string' ? raw : raw.toString())
+
+            // The SMUS URL is used verbatim — no derivation, no hardcoded stage.
+            assert.strictEqual(data.deepLink?.[appArn]?.refreshUrl, reconnectBaseUrl)
+            assert.strictEqual(data.deepLink?.[appArn]?.isSMUS, true)
+            assert.deepStrictEqual(data.deepLink?.[appArn]?.requests['initial-connection'], {
+                sessionId: 'sess-smus',
+                url: 'wss://smus-ws',
+                token: 'token-smus',
+                status: 'fresh',
+            })
+        })
+
+        it('ignores a provided refreshUrl when isSMUS=false and derives the SageMaker AI URL', async () => {
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+            sandbox.stub(fs, 'existsFile').resolves(false)
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            await persistSSMConnection(
+                appArn,
+                domain,
+                'sess-ai',
+                'wss://sm-ws',
+                'token-ai',
+                'jupyterlab',
+                false,
+                'https://should-be-ignored.example.com/projects/p/code-spaces'
+            )
+
+            const raw = writeStub.firstCall.args[1]
+            const data = JSON.parse(typeof raw === 'string' ? raw : raw.toString())
+
+            assertRefreshUrlMatches(data.deepLink?.[appArn]?.refreshUrl, 'studio.us-west-2.sagemaker.aws')
         })
 
         it('stores valid refreshUrl when isSMUS=false (SageMaker AI behavior)', async () => {
@@ -288,6 +343,19 @@ describe('credentialMapping', () => {
                 token: 'token-def',
                 status: 'fresh',
             })
+        })
+
+        it('persists isSMUS: false when called with isSMUS=false', async function () {
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+            sandbox.stub(fs, 'existsFile').resolves(false)
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            await persistSSMConnection(appArn, domain, 'sess-sm', 'wss://sm-ws', 'token-sm', 'jupyterlab', false)
+
+            const raw = writeStub.firstCall.args[1]
+            const data = JSON.parse(typeof raw === 'string' ? raw : raw.toString())
+
+            assert.strictEqual(data.deepLink?.[appArn]?.isSMUS, false)
         })
     })
 

--- a/packages/core/src/test/awsService/sagemaker/detached-server/routes/getSessionAsync.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/detached-server/routes/getSessionAsync.test.ts
@@ -24,13 +24,18 @@ function stubSagemakerBrowserFlow() {
 describe('handleGetSessionAsync', () => {
     let ctx: RouteTestContext
 
+    let openErrorPageStub: sinon.SinonStub
+
     beforeEach(() => {
         ctx = createRouteTestContext()
         sinon.stub(SessionStore.prototype, 'getFreshEntry').callsFake(ctx.storeStub.getFreshEntry)
         sinon.stub(SessionStore.prototype, 'getStatus').callsFake(ctx.storeStub.getStatus)
         sinon.stub(SessionStore.prototype, 'getRefreshUrl').callsFake(ctx.storeStub.getRefreshUrl)
+        sinon.stub(SessionStore.prototype, 'getIsSMUS').callsFake(ctx.storeStub.getIsSMUS)
+        sinon.stub(SessionStore.prototype, 'getAutoRefreshEnabled').callsFake(ctx.storeStub.getAutoRefreshEnabled)
         sinon.stub(SessionStore.prototype, 'markPending').callsFake(ctx.storeStub.markPending)
         sinon.stub(SessionStore.prototype, 'cleanupExpiredConnection').callsFake(ctx.storeStub.cleanupExpiredConnection)
+        openErrorPageStub = sinon.stub(errorPage, 'openErrorPage').resolves()
     })
 
     it('responds with 400 if required query parameters are missing', async () => {
@@ -94,13 +99,6 @@ describe('handleGetSessionAsync', () => {
     })
 
     describe('SMUS session expiration handling', () => {
-        let openErrorPageStub: sinon.SinonStub
-
-        beforeEach(() => {
-            // Stub the openErrorPage function to prevent actual browser opening
-            openErrorPageStub = sinon.stub(errorPage, 'openErrorPage').resolves()
-        })
-
         it('handles SMUS session expiration when refreshUrl is undefined', async () => {
             ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
 
@@ -142,6 +140,23 @@ describe('handleGetSessionAsync', () => {
             assert.strictEqual(actualJson.error, SmusDeeplinkSessionExpiredError.code)
         })
 
+        it('returns 400 when SMUS and autoRefreshEnabled is false (gate OFF)', async () => {
+            ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
+
+            ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
+            ctx.storeStub.getStatus.returns(Promise.resolve('not-started'))
+            ctx.storeStub.getRefreshUrl.returns(Promise.resolve(undefined))
+            ctx.storeStub.getAutoRefreshEnabled.returns(Promise.resolve(false))
+            ctx.storeStub.cleanupExpiredConnection.resolves()
+
+            await handleGetSessionAsync(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
+
+            assert(ctx.resWriteHead.calledWith(400))
+            const actualJson = JSON.parse(ctx.resEnd.firstCall.args[0])
+            assert.strictEqual(actualJson.error, SmusDeeplinkSessionExpiredError.code)
+            assert(ctx.storeStub.cleanupExpiredConnection.calledOnce)
+        })
+
         it('responds with 202 when refreshUrl is valid (existing SageMaker AI flow)', async () => {
             ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
 
@@ -158,6 +173,61 @@ describe('handleGetSessionAsync', () => {
             assert(ctx.resWriteHead.calledWith(202))
             assert(ctx.resEnd.calledWithMatch(/Session is not ready yet/))
             assert(ctx.storeStub.markPending.calledWith('abc', 'req123'))
+        })
+
+        it('proceeds to refresh flow when SMUS and autoRefreshEnabled is true (gate ON)', async () => {
+            ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
+
+            ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
+            ctx.storeStub.getStatus.returns(Promise.resolve('not-started'))
+            ctx.storeStub.getRefreshUrl.returns(Promise.resolve(undefined))
+            ctx.storeStub.getAutoRefreshEnabled.returns(Promise.resolve(true))
+            ctx.storeStub.getIsSMUS.returns(Promise.resolve(true))
+            ctx.storeStub.markPending.returns(Promise.resolve())
+
+            stubSagemakerBrowserFlow()
+            await handleGetSessionAsync(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
+
+            assert(ctx.resWriteHead.calledWith(202))
+            assert(ctx.resEnd.calledWithMatch(/Session is not ready yet/))
+            assert(ctx.storeStub.cleanupExpiredConnection.notCalled)
+        })
+
+        it('returns 400 when SMUS has refreshUrl but autoRefreshEnabled is false (gate blocks reconnect)', async () => {
+            ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
+
+            ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
+            ctx.storeStub.getStatus.returns(Promise.resolve('not-started'))
+            ctx.storeStub.getRefreshUrl.returns(Promise.resolve('https://smus-console.example.com/refresh'))
+            ctx.storeStub.getAutoRefreshEnabled.returns(Promise.resolve(false))
+            ctx.storeStub.getIsSMUS.returns(Promise.resolve(true))
+            ctx.storeStub.cleanupExpiredConnection.resolves()
+
+            await handleGetSessionAsync(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
+
+            assert(ctx.resWriteHead.calledWith(400))
+            const actualJson = JSON.parse(ctx.resEnd.firstCall.args[0])
+            assert.strictEqual(actualJson.error, SmusDeeplinkSessionExpiredError.code)
+            assert(ctx.storeStub.cleanupExpiredConnection.calledOnce)
+        })
+
+        it('SM-AI always reconnects when refreshUrl exists regardless of autoRefreshEnabled', async () => {
+            ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
+
+            ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
+            ctx.storeStub.getStatus.returns(Promise.resolve('not-started'))
+            ctx.storeStub.getRefreshUrl.returns(Promise.resolve('https://example.com/refresh'))
+            ctx.storeStub.getAutoRefreshEnabled.returns(Promise.resolve(false))
+            ctx.storeStub.getIsSMUS.returns(Promise.resolve(false))
+            ctx.storeStub.markPending.returns(Promise.resolve())
+
+            stubSagemakerBrowserFlow()
+
+            await handleGetSessionAsync(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
+
+            assert(ctx.resWriteHead.calledWith(202))
+            assert(ctx.resEnd.calledWithMatch(/Session is not ready yet/))
+            assert(ctx.storeStub.cleanupExpiredConnection.notCalled)
         })
 
         it('does not call cleanupExpiredConnection for SageMaker AI connections', async () => {

--- a/packages/core/src/test/awsService/sagemaker/detached-server/routes/refreshToken.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/detached-server/routes/refreshToken.test.ts
@@ -52,7 +52,7 @@ describe('handleRefreshToken', () => {
         await handleRefreshToken(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
 
         assert(ctx.resWriteHead.calledWith(200))
-        assert(ctx.resEnd.calledWith('Session token refreshed successfully'))
+        assert(ctx.resEnd.calledWith('Reconnection successful. You can close this tab and return to your IDE.'))
         assert(
             ctx.storeStub.setSession.calledWith('abc', 'req123', {
                 sessionId: 'sess123',

--- a/packages/core/src/test/awsService/sagemaker/detached-server/sessionStore.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/detached-server/sessionStore.test.ts
@@ -76,6 +76,72 @@ describe('SessionStore', () => {
         await assert.rejects(() => store.getRefreshUrl(connectionId), /No deepLink mapping found/)
     })
 
+    describe('getIsSMUS', function () {
+        it('returns true when isSMUS is true in the mapping', async function () {
+            const store = new SessionStore()
+            readMappingStub.returns({
+                deepLink: {
+                    [connectionId]: {
+                        refreshUrl: 'https://example.com/projects/p/code-spaces',
+                        isSMUS: true,
+                        requests: {
+                            'initial-connection': { sessionId: 's0', token: 't0', url: 'u0', status: 'fresh' },
+                        },
+                    },
+                },
+            })
+            const result = await store.getIsSMUS(connectionId)
+            assert.strictEqual(result, true)
+        })
+
+        it('returns false when isSMUS is false in the mapping', async function () {
+            const store = new SessionStore()
+            readMappingStub.returns({
+                deepLink: {
+                    [connectionId]: {
+                        refreshUrl: 'https://refresh.url',
+                        isSMUS: false,
+                        requests: {
+                            'initial-connection': { sessionId: 's0', token: 't0', url: 'u0', status: 'fresh' },
+                        },
+                    },
+                },
+            })
+            const result = await store.getIsSMUS(connectionId)
+            assert.strictEqual(result, false)
+        })
+
+        it('defaults to false when isSMUS field is absent', async function () {
+            const store = new SessionStore()
+            readMappingStub.returns({
+                deepLink: {
+                    [connectionId]: {
+                        refreshUrl: 'https://refresh.url',
+                        requests: {
+                            'initial-connection': { sessionId: 's0', token: 't0', url: 'u0', status: 'fresh' },
+                        },
+                    },
+                },
+            })
+            const result = await store.getIsSMUS(connectionId)
+            assert.strictEqual(result, false)
+        })
+
+        it('throws when no deepLink mapping exists', async function () {
+            const store = new SessionStore()
+            readMappingStub.returns({})
+
+            await assert.rejects(() => store.getIsSMUS(connectionId), /No deepLink mapping found/)
+        })
+
+        it('throws when connectionId is not found', async function () {
+            const store = new SessionStore()
+            readMappingStub.returns({ deepLink: {} })
+
+            await assert.rejects(() => store.getIsSMUS('missing'), /No mapping found/)
+        })
+    })
+
     it('returns fresh entry and marks consumed', async () => {
         const store = new SessionStore()
         const result = await store.getFreshEntry(connectionId, requestId)

--- a/packages/core/src/test/sagemakerunifiedstudio/uriHandlers.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/uriHandlers.test.ts
@@ -112,6 +112,18 @@ describe('SMUS URI Handler', function () {
             assert.strictEqual(resultWithoutOptional.smus_domain_region, undefined)
         })
 
+        it('parses reconnect_base_url when present and leaves it undefined when absent', function () {
+            const reconnectBaseUrl =
+                'https://d-abc123xyz789.sagemaker-gamma.us-west-2.on.aws/projects/4m8bqfexample/code-spaces'
+            const withParam = parseConnectParams(
+                new SearchParams({ ...validParams, reconnect_base_url: reconnectBaseUrl })
+            )
+            assert.strictEqual(withParam.reconnect_base_url, reconnectBaseUrl)
+
+            const withoutParam = parseConnectParams(new SearchParams(validParams))
+            assert.strictEqual(withoutParam.reconnect_base_url, undefined)
+        })
+
         it('recovers session from ws_url when session param is missing', function () {
             const { session: _removed, ...paramsWithoutSession } = validParams
             const paramsWithDataChannel = {
@@ -176,5 +188,39 @@ describe('SMUS URI Handler', function () {
         assert.ok(actualUrl.includes('X-Amz-Credential=AKIATEST%2F20240101%2Fus-west-2%2Fssmmessages%2Faws4_request'))
         assert.ok(actualUrl.includes('X-Amz-Expires=60'))
         assert.ok(actualUrl.includes('X-Amz-Signature=fakesignature123'))
+    })
+
+    describe('reconnect_base_url threading', function () {
+        const baseParams = {
+            connection_identifier: 'arn:aws:sagemaker:us-west-2:123456789012:space/d-abc123/my-space',
+            domain: 'd-abc123',
+            user_profile: 'test-user',
+            session: 'sess-abc123',
+            ws_url: 'wss://ssm.us-west-2.amazonaws.com/stream',
+            'cell-number': '1',
+            token: 'bearer-token-xyz',
+        }
+        // Positional index of `refreshUrl` in the deeplinkConnect signature.
+        const refreshUrlArgIndex = 11
+        const isSmusArgIndex = 10
+
+        it('passes reconnect_base_url through as the refreshUrl argument', async function () {
+            const reconnectBaseUrl =
+                'https://d-abc123xyz789.sagemaker-gamma.us-west-2.on.aws/projects/4m8bqfexample/code-spaces'
+
+            await handler.handleUri(createConnectUri({ ...baseParams, reconnect_base_url: reconnectBaseUrl }))
+
+            assert.ok(deeplinkConnectStub.calledOnce)
+            assert.strictEqual(deeplinkConnectStub.firstCall.args[isSmusArgIndex], true)
+            assert.strictEqual(deeplinkConnectStub.firstCall.args[refreshUrlArgIndex], reconnectBaseUrl)
+        })
+
+        it('passes undefined refreshUrl when reconnect_base_url is absent', async function () {
+            await handler.handleUri(createConnectUri(baseParams))
+
+            assert.ok(deeplinkConnectStub.calledOnce)
+            assert.strictEqual(deeplinkConnectStub.firstCall.args[isSmusArgIndex], true)
+            assert.strictEqual(deeplinkConnectStub.firstCall.args[refreshUrlArgIndex], undefined)
+        })
     })
 })


### PR DESCRIPTION
## Problem

When a SMUS deeplink SSH/SSM tunnel drops, the one-time session bundle is dead and the toolkit has no credentials to call `StartSession` itself. Unlike SageMaker AI connections which already support browser-based session refresh, SMUS deeplink connections cannot recover. The user must manually reconnect from the portal.

## Solution

Enable auto-refresh for SMUS deeplink connections by reusing the browser as the session-minting authority, mirroring the pattern already shipped for SageMaker AI. On tunnel drop, the detached server opens the SMUS portal with reconnect params. The portal calls `StartSession` using the browser's existing DataZone auth context and delivers a fresh bundle back to a localhost callback.

Key changes:
- New `reconnect_base_url` parameter from the initial deeplink connection for SMUS
- Thread `reconnect_base_url` from the deeplink URI through to `persistSSMConnection`, so SMUS connections get a `refreshUrl` in their persisted mapping
- Add DevSettings gate (default off) so these changes in the Toolkit will not affect customers yet. This PR is dependent on changes to the SMUS portal.
- Branch reconnect URL construction in `getSessionAsync.ts`: SMUS sends `reconnect_callback_port` only (Maxdome WAF blocks full localhost URLs in query strings); SM-AI keeps `reconnect_callback_url`
- Add `sagemaker_reconnect` telemetry metric with `result`, `isSmus`, `duration`, and `reason` fields
- Unit tests for metadata threading, `isSMUS` branching, refresh URL construction, session store reads, and URI handler param parsing

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
