### PR TITLE
fix(smus): Resolve tooling env via IAM connection

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioProjectNode.ts
+++ b/packages/core/src/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioProjectNode.ts
@@ -132,7 +132,9 @@ export class SageMakerUnifiedStudioProjectNode implements TreeNode {
                 const spaceAwsAccountRegion = toolingEnv.awsAccountRegion
 
                 if (!spaceAwsAccountRegion) {
-                    throw new Error('No AWS account region found in tooling environment')
+                    throw new ToolkitError('Tooling environment does not have AWS account region information', {
+                        code: SmusErrorCodes.RegionNotFound,
+                    })
                 }
                 if (this.isFirstTimeSelection && !this.hasShownFirstTimeMessage) {
                     this.hasShownFirstTimeMessage = true

--- a/packages/core/src/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode.ts
+++ b/packages/core/src/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode.ts
@@ -87,6 +87,13 @@ export class SageMakerUnifiedStudioSpacesParentNode implements TreeNode {
             ) {
                 return await this.getNoUserProfileChildren()
             }
+            // Handle missing SageMaker domain (custom blueprints may not provision one)
+            if (
+                error instanceof ToolkitError &&
+                (error.code === SmusErrorCodes.NoSageMakerDomain || error.code === SmusErrorCodes.RegionNotFound)
+            ) {
+                return this.getNoSpacesFoundChildren()
+            }
             if (error.message.includes('Failed to retrieve user profile information')) {
                 return this.getUserProfileErrorChildren(error.message)
             }
@@ -213,19 +220,31 @@ export class SageMakerUnifiedStudioSpacesParentNode implements TreeNode {
         }
 
         const toolingEnv = await datazoneClient.getToolingEnvironment(this.projectId)
+
+        if (!toolingEnv.awsAccountRegion) {
+            throw new ToolkitError('Tooling environment does not have AWS account region information', {
+                code: SmusErrorCodes.RegionNotFound,
+            })
+        }
+
         this.spaceAwsAccountRegion = toolingEnv.awsAccountRegion
         if (toolingEnv.provisionedResources) {
             for (const resource of toolingEnv.provisionedResources) {
                 if (resource.name === 'sageMakerDomainId') {
                     if (!resource.value) {
-                        throw new Error('SageMaker domain ID not found in tooling environment')
+                        throw new ToolkitError(
+                            "Spaces are unavailable — this project's tooling environment has no SageMaker domain",
+                            { code: SmusErrorCodes.NoSageMakerDomain }
+                        )
                     }
                     getLogger('smus').debug(`Found SageMaker domain ID: ${resource.value}`)
                     return resource.value
                 }
             }
         }
-        throw new Error('No SageMaker domain found in the tooling environment')
+        throw new ToolkitError("Spaces are unavailable — this project's tooling environment has no SageMaker domain", {
+            code: SmusErrorCodes.NoSageMakerDomain,
+        })
     }
 
     private async updatePendingNodes() {

--- a/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneClient.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneClient.ts
@@ -104,9 +104,6 @@ export interface DataZoneConnection {
     glueConnectionName?: string
 }
 
-// Constants for DataZone environment configuration
-const sageMakerProviderName = 'Amazon SageMaker'
-
 /**
  * Client for interacting with AWS DataZone API
  *
@@ -844,48 +841,48 @@ export class DataZoneClient {
     }
 
     /**
-     * Gets the tooling blueprint for a domain.
-     * Finds the tooling environment for a project by listing blueprints matching "Tooling"
-     * (which returns both Tooling and ToolingLite) and checking which one has an environment.
-     * A project can only have either a Tooling or ToolingLite environment.
-     * @param datazoneClient The DataZone client
+     * Finds the tooling environment for a project by resolving the IAM connection's
+     * environmentId. This works regardless of whether the tooling environment was created
+     * from a managed blueprint (Tooling/ToolingLite) or a custom blueprint.
+     *
+     * Resolution order: `project.iam` (IdC domains) → `default.iam` (IAM domains, guaranteed present).
+     *
+     * @param _datazoneClient Unused — retained for signature compatibility with callers
      * @param domainId The domain identifier
      * @param projectId The project identifier
-     * @returns The tooling environment, or undefined if not found
+     * @returns The tooling environment details, or undefined if no IAM connection found
      */
     private async getToolingEnvironmentForProject(
-        datazoneClient: DataZone,
+        _datazoneClient: DataZone,
         domainId: string,
         projectId: string
-    ): Promise<import('@aws-sdk/client-datazone').EnvironmentSummary | undefined> {
+    ): Promise<GetEnvironmentCommandOutput | undefined> {
         try {
-            // prefix search - will return both Tooling and ToolingLite
-            const blueprintResult = await datazoneClient.listEnvironmentBlueprints({
-                domainIdentifier: domainId,
-                managed: true,
-                name: 'Tooling',
-            })
+            // Find the IAM connection — its environmentId points to the tooling environment
+            const response = await this.fetchConnections(domainId, projectId, ConnectionType.IAM)
+            const iamConnection =
+                response.items?.find((conn) => conn.name === 'project.iam') ??
+                response.items?.find((conn) => conn.name === 'default.iam')
 
-            if (!blueprintResult.items?.length) {
+            if (!iamConnection?.environmentId) {
+                this.logger.debug(
+                    `No IAM connection with environmentId found for domain ${domainId}, project ${projectId}`
+                )
                 return undefined
             }
 
-            for (const blueprint of blueprintResult.items) {
-                const envResult = await datazoneClient.listEnvironments({
-                    domainIdentifier: domainId,
-                    projectIdentifier: projectId,
-                    environmentBlueprintIdentifier: blueprint.id,
-                    provider: sageMakerProviderName,
-                })
-                if (envResult.items?.length) {
-                    this.logger.debug(
-                        `Found tooling environment ${envResult.items[0].id} via blueprint ${blueprint.name}`
-                    )
-                    return envResult.items[0]
-                }
-            }
+            this.logger.debug(
+                `Found tooling environment ${iamConnection.environmentId} via IAM connection '${iamConnection.name}'`
+            )
 
-            return undefined
+            // Use getEnvironment to retrieve the full environment details
+            const datazoneClient = await this.getDataZoneClient()
+            const env = await datazoneClient.getEnvironment({
+                domainIdentifier: domainId,
+                identifier: iamConnection.environmentId,
+            })
+
+            return env
         } catch (err) {
             this.logger.error('Failed to get tooling environment for domain %s: %s', domainId, (err as Error).message)
             throw new ToolkitError('Failed to get tooling environment', { code: 'ToolingEnvironmentError' })

--- a/packages/core/src/sagemakerunifiedstudio/shared/smusUtils.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/smusUtils.ts
@@ -99,6 +99,8 @@ export const SmusErrorCodes = {
     NoIamConnectionFound: 'NoIamConnectionFound',
     /** Error code for when IAM connection credentials are not available */
     NoIamConnectionCredentials: 'NoIamConnectionCredentials',
+    /** Error code for when no SageMaker domain is provisioned in the tooling environment (custom blueprints) */
+    NoSageMakerDomain: 'NoSageMakerDomain',
 } as const
 
 /**
@@ -584,15 +586,11 @@ export async function isExpressDomain(client: DataZoneClient, domainId: string, 
         )
 
         if (defaultIam && projectIam) {
-            // Additional check: verify 'default.iam' connection's environment uses the ToolingLite blueprint.
-            // Can't use getEnvironment because ProjectRole doesn't have this permission.
-            const environment = await client.getEnvironmentDetails(defaultIam.environmentId!, projectId)
-            const blueprints = await client.listEnvironmentBlueprints(domainId, { managed: true, name: 'ToolingLite' })
-            const isToolingLite = blueprints.length === 1 && blueprints[0].id === environment.environmentBlueprintId
+            // Both connections exist (e.g. migrated domain). Presence of default.iam is authoritative.
             logger.debug(
-                `isExpressDomain: ToolingLite blueprint check for domain ${domainId}: isToolingLite=${isToolingLite}`
+                `isExpressDomain: both default.iam and project.iam exist for domain ${domainId}, treating as IAM domain`
             )
-            return isToolingLite
+            return true
         }
 
         return !!defaultIam

--- a/packages/core/src/sagemakerunifiedstudio/shared/telemetry.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/telemetry.ts
@@ -99,7 +99,7 @@ export async function recordSpaceTelemetry(
         try {
             const dzClient = await createDZClientBaseOnDomainMode(authProvider)
             const toolingEnv = await dzClient.getToolingEnvironment(projectId)
-            span.record({ smusProjectRegion: toolingEnv.awsAccountRegion })
+            span.record({ smusProjectRegion: toolingEnv.awsAccountRegion ?? notSet })
         } catch (err) {
             span.record({ smusProjectRegion: notSet })
             logger.warn(`Failed to get project region for telemetry: ${(err as Error).message}`)

--- a/packages/core/src/test/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/explorer/nodes/sageMakerUnifiedStudioSpacesParentNode.test.ts
@@ -207,7 +207,7 @@ describe('SageMakerUnifiedStudioSpacesParentNode', function () {
             )
         })
 
-        it('throws error when SageMaker domain ID not found in resources', async function () {
+        it('throws ToolkitError with NoSageMakerDomain code when sageMakerDomainId not in provisioned resources', async function () {
             mockDataZoneClient.getDomainId.returns('domain-123')
             mockDataZoneClient.getToolingEnvironment.resolves({
                 projectId: 'project-123',
@@ -220,7 +220,11 @@ describe('SageMakerUnifiedStudioSpacesParentNode', function () {
 
             await assert.rejects(
                 async () => await spacesNode.getSageMakerDomainId(),
-                /No SageMaker domain found in the tooling environment/
+                (err: any) => {
+                    assert(err instanceof ToolkitError)
+                    assert.strictEqual(err.code, SmusErrorCodes.NoSageMakerDomain)
+                    return true
+                }
             )
         })
 
@@ -289,6 +293,28 @@ describe('SageMakerUnifiedStudioSpacesParentNode', function () {
             assert.strictEqual(children.length, 1)
             assert.strictEqual(children[0].id, 'smusNoSpaces')
         })
+
+        function assertNoSpacesFoundForError(errorCode: string, errorMessage: string) {
+            it(`returns no spaces found node when ${errorCode} error is thrown`, async function () {
+                updateChildrenStub.rejects(new ToolkitError(errorMessage, { code: errorCode }))
+
+                const children = await spacesNode.getChildren()
+
+                assert.strictEqual(children.length, 1)
+                assert.strictEqual(children[0].id, 'smusNoSpaces')
+                const treeItem = await children[0].getTreeItem()
+                assert.strictEqual(treeItem.label, '[No Spaces found]')
+            })
+        }
+
+        assertNoSpacesFoundForError(
+            SmusErrorCodes.NoSageMakerDomain,
+            "Spaces are unavailable — this project's tooling environment has no SageMaker domain"
+        )
+        assertNoSpacesFoundForError(
+            SmusErrorCodes.RegionNotFound,
+            'Tooling environment does not have AWS account region information'
+        )
 
         it('returns access denied node when AccessDeniedException is thrown', async function () {
             const accessDeniedError = new Error('Access denied')

--- a/packages/core/src/test/sagemakerunifiedstudio/shared/client/datazoneClient.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/shared/client/datazoneClient.test.ts
@@ -600,94 +600,118 @@ describe('DataZoneClient', () => {
             sinon.restore()
         })
 
-        it('should return environment from first matching blueprint', async function () {
+        it('should resolve tooling environment via project.iam connection', async function () {
+            const mockEnv = { id: 'env-1', name: 'CustomTooling', awsAccountRegion: 'us-west-2' }
             const mockDataZone = {
-                listEnvironmentBlueprints: sinon.stub().resolves({
-                    items: [
-                        { id: 'blueprint-tooling', name: 'Tooling' },
-                        { id: 'blueprint-lite', name: 'ToolingLite' },
-                    ],
-                }),
-                listEnvironments: sinon.stub(),
+                getEnvironment: sinon.stub().resolves(mockEnv),
             }
 
-            // First blueprint has no environment, second does
-            mockDataZone.listEnvironments.onFirstCall().resolves({ items: [] })
-            mockDataZone.listEnvironments.onSecondCall().resolves({
-                items: [{ id: 'env-1', name: 'ToolingLite' }],
+            sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
+                items: [
+                    { name: 'project.iam', environmentId: 'env-1', connectionId: 'conn-1' },
+                    { name: 'default.iam', environmentId: 'env-2', connectionId: 'conn-2' },
+                ],
+            })
+            sinon.stub(dataZoneClient as any, 'getDataZoneClient').resolves(mockDataZone)
+
+            const result = await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
+
+            assert.strictEqual(result?.id, 'env-1')
+            // Should prefer project.iam over default.iam
+            assert.ok(mockDataZone.getEnvironment.calledOnce)
+            assert.strictEqual(mockDataZone.getEnvironment.firstCall.args[0].identifier, 'env-1')
+        })
+
+        it('should fall back to default.iam when project.iam is absent', async function () {
+            const mockEnv = { id: 'env-2', name: 'ToolingLite', awsAccountRegion: 'us-east-1' }
+            const mockDataZone = {
+                getEnvironment: sinon.stub().resolves(mockEnv),
+            }
+
+            sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
+                items: [{ name: 'default.iam', environmentId: 'env-2', connectionId: 'conn-2' }],
+            })
+            sinon.stub(dataZoneClient as any, 'getDataZoneClient').resolves(mockDataZone)
+
+            const result = await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
+
+            assert.strictEqual(result?.id, 'env-2')
+        })
+
+        it('should resolve correctly with custom blueprint (no managed Tooling name)', async function () {
+            const mockEnv = {
+                id: 'env-custom',
+                name: 'MyCustomTooling',
+                awsAccountRegion: 'eu-west-1',
+                provisionedResources: [{ name: 'sageMakerDomainId', value: 'd-abc123' }],
+            }
+            const mockDataZone = {
+                getEnvironment: sinon.stub().resolves(mockEnv),
+            }
+
+            sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
+                items: [{ name: 'default.iam', environmentId: 'env-custom', connectionId: 'conn-1' }],
+            })
+            sinon.stub(dataZoneClient as any, 'getDataZoneClient').resolves(mockDataZone)
+
+            const result = await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
+
+            assert.strictEqual(result?.id, 'env-custom')
+            assert.strictEqual(result?.awsAccountRegion, 'eu-west-1')
+        })
+
+        it('should return undefined when no IAM connections exist', async function () {
+            sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
+                items: [],
             })
 
-            const result = await (dataZoneClient as any).getToolingEnvironmentForProject(
-                mockDataZone,
-                'domain-1',
-                'project-1'
-            )
-
-            assert.strictEqual(result?.id, 'env-1')
-            assert.strictEqual(mockDataZone.listEnvironments.callCount, 2)
-        })
-
-        it('should return environment from single blueprint', async function () {
-            const mockDataZone = {
-                listEnvironmentBlueprints: sinon.stub().resolves({
-                    items: [{ id: 'blueprint-lite', name: 'ToolingLite' }],
-                }),
-                listEnvironments: sinon.stub().resolves({
-                    items: [{ id: 'env-1', name: 'ToolingLite' }],
-                }),
-            }
-
-            const result = await (dataZoneClient as any).getToolingEnvironmentForProject(
-                mockDataZone,
-                'domain-1',
-                'project-1'
-            )
-
-            assert.strictEqual(result?.id, 'env-1')
-        })
-
-        it('should return undefined when no blueprints found', async function () {
-            const mockDataZone = {
-                listEnvironmentBlueprints: sinon.stub().resolves({ items: [] }),
-            }
-
-            const result = await (dataZoneClient as any).getToolingEnvironmentForProject(
-                mockDataZone,
-                'domain-1',
-                'project-1'
-            )
+            const result = await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
 
             assert.strictEqual(result, undefined)
         })
 
-        it('should return undefined when no environments found for any blueprint', async function () {
-            const mockDataZone = {
-                listEnvironmentBlueprints: sinon.stub().resolves({
-                    items: [{ id: 'blueprint-1', name: 'Tooling' }],
-                }),
-                listEnvironments: sinon.stub().resolves({ items: [] }),
-            }
+        it('should return undefined when IAM connection has no environmentId', async function () {
+            sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
+                items: [{ name: 'default.iam', environmentId: undefined, connectionId: 'conn-1' }],
+            })
 
-            const result = await (dataZoneClient as any).getToolingEnvironmentForProject(
-                mockDataZone,
-                'domain-1',
-                'project-1'
-            )
+            const result = await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
 
             assert.strictEqual(result, undefined)
         })
 
-        it('should throw ToolkitError when API call fails', async function () {
-            const mockDataZone = {
-                listEnvironmentBlueprints: sinon.stub().rejects(new Error('API Error')),
-            }
+        it('should throw ToolkitError when fetchConnections fails', async function () {
+            sinon.stub(dataZoneClient as any, 'fetchConnections').rejects(new Error('API Error'))
 
             await assert.rejects(
                 async () => {
-                    await (dataZoneClient as any).getToolingEnvironmentForProject(mockDataZone, 'domain-1', 'project-1')
+                    await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
                 },
                 (error: Error) => {
                     assert.ok(error instanceof ToolkitError)
+                    assert.ok(error.message.includes('Failed to get tooling environment'))
+                    return true
+                }
+            )
+        })
+
+        it('should throw ToolkitError when getEnvironment fails', async function () {
+            const mockDataZone = {
+                getEnvironment: sinon.stub().rejects(new Error('GetEnvironment access denied')),
+            }
+
+            sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
+                items: [{ name: 'default.iam', environmentId: 'env-1', connectionId: 'conn-1' }],
+            })
+            sinon.stub(dataZoneClient as any, 'getDataZoneClient').resolves(mockDataZone)
+
+            await assert.rejects(
+                async () => {
+                    await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
+                },
+                (error: Error) => {
+                    assert.ok(error instanceof ToolkitError)
+                    assert.strictEqual((error as ToolkitError).code, 'ToolingEnvironmentError')
                     assert.ok(error.message.includes('Failed to get tooling environment'))
                     return true
                 }

--- a/packages/core/src/test/sagemakerunifiedstudio/shared/smusUtils.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/shared/smusUtils.test.ts
@@ -858,4 +858,23 @@ describe('isExpressDomain', () => {
         assert.strictEqual(result, true)
         assert.ok(mockClient.fetchConnections.calledOnceWith('test-domain-id', 'test-project-id', ConnectionType.IAM))
     })
+
+    it('should return true when both default.iam and project.iam exist (migrated domain)', async () => {
+        mockClient.fetchConnections.resolves({
+            items: [
+                { name: 'default.iam', environmentId: 'env-1' },
+                { name: 'project.iam', environmentId: 'env-2' },
+            ],
+        })
+        const result = await isExpressDomain(mockClient as any, 'test-domain-id', 'test-project-id')
+        assert.strictEqual(result, true)
+    })
+
+    it('should return false when only project.iam exists (IdC domain)', async () => {
+        mockClient.fetchConnections.resolves({
+            items: [{ name: 'project.iam', environmentId: 'env-1' }],
+        })
+        const result = await isExpressDomain(mockClient as any, 'test-domain-id', 'test-project-id')
+        assert.strictEqual(result, false)
+    })
 })


### PR DESCRIPTION
## Problem
 
SMUS projects can use custom blueprints in the tooling slot. These blueprints have arbitrary names so the current resolution path for `ListEnvironmentBlueprints(name="Tooling")` → match blueprint → `ListEnvironments(blueprintId)` returns no results and tooling environment lookup silently fails.
  
Additionally, custom blueprints may not provision a SageMaker domain at all, causing unhandled `Error` throws that crash the spaces tree.
  
## Solution
  
Resolve the tooling environment via the IAM connection's `environmentId` rather than blueprint name lookup. The IAM connection (`project.iam` for IdC domains, `default.iam` for IAM domains) always references the tooling environment regardless of the underlying blueprint name. Call `GetEnvironment` with that ID to retrieve the full environment details.
  
Secondary changes:
- Tolerate missing `sageMakerDomainId` in provisioned resources by catching `NoSageMakerDomain` / `RegionNotFound` error codes and rendering a no spaces found tree node instead of crashing the tree
- Replace bare `Error` throws to `ToolkitError` with structured codes (`NoSageMakerDomain`, `RegionNotFound`) for clean programmatic catch handling
- Simplify `isExpressDomain`: presence of `default.iam` is authoritative for IAM domains, removing the extra `ListEnvironmentBlueprints(name="ToolingLite")` + `getEnvironmentDetails` verification
- Add `notSet` fallback in space telemetry when `awsAccountRegion` is undefined (previously threw inside the telemetry span)

## Testing
  
  **Unit tests** (added/updated in `datazoneClient.test.ts`, `smusUtils.test.ts`, `sageMakerUnifiedStudioSpacesParentNode.test.ts`):
  - Tooling environment resolves via a custom blueprint (no managed `Tooling`/`ToolingLite` name) through the `default.iam` connection
  - Returns `undefined` when no IAM connection exists, and when the IAM connection has no `environmentId`
  - `getEnvironment` failure surfaces as a `ToolkitError` (`ToolingEnvironmentError`)
  - Missing `sageMakerDomainId` (`NoSageMakerDomain`) and missing region (`RegionNotFound`) both render the standard `[No Spaces found]` node instead of throwing
  - `isExpressDomain` returns `true` for a migrated domain (both `default.iam` + `project.iam`) and `false` when only `project.iam` exists (IdC domain)
  
  **Manual testing:** Verified end-to-end, including space connection, against both an IAM domain and an IdC domain (managed-blueprint prod domains)
- login, project listing, tree expansion (Data Explorer + Compute), spaces listing, and connecting to a space all succeed with no regression.
- validated end-to-end space connection against a gamma domain with a full-capabilities custom tooling project 
- validated that a custom tooling project with no provisioned SageMaker domain shows a no spaces found tree node

## Custom tooling project with full capabilities
https://github.com/user-attachments/assets/86e82052-31d8-479a-98e0-82022ae3e42e
 
## Custom tooling project with no provisioned SageMaker domain
<img width="521" height="189" alt="Screenshot 2026-08-14 at 2 43 00 PM" src="https://github.com/user-attachments/assets/b3ff1961-0ab0-45bf-a368-a6af3060120e" />
