### PR TITLE
feat(smus): Add deeplink auto-refresh for SMUS

### DIFF
--- a/packages/core/src/awsService/sagemaker/credentialMapping.ts
+++ b/packages/core/src/awsService/sagemaker/credentialMapping.ts
@@ -94,7 +94,8 @@ export async function persistSmusProjectCreds(spaceArn: string, node: SagemakerU
  * @param wsUrl - SSM WebSocket URL.
  * @param token - Bearer token for the session.
  * @param appType - Application type (e.g., 'jupyterlab', 'codeeditor').
- * @param isSMUS - If true, skip refreshUrl construction (SMUS connections cannot refresh).
+ * @param isSMUS - If true, use providedRefreshUrl instead of deriving one from region/endpoint.
+ * @param providedRefreshUrl - Console-supplied refresh URL for SMUS connections; ignored for SM-AI.
  */
 export async function persistSSMConnection(
     spaceArn: string,
@@ -103,9 +104,11 @@ export async function persistSSMConnection(
     wsUrl?: string,
     token?: string,
     appType?: string,
-    isSMUS?: boolean
+    isSMUS?: boolean,
+    providedRefreshUrl?: string
 ): Promise<void> {
-    let refreshUrl: string | undefined
+    // SageMaker AI derives its refresh URL below; SMUS uses the console-supplied one as-is.
+    let refreshUrl: string | undefined = providedRefreshUrl
 
     if (!isSMUS) {
         // Construct refreshUrl for SageMaker AI connections
@@ -136,13 +139,18 @@ export async function persistSSMConnection(
 
         refreshUrl = `https://studio-${domain}.${baseDomain}/${appSubDomain}`
     }
-    // For SMUS connections, refreshUrl remains undefined
+    // For SMUS, refreshUrl is the console-supplied `providedRefreshUrl` (undefined = cannot refresh).
 
-    await setSpaceCredentials(spaceArn, refreshUrl, {
-        sessionId: session ?? '-',
-        url: wsUrl ?? '-',
-        token: token ?? '-',
-    })
+    await setSpaceCredentials(
+        spaceArn,
+        refreshUrl,
+        {
+            sessionId: session ?? '-',
+            url: wsUrl ?? '-',
+            token: token ?? '-',
+        },
+        isSMUS
+    )
 }
 
 /**
@@ -197,19 +205,22 @@ export async function setSmusSpaceProfile(
  * Stores SSM connection information for a given space, typically from a deep link session.
  * This initializes the request as 'fresh' and includes a refresh URL if provided.
  * @param spaceArn - The arn of the SageMaker space.
- * @param refreshUrl - URL to use for refreshing session tokens (undefined for SMUS connections).
+ * @param refreshUrl - URL to use for refreshing session tokens (undefined for connections without auto-refresh).
  * @param credentials - The session information used to initiate the connection.
+ * @param isSMUS - Whether this is a SMUS connection (vs SageMaker AI).
  */
 export async function setSpaceCredentials(
     spaceArn: string,
     refreshUrl: string | undefined,
-    credentials: SsmConnectionInfo
+    credentials: SsmConnectionInfo,
+    isSMUS?: boolean
 ): Promise<void> {
     const data = await loadMappings()
     data.deepLink ??= {}
 
     data.deepLink[spaceArn] = {
         refreshUrl,
+        isSMUS,
         requests: {
             'initial-connection': {
                 ...credentials,

--- a/packages/core/src/awsService/sagemaker/detached-server/routes/getSessionAsync.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/routes/getSessionAsync.ts
@@ -50,9 +50,8 @@ export async function handleGetSessionAsync(req: IncomingMessage, res: ServerRes
         } else if (status === 'not-started') {
             const refreshUrl = await store.getRefreshUrl(connectionIdentifier)
 
-            // Check if this is a SMUS connection (no refreshUrl available)
-            if (refreshUrl === undefined) {
-                console.log(`SMUS session expired for connection: ${connectionIdentifier}`)
+            if (!refreshUrl) {
+                console.log(`Session expired for connection: ${connectionIdentifier}`)
 
                 // Clean up the expired connection entry
                 try {
@@ -74,15 +73,21 @@ export async function handleGetSessionAsync(req: IncomingMessage, res: ServerRes
                 return
             }
 
-            // Continue with existing SageMaker AI refresh flow
+            // Open the browser to refresh the session.
+            const isSMUS = await store.getIsSMUS(connectionIdentifier)
             const serverInfo = await readServerInfo()
             const { resourceName: spaceName } = parseArn(connectionIdentifier)
 
-            const url = `${refreshUrl}/${encodeURIComponent(spaceName)}?remote_access_token_refresh=true&reconnect_identifier=${encodeURIComponent(
+            const baseUrl = `${refreshUrl}/${encodeURIComponent(spaceName)}?remote_access_token_refresh=true&reconnect_identifier=${encodeURIComponent(
                 connectionIdentifier
-            )}&reconnect_request_id=${encodeURIComponent(requestId)}&reconnect_callback_url=${encodeURIComponent(
-                `http://localhost:${serverInfo.port}/refresh_token`
-            )}`
+            )}&reconnect_request_id=${encodeURIComponent(requestId)}`
+
+            // SMUS sends only port (Maxdome WAF blocks localhost URLs); SM AI sends full callback URL.
+            const url = isSMUS
+                ? `${baseUrl}&reconnect_callback_port=${encodeURIComponent(String(serverInfo.port))}`
+                : `${baseUrl}&reconnect_callback_url=${encodeURIComponent(
+                      `http://localhost:${serverInfo.port}/refresh_token`
+                  )}`
 
             await open(url)
             res.writeHead(202, { 'Content-Type': 'text/plain' })

--- a/packages/core/src/awsService/sagemaker/detached-server/sessionStore.ts
+++ b/packages/core/src/awsService/sagemaker/detached-server/sessionStore.ts
@@ -8,33 +8,39 @@ import { readMapping, writeMapping } from './utils'
 
 export type SessionStatus = 'pending' | 'fresh' | 'consumed' | 'not-started'
 
+/**
+ * Reads the mapping file and resolves the deepLink entry for the given connectionId.
+ * Throws if the mapping or entry is missing.
+ */
+async function resolveDeepLinkEntry(connectionId: string) {
+    const mapping = await readMapping()
+
+    if (!mapping.deepLink) {
+        throw new Error('No deepLink mapping found')
+    }
+
+    const entry = mapping.deepLink[connectionId]
+    if (!entry) {
+        throw new Error(`No mapping found for connectionId: "${connectionId}"`)
+    }
+
+    return { mapping, entry }
+}
+
 export class SessionStore {
     async getRefreshUrl(connectionId: string): Promise<string | undefined> {
-        const mapping = await readMapping()
-
-        if (!mapping.deepLink) {
-            throw new Error('No deepLink mapping found')
-        }
-
-        const entry = mapping.deepLink[connectionId]
-        if (!entry) {
-            throw new Error(`No mapping found for connectionId: "${connectionId}"`)
-        }
-
+        const { entry } = await resolveDeepLinkEntry(connectionId)
         return entry.refreshUrl
     }
 
+    /** Returns true if this is a SMUS connection. Defaults to false for legacy entries. */
+    async getIsSMUS(connectionId: string): Promise<boolean> {
+        const { entry } = await resolveDeepLinkEntry(connectionId)
+        return entry.isSMUS ?? false
+    }
+
     async getFreshEntry(connectionId: string, requestId: string) {
-        const mapping = await readMapping()
-
-        if (!mapping.deepLink) {
-            throw new Error('No deepLink mapping found')
-        }
-
-        const entry = mapping.deepLink[connectionId]
-        if (!entry) {
-            throw new Error(`No mapping found for connectionId: "${connectionId}"`)
-        }
+        const { mapping, entry } = await resolveDeepLinkEntry(connectionId)
 
         const requests = entry.requests
         const initialEntry = requests['initial-connection']
@@ -54,30 +60,13 @@ export class SessionStore {
     }
 
     async getStatus(connectionId: string, requestId: string) {
-        const mapping = await readMapping()
-
-        if (!mapping.deepLink) {
-            throw new Error('No deepLink mapping found')
-        }
-        const entry = mapping.deepLink[connectionId]
-        if (!entry) {
-            throw new Error(`No mapping found for connectionId: "${connectionId}"`)
-        }
-
+        const { entry } = await resolveDeepLinkEntry(connectionId)
         const status = entry.requests?.[requestId]?.status
         return status ?? 'not-started'
     }
 
     async markConsumed(connectionId: string, requestId: string) {
-        const mapping = await readMapping()
-
-        if (!mapping.deepLink) {
-            throw new Error('No deepLink mapping found')
-        }
-        const entry = mapping.deepLink[connectionId]
-        if (!entry) {
-            throw new Error(`No mapping found for connectionId: "${connectionId}"`)
-        }
+        const { mapping, entry } = await resolveDeepLinkEntry(connectionId)
 
         const requests = entry.requests
         if (!requests[requestId]) {
@@ -89,15 +78,7 @@ export class SessionStore {
     }
 
     async markPending(connectionId: string, requestId: string) {
-        const mapping = await readMapping()
-
-        if (!mapping.deepLink) {
-            throw new Error('No deepLink mapping found')
-        }
-        const entry = mapping.deepLink[connectionId]
-        if (!entry) {
-            throw new Error(`No mapping found for connectionId: "${connectionId}"`)
-        }
+        const { mapping, entry } = await resolveDeepLinkEntry(connectionId)
 
         entry.requests[requestId] = {
             sessionId: '',
@@ -124,15 +105,7 @@ export class SessionStore {
     }
 
     async setSession(connectionId: string, requestId: string, ssmConnectionInfo: SsmConnectionInfo) {
-        const mapping = await readMapping()
-
-        if (!mapping.deepLink) {
-            throw new Error('No deepLink mapping found')
-        }
-        const entry = mapping.deepLink[connectionId]
-        if (!entry) {
-            throw new Error(`No mapping found for connectionId: "${connectionId}"`)
-        }
+        const { mapping, entry } = await resolveDeepLinkEntry(connectionId)
 
         entry.requests[requestId] = {
             sessionId: ssmConnectionInfo.sessionId,

--- a/packages/core/src/awsService/sagemaker/model.ts
+++ b/packages/core/src/awsService/sagemaker/model.ts
@@ -199,7 +199,7 @@ export async function prepareDevEnvConnection(opts: DevEnvConnectionOptions) {
             await persistSmusProjectCreds(spaceArn, node as SagemakerUnifiedStudioSpaceNode)
         }
     } else if (connectionType === 'sm_dl') {
-        await persistSSMConnection(spaceArn, domain ?? '', session, wsUrl, token, appType, isSMUS)
+        await persistSSMConnection(spaceArn, domain ?? '', session, wsUrl, token, appType, isSMUS, refreshUrl)
     } else if (connectionType.startsWith('smhp_')) {
         await persistHyperpodConnection(
             workspaceName!,

--- a/packages/core/src/awsService/sagemaker/types.ts
+++ b/packages/core/src/awsService/sagemaker/types.ts
@@ -17,6 +17,8 @@ export type LocalCredentialProfile =
 export interface DeeplinkSession {
     requests: Record<string, SsmConnectionInfo>
     refreshUrl?: string
+    /** Whether this is a SMUS connection (vs SageMaker AI). */
+    isSMUS?: boolean
 }
 
 export interface SsmConnectionInfo {

--- a/packages/core/src/sagemakerunifiedstudio/uriHandlers.ts
+++ b/packages/core/src/sagemakerunifiedstudio/uriHandlers.ts
@@ -68,7 +68,8 @@ export function register(ctx: ExtContext) {
                 undefined,
                 undefined,
                 undefined,
-                true // isSMUS=true for SMUS connections
+                true, // isSMUS
+                params.reconnect_base_url
             )
         })
     }
@@ -95,6 +96,7 @@ export function register(ctx: ExtContext) {
  * - smus_project_id: SMUS project identifier
  * - smus_domain_region: SMUS domain region
  * - smus_auth_mode: Authentication mode (sso or iam)
+ * - reconnect_base_url: Console base URL for session reconnect (absent on older consoles)
  *
  * Note: The ws_url from startSession API originally includes cell-number as a query parameter.
  * However, when the deeplink URL is processed, the URI handler extracts cell-number as a
@@ -134,7 +136,8 @@ export function parseConnectParams(query: SearchParams) {
         'smus_project_id',
         'smus_domain_region',
         'smus_auth_mode',
-        'smus_domain_mode'
+        'smus_domain_mode',
+        'reconnect_base_url'
     )
 
     const amzHeaderParams = query.getFromKeys(...amzHeaders)

--- a/packages/core/src/test/awsService/sagemaker/credentialMapping.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/credentialMapping.test.ts
@@ -221,7 +221,7 @@ describe('credentialMapping', () => {
             })
         })
 
-        it('stores undefined refreshUrl when isSMUS=true', async () => {
+        it('stores undefined refreshUrl when isSMUS=true and no providedRefreshUrl (older console)', async () => {
             sandbox.stub(DevSettings.instance, 'get').returns({})
             sandbox.stub(fs, 'existsFile').resolves(false)
             const writeStub = sandbox.stub(fs, 'writeFile').resolves()
@@ -231,7 +231,7 @@ describe('credentialMapping', () => {
             const raw = writeStub.firstCall.args[1]
             const data = JSON.parse(typeof raw === 'string' ? raw : raw.toString())
 
-            // Verify refreshUrl is undefined for SMUS connections
+            // No providedRefreshUrl → refreshUrl stays undefined (connection cannot refresh)
             assert.strictEqual(data.deepLink?.[appArn]?.refreshUrl, undefined)
 
             // Verify SSM connection info is stored correctly
@@ -241,6 +241,61 @@ describe('credentialMapping', () => {
                 token: 'token-xyz',
                 status: 'fresh',
             })
+        })
+
+        it('persists the console-supplied refreshUrl when isSMUS=true', async () => {
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+            sandbox.stub(fs, 'existsFile').resolves(false)
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            const reconnectBaseUrl =
+                'https://d-abc123xyz789.sagemaker-gamma.us-west-2.on.aws/projects/4m8bqfexample/code-spaces'
+
+            await persistSSMConnection(
+                appArn,
+                domain,
+                'sess-smus',
+                'wss://smus-ws',
+                'token-smus',
+                'jupyterlab',
+                true,
+                reconnectBaseUrl
+            )
+
+            const raw = writeStub.firstCall.args[1]
+            const data = JSON.parse(typeof raw === 'string' ? raw : raw.toString())
+
+            // The SMUS URL is used verbatim — no derivation, no hardcoded stage.
+            assert.strictEqual(data.deepLink?.[appArn]?.refreshUrl, reconnectBaseUrl)
+            assert.strictEqual(data.deepLink?.[appArn]?.isSMUS, true)
+            assert.deepStrictEqual(data.deepLink?.[appArn]?.requests['initial-connection'], {
+                sessionId: 'sess-smus',
+                url: 'wss://smus-ws',
+                token: 'token-smus',
+                status: 'fresh',
+            })
+        })
+
+        it('ignores a provided refreshUrl when isSMUS=false and derives the SageMaker AI URL', async () => {
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+            sandbox.stub(fs, 'existsFile').resolves(false)
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            await persistSSMConnection(
+                appArn,
+                domain,
+                'sess-ai',
+                'wss://sm-ws',
+                'token-ai',
+                'jupyterlab',
+                false,
+                'https://should-be-ignored.example.com/projects/p/code-spaces'
+            )
+
+            const raw = writeStub.firstCall.args[1]
+            const data = JSON.parse(typeof raw === 'string' ? raw : raw.toString())
+
+            assertRefreshUrlMatches(data.deepLink?.[appArn]?.refreshUrl, 'studio.us-west-2.sagemaker.aws')
         })
 
         it('stores valid refreshUrl when isSMUS=false (SageMaker AI behavior)', async () => {
@@ -288,6 +343,19 @@ describe('credentialMapping', () => {
                 token: 'token-def',
                 status: 'fresh',
             })
+        })
+
+        it('persists isSMUS: false when called with isSMUS=false', async function () {
+            sandbox.stub(DevSettings.instance, 'get').returns({})
+            sandbox.stub(fs, 'existsFile').resolves(false)
+            const writeStub = sandbox.stub(fs, 'writeFile').resolves()
+
+            await persistSSMConnection(appArn, domain, 'sess-sm', 'wss://sm-ws', 'token-sm', 'jupyterlab', false)
+
+            const raw = writeStub.firstCall.args[1]
+            const data = JSON.parse(typeof raw === 'string' ? raw : raw.toString())
+
+            assert.strictEqual(data.deepLink?.[appArn]?.isSMUS, false)
         })
     })
 

--- a/packages/core/src/test/awsService/sagemaker/detached-server/routes/getSessionAsync.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/detached-server/routes/getSessionAsync.test.ts
@@ -21,19 +21,55 @@ function stubSagemakerBrowserFlow() {
     sinon.stub(utils, 'open').resolves()
 }
 
-describe('handleGetSessionAsync', () => {
+describe('handleGetSessionAsync', function () {
     let ctx: RouteTestContext
 
-    beforeEach(() => {
+    let openErrorPageStub: sinon.SinonStub
+
+    beforeEach(function () {
         ctx = createRouteTestContext()
         sinon.stub(SessionStore.prototype, 'getFreshEntry').callsFake(ctx.storeStub.getFreshEntry)
         sinon.stub(SessionStore.prototype, 'getStatus').callsFake(ctx.storeStub.getStatus)
         sinon.stub(SessionStore.prototype, 'getRefreshUrl').callsFake(ctx.storeStub.getRefreshUrl)
+        sinon.stub(SessionStore.prototype, 'getIsSMUS').callsFake(ctx.storeStub.getIsSMUS)
         sinon.stub(SessionStore.prototype, 'markPending').callsFake(ctx.storeStub.markPending)
         sinon.stub(SessionStore.prototype, 'cleanupExpiredConnection').callsFake(ctx.storeStub.cleanupExpiredConnection)
+        openErrorPageStub = sinon.stub(errorPage, 'openErrorPage').resolves()
     })
 
-    it('responds with 400 if required query parameters are missing', async () => {
+    /** Stubs a not-started session that has a valid refreshUrl (reconnect flow). */
+    function stubNotStartedWithRefreshUrl(refreshUrl = 'https://example.com/refresh') {
+        ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
+        ctx.storeStub.getStatus.returns(Promise.resolve('not-started'))
+        ctx.storeStub.getRefreshUrl.returns(Promise.resolve(refreshUrl))
+        ctx.storeStub.markPending.returns(Promise.resolve())
+        stubSagemakerBrowserFlow()
+    }
+
+    /** Stubs a not-started session with no refreshUrl (expiration scenario). */
+    function stubNotStartedExpired() {
+        ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
+        ctx.storeStub.getStatus.returns(Promise.resolve('not-started'))
+        ctx.storeStub.getRefreshUrl.returns(Promise.resolve(undefined))
+        ctx.storeStub.cleanupExpiredConnection.resolves()
+    }
+
+    /** Asserts the response is a 202 pending reconnect with markPending called. */
+    function assertPendingReconnectResponse() {
+        assert(ctx.resWriteHead.calledWith(202))
+        assert(ctx.resEnd.calledWithMatch(/Session is not ready yet/))
+        assert(ctx.storeStub.markPending.calledWith('abc', 'req123'))
+    }
+
+    /** Asserts the response is a 400 expired-session error with cleanup invoked. */
+    function assertExpiredSessionResponse() {
+        assert(ctx.resWriteHead.calledWith(400))
+        const actualJson = JSON.parse(ctx.resEnd.firstCall.args[0])
+        assert.strictEqual(actualJson.error, SmusDeeplinkSessionExpiredError.code)
+        assert(ctx.storeStub.cleanupExpiredConnection.calledOnce)
+    }
+
+    it('responds with 400 if required query parameters are missing', async function () {
         ctx.req = { url: '/session_async?connection_identifier=abc' } // missing request_id
         await handleGetSessionAsync(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
 
@@ -41,7 +77,7 @@ describe('handleGetSessionAsync', () => {
         assert(ctx.resEnd.calledWithMatch(/Missing required query parameters/))
     })
 
-    it('responds with 200 and session data if freshEntry exists', async () => {
+    it('responds with 200 and session data if freshEntry exists', async function () {
         ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
         ctx.storeStub.getFreshEntry.returns(Promise.resolve({ sessionId: 'sid', token: 'tok', url: 'wss://test' }))
 
@@ -56,7 +92,7 @@ describe('handleGetSessionAsync', () => {
         })
     })
 
-    it('responds with 204 if session is pending', async () => {
+    it('responds with 204 if session is pending', async function () {
         ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
         ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
         ctx.storeStub.getStatus.returns(Promise.resolve('pending'))
@@ -67,23 +103,27 @@ describe('handleGetSessionAsync', () => {
         assert(ctx.resEnd.calledOnce)
     })
 
-    it('responds with 202 if status is not-started and opens browser', async () => {
+    it('responds with 202 and opens browser when refreshUrl exists (SM-AI)', async function () {
         ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
+        stubNotStartedWithRefreshUrl()
+        ctx.storeStub.getIsSMUS.returns(Promise.resolve(false))
 
-        ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
-        ctx.storeStub.getStatus.returns(Promise.resolve('not-started'))
-        ctx.storeStub.getRefreshUrl.returns(Promise.resolve('https://example.com/refresh'))
-        ctx.storeStub.markPending.returns(Promise.resolve())
-
-        stubSagemakerBrowserFlow()
         await handleGetSessionAsync(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
 
-        assert(ctx.resWriteHead.calledWith(202))
-        assert(ctx.resEnd.calledWithMatch(/Session is not ready yet/))
-        assert(ctx.storeStub.markPending.calledWith('abc', 'req123'))
+        assertPendingReconnectResponse()
     })
 
-    it('responds with 500 if unexpected error occurs', async () => {
+    it('responds with 202 and opens browser when refreshUrl exists (SMUS)', async function () {
+        ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
+        stubNotStartedWithRefreshUrl('https://smus-console.example.com/refresh')
+        ctx.storeStub.getIsSMUS.returns(Promise.resolve(true))
+
+        await handleGetSessionAsync(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
+
+        assertPendingReconnectResponse()
+    })
+
+    it('responds with 500 if unexpected error occurs', async function () {
         ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
         ctx.storeStub.getFreshEntry.throws(new Error('fail'))
 
@@ -93,33 +133,18 @@ describe('handleGetSessionAsync', () => {
         assert(ctx.resEnd.calledWith('Unexpected error'))
     })
 
-    describe('SMUS session expiration handling', () => {
-        let openErrorPageStub: sinon.SinonStub
-
-        beforeEach(() => {
-            // Stub the openErrorPage function to prevent actual browser opening
-            openErrorPageStub = sinon.stub(errorPage, 'openErrorPage').resolves()
-        })
-
-        it('handles SMUS session expiration when refreshUrl is undefined', async () => {
+    describe('session expiration handling', function () {
+        it('returns 400 and opens error page when refreshUrl is undefined', async function () {
             ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
-
-            ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
-            ctx.storeStub.getStatus.returns(Promise.resolve('not-started'))
-            ctx.storeStub.getRefreshUrl.returns(Promise.resolve(undefined)) // SMUS case: no refreshUrl
-            ctx.storeStub.cleanupExpiredConnection.resolves()
+            stubNotStartedExpired()
 
             await handleGetSessionAsync(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
 
-            // Verify HTTP 400 response with correct error structure
-            assert(ctx.resWriteHead.calledWith(400))
-            const actualJson = JSON.parse(ctx.resEnd.firstCall.args[0])
-            assert.strictEqual(actualJson.error, SmusDeeplinkSessionExpiredError.code)
-            assert.strictEqual(actualJson.message, SmusDeeplinkSessionExpiredError.shortMessage)
-
-            // Verify cleanup was called
-            assert(ctx.storeStub.cleanupExpiredConnection.calledOnce)
+            assertExpiredSessionResponse()
             assert(ctx.storeStub.cleanupExpiredConnection.calledWith('abc'))
+
+            const actualJson = JSON.parse(ctx.resEnd.firstCall.args[0])
+            assert.strictEqual(actualJson.message, SmusDeeplinkSessionExpiredError.shortMessage)
 
             // Verify error page was opened with correct message
             assert(openErrorPageStub.calledOnce)
@@ -127,7 +152,7 @@ describe('handleGetSessionAsync', () => {
             assert.strictEqual(openErrorPageStub.firstCall.args[1], SmusDeeplinkSessionExpiredError.message)
         })
 
-        it('responds with 400 even if cleanup fails', async () => {
+        it('responds with 400 even if cleanup fails', async function () {
             ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
 
             ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
@@ -142,43 +167,18 @@ describe('handleGetSessionAsync', () => {
             assert.strictEqual(actualJson.error, SmusDeeplinkSessionExpiredError.code)
         })
 
-        it('responds with 202 when refreshUrl is valid (existing SageMaker AI flow)', async () => {
+        it('does not call cleanupExpiredConnection when refreshUrl exists', async function () {
             ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
-
-            ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
-            ctx.storeStub.getStatus.returns(Promise.resolve('not-started'))
-            ctx.storeStub.getRefreshUrl.returns(Promise.resolve('https://example.com/refresh')) // Valid refreshUrl
-            ctx.storeStub.markPending.returns(Promise.resolve())
-
-            stubSagemakerBrowserFlow()
-
-            await handleGetSessionAsync(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
-
-            // Verify SageMaker AI flow still works correctly
-            assert(ctx.resWriteHead.calledWith(202))
-            assert(ctx.resEnd.calledWithMatch(/Session is not ready yet/))
-            assert(ctx.storeStub.markPending.calledWith('abc', 'req123'))
-        })
-
-        it('does not call cleanupExpiredConnection for SageMaker AI connections', async () => {
-            ctx.req = { url: '/session_async?connection_identifier=abc&request_id=req123' }
-
-            ctx.storeStub.getFreshEntry.returns(Promise.resolve(undefined))
-            ctx.storeStub.getStatus.returns(Promise.resolve('not-started'))
-            ctx.storeStub.getRefreshUrl.returns(Promise.resolve('https://example.com/refresh'))
-            ctx.storeStub.markPending.returns(Promise.resolve())
+            stubNotStartedWithRefreshUrl()
             ctx.storeStub.cleanupExpiredConnection.resolves()
 
-            stubSagemakerBrowserFlow()
-
             await handleGetSessionAsync(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
 
-            // Verify cleanup was NOT called
             assert(ctx.storeStub.cleanupExpiredConnection.notCalled)
         })
     })
 
-    afterEach(() => {
+    afterEach(function () {
         sinon.restore()
     })
 })

--- a/packages/core/src/test/awsService/sagemaker/detached-server/routes/refreshToken.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/detached-server/routes/refreshToken.test.ts
@@ -52,7 +52,7 @@ describe('handleRefreshToken', () => {
         await handleRefreshToken(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
 
         assert(ctx.resWriteHead.calledWith(200))
-        assert(ctx.resEnd.calledWith('Session token refreshed successfully'))
+        assert(ctx.resEnd.calledWith('Reconnection successful. You can close this tab and return to your IDE.'))
         assert(
             ctx.storeStub.setSession.calledWith('abc', 'req123', {
                 sessionId: 'sess123',

--- a/packages/core/src/test/awsService/sagemaker/detached-server/sessionStore.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/detached-server/sessionStore.test.ts
@@ -27,6 +27,21 @@ describe('SessionStore', () => {
         },
     }
 
+    /** Creates a single-connection deepLink mapping with optional overrides on the entry. */
+    function createSingleEntryMapping(entryOverrides: Record<string, unknown> = {}) {
+        return {
+            deepLink: {
+                [connectionId]: {
+                    refreshUrl: 'https://refresh.url',
+                    requests: {
+                        'initial-connection': { sessionId: 's0', token: 't0', url: 'u0', status: 'fresh' },
+                    },
+                    ...entryOverrides,
+                },
+            },
+        }
+    }
+
     beforeEach(() => {
         readMappingStub = sinon.stub(utils, 'readMapping').returns(JSON.parse(JSON.stringify(baseMapping)))
         writeMappingStub = sinon.stub(utils, 'writeMapping')
@@ -42,16 +57,7 @@ describe('SessionStore', () => {
 
     it('returns undefined for SMUS connections (no refreshUrl)', async () => {
         const store = new SessionStore()
-        readMappingStub.returns({
-            deepLink: {
-                [connectionId]: {
-                    refreshUrl: undefined,
-                    requests: {
-                        'initial-connection': { sessionId: 's0', token: 't0', url: 'u0', status: 'fresh' },
-                    },
-                },
-            },
-        })
+        readMappingStub.returns(createSingleEntryMapping({ refreshUrl: undefined }))
         const result = await store.getRefreshUrl(connectionId)
         assert.strictEqual(result, undefined)
     })
@@ -74,6 +80,48 @@ describe('SessionStore', () => {
         readMappingStub.returns({})
 
         await assert.rejects(() => store.getRefreshUrl(connectionId), /No deepLink mapping found/)
+    })
+
+    describe('getIsSMUS', function () {
+        it('returns true when isSMUS is true in the mapping', async function () {
+            const store = new SessionStore()
+            readMappingStub.returns(
+                createSingleEntryMapping({
+                    refreshUrl: 'https://example.com/projects/p/code-spaces',
+                    isSMUS: true,
+                })
+            )
+            const result = await store.getIsSMUS(connectionId)
+            assert.strictEqual(result, true)
+        })
+
+        it('returns false when isSMUS is false in the mapping', async function () {
+            const store = new SessionStore()
+            readMappingStub.returns(createSingleEntryMapping({ isSMUS: false }))
+            const result = await store.getIsSMUS(connectionId)
+            assert.strictEqual(result, false)
+        })
+
+        it('defaults to false when isSMUS field is absent', async function () {
+            const store = new SessionStore()
+            readMappingStub.returns(createSingleEntryMapping())
+            const result = await store.getIsSMUS(connectionId)
+            assert.strictEqual(result, false)
+        })
+
+        it('throws when no deepLink mapping exists', async function () {
+            const store = new SessionStore()
+            readMappingStub.returns({})
+
+            await assert.rejects(() => store.getIsSMUS(connectionId), /No deepLink mapping found/)
+        })
+
+        it('throws when connectionId is not found', async function () {
+            const store = new SessionStore()
+            readMappingStub.returns({ deepLink: {} })
+
+            await assert.rejects(() => store.getIsSMUS('missing'), /No mapping found/)
+        })
     })
 
     it('returns fresh entry and marks consumed', async () => {

--- a/packages/core/src/test/awsService/sagemaker/uriHandlerTestUtils.ts
+++ b/packages/core/src/test/awsService/sagemaker/uriHandlerTestUtils.ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+
+/** Standard AMZ SigV4 header values used in URI handler tests. */
+export const amzHeaderParams = {
+    'X-Amz-Security-Token': 'fake/token+with=special',
+    'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+    'X-Amz-Date': '20240101T120000Z',
+    'X-Amz-SignedHeaders': 'host',
+    'X-Amz-Credential': 'AKIATEST/20240101/us-west-2/ssmmessages/aws4_request',
+    'X-Amz-Expires': '60',
+    'X-Amz-Signature': 'fakesignature123',
+}
+
+/**
+ * Asserts that a WebSocket URL contains all expected AMZ header parameters
+ * with correct percent-encoding.
+ */
+export function assertAmzHeadersInUrl(actualUrl: string, cellNumber: string) {
+    assert.ok(actualUrl.includes(`cell-number=${cellNumber}`))
+    assert.ok(actualUrl.includes('X-Amz-Security-Token=fake%2Ftoken%2Bwith%3Dspecial'))
+    assert.ok(actualUrl.includes('X-Amz-Algorithm=AWS4-HMAC-SHA256'))
+    assert.ok(actualUrl.includes('X-Amz-Date=20240101T120000Z'))
+    assert.ok(actualUrl.includes('X-Amz-SignedHeaders=host'))
+    assert.ok(actualUrl.includes('X-Amz-Credential=AKIATEST%2F20240101%2Fus-west-2%2Fssmmessages%2Faws4_request'))
+    assert.ok(actualUrl.includes('X-Amz-Expires=60'))
+    assert.ok(actualUrl.includes('X-Amz-Signature=fakesignature123'))
+}

--- a/packages/core/src/test/awsService/sagemaker/uriHandlers.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/uriHandlers.test.ts
@@ -9,6 +9,7 @@ import assert from 'assert'
 import { UriHandler } from '../../../shared/vscode/uriHandler'
 import { VSCODE_EXTENSION_ID_CONSTANTS } from '../../../shared/extensionIds'
 import { register } from '../../../awsService/sagemaker/uriHandlers'
+import { amzHeaderParams, assertAmzHeadersInUrl } from './uriHandlerTestUtils'
 
 function createConnectUri(params: { [key: string]: string }): vscode.Uri {
     const query = Object.entries(params)
@@ -106,30 +107,14 @@ describe('SageMaker URI handler', function () {
             ws_url: 'wss://example.com',
             'cell-number': 'test123',
             token: 'my-token',
-            'X-Amz-Security-Token': 'fake/token+with=special',
-            'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
-            'X-Amz-Date': '20240101T120000Z',
-            'X-Amz-SignedHeaders': 'host',
-            'X-Amz-Credential': 'AKIATEST/20240101/us-west-2/ssmmessages/aws4_request',
-            'X-Amz-Expires': '60',
-            'X-Amz-Signature': 'fakesignature123',
+            ...amzHeaderParams,
         }
 
         const uri = createConnectUri(params)
         await handler.handleUri(uri)
 
         assert.ok(deeplinkConnectStub.calledOnce)
-        const actualUrl = deeplinkConnectStub.firstCall.args[3]
-
-        // Verify all AMZ headers are included and properly encoded
-        assert.ok(actualUrl.includes('cell-number=test123'))
-        assert.ok(actualUrl.includes('X-Amz-Security-Token=fake%2Ftoken%2Bwith%3Dspecial'))
-        assert.ok(actualUrl.includes('X-Amz-Algorithm=AWS4-HMAC-SHA256'))
-        assert.ok(actualUrl.includes('X-Amz-Date=20240101T120000Z'))
-        assert.ok(actualUrl.includes('X-Amz-SignedHeaders=host'))
-        assert.ok(actualUrl.includes('X-Amz-Credential=AKIATEST%2F20240101%2Fus-west-2%2Fssmmessages%2Faws4_request'))
-        assert.ok(actualUrl.includes('X-Amz-Expires=60'))
-        assert.ok(actualUrl.includes('X-Amz-Signature=fakesignature123'))
+        assertAmzHeadersInUrl(deeplinkConnectStub.firstCall.args[3], 'test123')
     })
 
     it('works without AMZ headers', async function () {

--- a/packages/core/src/test/sagemakerunifiedstudio/uriHandlers.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/uriHandlers.test.ts
@@ -9,6 +9,7 @@ import assert from 'assert'
 import { SearchParams, UriHandler } from '../../shared/vscode/uriHandler'
 import { VSCODE_EXTENSION_ID_CONSTANTS } from '../../shared/extensionIds'
 import { parseConnectParams, register } from '../../sagemakerunifiedstudio/uriHandlers'
+import { amzHeaderParams, assertAmzHeadersInUrl } from '../awsService/sagemaker/uriHandlerTestUtils'
 
 function createConnectUri(params: { [key: string]: string }): vscode.Uri {
     const query = Object.entries(params)
@@ -112,6 +113,18 @@ describe('SMUS URI Handler', function () {
             assert.strictEqual(resultWithoutOptional.smus_domain_region, undefined)
         })
 
+        it('parses reconnect_base_url when present and leaves it undefined when absent', function () {
+            const reconnectBaseUrl =
+                'https://d-abc123xyz789.sagemaker-gamma.us-west-2.on.aws/projects/4m8bqfexample/code-spaces'
+            const withParam = parseConnectParams(
+                new SearchParams({ ...validParams, reconnect_base_url: reconnectBaseUrl })
+            )
+            assert.strictEqual(withParam.reconnect_base_url, reconnectBaseUrl)
+
+            const withoutParam = parseConnectParams(new SearchParams(validParams))
+            assert.strictEqual(withoutParam.reconnect_base_url, undefined)
+        })
+
         it('recovers session from ws_url when session param is missing', function () {
             const { session: _removed, ...paramsWithoutSession } = validParams
             const paramsWithDataChannel = {
@@ -153,28 +166,47 @@ describe('SMUS URI Handler', function () {
             ws_url: 'wss://ssm.us-west-2.amazonaws.com/stream',
             'cell-number': 'test123',
             token: 'bearer-token-xyz',
-            'X-Amz-Security-Token': 'fake/token+with=special',
-            'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
-            'X-Amz-Date': '20240101T120000Z',
-            'X-Amz-SignedHeaders': 'host',
-            'X-Amz-Credential': 'AKIATEST/20240101/us-west-2/ssmmessages/aws4_request',
-            'X-Amz-Expires': '60',
-            'X-Amz-Signature': 'fakesignature123',
+            ...amzHeaderParams,
         }
 
         const uri = createConnectUri(params)
         await handler.handleUri(uri)
 
         assert.ok(deeplinkConnectStub.calledOnce)
-        const actualUrl = deeplinkConnectStub.firstCall.args[3]
+        assertAmzHeadersInUrl(deeplinkConnectStub.firstCall.args[3], 'test123')
+    })
 
-        assert.ok(actualUrl.includes('cell-number=test123'))
-        assert.ok(actualUrl.includes('X-Amz-Security-Token=fake%2Ftoken%2Bwith%3Dspecial'))
-        assert.ok(actualUrl.includes('X-Amz-Algorithm=AWS4-HMAC-SHA256'))
-        assert.ok(actualUrl.includes('X-Amz-Date=20240101T120000Z'))
-        assert.ok(actualUrl.includes('X-Amz-SignedHeaders=host'))
-        assert.ok(actualUrl.includes('X-Amz-Credential=AKIATEST%2F20240101%2Fus-west-2%2Fssmmessages%2Faws4_request'))
-        assert.ok(actualUrl.includes('X-Amz-Expires=60'))
-        assert.ok(actualUrl.includes('X-Amz-Signature=fakesignature123'))
+    describe('reconnect_base_url threading', function () {
+        const baseParams = {
+            connection_identifier: 'arn:aws:sagemaker:us-west-2:123456789012:space/d-abc123/my-space',
+            domain: 'd-abc123',
+            user_profile: 'test-user',
+            session: 'sess-abc123',
+            ws_url: 'wss://ssm.us-west-2.amazonaws.com/stream',
+            'cell-number': '1',
+            token: 'bearer-token-xyz',
+        }
+        // Positional index of `refreshUrl` in the deeplinkConnect signature.
+        const refreshUrlArgIndex = 11
+        const isSmusArgIndex = 10
+
+        it('passes reconnect_base_url through as the refreshUrl argument', async function () {
+            const reconnectBaseUrl =
+                'https://d-abc123xyz789.sagemaker-gamma.us-west-2.on.aws/projects/4m8bqfexample/code-spaces'
+
+            await handler.handleUri(createConnectUri({ ...baseParams, reconnect_base_url: reconnectBaseUrl }))
+
+            assert.ok(deeplinkConnectStub.calledOnce)
+            assert.strictEqual(deeplinkConnectStub.firstCall.args[isSmusArgIndex], true)
+            assert.strictEqual(deeplinkConnectStub.firstCall.args[refreshUrlArgIndex], reconnectBaseUrl)
+        })
+
+        it('passes undefined refreshUrl when reconnect_base_url is absent', async function () {
+            await handler.handleUri(createConnectUri(baseParams))
+
+            assert.ok(deeplinkConnectStub.calledOnce)
+            assert.strictEqual(deeplinkConnectStub.firstCall.args[isSmusArgIndex], true)
+            assert.strictEqual(deeplinkConnectStub.firstCall.args[refreshUrlArgIndex], undefined)
+        })
     })
 })

--- a/packages/toolkit/.changes/next-release/Feature-e8bacc8b-96ce-470d-bee2-eb1f706657d2.json
+++ b/packages/toolkit/.changes/next-release/Feature-e8bacc8b-96ce-470d-bee2-eb1f706657d2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SageMaker Unified Studio: Automatically reconnect a deeplink-connected Space by refreshing credentials in the browser when the SSH tunnel drops."
+}


### PR DESCRIPTION
## Problem

When a SMUS deeplink SSH/SSM tunnel drops, the one-time session bundle is dead and the toolkit has no credentials to call `StartSession` itself. Unlike SageMaker AI connections which already support browser-based session refresh, SMUS deeplink connections cannot recover. The user must manually reconnect from the portal.

## Solution

Enable auto-refresh for SMUS deeplink connections by reusing the browser as the session-minting authority, mirroring the pattern already shipped for SageMaker AI. On tunnel drop, the detached server opens the SMUS portal with reconnect params. The portal calls `StartSession` using the browser's existing DataZone auth context and delivers a fresh bundle back to a localhost callback.

Key changes:
- New `reconnect_base_url` parameter from the initial deeplink connection for SMUS
- Thread `reconnect_base_url` from the deeplink URI through to `persistSSMConnection`, so SMUS connections get a `refreshUrl` in their persisted mapping
- Add DevSettings gate (default off) so these changes in the Toolkit will not affect customers yet. This PR is dependent on changes to the SMUS portal.
- Branch reconnect URL construction in `getSessionAsync.ts`: SMUS sends `reconnect_callback_port` only (Maxdome WAF blocks full localhost URLs in query strings); SM-AI keeps `reconnect_callback_url`

## Verification
- Unit tests for metadata threading, `isSMUS` branching, refresh URL construction, session store reads, and URI handler param parsing
- Manually confirmed SM-AI deeplink + refresh flow unaffected
- Manually confirmed SMUS deeplink + refresh flow works

---


- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
