### PR TITLE
fix(smus): Remove redundant GetEnvironment call from tooling env resolution

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneClient.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneClient.ts
@@ -856,7 +856,7 @@ export class DataZoneClient {
         _datazoneClient: DataZone,
         domainId: string,
         projectId: string
-    ): Promise<GetEnvironmentCommandOutput | undefined> {
+    ): Promise<{ id: string } | undefined> {
         try {
             // Find the IAM connection — its environmentId points to the tooling environment
             const response = await this.fetchConnections(domainId, projectId, ConnectionType.IAM)
@@ -875,14 +875,10 @@ export class DataZoneClient {
                 `Found tooling environment ${iamConnection.environmentId} via IAM connection '${iamConnection.name}'`
             )
 
-            // Use getEnvironment to retrieve the full environment details
-            const datazoneClient = await this.getDataZoneClient()
-            const env = await datazoneClient.getEnvironment({
-                domainIdentifier: domainId,
-                identifier: iamConnection.environmentId,
-            })
-
-            return env
+            // Do not call getEnvironment here. The scoped-down admin creds used on the
+            // SSO + IAM domain path lack that permission. getEnvironmentDetails() fetches
+            // project creds before calling it downstream.
+            return { id: iamConnection.environmentId }
         } catch (err) {
             this.logger.error('Failed to get tooling environment for domain %s: %s', domainId, (err as Error).message)
             throw new ToolkitError('Failed to get tooling environment', { code: 'ToolingEnvironmentError' })

--- a/packages/core/src/test/sagemakerunifiedstudio/shared/client/datazoneClient.test.ts
+++ b/packages/core/src/test/sagemakerunifiedstudio/shared/client/datazoneClient.test.ts
@@ -600,38 +600,40 @@ describe('DataZoneClient', () => {
             sinon.restore()
         })
 
-        it('should resolve tooling environment via project.iam connection', async function () {
-            const mockEnv = { id: 'env-1', name: 'CustomTooling', awsAccountRegion: 'us-west-2' }
-            const mockDataZone = {
-                getEnvironment: sinon.stub().resolves(mockEnv),
-            }
-
+        it('should resolve tooling environment ID via project.iam connection (preferred over default.iam)', async function () {
             sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
                 items: [
                     { name: 'project.iam', environmentId: 'env-1', connectionId: 'conn-1' },
                     { name: 'default.iam', environmentId: 'env-2', connectionId: 'conn-2' },
                 ],
             })
-            sinon.stub(dataZoneClient as any, 'getDataZoneClient').resolves(mockDataZone)
 
             const result = await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
 
+            // Returns just { id } from the connection. Does not call getEnvironment.
             assert.strictEqual(result?.id, 'env-1')
-            // Should prefer project.iam over default.iam
-            assert.ok(mockDataZone.getEnvironment.calledOnce)
-            assert.strictEqual(mockDataZone.getEnvironment.firstCall.args[0].identifier, 'env-1')
+        })
+
+        it('should not call getEnvironment (scoped-down admin creds lack that permission)', async function () {
+            sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
+                items: [{ name: 'default.iam', environmentId: 'env-1', connectionId: 'conn-1' }],
+            })
+            // Watch getEnvironment. Calling getDataZoneClient is fine. getEnvironment is not.
+            const getEnvironmentStub = sinon.stub()
+            sinon.stub(dataZoneClient as any, 'getDataZoneClient').resolves({ getEnvironment: getEnvironmentStub })
+
+            const result = await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
+
+            // Regression guard. The env id comes from the IAM connection, so getEnvironment
+            // is never needed. It would fail with AccessDenied under scoped-down admin creds.
+            assert.deepStrictEqual(result, { id: 'env-1' })
+            assert.ok(getEnvironmentStub.notCalled, 'getEnvironment must not be called')
         })
 
         it('should fall back to default.iam when project.iam is absent', async function () {
-            const mockEnv = { id: 'env-2', name: 'ToolingLite', awsAccountRegion: 'us-east-1' }
-            const mockDataZone = {
-                getEnvironment: sinon.stub().resolves(mockEnv),
-            }
-
             sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
                 items: [{ name: 'default.iam', environmentId: 'env-2', connectionId: 'conn-2' }],
             })
-            sinon.stub(dataZoneClient as any, 'getDataZoneClient').resolves(mockDataZone)
 
             const result = await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
 
@@ -639,25 +641,13 @@ describe('DataZoneClient', () => {
         })
 
         it('should resolve correctly with custom blueprint (no managed Tooling name)', async function () {
-            const mockEnv = {
-                id: 'env-custom',
-                name: 'MyCustomTooling',
-                awsAccountRegion: 'eu-west-1',
-                provisionedResources: [{ name: 'sageMakerDomainId', value: 'd-abc123' }],
-            }
-            const mockDataZone = {
-                getEnvironment: sinon.stub().resolves(mockEnv),
-            }
-
             sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
                 items: [{ name: 'default.iam', environmentId: 'env-custom', connectionId: 'conn-1' }],
             })
-            sinon.stub(dataZoneClient as any, 'getDataZoneClient').resolves(mockDataZone)
 
             const result = await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
 
             assert.strictEqual(result?.id, 'env-custom')
-            assert.strictEqual(result?.awsAccountRegion, 'eu-west-1')
         })
 
         it('should return undefined when no IAM connections exist', async function () {
@@ -689,29 +679,6 @@ describe('DataZoneClient', () => {
                 },
                 (error: Error) => {
                     assert.ok(error instanceof ToolkitError)
-                    assert.ok(error.message.includes('Failed to get tooling environment'))
-                    return true
-                }
-            )
-        })
-
-        it('should throw ToolkitError when getEnvironment fails', async function () {
-            const mockDataZone = {
-                getEnvironment: sinon.stub().rejects(new Error('GetEnvironment access denied')),
-            }
-
-            sinon.stub(dataZoneClient as any, 'fetchConnections').resolves({
-                items: [{ name: 'default.iam', environmentId: 'env-1', connectionId: 'conn-1' }],
-            })
-            sinon.stub(dataZoneClient as any, 'getDataZoneClient').resolves(mockDataZone)
-
-            await assert.rejects(
-                async () => {
-                    await (dataZoneClient as any).getToolingEnvironmentForProject({}, 'domain-1', 'project-1')
-                },
-                (error: Error) => {
-                    assert.ok(error instanceof ToolkitError)
-                    assert.strictEqual((error as ToolkitError).code, 'ToolingEnvironmentError')
                     assert.ok(error.message.includes('Failed to get tooling environment'))
                     return true
                 }

--- a/packages/toolkit/.changes/next-release/Bug Fix-066b78df-c97d-485d-a755-70a4c9fe4c81.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-066b78df-c97d-485d-a755-70a4c9fe4c81.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SageMaker Unified Studio: Fixed Spaces not appearing in the tree view after signing in with SSO to an IAM-based domain (caught in pre-release)."
+}


### PR DESCRIPTION
## Problem

`getToolingEnvironmentForProject` (introduced in #8848) calls `datazone:GetEnvironment` using the DataZoneClient's own credentials. For SSO users, those are scoped down admin project credentials, whose session policy does not include `datazone:GetEnvironment`.

This causes `AccessDeniedException` on the SSO login + IAM domain path, which propagates up to `ProjectNode.getChildren()` and prevents the Spaces tree from rendering.

Error from prod:

```
User: arn:aws:sts::769793001167:assumed-role/AmazonSageMakerAdminIAMExecutionRole_2/...
is not authorized to perform: datazone:GetEnvironment on resource:
arn:aws:datazone:us-west-2:769793001167:domain/dzd-3hii27v4vtm9cg
because no session policy allows the datazone:GetEnvironment action
```

The call is also redundant: the only consumer (`getToolingEnvironmentId`) reads `.id` from the result, then passes it to `getEnvironmentDetails(id, projectId)` which correctly fetches project credentials before calling `GetEnvironment`.

## Solution

Remove the `getEnvironment()` call from `getToolingEnvironmentForProject`. Return `{ id: iamConnection.environmentId }` directly 
- the environment ID is already on the IAM connection object with no API call needed. The downstream chain handles the privileged `GetEnvironment` call with the correct (project-scoped) credentials.

## Verification

- Unit tests pass (31/31 in `datazoneClient.test.ts`)
- Manual test against prod IAM domain (`dzd-3hii27v4vtm9cg`) with SSO login:
  - Without fix: spaces tree fails to render, logs show `AccessDeniedException` on `datazone:GetEnvironment`
  - With fix: spaces render correctly
- All 4 login X domain methods resolve correctly all the way to space connection
- custom blueprints projects still work
  - all capabilities project -> verified to space connection
  - min capabilities project -> we fail gracefully and show no spaces found tree node
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
