### PR TITLE
chore: remove stray root-level changelog entries

### DIFF
--- a/.changes/next-release/Bug Fix-77137e24-593d-4859-a15f-e029edf843a7.json
+++ b/.changes/next-release/Bug Fix-77137e24-593d-4859-a15f-e029edf843a7.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "Resource Explorer: S3 tree view now shows bucket contents correctly, even when restricted to root prefix."
-}

--- a/.changes/next-release/Bug Fix-codecatalyst-token-permissions.json
+++ b/.changes/next-release/Bug Fix-codecatalyst-token-permissions.json
@@ -1,4 +1,0 @@
-{
-  "type": "Bug Fix",
-  "description": "CodeCatalyst: Dev Environment connection token stored with insecure file permissions"
-}

--- a/.changes/next-release/Removal-remove-amazon-q-install-prompt.json
+++ b/.changes/next-release/Removal-remove-amazon-q-install-prompt.json
@@ -1,4 +1,0 @@
-{
-    "type": "Removal",
-    "description": "No longer prompts users to install Amazon Q on startup"
-}

--- a/.changes/next-release/bugfix-cfn-resource-import-1772138230.json
+++ b/.changes/next-release/bugfix-cfn-resource-import-1772138230.json
@@ -1,4 +1,0 @@
-{
-  "type": "bugfix",
-  "description": "Display AWS error message when importing CloudFormation resource state fails. Currently users only see 'Failed to import * resource(s)'."
-}

--- a/.changes/next-release/bugfix-infrastructure-composer-initialization.json
+++ b/.changes/next-release/bugfix-infrastructure-composer-initialization.json
@@ -1,4 +1,0 @@
-{
-  "type": "Bug Fix",
-  "description": "Infrastructure Composer: A failure to initialize (eg when 'https://ide-toolkits.app-composer.aws.dev' is not reachable) no longer prevents the rest of Toolkit from activating."
-}

--- a/.changes/next-release/bugfix-redshift-notebook-xss.json
+++ b/.changes/next-release/bugfix-redshift-notebook-xss.json
@@ -1,4 +1,0 @@
-{
-  "type": "Bug Fix",
-  "description": "Redshift SQL Notebook: Query results with HTML special characters in column names or cell values are now displayed safely instead of being interpreted as HTML."
-}

--- a/.changes/next-release/bugfix-workspace-setting-override.json
+++ b/.changes/next-release/bugfix-workspace-setting-override.json
@@ -1,4 +1,0 @@
-{
-  "type": "Bug Fix",
-  "description": "Cloudformation Language Server: prevent workspace level settings from overriding the code path used to load the language server js file, which could cause code execution when trusting a specially crafted VSCode workspace."
-}

--- a/.changes/next-release/feat-hyperpod-deeplink-reconnection.json
+++ b/.changes/next-release/feat-hyperpod-deeplink-reconnection.json
@@ -1,4 +1,0 @@
-{
-  "type": "Feature",
-  "description": "HyperPod: Supporting reconnection for hyperpod spaces connected through deeplink."
-}

--- a/.changes/next-release/feat-workspace-connection-ide-type.json
+++ b/.changes/next-release/feat-workspace-connection-ide-type.json
@@ -1,4 +1,0 @@
-{
-  "type": "Feature",
-  "description": "HyperPod: Send correct IDE type (vscode-remote, cursor-remote, kiro-remote) when creating workspace connections, enabling proper multi-IDE support."
-}


### PR DESCRIPTION
## Problem

The repo has a stray `.changes/next-release/` directory at the root with 9 changelog entries in it. These files do nothing: the release tooling (`createRelease.ts`) only reads the per-package directories like `packages/toolkit/.changes/next-release/`, so entries at the root are never included in any release's CHANGELOG.

They end up there by accident when someone runs `npm run newChange` from the repo root instead of `npm run newChange -w packages/toolkit`. The script writes to `.changes/next-release/` relative to the current directory, so running it from the root silently drops the entry in the wrong place. All 9 entries describe changes that already shipped — their changelog notes just never made it into the release notes.

## Solution

Delete the root-level `.changes/next-release/` directory. This is the same cleanup that was done in #4893.

Note for contributors: always use the workspace flag when creating changelog entries, e.g. `npm run newChange -w packages/toolkit`.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.