### PR TITLE
fix(smus): Filter user profiles by ACTIVATED status

### DIFF
--- a/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.ts
+++ b/packages/core/src/sagemakerunifiedstudio/shared/client/datazoneCustomClientHelper.ts
@@ -542,7 +542,7 @@ export class DataZoneCustomClientHelper {
                     `DataZoneCustomClientHelper: Received ${response.items.length} user profiles matching role ARN in current page (total checked: ${totalProfilesChecked})`
                 )
 
-                // Find exact match in current page using client-side filtering for session name
+                // Find exact match in current page using client-side filtering for session name and status
                 // Server-side filtering by role ARN should have already reduced the result set significantly
                 for (const profile of response.items) {
                     // Match based on session name (role ARN already filtered by searchText)
@@ -551,9 +551,13 @@ export class DataZoneCustomClientHelper {
                         profile.details?.iam?.sessionName === sessionName ||
                         profile.details?.iam?.principalId?.endsWith(`:${sessionName}`)
 
-                    if (matchesSession) {
+                    // Only return profiles with ACTIVATED status to avoid returning deactivated profiles
+                    // when multiple profiles exist for the same IAM role session
+                    const isActivated = profile.status === 'ACTIVATED'
+
+                    if (matchesSession && isActivated) {
                         this.logger.info(
-                            `DataZoneCustomClientHelper: Found matching user profile with ID: ${profile.id} (role: ${iamRoleArn}, session: ${sessionName}) after checking ${totalProfilesChecked} profiles`
+                            `DataZoneCustomClientHelper: Found matching user profile with ID: ${profile.id} (role: ${iamRoleArn}, session: ${sessionName}, status: ${profile.status}) after checking ${totalProfilesChecked} profiles`
                         )
                         return profile.id!
                     }
@@ -562,9 +566,8 @@ export class DataZoneCustomClientHelper {
                 nextToken = response.nextToken
             } while (nextToken)
 
-            // No matching profile found after checking all pages
             this.logger.error(
-                `DataZoneCustomClientHelper: No user profile found for role: ${iamRoleArn} with session: ${sessionName} after checking ${totalProfilesChecked} profiles`
+                `DataZoneCustomClientHelper: No ACTIVATED user profile found for role: ${iamRoleArn} with session: ${sessionName} after checking ${totalProfilesChecked} profiles`
             )
             return ''
         } catch (err) {

--- a/packages/toolkit/.changes/next-release/Bug Fix-b148103b-4c56-4784-8984-fd267ab9cfcb.json
+++ b/packages/toolkit/.changes/next-release/Bug Fix-b148103b-4c56-4784-8984-fd267ab9cfcb.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SageMaker Unified Studio: only activated user profiles are used for space filtering."
+}


### PR DESCRIPTION
## Problem

When multiple user profiles exist for the same IAM role ARN (e.g., one DEACTIVATED and one ACTIVATED), only return the profile with ACTIVATED status. This situation happens when the role was deleted and created again. Previously the code would return whichever matched the session name first, which could be a deactivated profile.

## Test
- the spaces are shown correctly for the IAM role session
<img width="678" height="591" alt="Screenshot 2026-08-18 at 11 27 25 AM" src="https://github.com/user-attachments/assets/2f7c88ef-1554-4bf9-9d47-4697558cfd24" />
