### PR TITLE
test(smus): Align refreshToken test with actual response message

### DIFF
--- a/packages/core/src/test/awsService/sagemaker/detached-server/routes/refreshToken.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/detached-server/routes/refreshToken.test.ts
@@ -52,7 +52,7 @@ describe('handleRefreshToken', () => {
         await handleRefreshToken(ctx.req as http.IncomingMessage, ctx.res as http.ServerResponse)
 
         assert(ctx.resWriteHead.calledWith(200))
-        assert(ctx.resEnd.calledWith('Reconnection successful. You can close this tab and return to your IDE.'))
+        assert(ctx.resEnd.calledWith('Session token refreshed successfully'))
         assert(
             ctx.storeStub.setSession.calledWith('abc', 'req123', {
                 sessionId: 'sess123',


### PR DESCRIPTION
## Problem
Unit test wasn't updated when the title was reverted back to it's original state

## Solution
Fix the failing unit test by checking for the right title.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
