### PR TITLE
fix(sagemaker): resolve IdC user profiles via SSO binding

### DIFF
--- a/packages/core/src/awsService/sagemaker/commands.ts
+++ b/packages/core/src/awsService/sagemaker/commands.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { SagemakerConstants } from './explorer/constants'
 import { SagemakerStudioNode } from './explorer/sagemakerStudioNode'
-import { DomainKeyDelimiter } from './utils'
+import { DomainKeyDelimiter, promptAndApplyExplorerFilter } from './utils'
 import { startVscodeRemote } from '../../shared/extensions/ssh'
 import { getLogger } from '../../shared/logger/logger'
 import { SagemakerSpaceNode, tryRefreshNode } from './explorer/sagemakerSpaceNode'
@@ -65,9 +65,20 @@ export async function filterSpaceAppsByDomainUserProfiles(studioNode: SagemakerS
     )
 
     const previousSelection = await studioNode.getSelectedDomainUsers()
+
+    // For IdC callers the selection can only ever narrow to profiles bound to their own IdC
+    // identity, so offering other profiles in the picker would present choices that are silently
+    // discarded. Restrict the options to what the caller actually owns.
+    const selectableKeys = studioNode.isIdcCaller()
+        ? new Set(await studioNode.getDefaultSelectedDomainUsers())
+        : undefined
+
     const items: (vscode.QuickPickItem & { key: string })[] = []
 
     for (const [key, userMetadata] of sortedDomainUserProfiles) {
+        if (selectableKeys && !selectableKeys.has(key)) {
+            continue
+        }
         const [_, userProfile] = key.split(DomainKeyDelimiter)
         items.push({
             label: userProfile,
@@ -77,22 +88,16 @@ export async function filterSpaceAppsByDomainUserProfiles(studioNode: SagemakerS
         })
     }
 
+    if (items.length === 0) {
+        getLogger().info(SagemakerConstants.NoSpaceToFilter)
+        void vscode.window.showInformationMessage(SagemakerConstants.NoSpaceToFilter)
+        return
+    }
+
     const placeholder = localize(SagemakerConstants.FilterPlaceholderKey, SagemakerConstants.FilterPlaceholderMessage)
-    const result = await vscode.window.showQuickPick(items, {
-        placeHolder: placeholder,
-        canPickMany: true,
-        matchOnDetail: true,
-    })
-
-    if (!result) {
-        return // User canceled.
-    }
-
-    const newSelection = result.map((r) => r.key)
-    if (newSelection.length !== previousSelection.size || newSelection.some((key) => !previousSelection.has(key))) {
-        studioNode.saveSelectedDomainUsers(newSelection)
-        await vscode.commands.executeCommand('aws.refreshAwsExplorerNode', studioNode)
-    }
+    await promptAndApplyExplorerFilter(studioNode, items, placeholder, previousSelection, (selection) =>
+        studioNode.saveSelectedDomainUsers(selection)
+    )
 }
 
 export async function deeplinkConnect(

--- a/packages/core/src/awsService/sagemaker/explorer/constants.ts
+++ b/packages/core/src/awsService/sagemaker/explorer/constants.ts
@@ -10,6 +10,8 @@ export abstract class SagemakerConstants {
     static readonly FilterHyperpodPlaceholderKey = 'aws.filterHyperpodSpacesPlaceholder'
     static readonly FilterHyperpodPlaceholderMessage = 'Filter dev spaces by name spaces or cluster (unselect to hide)'
     static readonly PlaceHolderMessage = '[No Sagemaker Spaces Found]'
+    static readonly IdcNoOwnedSpacesMessage = '[No spaces owned by your user profile]'
+    static readonly IdcUnresolvedProfileMessage = '[Unable to determine your Studio user profile]'
     static readonly EnableIdentityFilteringSetting = 'aws.sagemaker.studio.spaces.enableIdentityFiltering'
     static readonly SelectedDomainUsersState = 'aws.sagemaker.selectedDomainUsers'
     static readonly FilterPlaceholderKey = 'aws.filterSagemakerSpacesPlaceholder'

--- a/packages/core/src/awsService/sagemaker/explorer/sagemakerStudioNode.ts
+++ b/packages/core/src/awsService/sagemaker/explorer/sagemakerStudioNode.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { GetCallerIdentityResponse } from 'aws-sdk/clients/sts'
-import { DescribeDomainResponse } from '@amzn/sagemaker-client'
+import { DescribeDomainResponse, SharingType } from '@amzn/sagemaker-client'
 import { SagemakerClient, SagemakerSpaceApp } from '../../../shared/clients/sagemaker'
 import { DefaultStsClient } from '../../../shared/clients/stsClient'
 import globals from '../../../shared/extensionGlobals'
@@ -16,7 +16,7 @@ import { updateInPlace } from '../../../shared/utilities/collectionUtils'
 import { isRemoteWorkspace } from '../../../shared/vscode/env'
 import { SagemakerConstants } from './constants'
 import { SagemakerSpaceNode } from './sagemakerSpaceNode'
-import { getDomainSpaceKey, getDomainUserProfileKey, getSpaceAppsForUserProfile } from '../utils'
+import { getDomainUserProfileKey, getSpaceAppsForUserProfile } from '../utils'
 import { PollingSet } from '../../../shared/utilities/pollingSet'
 import { getRemoteAppMetadata } from '../remoteUtils'
 
@@ -36,6 +36,21 @@ export class SagemakerStudioNode extends AWSTreeNodeBase {
     domainUserProfiles: Map<string, UserProfileMetadata> = new Map()
     spaceApps: Map<string, SagemakerSpaceApp> = new Map()
     callerIdentity: GetCallerIdentityResponse = {}
+    /** Whether the IdC caller's Studio user profile was successfully resolved on the last refresh. */
+    private idcProfileResolved: boolean = false
+    /**
+     * Number of space apps returned by the API before filtering. `updateChildren` prunes
+     * `this.spaceApps` in place, so its post-filter size cannot distinguish "domain has no spaces"
+     * from "all spaces were filtered out".
+     */
+    private spaceAppCountBeforeFilter: number = 0
+    /**
+     * Owned domain-user-profile keys for an IdC caller, resolved once per tree refresh.
+     * Resolution costs a DescribeUserProfile per distinct space owner, so it must not re-run for
+     * every consumer (the tree build and the filter picker both need it). Invalidated at the start
+     * of {@link updateChildren}.
+     */
+    private idcOwnedKeysCache: string[] | undefined
     public readonly pollingSet: PollingSet<string> = new PollingSet(5000, this.updatePendingNodes.bind(this))
 
     public constructor(
@@ -53,11 +68,25 @@ export class SagemakerStudioNode extends AWSTreeNodeBase {
                 await this.updateChildren()
                 return [...this.sagemakerSpaceNodes.values()]
             },
-            getNoChildrenPlaceholderNode: async () => new PlaceholderNode(this, SagemakerConstants.PlaceHolderMessage),
+            getNoChildrenPlaceholderNode: async () => new PlaceholderNode(this, this.getPlaceholderMessage()),
             sort: (nodeA, nodeB) => nodeA.name.localeCompare(nodeB.name),
         })
 
         return result
+    }
+
+    /**
+     * Distinguishes "the domain has no spaces" from "this IdC user owns none of them" from "we
+     * could not resolve this IdC user's Studio user profile". All three render an empty tree, but
+     * they need very different follow-up actions, so they must not share one message.
+     */
+    private getPlaceholderMessage(): string {
+        if (!this.isIdcCaller() || this.spaceAppCountBeforeFilter === 0) {
+            return SagemakerConstants.PlaceHolderMessage
+        }
+        return this.idcProfileResolved
+            ? SagemakerConstants.IdcNoOwnedSpacesMessage
+            : SagemakerConstants.IdcUnresolvedProfileMessage
     }
 
     public trackPendingNode(domainSpaceKey: string) {
@@ -88,18 +117,94 @@ export class SagemakerStudioNode extends AWSTreeNodeBase {
         }
     }
 
+    /**
+     * True when the signed-in connection is an IAM Identity Center (SSO) identity.
+     *
+     * IdC connections are scoped to the caller's own Studio user profile: the Jorus remote-connect
+     * flow authorizes on the browser's IdC session, so surfacing spaces owned by other user
+     * profiles invites connect attempts the user has no legitimate claim to. IAM connections keep
+     * their historical behavior, gated by EnableIdentityFilteringSetting.
+     */
+    public isIdcCaller(): boolean {
+        return !!this.callerIdentity.Arn?.match(SagemakerConstants.IdentityCenterArnRegex)
+    }
+
+    /**
+     * The IdC user name captured from the caller's assumed-role session ARN
+     * (`.../AWSReservedSSO_<permission-set>_<id>/<idc-user-name>`), or undefined for non-IdC callers.
+     */
+    private getIdcUserName(): string | undefined {
+        const match = this.callerIdentity.Arn?.match(SagemakerConstants.IdentityCenterArnRegex)
+        return match && match.length >= 2 ? match[1] : undefined
+    }
+
+    /**
+     * Resolves the domain-user-profile keys this IdC caller owns, using the authoritative
+     * SingleSignOnUserValue binding on each user profile rather than guessing a user profile name
+     * from the caller ARN.
+     *
+     * Fails CLOSED: if the caller's user profile cannot be resolved in a domain, that domain's
+     * spaces are excluded. Returning an empty list here hides everything, which is the intended
+     * outcome -- an unresolvable identity must not fall back to showing the whole domain.
+     */
+    private async getIdcOwnedDomainUsers(): Promise<string[]> {
+        if (this.idcOwnedKeysCache) {
+            return this.idcOwnedKeysCache
+        }
+
+        const ssoUserName = this.getIdcUserName()
+        if (!ssoUserName) {
+            this.idcOwnedKeysCache = []
+            return this.idcOwnedKeysCache
+        }
+
+        const userProfilesByDomain = new Map<string, Set<string>>()
+        for (const app of this.spaceApps.values()) {
+            const domainId = app.DomainId
+            const userProfileName = app.OwnershipSettingsSummary?.OwnerUserProfileName
+            if (!domainId || !userProfileName || app.SpaceSharingSettingsSummary?.SharingType === SharingType.Shared) {
+                continue
+            }
+
+            const profileNames = userProfilesByDomain.get(domainId) ?? new Set<string>()
+            profileNames.add(userProfileName)
+            userProfilesByDomain.set(domainId, profileNames)
+        }
+        if (userProfilesByDomain.size === 0) {
+            this.idcOwnedKeysCache = []
+            return this.idcOwnedKeysCache
+        }
+
+        const ownedByDomain = await this.sagemakerClient.resolveUserProfilesForSsoUser(
+            userProfilesByDomain,
+            ssoUserName
+        )
+
+        const keys: string[] = []
+        for (const [domainId, profileNames] of ownedByDomain) {
+            for (const profileName of profileNames) {
+                keys.push(getDomainUserProfileKey(domainId, profileName))
+            }
+        }
+        this.idcProfileResolved = keys.length > 0
+        this.idcOwnedKeysCache = keys
+        return keys
+    }
+
     public async getLocalSelectedDomainUsers(): Promise<string[]> {
+        // IdC callers are always scoped to the user profiles actually bound to their IdC identity.
+        if (this.isIdcCaller()) {
+            return this.getIdcOwnedDomainUsers()
+        }
+
         const iamMatches =
             this.callerIdentity.Arn?.match(SagemakerConstants.IamUserArnRegex) ||
             this.callerIdentity.Arn?.match(SagemakerConstants.IamSessionArnRegex)
-        const idcMatches = this.callerIdentity.Arn?.match(SagemakerConstants.IdentityCenterArnRegex)
 
         const matches =
             iamMatches && vscode.workspace.getConfiguration().get(SagemakerConstants.EnableIdentityFilteringSetting)
                 ? iamMatches
-                : idcMatches
-                  ? idcMatches
-                  : undefined
+                : undefined
 
         const userProfilePrefix =
             matches && matches.length >= 2
@@ -136,6 +241,14 @@ export class SagemakerStudioNode extends AWSTreeNodeBase {
         const cachedDomainUsers = selectedDomainUsersMap.get(this.callerIdentity.Arn || '')
 
         if (cachedDomainUsers && cachedDomainUsers.length > 0) {
+            // For IdC callers the manual filter may only narrow, never widen: intersect any saved
+            // selection with what the IdC identity actually owns. Without this, a selection saved
+            // before this scoping existed (or made via the filter picker) would resurrect spaces
+            // belonging to other user profiles.
+            if (this.isIdcCaller()) {
+                const allowed = new Set(defaultSelectedDomainUsers)
+                return new Set(cachedDomainUsers.filter((key) => allowed.has(key)))
+            }
             return new Set(cachedDomainUsers)
         } else {
             return new Set(defaultSelectedDomainUsers)
@@ -162,20 +275,37 @@ export class SagemakerStudioNode extends AWSTreeNodeBase {
     public async updateChildren(): Promise<void> {
         const [spaceApps, domains] = await this.sagemakerClient.fetchSpaceAppsAndDomains()
         this.spaceApps = spaceApps
+        this.spaceAppCountBeforeFilter = spaceApps.size
+        this.idcProfileResolved = false
+        this.idcOwnedKeysCache = undefined
 
         this.callerIdentity = await this.stsClient.getCallerIdentity()
         const selectedDomainUsers = await this.getSelectedDomainUsers()
+        const isIdcCaller = this.isIdcCaller()
         this.domainUserProfiles.clear()
 
-        for (const app of spaceApps.values()) {
+        for (const [domainSpaceKey, app] of spaceApps) {
             const domainId = app.DomainId
             const userProfile = app.OwnershipSettingsSummary?.OwnerUserProfileName
-            if (!domainId || !userProfile) {
+            if (!domainId) {
+                if (isIdcCaller) {
+                    spaceApps.delete(domainSpaceKey)
+                }
+                continue
+            }
+
+            if (isIdcCaller && app.SpaceSharingSettingsSummary?.SharingType === SharingType.Shared) {
+                continue
+            }
+
+            if (!userProfile) {
+                if (isIdcCaller) {
+                    spaceApps.delete(domainSpaceKey)
+                }
                 continue
             }
 
             const domainUserProfileKey = getDomainUserProfileKey(domainId, userProfile)
-            const domainSpaceKey = getDomainSpaceKey(domainId, app.SpaceName || '')
 
             this.domainUserProfiles.set(domainUserProfileKey, {
                 domain: domains.get(domainId) as DescribeDomainResponse,

--- a/packages/core/src/awsService/sagemaker/hyperpodCommands.ts
+++ b/packages/core/src/awsService/sagemaker/hyperpodCommands.ts
@@ -16,6 +16,7 @@ import { startVscodeRemote } from '../../shared/extensions/ssh'
 import { ensureSageMakerSshKiroExtension } from './sagemakerSshKiroUtils'
 import globals from '../../shared/extensionGlobals'
 import { getIdeType } from '../../shared/extensionUtilities'
+import { promptAndApplyExplorerFilter } from './utils'
 
 const localize = nls.loadMessageBundle()
 
@@ -207,19 +208,7 @@ export async function filterDevSpacesByNamespaceCluster(hpNode: SagemakerHyperpo
         SagemakerConstants.FilterHyperpodPlaceholderKey,
         SagemakerConstants.FilterHyperpodPlaceholderMessage
     )
-    const result = await vscode.window.showQuickPick(items, {
-        placeHolder: placeholder,
-        canPickMany: true,
-        matchOnDetail: true,
-    })
-
-    if (!result) {
-        return // User canceled
-    }
-
-    const newSelection = result.map((r) => r.key)
-    if (newSelection.length !== previousSelection.size || newSelection.some((key) => !previousSelection.has(key))) {
-        hpNode.saveSelectedClusterNamespaces(newSelection)
-        await vscode.commands.executeCommand('aws.refreshAwsExplorerNode', hpNode)
-    }
+    await promptAndApplyExplorerFilter(hpNode, items, placeholder, previousSelection, (selection) =>
+        hpNode.saveSelectedClusterNamespaces(selection)
+    )
 }

--- a/packages/core/src/awsService/sagemaker/utils.ts
+++ b/packages/core/src/awsService/sagemaker/utils.ts
@@ -13,6 +13,7 @@ import { sshLogFileLocation } from '../../shared/sshConfig'
 import { fs } from '../../shared/fs/fs'
 import { getLogger } from '../../shared/logger/logger'
 import { ToolkitError } from '../../shared/errors'
+import type { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 
 export const DomainKeyDelimiter = '__'
 export { parseArn } from './detached-server/utils'
@@ -85,6 +86,37 @@ export function getSpaceAppsForUserProfile(
 
         return result
     }, [] as string[])
+}
+
+/**
+ * Shows a multi-select QuickPick of explorer filter options and, when the selection changes,
+ * persists it and refreshes the node.
+ *
+ * Shared by the Studio user-profile filter and the HyperPod cluster/namespace filter, which
+ * differ only in how their items are built and where the selection is stored.
+ */
+export async function promptAndApplyExplorerFilter(
+    node: AWSTreeNodeBase,
+    items: (vscode.QuickPickItem & { key: string })[],
+    placeholder: string,
+    previousSelection: Set<string>,
+    saveSelection: (selection: string[]) => void
+): Promise<void> {
+    const result = await vscode.window.showQuickPick(items, {
+        placeHolder: placeholder,
+        canPickMany: true,
+        matchOnDetail: true,
+    })
+
+    if (!result) {
+        return // User canceled.
+    }
+
+    const newSelection = result.map((r) => r.key)
+    if (newSelection.length !== previousSelection.size || newSelection.some((key) => !previousSelection.has(key))) {
+        saveSelection(newSelection)
+        await vscode.commands.executeCommand('aws.refreshAwsExplorerNode', node)
+    }
 }
 
 export function getSmSsmEnv(ssmPath: string, sagemakerLocalServerPath: string): NodeJS.ProcessEnv {

--- a/packages/core/src/shared/clients/sagemaker.ts
+++ b/packages/core/src/shared/clients/sagemaker.ts
@@ -22,6 +22,9 @@ import {
     DescribeSpaceCommand,
     DescribeSpaceCommandInput,
     DescribeSpaceCommandOutput,
+    DescribeUserProfileCommand,
+    DescribeUserProfileCommandInput,
+    DescribeUserProfileCommandOutput,
     ListAppsCommandInput,
     ListSpacesCommandInput,
     ResourceSpec,
@@ -131,6 +134,59 @@ export class SagemakerClient extends ClientWrapper<SageMakerClient> {
 
     public describeSpace(request: DescribeSpaceCommandInput): Promise<DescribeSpaceCommandOutput> {
         return this.makeRequest(DescribeSpaceCommand, request)
+    }
+
+    public describeUserProfile(request: DescribeUserProfileCommandInput): Promise<DescribeUserProfileCommandOutput> {
+        return this.makeRequest(DescribeUserProfileCommand, request)
+    }
+
+    /**
+     * Resolves which candidate user profiles are bound to the supplied IAM Identity Center user,
+     * using the authoritative `SingleSignOnUserValue` binding that SageMaker records on the user
+     * profile at creation time.
+     *
+     * Returns the matching user profile names keyed by domain. A domain with no match is omitted,
+     * which callers must treat as "this IdC user owns nothing in that domain" (fail closed) rather
+     * than as "unknown, show everything".
+     */
+    public async resolveUserProfilesForSsoUser(
+        userProfilesByDomain: ReadonlyMap<string, ReadonlySet<string>>,
+        ssoUserValue: string
+    ): Promise<Map<string, string[]>> {
+        const result = new Map<string, string[]>()
+        const target = ssoUserValue.toLowerCase()
+
+        for (const [domainId, userProfileNames] of userProfilesByDomain) {
+            const matched: string[] = []
+            for (const userProfileName of userProfileNames) {
+                try {
+                    const response = await this.describeUserProfile({
+                        DomainId: domainId,
+                        UserProfileName: userProfileName,
+                    })
+                    if (response.SingleSignOnUserValue?.toLowerCase() === target) {
+                        matched.push(userProfileName)
+                    }
+                } catch (err) {
+                    getLogger().error(
+                        'SagemakerClient: failed to describe a user profile in domain %s: %O',
+                        domainId,
+                        err
+                    )
+                }
+            }
+
+            if (matched.length > 0) {
+                result.set(domainId, matched)
+            } else {
+                getLogger().warn(
+                    'SagemakerClient: no user profile in domain %s has SingleSignOnUserValue matching the signed-in IdC user. Spaces in this domain will be hidden.',
+                    domainId
+                )
+            }
+        }
+
+        return result
     }
 
     public updateSpace(request: UpdateSpaceCommandInput): Promise<UpdateSpaceCommandOutput> {

--- a/packages/core/src/test/awsService/sagemaker/explorer/sagemakerStudioNode.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/explorer/sagemakerStudioNode.test.ts
@@ -32,28 +32,29 @@ describe('sagemakerStudioNode', function () {
         ['domain1', { DomainId: 'domain1', DomainName: 'domainName1' }],
         ['domain2', { DomainId: 'domain2', DomainName: 'domainName2' }],
     ])
-    const spaceAppsMap: Map<string, SagemakerSpaceApp> = new Map([
-        [
-            'domain1__name1',
-            {
-                SpaceName: 'name1',
-                DomainId: 'domain1',
-                OwnershipSettingsSummary: { OwnerUserProfileName: 'user1-abcd' },
-                Status: 'InService',
-                DomainSpaceKey: 'domain1__name1',
-            },
-        ],
-        [
-            'domain2__name2',
-            {
-                SpaceName: 'name2',
-                DomainId: 'domain2',
-                OwnershipSettingsSummary: { OwnerUserProfileName: 'user2-efgh' },
-                Status: 'InService',
-                DomainSpaceKey: 'domain2__name2',
-            },
-        ],
-    ])
+    const createSpaceAppsMap = (): Map<string, SagemakerSpaceApp> =>
+        new Map([
+            [
+                'domain1__name1',
+                {
+                    SpaceName: 'name1',
+                    DomainId: 'domain1',
+                    OwnershipSettingsSummary: { OwnerUserProfileName: 'user1-abcd' },
+                    Status: 'InService',
+                    DomainSpaceKey: 'domain1__name1',
+                },
+            ],
+            [
+                'domain2__name2',
+                {
+                    SpaceName: 'name2',
+                    DomainId: 'domain2',
+                    OwnershipSettingsSummary: { OwnerUserProfileName: 'user2-efgh' },
+                    Status: 'InService',
+                    DomainSpaceKey: 'domain2__name2',
+                },
+            ],
+        ])
     const spaceAppsMapPending: Map<string, SagemakerSpaceApp> = new Map([
         [
             'domain1__name3',
@@ -133,14 +134,15 @@ describe('sagemakerStudioNode', function () {
     })
 
     it('has child nodes', async function () {
-        fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([spaceAppsMap, domainsMap]))
+        const spaceApps = createSpaceAppsMap()
+        fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([spaceApps, domainsMap]))
         getCallerIdentityStub.returns(Promise.resolve(iamUser))
         sinon
             .stub(vscode.workspace, 'getConfiguration')
             .returns(getConfigFalse as unknown as vscode.WorkspaceConfiguration)
 
         const childNodes = await testNode.getChildren()
-        assert.strictEqual(childNodes.length, spaceAppsMap.size, 'Unexpected child count')
+        assert.strictEqual(childNodes.length, spaceApps.size, 'Unexpected child count')
         assert.strictEqual(childNodes[0].label, 'name1 (Stopped)', 'Unexpected node label')
         assert.strictEqual(childNodes[1].label, 'name2 (Stopped)', 'Unexpected node label')
     })
@@ -154,43 +156,150 @@ describe('sagemakerStudioNode', function () {
         fetchSpaceAppsAndDomainsStub.restore()
     })
 
-    it('filters spaces owned by user profiles that match the IAM user', async function () {
-        fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([spaceAppsMap, domainsMap]))
-        getCallerIdentityStub.returns(Promise.resolve(iamUser))
-        sinon
-            .stub(vscode.workspace, 'getConfiguration')
-            .returns(getConfigTrue as unknown as vscode.WorkspaceConfiguration)
+    // These two cases differ only in which caller identity is returned, so drive them from a
+    // table rather than duplicating the body.
+    for (const { description, callerIdentity } of [
+        { description: 'the IAM user', callerIdentity: () => iamUser },
+        { description: 'the IAM assumed-role session name', callerIdentity: () => assumedRoleUser },
+    ]) {
+        it(`filters spaces owned by user profiles that match ${description}`, async function () {
+            fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([createSpaceAppsMap(), domainsMap]))
+            getCallerIdentityStub.returns(Promise.resolve(callerIdentity()))
+            sinon
+                .stub(vscode.workspace, 'getConfiguration')
+                .returns(getConfigTrue as unknown as vscode.WorkspaceConfiguration)
 
-        const childNodes = await testNode.getChildren()
-        assert.strictEqual(childNodes.length, 1, 'Unexpected child count')
-        assert.strictEqual(childNodes[0].label, 'name2 (Stopped)', 'Unexpected node label')
+            const childNodes = await testNode.getChildren()
+            assert.strictEqual(childNodes.length, 1, 'Unexpected child count')
+            assert.strictEqual(childNodes[0].label, 'name2 (Stopped)', 'Unexpected node label')
+        })
+    }
+
+    describe('Identity Center callers', function () {
+        let resolveStub: sinon.SinonStub
+
+        beforeEach(function () {
+            resolveStub = sinon.stub(SagemakerClient.prototype, 'resolveUserProfilesForSsoUser')
+        })
+
+        it('shows only spaces owned by the user profile bound to the Identity Center user', async function () {
+            fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([createSpaceAppsMap(), domainsMap]))
+            getCallerIdentityStub.returns(Promise.resolve(ssoUser))
+            // domain2's user2-efgh profile carries SingleSignOnUserValue === 'user2'
+            resolveStub.returns(Promise.resolve(new Map([['domain2', ['user2-efgh']]])))
+
+            const childNodes = await testNode.getChildren()
+            assert.strictEqual(childNodes.length, 1, 'Unexpected child count')
+            assert.strictEqual(childNodes[0].label, 'name2 (Stopped)', 'Unexpected node label')
+        })
+
+        it('resolves the Identity Center user name from the assumed-role session ARN', async function () {
+            const spaces = createSpaceAppsMap()
+            spaces.set('domain2__name3', {
+                SpaceName: 'name3',
+                DomainId: 'domain2',
+                OwnershipSettingsSummary: { OwnerUserProfileName: 'user2-efgh' },
+                Status: 'InService',
+                DomainSpaceKey: 'domain2__name3',
+            })
+            fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([spaces, domainsMap]))
+            getCallerIdentityStub.returns(Promise.resolve(ssoUser))
+            resolveStub.returns(Promise.resolve(new Map([['domain2', ['user2-efgh']]])))
+
+            await testNode.getChildren()
+            assert.ok(resolveStub.calledOnce, 'Expected SSO profile resolution to run exactly once')
+            const [userProfilesByDomain, ssoUserValue] = resolveStub.firstCall.args
+            assert.deepStrictEqual(
+                [...userProfilesByDomain].map(([domainId, userProfileNames]) => [domainId, [...userProfileNames]]),
+                [
+                    ['domain1', ['user1-abcd']],
+                    ['domain2', ['user2-efgh']],
+                ],
+                'Unexpected user profiles queried'
+            )
+            assert.strictEqual(ssoUserValue, 'user2', 'Unexpected IdC user name extracted from ARN')
+        })
+
+        it('fails closed and hides all spaces when the user profile cannot be resolved', async function () {
+            fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([createSpaceAppsMap(), domainsMap]))
+            getCallerIdentityStub.returns(Promise.resolve(ssoUser))
+            resolveStub.returns(Promise.resolve(new Map()))
+
+            const childNodes = await testNode.getChildren()
+            assertNodeListOnlyHasPlaceholderNode(childNodes)
+            assert.strictEqual(
+                (childNodes[0] as unknown as { label: string }).label,
+                SagemakerConstants.IdcUnresolvedProfileMessage,
+                'Unresolved IdC profile should use its own placeholder message'
+            )
+        })
+
+        it('keeps shared spaces and hides ownerless spaces that are not explicitly shared', async function () {
+            const spaces = new Map<string, SagemakerSpaceApp>([
+                [
+                    'domain1__shared',
+                    {
+                        SpaceName: 'shared',
+                        DomainId: 'domain1',
+                        SpaceSharingSettingsSummary: { SharingType: 'Shared' },
+                        Status: 'InService',
+                        DomainSpaceKey: 'domain1__shared',
+                    },
+                ],
+                [
+                    'domain1__private',
+                    {
+                        SpaceName: 'private',
+                        DomainId: 'domain1',
+                        SpaceSharingSettingsSummary: { SharingType: 'Private' },
+                        Status: 'InService',
+                        DomainSpaceKey: 'domain1__private',
+                    },
+                ],
+                [
+                    'domain1__unknown',
+                    {
+                        SpaceName: 'unknown',
+                        DomainId: 'domain1',
+                        Status: 'InService',
+                        DomainSpaceKey: 'domain1__unknown',
+                    },
+                ],
+            ])
+            fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([spaces, domainsMap]))
+            getCallerIdentityStub.returns(Promise.resolve(ssoUser))
+
+            const childNodes = await testNode.getChildren()
+
+            assert.deepStrictEqual(
+                childNodes.map((node) => node.label),
+                ['shared (Stopped)']
+            )
+            assert.strictEqual(resolveStub.callCount, 0, 'Ownerless spaces must not trigger profile resolution')
+        })
+
+        it('does not let a cached filter selection widen beyond what the IdC user owns', async function () {
+            await globals.globalState.update(SagemakerConstants.SelectedDomainUsersState, [
+                [testRegion, [[ssoUser.Arn, ['domain1__user1-abcd', 'domain2__user2-efgh']]]],
+            ])
+            fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([createSpaceAppsMap(), domainsMap]))
+            getCallerIdentityStub.returns(Promise.resolve(ssoUser))
+            resolveStub.returns(Promise.resolve(new Map([['domain2', ['user2-efgh']]])))
+
+            const childNodes = await testNode.getChildren()
+            assert.strictEqual(childNodes.length, 1, 'Cached selection must not resurrect unowned spaces')
+            assert.strictEqual(childNodes[0].label, 'name2 (Stopped)', 'Unexpected node label')
+
+            await globals.globalState.update(SagemakerConstants.SelectedDomainUsersState, [])
+        })
     })
 
-    it('filters spaces owned by user profiles that match the IAM assumed-role session name', async function () {
-        fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([spaceAppsMap, domainsMap]))
-        getCallerIdentityStub.returns(Promise.resolve(assumedRoleUser))
-        sinon
-            .stub(vscode.workspace, 'getConfiguration')
-            .returns(getConfigTrue as unknown as vscode.WorkspaceConfiguration)
-
-        const childNodes = await testNode.getChildren()
-        assert.strictEqual(childNodes.length, 1, 'Unexpected child count')
-        assert.strictEqual(childNodes[0].label, 'name2 (Stopped)', 'Unexpected node label')
-    })
-
-    it('filters spaces owned by user profiles that match the Identity Center user', async function () {
-        fetchSpaceAppsAndDomainsStub.returns(Promise.resolve([spaceAppsMap, domainsMap]))
-        getCallerIdentityStub.returns(Promise.resolve(ssoUser))
-        sinon
-            .stub(vscode.workspace, 'getConfiguration')
-            .returns(getConfigFalse as unknown as vscode.WorkspaceConfiguration)
-
-        const childNodes = await testNode.getChildren()
-        assert.strictEqual(childNodes.length, 1, 'Unexpected child count')
-        assert.strictEqual(childNodes[0].label, 'name2 (Stopped)', 'Unexpected node label')
-    })
-
-    describe('getSelectedDomainUsers', function () {
+    /**
+     * Installs hooks giving each test a fresh node and restoring the persisted
+     * selected-domain-users state afterwards. Shared by the suites below, which would
+     * otherwise declare identical setup.
+     */
+    function useFreshNodeWithPreservedSelectionState() {
         let originalState: Map<string, SelectedDomainUsers>
 
         beforeEach(async function () {
@@ -203,6 +312,10 @@ describe('sagemakerStudioNode', function () {
         afterEach(async function () {
             await globals.globalState.update(SagemakerConstants.SelectedDomainUsersState, [...originalState])
         })
+    }
+
+    describe('getSelectedDomainUsers', function () {
+        useFreshNodeWithPreservedSelectionState()
 
         it('gets cached selectedDomainUsers for a given region', async function () {
             await globals.globalState.update(SagemakerConstants.SelectedDomainUsersState, [
@@ -223,7 +336,7 @@ describe('sagemakerStudioNode', function () {
 
         it('gets default selectedDomainUsers', async function () {
             await globals.globalState.update(SagemakerConstants.SelectedDomainUsersState, [])
-            testNode.spaceApps = spaceAppsMap
+            testNode.spaceApps = createSpaceAppsMap()
             testNode.callerIdentity = iamUser
             sinon
                 .stub(vscode.workspace, 'getConfiguration')
@@ -239,18 +352,7 @@ describe('sagemakerStudioNode', function () {
     })
 
     describe('saveSelectedDomainUsers', function () {
-        let originalState: Map<string, SelectedDomainUsers>
-
-        beforeEach(async function () {
-            testNode = new SagemakerStudioNode(testRegion, client)
-            originalState = new Map(
-                globals.globalState.get<SelectedDomainUsersByRegion>(SagemakerConstants.SelectedDomainUsersState, [])
-            )
-        })
-
-        afterEach(async function () {
-            await globals.globalState.update(SagemakerConstants.SelectedDomainUsersState, [...originalState])
-        })
+        useFreshNodeWithPreservedSelectionState()
 
         it('saves selectedDomainUsers for a given region', async function () {
             testNode.callerIdentity = iamUser
@@ -312,7 +414,7 @@ describe('sagemakerStudioNode', function () {
             assert.deepStrictEqual(result, ['domain1__user2-xyz'], 'Should match only user2-prefixed space')
         })
 
-        it('matches Identity Center ARN when IAM filtering is disabled', async function () {
+        it('uses resolved Identity Center ownership when IAM filtering is disabled', async function () {
             testNode.callerIdentity = {
                 Arn: 'arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_PermissionSet_abcd/user3',
             }
@@ -323,9 +425,13 @@ describe('sagemakerStudioNode', function () {
             ])
 
             sinon.stub(vscode.workspace, 'getConfiguration').returns(getConfigFalse as any)
+            const resolveStub = sinon
+                .stub(client, 'resolveUserProfilesForSsoUser')
+                .resolves(new Map([['domain1', ['user3-aaa']]]))
 
             const result = await testNode.getLocalSelectedDomainUsers()
-            assert.deepStrictEqual(result, ['domain1__user3-aaa'], 'Should match only user3-prefixed space')
+            assert.deepStrictEqual(result, ['domain1__user3-aaa'], 'Should match only the resolved IdC user profile')
+            assert.strictEqual(resolveStub.callCount, 1)
         })
 
         it('returns empty array if no match is found', async function () {

--- a/packages/core/src/test/awsService/sagemaker/utils.test.ts
+++ b/packages/core/src/test/awsService/sagemaker/utils.test.ts
@@ -7,6 +7,8 @@ import { AppStatus, SpaceStatus } from '@aws-sdk/client-sagemaker'
 import { generateSpaceStatus, ActivityCheckInterval } from '../../../awsService/sagemaker/utils'
 import * as assert from 'assert'
 import * as sinon from 'sinon'
+import * as vscode from 'vscode'
+import { getTestWindow } from '../../shared/vscode/window'
 import { fs } from '../../../shared/fs/fs'
 import * as utils from '../../../awsService/sagemaker/utils'
 
@@ -146,5 +148,88 @@ describe('checkTerminalActivity', function () {
         // Should continue and find activity on second file
         assert.strictEqual(fsStatStub.callCount, 2)
         assert.strictEqual(fsWriteFileStub.callCount, 1)
+    })
+})
+
+describe('promptAndApplyExplorerFilter', function () {
+    let executeCommandStub: sinon.SinonStub
+    let saveSelection: sinon.SinonStub
+    const node = { label: 'test-node' } as any
+
+    const items = [
+        { label: 'a', key: 'k-a' },
+        { label: 'b', key: 'k-b' },
+    ]
+
+    beforeEach(function () {
+        executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves()
+        saveSelection = sinon.stub()
+    })
+
+    afterEach(function () {
+        sinon.restore()
+    })
+
+    it('shows the items and placeholder in the QuickPick', async function () {
+        let seenItems: readonly vscode.QuickPickItem[] = []
+        let seenPlaceholder: string | undefined
+        getTestWindow().onDidShowQuickPick((picker) => {
+            seenItems = picker.items
+            seenPlaceholder = picker.placeholder
+            picker.dispose()
+        })
+
+        await utils.promptAndApplyExplorerFilter(node, items, 'pick something', new Set(), saveSelection)
+
+        assert.deepStrictEqual(
+            seenItems.map((i) => i.label),
+            ['a', 'b']
+        )
+        assert.strictEqual(seenPlaceholder, 'pick something')
+    })
+
+    it('does nothing when the user cancels', async function () {
+        getTestWindow().onDidShowQuickPick((picker) => picker.dispose())
+
+        await utils.promptAndApplyExplorerFilter(node, items, 'p', new Set(['k-a']), saveSelection)
+
+        assert.strictEqual(saveSelection.callCount, 0, 'Cancel must not persist a selection')
+        assert.strictEqual(executeCommandStub.callCount, 0, 'Cancel must not refresh the tree')
+    })
+
+    it('saves and refreshes when the selection grows', async function () {
+        getTestWindow().onDidShowQuickPick((picker) => picker.acceptItems(...picker.items))
+
+        await utils.promptAndApplyExplorerFilter(node, items, 'p', new Set(['k-a']), saveSelection)
+
+        assert.deepStrictEqual(saveSelection.firstCall.args[0], ['k-a', 'k-b'])
+        assert.ok(executeCommandStub.calledOnceWith('aws.refreshAwsExplorerNode', node))
+    })
+
+    it('saves and refreshes when the selection shrinks', async function () {
+        getTestWindow().onDidShowQuickPick((picker) => picker.acceptItems(picker.items[0]))
+
+        await utils.promptAndApplyExplorerFilter(node, items, 'p', new Set(['k-a', 'k-b']), saveSelection)
+
+        assert.deepStrictEqual(saveSelection.firstCall.args[0], ['k-a'])
+        assert.strictEqual(executeCommandStub.callCount, 1)
+    })
+
+    it('saves and refreshes when the selection swaps a key but keeps the same size', async function () {
+        getTestWindow().onDidShowQuickPick((picker) => picker.acceptItems(picker.items[1]))
+
+        await utils.promptAndApplyExplorerFilter(node, items, 'p', new Set(['k-a']), saveSelection)
+
+        assert.deepStrictEqual(saveSelection.firstCall.args[0], ['k-b'])
+        assert.strictEqual(executeCommandStub.callCount, 1, 'Same-size but different keys is still a change')
+    })
+
+    it('does not save or refresh when the selection is unchanged', async function () {
+        getTestWindow().onDidShowQuickPick((picker) => picker.acceptItems(...picker.items))
+
+        await utils.promptAndApplyExplorerFilter(node, items, 'p', new Set(['k-a', 'k-b']), saveSelection)
+
+        assert.strictEqual(saveSelection.callCount, 0, 'Unchanged selection must not be persisted')
+        assert.strictEqual(executeCommandStub.callCount, 0, 'Unchanged selection must not refresh the tree')
     })
 })

--- a/packages/core/src/test/shared/clients/sagemakerClient.test.ts
+++ b/packages/core/src/test/shared/clients/sagemakerClient.test.ts
@@ -519,3 +519,175 @@ describe('SagemakerClient.startSpace', function () {
         await assert.rejects(promise, (err: ToolkitError) => err.message === 'InstanceType has insufficient memory.')
     })
 })
+
+describe('SagemakerClient.resolveUserProfilesForSsoUser', function () {
+    const region = 'test-region'
+    let client: SagemakerClient
+    let describeUserProfileStub: sinon.SinonStub
+
+    function candidateProfiles(profilesByDomain: Record<string, string[]>): Map<string, Set<string>> {
+        return new Map(
+            Object.entries(profilesByDomain).map(([domainId, userProfileNames]) => [
+                domainId,
+                new Set(userProfileNames),
+            ])
+        )
+    }
+
+    /** Maps `${domainId}/${userProfileName}` -> SingleSignOnUserValue (undefined = no SSO binding). */
+    function stubProfiles(
+        profilesByDomain: Record<string, Record<string, string | undefined>>
+    ): Map<string, Set<string>> {
+        describeUserProfileStub = sinon
+            .stub(client, 'describeUserProfile')
+            .callsFake(async ({ DomainId, UserProfileName }) => {
+                const value = profilesByDomain[DomainId as string]?.[UserProfileName as string]
+                return {
+                    DomainId,
+                    UserProfileName,
+                    SingleSignOnUserIdentifier: value ? 'UserName' : undefined,
+                    SingleSignOnUserValue: value,
+                } as any
+            })
+        return candidateProfiles(
+            Object.fromEntries(
+                Object.entries(profilesByDomain).map(([domainId, profiles]) => [domainId, Object.keys(profiles)])
+            )
+        )
+    }
+
+    beforeEach(function () {
+        client = new SagemakerClient(region)
+    })
+
+    afterEach(function () {
+        sinon.restore()
+    })
+
+    it('returns only the user profile whose SingleSignOnUserValue matches the IdC user', async function () {
+        const candidates = stubProfiles({
+            domain1: { alice: 'alice@example.com', bob: 'bob@example.com' },
+        })
+
+        const result = await client.resolveUserProfilesForSsoUser(candidates, 'alice@example.com')
+
+        assert.deepStrictEqual([...result.entries()], [['domain1', ['alice']]])
+        assert.strictEqual(describeUserProfileStub.callCount, 2, 'Expected a describe per candidate profile')
+    })
+
+    it('matches case-insensitively', async function () {
+        const candidates = stubProfiles({ domain1: { alice: 'Alice@Example.COM' } })
+
+        const result = await client.resolveUserProfilesForSsoUser(candidates, 'alice@example.com')
+
+        assert.deepStrictEqual([...result.entries()], [['domain1', ['alice']]])
+    })
+
+    it('omits a domain when no profile matches, so callers fail closed', async function () {
+        const candidates = stubProfiles({ domain1: { bob: 'bob@example.com' } })
+
+        const result = await client.resolveUserProfilesForSsoUser(candidates, 'alice@example.com')
+
+        assert.strictEqual(result.size, 0, 'Unmatched domain must be omitted rather than returned empty')
+    })
+
+    it('omits a domain whose profiles carry no SSO binding at all', async function () {
+        const candidates = stubProfiles({ domain1: { legacy: undefined } })
+
+        const result = await client.resolveUserProfilesForSsoUser(candidates, 'alice@example.com')
+
+        assert.strictEqual(result.size, 0)
+    })
+
+    it('resolves across multiple domains independently', async function () {
+        const candidates = stubProfiles({
+            domain1: { alice: 'alice@example.com' },
+            domain2: { bob: 'bob@example.com' },
+            domain3: { 'alice-alt': 'alice@example.com' },
+        })
+
+        const result = await client.resolveUserProfilesForSsoUser(candidates, 'alice@example.com')
+
+        assert.deepStrictEqual(
+            [...result.entries()],
+            [
+                ['domain1', ['alice']],
+                ['domain3', ['alice-alt']],
+            ],
+            'domain2 has no matching profile and must be absent'
+        )
+    })
+
+    it('returns every matching profile when the IdC user owns more than one in a domain', async function () {
+        const candidates = stubProfiles({
+            domain1: { alice: 'alice@example.com', 'alice-2': 'alice@example.com', bob: 'bob@example.com' },
+        })
+
+        const result = await client.resolveUserProfilesForSsoUser(candidates, 'alice@example.com')
+
+        assert.deepStrictEqual([...result.entries()], [['domain1', ['alice', 'alice-2']]])
+    })
+
+    it('describes candidate profiles sequentially', async function () {
+        let activeRequests = 0
+        let maxActiveRequests = 0
+        describeUserProfileStub = sinon.stub(client, 'describeUserProfile').callsFake(async () => {
+            activeRequests++
+            maxActiveRequests = Math.max(maxActiveRequests, activeRequests)
+            await Promise.resolve()
+            activeRequests--
+            return { SingleSignOnUserValue: 'alice@example.com' } as any
+        })
+        const candidates = candidateProfiles({
+            domain1: ['profile1', 'profile2', 'profile3', 'profile4', 'profile5', 'profile6'],
+        })
+
+        await client.resolveUserProfilesForSsoUser(candidates, 'alice@example.com')
+
+        assert.strictEqual(maxActiveRequests, 1)
+        assert.strictEqual(describeUserProfileStub.callCount, 6)
+    })
+
+    it('omits the domain when its only DescribeUserProfile call fails', async function () {
+        sinon.stub(client, 'describeUserProfile').rejects(new Error('ThrottlingException'))
+        const candidates = candidateProfiles({ domain1: ['alice'] })
+
+        const result = await client.resolveUserProfilesForSsoUser(candidates, 'alice@example.com')
+
+        assert.strictEqual(result.size, 0)
+    })
+
+    it('keeps confirmed matches when another profile description fails', async function () {
+        sinon.stub(client, 'describeUserProfile').callsFake(async ({ UserProfileName }) => {
+            if (UserProfileName === 'broken') {
+                throw new Error('ThrottlingException')
+            }
+            return { SingleSignOnUserValue: 'alice@example.com' } as any
+        })
+        const candidates = candidateProfiles({ domain1: ['broken', 'alice'] })
+
+        const result = await client.resolveUserProfilesForSsoUser(candidates, 'alice@example.com')
+
+        assert.deepStrictEqual([...result.entries()], [['domain1', ['alice']]])
+    })
+
+    it('keeps resolving later domains after one fails', async function () {
+        sinon.stub(client, 'describeUserProfile').callsFake(async ({ DomainId }) => {
+            if (DomainId === 'domain1') {
+                throw new Error('ThrottlingException')
+            }
+            return { SingleSignOnUserValue: 'alice@example.com' } as any
+        })
+        const candidates = candidateProfiles({ domain1: ['alice'], domain2: ['alice'] })
+
+        const result = await client.resolveUserProfilesForSsoUser(candidates, 'alice@example.com')
+
+        assert.deepStrictEqual([...result.entries()], [['domain2', ['alice']]])
+    })
+
+    it('returns an empty map for no candidate profiles', async function () {
+        const result = await client.resolveUserProfilesForSsoUser(new Map(), 'alice@example.com')
+
+        assert.strictEqual(result.size, 0)
+    })
+})


### PR DESCRIPTION
## Problem

For IAM Identity Center (IdC/SSO) callers, the SageMaker Studio explorer tree lists every Space in the domain rather than only the Spaces belonging to the signed-in user.

## Solution

Resolve the user profile authoritatively from the `SingleSignOnUserValue` field SageMaker stores — the same binding Studio uses to scope its "My Spaces" view. IAM domains are unaffected.

- IdC callers see only Spaces owned by their resolved profiles. If resolution fails or matches nothing, no Spaces are listed rather than all of them.
- The filter picker lists only the caller's own profiles, and a persisted selection is intersected with them, so it can narrow but never widen.
- Resolution is cached per tree refresh and invalidated on refresh, so opening the picker doesn't repeat the lookups the tree build just did.

## Testing

- Unit tests
- Manually verified with a locally built VSIX against an SSO domain containing multiple profiles owned by different IdC users
- Additional confirmation via pentest

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.